### PR TITLE
feat: add boolean checkbox support

### DIFF
--- a/examples/remix/app/routes/signup.tsx
+++ b/examples/remix/app/routes/signup.tsx
@@ -14,6 +14,7 @@ const signup = z
 			.string({ required_error: 'Password is required' })
 			.min(8, 'The minimum password length is 8 characters'),
 		confirm: z.string({ required_error: 'Confirm password is required' }),
+		remember: z.boolean(),
 	})
 	.refine((value) => value.password === value.confirm, {
 		message: 'The password do not match',
@@ -32,9 +33,12 @@ export let action: ActionFunction = async ({ request }) => {
 export default function SignupForm() {
 	const formResult = useActionData();
 	const formProps = useForm();
-	const [fieldsetProps, { email, password, confirm }] = useFieldset(schema, {
-		error: formResult?.error,
-	});
+	const [fieldsetProps, { email, password, confirm, remember }] = useFieldset(
+		schema,
+		{
+			error: formResult?.error,
+		},
+	);
 
 	return (
 		<Form method="post" {...formProps}>
@@ -70,6 +74,19 @@ export default function SignupForm() {
 						{...conform.input(confirm, { type: 'password' })}
 					/>
 					<p className={styles.errorMessage}>{confirm.error}</p>
+				</label>
+				<label className={styles.optionLabel}>
+					<input
+						className={styles.optionInput}
+						{...conform.input(remember, {
+							type: 'checkbox',
+						})}
+					/>
+					<span
+						className={remember.error ? styles.invalidOption : styles.option}
+					>
+						Remember me
+					</span>
 				</label>
 				<button type="submit" className={styles.buttonPrimary}>
 					Sign up

--- a/examples/remix/app/routes/signup.tsx
+++ b/examples/remix/app/routes/signup.tsx
@@ -14,7 +14,7 @@ const signup = z
 			.string({ required_error: 'Password is required' })
 			.min(8, 'The minimum password length is 8 characters'),
 		confirm: z.string({ required_error: 'Confirm password is required' }),
-		remember: z.boolean(),
+		remember: z.boolean().optional(),
 	})
 	.refine((value) => value.password === value.confirm, {
 		message: 'The password do not match',

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -1,28 +1,24 @@
-export type Constraint<Type> = (Type extends string | number | Date | undefined
-	? {
-			required?: boolean;
-			minLength?: number;
-			maxLength?: number;
-			min?: string;
-			max?: string;
-			step?: string;
-			multiple?: boolean;
-			pattern?: string;
-	  }
-	: {}) &
-	(undefined extends Type ? { required?: false } : { required: true }) &
-	(Type extends Array<any> ? { multiple: true } : { multiple?: false });
+export type Constraint = {
+	required?: boolean;
+	minLength?: number;
+	maxLength?: number;
+	min?: string;
+	max?: string;
+	step?: string;
+	multiple?: boolean;
+	pattern?: string;
+};
 
 export interface FieldConfig<Type = any> {
 	name: string;
 	initialValue?: FieldsetData<Type, string>;
 	error?: FieldsetData<Type, string>;
 	form?: string;
-	constraint?: Constraint<Type>;
+	constraint?: Constraint;
 }
 
 export type Schema<Type extends Record<string, any>> = {
-	fields: { [Key in keyof Type]-?: Constraint<Type[Key]> };
+	fields: { [Key in keyof Type]-?: Constraint };
 	validate?: (element: FieldsetElement) => void;
 };
 
@@ -148,7 +144,6 @@ export function createFieldConfig<Type extends Record<string, any>>(
 			form: options.form,
 			initialValue: options.initialValue?.[key],
 			error: options.error?.[key],
-			// @ts-expect-error
 			constraint,
 		};
 

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -5,23 +5,17 @@ import {
 	type TextareaHTMLAttributes,
 } from 'react';
 
-export function input<Type extends string | number | Date | undefined>(
+export function input<
+	Type extends string | number | Date | boolean | undefined,
+>(
 	config: FieldConfig<Type>,
 	{ type, value }: { type?: string; value?: string } = {},
 ): InputHTMLAttributes<HTMLInputElement> {
 	const isCheckboxOrRadio = type === 'checkbox' || type === 'radio';
-
-	return {
+	const attributes: InputHTMLAttributes<HTMLInputElement> = {
 		type,
 		name: config.name,
 		form: config.form,
-		value: isCheckboxOrRadio ? value : undefined,
-		defaultValue: !isCheckboxOrRadio
-			? `${config.initialValue ?? ''}`
-			: undefined,
-		defaultChecked: isCheckboxOrRadio
-			? config.initialValue === value
-			: undefined,
 		required: config.constraint?.required,
 		minLength: config.constraint?.minLength,
 		maxLength: config.constraint?.maxLength,
@@ -30,6 +24,15 @@ export function input<Type extends string | number | Date | undefined>(
 		step: config.constraint?.step,
 		pattern: config.constraint?.pattern,
 	};
+
+	if (isCheckboxOrRadio) {
+		attributes.value = value ?? 'on';
+		attributes.defaultChecked = config.initialValue === attributes.value;
+	} else {
+		attributes.defaultValue = `${config.initialValue ?? ''}`;
+	}
+
+	return attributes;
 }
 
 export function select<T extends any>(

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -358,7 +358,6 @@ export function useFieldList<Type extends Array<any>>(
 					name: `${config.name}[${index}]`,
 					initialValue: config.initialValue?.[index],
 					error: config.error?.[index],
-					// @ts-expect-error
 					constraint: {
 						...config.constraint,
 						multiple: false,

--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -11,12 +11,9 @@ import {
 } from '@conform-to/dom';
 import * as z from 'zod';
 
-function inferConstraint<T extends z.ZodTypeAny>(
-	schema: T,
-): Constraint<z.infer<T>> {
+function inferConstraint<T extends z.ZodTypeAny>(schema: T): Constraint {
 	let def = schema;
 
-	// @ts-expect-error
 	const constraint: Constraint = {
 		required: !def.isOptional(),
 	};
@@ -219,7 +216,7 @@ export function resolve<T extends Record<string, any>>(
 	return {
 		// @ts-expect-error
 		fields: Object.fromEntries(
-			Object.entries(shape).map<[string, Constraint<any>]>(([key, def]) => [
+			Object.entries(shape).map<[string, Constraint]>(([key, def]) => [
 				key,
 				inferConstraint(def),
 			]),

--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -63,6 +63,11 @@ function inferConstraint<T extends z.ZodTypeAny>(schema: T): Constraint {
 					break;
 			}
 		}
+	} else if (schema instanceof z.ZodBoolean) {
+		// Making a checkbox required would result in either `true` or undefined
+		// It would be simpler to treat undefined or empty string as `false` and
+		// make it always optional in the form instead
+		constraint.required = false;
 	}
 
 	return constraint;
@@ -113,10 +118,6 @@ function createParser<T extends z.ZodType<any>>(
 		};
 	} else if (schema instanceof z.ZodBoolean) {
 		return (value) => {
-			if (typeof value !== 'string' || value === '') {
-				return;
-			}
-
 			return value === 'on';
 		};
 	} else if (schema instanceof z.ZodOptional) {

--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -63,11 +63,6 @@ function inferConstraint<T extends z.ZodTypeAny>(schema: T): Constraint {
 					break;
 			}
 		}
-	} else if (schema instanceof z.ZodBoolean) {
-		// Making a checkbox required would result in either `true` or undefined
-		// It would be simpler to treat undefined or empty string as `false` and
-		// make it always optional in the form instead
-		constraint.required = false;
 	}
 
 	return constraint;


### PR DESCRIPTION
## Context

Just noticed currently there is no way to setup a checkbox and map it to a boolean which should be a common need for many forms like the remember me checkbox on a login form.

## What's changed?

- No breaking changes

### conform-dom

- Constraint type checking is loosen as it gives no additional value

### conform-react

- `conform.input()` helper should now accept boolean field config. It also default to `on` if no value is provided for checkbox or radio. Same as the browser default.