### PR TITLE
fix: valdiate should be called before report

### DIFF
--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -102,7 +102,11 @@ export function useForm({
 		}
 
 		const handleChange = (event: Event) => {
-			if (!isFieldElement(event.target) || event.target?.form !== ref.current) {
+			if (
+				!ref.current ||
+				!isFieldElement(event.target) ||
+				event.target?.form !== ref.current
+			) {
 				return;
 			}
 
@@ -110,12 +114,14 @@ export function useForm({
 				setFieldState(event.target, { touched: true });
 			}
 
-			if (ref.current) {
-				reportValidity(ref.current);
-			}
+			reportValidity(ref.current);
 		};
 		const handleBlur = (event: FocusEvent) => {
-			if (!isFieldElement(event.target) || event.target?.form !== ref.current) {
+			if (
+				!ref.current ||
+				!isFieldElement(event.target) ||
+				event.target?.form !== ref.current
+			) {
 				return;
 			}
 
@@ -123,17 +129,15 @@ export function useForm({
 				setFieldState(event.target, { touched: true });
 			}
 
-			if (ref.current) {
-				reportValidity(ref.current);
-			}
+			reportValidity(ref.current);
 		};
 
-		document.body.addEventListener('input', handleChange);
-		document.body.addEventListener('focusout', handleBlur);
+		document.addEventListener('input', handleChange);
+		document.addEventListener('focusout', handleBlur);
 
 		return () => {
-			document.body.removeEventListener('input', handleChange);
-			document.body.removeEventListener('focusout', handleBlur);
+			document.removeEventListener('input', handleChange);
+			document.removeEventListener('focusout', handleBlur);
 		};
 	}, [noValidate, initialReport]);
 

--- a/playground/app/components.tsx
+++ b/playground/app/components.tsx
@@ -42,7 +42,7 @@ export function Playground<T>({
 	children,
 }: PlaygroundProps<T>) {
 	return (
-		<div className="lg:grid lg:grid-cols-2 lg:gap-6">
+		<div className="lg:grid lg:grid-cols-2 lg:gap-6" data-playground={title}>
 			<aside className="flex flex-col">
 				<header className="px-4 lg:px-0">
 					<h3 className="text-lg font-medium leading-6 text-gray-900">

--- a/playground/app/components.tsx
+++ b/playground/app/components.tsx
@@ -3,15 +3,24 @@ import type { ReactElement } from 'react';
 
 interface FieldProps {
 	label: string;
+	inline?: boolean;
 	error?: string;
 	children: ReactElement;
 }
 
-export function Field({ label, error, children }: FieldProps) {
+export function Field({ label, inline, error, children }: FieldProps) {
 	return (
-		<label className="block mb-4">
-			<div className="block text-sm font-medium text-gray-700">{label}</div>
-			{children}
+		<label className="mb-4 block">
+			<div
+				className={
+					inline
+						? 'flex flex-row justify-between items-center gap-8 whitespace-nowrap'
+						: ''
+				}
+			>
+				<div className="block text-sm font-medium text-gray-700">{label}</div>
+				{children}
+			</div>
 			<p className="my-1 text-pink-600 text-sm peer-valid:invisible">{error}</p>
 		</label>
 	);
@@ -50,29 +59,31 @@ export function Playground<T>({
 					</details>
 				) : null}
 			</aside>
-			<main className="shadow lg:rounded-md lg:overflow-hidden">
-				<div className="mt-5 lg:mt-0 lg:col-span-2 px-4 py-5 bg-white lg:p-6">
-					{children}
-				</div>
-				{form ? (
-					<footer className="px-4 py-3 bg-gray-50 flex flex-row-reverse lg:px-6 gap-2">
-						<button
-							type="submit"
-							className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-							form={form}
-						>
-							Submit
-						</button>
-						<button
-							type="reset"
-							className="inline-flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-gray-700 bg-gray-50 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-							form={form}
-						>
-							Reset
-						</button>
-					</footer>
-				) : null}
-			</main>
+			<div>
+				<main className="shadow lg:rounded-md lg:overflow-hidden">
+					<div className="mt-5 lg:mt-0 lg:col-span-2 px-4 py-5 bg-white lg:p-6">
+						{children}
+					</div>
+					{form ? (
+						<footer className="px-4 py-3 bg-gray-50 flex flex-row-reverse lg:px-6 gap-2">
+							<button
+								type="submit"
+								className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+								form={form}
+							>
+								Submit
+							</button>
+							<button
+								type="reset"
+								className="inline-flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-gray-700 bg-gray-50 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+								form={form}
+							>
+								Reset
+							</button>
+						</footer>
+					) : null}
+				</main>
+			</div>
 		</div>
 	);
 }

--- a/playground/app/config.ts
+++ b/playground/app/config.ts
@@ -1,5 +1,8 @@
+import { type FormResult } from '@conform-to/dom';
+import { parse as baseParse } from '@conform-to/react';
 import { parse } from '@conform-to/zod';
 import { useFormAction, useMatches } from '@remix-run/react';
+import { type FormEventHandler, useState } from 'react';
 import { z } from 'zod';
 
 const FormConfigSchema = z.object({
@@ -34,4 +37,34 @@ export function useFormConfig(): [FormConfig, string] {
 	}
 
 	return [config, `${action}?${searchParams}`];
+}
+
+export function useFormResult(): [
+	Record<string, FormResult<any> | undefined>,
+	FormEventHandler<HTMLFormElement>,
+	FormEventHandler<HTMLFormElement>,
+] {
+	const [map, setMap] = useState({});
+	const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+		e.preventDefault();
+
+		const form = e.currentTarget;
+		const formData = new FormData(form);
+		const result = baseParse(formData);
+
+		setMap((map) => ({
+			...map,
+			[form.id]: result,
+		}));
+	};
+	const handleReset: FormEventHandler<HTMLFormElement> = (e) => {
+		const form = e.currentTarget;
+
+		setMap((map) => ({
+			...map,
+			[form.id]: undefined,
+		}));
+	};
+
+	return [map, handleSubmit, handleReset];
 }

--- a/playground/app/helpers.ts
+++ b/playground/app/helpers.ts
@@ -5,4 +5,6 @@ export const styles = {
         touched:invalid:border-pink-500 touched:invalid:text-pink-600
         touched:focus:invalid:border-pink-500 touched:focus:invalid:ring-pink-500
     `,
+	checkbox: `h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded`,
+	divider: 'my-8 border-t border-gray-200',
 };

--- a/playground/app/root.tsx
+++ b/playground/app/root.tsx
@@ -14,7 +14,6 @@ import {
 
 import stylesUrl from '~/styles/tailwind.css';
 import { getFormConfig } from '~/config';
-import { styles } from './helpers';
 
 export let links: LinksFunction = () => {
 	return [{ rel: 'stylesheet', href: stylesUrl }];
@@ -40,7 +39,7 @@ export default function App() {
 				<Meta />
 				<Links />
 			</head>
-			<body className="antialiased font-sans bg-gray-200 max-w-7xl mx-auto py-10 lg:px-6 lg:px-8">
+			<body className="antialiased font-sans bg-gray-100 max-w-7xl mx-auto py-10 lg:px-8">
 				<Outlet />
 				<ScrollRestoration />
 				<Scripts />

--- a/playground/app/routes/basic.tsx
+++ b/playground/app/routes/basic.tsx
@@ -1,81 +1,154 @@
-import { type FormResult } from '@conform-to/dom';
 import {
-	type Schema,
 	useFieldset,
 	conform,
 	useForm,
-	parse,
+	getFieldElements,
 } from '@conform-to/react';
 import { Form } from '@remix-run/react';
-import { useState } from 'react';
 import { Field, Playground } from '~/components';
-import { useFormConfig } from '~/config';
+import { useFormConfig, useFormResult } from '~/config';
 import { styles } from '~/helpers';
 
-const schema: Schema<{ email: string; password: string; age: string }> = {
-	fields: {
-		email: {
-			required: true,
-		},
-		password: {
-			required: true,
-			minLength: 8,
-			maxLength: 20,
-			pattern: '[0-9a-zA-Z]{8,20}',
-		},
-		age: {
-			min: '1',
-			max: '100',
-			step: '10',
-		},
-	},
-};
-
 export default function Basic() {
-	const [result, setResult] = useState<FormResult<any> | undefined>();
+	const [result, onSubmit, onReset] = useFormResult();
 	const [config] = useFormConfig();
 	const formProps = useForm({
 		...config,
-		onSubmit(e) {
-			e.preventDefault();
-
-			const formData = new FormData(e.currentTarget);
-			const result = parse(formData);
-
-			setResult(result);
-		},
+		onSubmit,
+		onReset,
 	});
-	const [fieldsetProps, { email, password, age }] = useFieldset(schema);
 
 	return (
-		<Playground
-			title="Basic"
-			description="React only example"
-			result={result}
-			form="basic"
-		>
-			<Form id="basic" {...formProps}>
-				<fieldset {...fieldsetProps}>
-					<Field label="Email" error={email.error}>
-						<input
-							className={styles.input}
-							{...conform.input(email, { type: 'email' })}
-						/>
-					</Field>
-					<Field label="Password" error={password.error}>
-						<input
-							className={styles.input}
-							{...conform.input(password, { type: 'password' })}
-						/>
-					</Field>
-					<Field label="Age" error={age.error}>
-						<input
-							className={styles.input}
-							{...conform.input(age, { type: 'number' })}
-						/>
-					</Field>
-				</fieldset>
-			</Form>
-		</Playground>
+		<>
+			<Playground
+				title="Native constraints"
+				description="Reporting error messages provided by the browser vendor"
+				result={result['native']}
+				form="native"
+			>
+				<Form id="native" {...formProps}>
+					<NativeConstraintFieldset />
+				</Form>
+			</Playground>
+			<hr className={styles.divider} />
+			<Playground
+				title="Custom constraints"
+				description="Setting up custom validation rules with user-defined error messages"
+				result={result['custom']}
+				form="custom"
+			>
+				<Form id="custom" {...formProps}>
+					<CustomValidationFieldset />
+				</Form>
+			</Playground>
+		</>
+	);
+}
+
+function NativeConstraintFieldset() {
+	const [fieldsetProps, { email, password, age }] = useFieldset<{
+		email: string;
+		password: string;
+		age: string;
+	}>({
+		fields: {
+			email: {
+				required: true,
+			},
+			password: {
+				required: true,
+				minLength: 8,
+				maxLength: 20,
+				pattern: '[0-9a-zA-Z]{8,20}',
+			},
+			age: {
+				min: '1',
+				max: '100',
+				step: '10',
+			},
+		},
+	});
+
+	return (
+		<fieldset {...fieldsetProps}>
+			<Field label="Email" error={email.error}>
+				<input
+					className={styles.input}
+					{...conform.input(email, { type: 'email' })}
+				/>
+			</Field>
+			<Field label="Password" error={password.error}>
+				<input
+					className={styles.input}
+					{...conform.input(password, { type: 'password' })}
+				/>
+			</Field>
+			<Field label="Age" error={age.error}>
+				<input
+					className={styles.input}
+					{...conform.input(age, { type: 'number' })}
+				/>
+			</Field>
+		</fieldset>
+	);
+}
+
+function CustomValidationFieldset() {
+	const [fieldsetProps, { number, accept }] = useFieldset<{
+		number: string;
+		accept: string;
+	}>({
+		fields: {
+			number: {
+				required: true,
+				min: '1',
+				max: '10',
+			},
+			accept: {
+				required: true,
+			},
+		},
+		validate(element) {
+			const [number] = getFieldElements(element, 'number');
+			const [accept] = getFieldElements(element, 'accept');
+
+			if (number.validity.valueMissing) {
+				number.setCustomValidity('Number is required');
+			} else if (number.validity.typeMismatch) {
+				number.setCustomValidity('Number is invalid');
+			} else if (
+				number.validity.rangeUnderflow ||
+				number.validity.rangeOverflow
+			) {
+				number.setCustomValidity('Number must be between 1 and 10');
+			} else if (number.value === '5') {
+				number.setCustomValidity('Are you sure?');
+			} else {
+				number.setCustomValidity('');
+			}
+
+			if (accept.validity.valueMissing) {
+				accept.setCustomValidity('Please accept before submit');
+			} else {
+				accept.setCustomValidity('');
+			}
+		},
+	});
+
+	return (
+		<fieldset {...fieldsetProps}>
+			<Field label="Your lucky number" error={number.error} inline>
+				<input
+					className={styles.input}
+					{...conform.input(number, { type: 'number' })}
+				/>
+			</Field>
+			<Field label="Accept" error={accept.error} inline>
+				<input
+					className={styles.checkbox}
+					{...conform.input(accept, { type: 'checkbox' })}
+				/>
+			</Field>
+		</fieldset>
 	);
 }

--- a/playground/app/routes/basic.tsx
+++ b/playground/app/routes/basic.tsx
@@ -12,32 +12,29 @@ import { styles } from '~/helpers';
 export default function Basic() {
 	const [result, onSubmit, onReset] = useFormResult();
 	const [config] = useFormConfig();
-	const formProps = useForm({
-		...config,
-		onSubmit,
-		onReset,
-	});
+	const nativeFormProps = useForm({ ...config, onSubmit, onReset });
+	const customFormProps = useForm({ ...config, onSubmit, onReset });
 
 	return (
 		<>
 			<Playground
-				title="Native constraints"
+				title="Native Constraint"
 				description="Reporting error messages provided by the browser vendor"
 				result={result['native']}
 				form="native"
 			>
-				<Form id="native" {...formProps}>
+				<Form id="native" {...nativeFormProps}>
 					<NativeConstraintFieldset />
 				</Form>
 			</Playground>
 			<hr className={styles.divider} />
 			<Playground
-				title="Custom constraints"
+				title="Custom Constraint"
 				description="Setting up custom validation rules with user-defined error messages"
 				result={result['custom']}
 				form="custom"
 			>
-				<Form id="custom" {...formProps}>
+				<Form id="custom" {...customFormProps}>
 					<CustomValidationFieldset />
 				</Form>
 			</Playground>

--- a/playground/app/routes/basic.tsx
+++ b/playground/app/routes/basic.tsx
@@ -111,8 +111,6 @@ function CustomValidationFieldset() {
 
 			if (number.validity.valueMissing) {
 				number.setCustomValidity('Number is required');
-			} else if (number.validity.typeMismatch) {
-				number.setCustomValidity('Number is invalid');
 			} else if (
 				number.validity.rangeUnderflow ||
 				number.validity.rangeOverflow

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -103,7 +103,7 @@ const config: PlaywrightTestConfig = {
 	/* Run your local dev server before starting the tests */
 	webServer: {
 		command: 'npm run playground',
-		port: 3000,
+		port: process.env.PORT ? Number(process.env.PORT) : 3000,
 	},
 };
 

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -144,3 +144,47 @@ test.describe('Native Constraint', () => {
 		});
 	});
 });
+
+test.describe('Custom Constraint', () => {
+	test('report error messages correctly', async ({ page }) => {
+		const playground = getPlaygroundLocator(page, 'Custom Constraint');
+		const number = playground.locator('[name="number"]');
+		const accept = playground.locator('[name="accept"]');
+
+		await clickSubmitButton(playground);
+
+		expect(await getErrorMessages(playground)).toEqual([
+			'Number is required',
+			'Please accept before submit',
+		]);
+
+		await number.type('0');
+		expect(await getErrorMessages(playground)).toEqual([
+			'Number must be between 1 and 10',
+			'Please accept before submit',
+		]);
+
+		await number.fill('');
+		await number.type('5');
+		expect(await getErrorMessages(playground)).toEqual([
+			'Are you sure?',
+			'Please accept before submit',
+		]);
+
+		await number.fill('');
+		await number.type('10');
+		expect(await getErrorMessages(playground)).toEqual([
+			'',
+			'Please accept before submit',
+		]);
+
+		await accept.check();
+		expect(await getErrorMessages(playground)).toEqual(['', '']);
+
+		await clickSubmitButton(playground);
+		expect(await getFormResult(playground)).toEqual({
+			number: '10',
+			accept: 'on',
+		});
+	});
+});


### PR DESCRIPTION
## Context

The `useForm` hook was listening to the `input` and `focusout` event on the document body to decide when to **report**. However, I notice it end up triggering the **report** earlier than the `validate` done by fieldset.

The issue is likely cause by the event listener of the fieldset being setup through React while the one for form is done manually, in which React register the event listeners on the document (or root). The event listener does not trigger in the same order as expected. 