### PR TITLE
fix: error messages should be cleared with fields revalidated on reset

### DIFF
--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -156,7 +156,6 @@ interface FieldsetProps {
 	name?: string;
 	form?: string;
 	onInput: FormEventHandler<HTMLFieldSetElement>;
-	onReset: FormEventHandler<HTMLFieldSetElement>;
 	onInvalid: FormEventHandler<HTMLFieldSetElement>;
 }
 
@@ -278,6 +277,21 @@ export function useFieldset<Type extends Record<string, any>>(
 
 			schema.validate?.(fieldset);
 			dispatch({ type: 'cleanup', payload: { fieldset } });
+
+			const resetHandler = (e: Event) => {
+				if (e.target !== fieldset.form) {
+					return;
+				}
+
+				schema.validate?.(fieldset);
+				dispatch({ type: 'reset' });
+			};
+
+			document.addEventListener('reset', resetHandler);
+
+			return () => {
+				document.removeEventListener('reset', resetHandler);
+			};
 		},
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[schema.validate],
@@ -303,10 +317,6 @@ export function useFieldset<Type extends Record<string, any>>(
 
 				schema.validate?.(fieldset);
 				dispatch({ type: 'cleanup', payload: { fieldset } });
-			},
-			onReset(e: FormEvent<FieldsetElement>) {
-				setFieldState(e.currentTarget, { touched: false });
-				dispatch({ type: 'reset' });
 			},
 			onInvalid(e: FormEvent<FieldsetElement>) {
 				const element = isFieldElement(e.target) ? e.target : null;

--- a/playground/app/helpers.ts
+++ b/playground/app/helpers.ts
@@ -5,6 +5,6 @@ export const styles = {
         touched:invalid:border-pink-500 touched:invalid:text-pink-600
         touched:focus:invalid:border-pink-500 touched:focus:invalid:ring-pink-500
     `,
-	checkbox: `h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded`,
+	checkbox: `h-4 w-4 text-indigo-600 touched:invalid:border-pink-500 touched:focus:invalid:ring-pink-500 focus:ring-indigo-500 border-gray-300 rounded`,
 	divider: 'my-8 border-t border-gray-200',
 };


### PR DESCRIPTION
## Context

The initial version of conform has a wrong assumption in which reset event will be bubbled up and triggered the fieldset `reset` event handler. 

This fix, instead, register a reset event handler on the document and does 2 things:
1. Clear all error messages
2. Revalidate the fieldset