### PR TITLE
fix(conform-zod): ensure constraint inferred from zod to be valid

### DIFF
--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -68,6 +68,13 @@ function inferConstraint<T extends z.ZodTypeAny>(schema: T): Constraint {
 					break;
 			}
 		}
+	} else if (schema instanceof z.ZodEnum) {
+		constraint.pattern = schema.options
+			.map((option: string) =>
+				// To escape unsafe characters on regex
+				option.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d'),
+			)
+			.join('|');
 	}
 
 	return constraint;

--- a/playground/app/components.tsx
+++ b/playground/app/components.tsx
@@ -50,11 +50,17 @@ export function Playground({
 					</h3>
 					<p className="mt-1 mb-2 text-sm text-gray-600">{description}</p>
 				</header>
-				{result?.state === 'accepted' ? (
+				{result ? (
 					<details open={true}>
 						<summary>Result</summary>
-						<pre className="m-4 border-l-4 border-emerald-500 pl-4 py-2 mt-4">
-							{JSON.stringify(result.value, null, 2)}
+						<pre
+							className={`m-4 border-l-4 ${
+								result.state === 'rejected'
+									? 'border-pink-600'
+									: 'border-emerald-500'
+							} pl-4 py-2 mt-4`}
+						>
+							{JSON.stringify(result, null, 2)}
 						</pre>
 					</details>
 				) : null}

--- a/playground/app/playground.tsx
+++ b/playground/app/playground.tsx
@@ -52,7 +52,17 @@ export function useActionData() {
 	const action = useFormAction();
 	const [formDataById, setFormDataById] = useState<
 		Record<string, URLSearchParams | undefined>
-	>({});
+	>(() => {
+		if (actionData) {
+			const { form, entries } = actionData;
+
+			return {
+				[form]: entries,
+			};
+		}
+
+		return {};
+	});
 	const searchParams = new URLSearchParams();
 
 	for (const [key, value] of Object.entries(config)) {

--- a/playground/app/routes/zod.tsx
+++ b/playground/app/routes/zod.tsx
@@ -44,29 +44,30 @@ export default function ZodIntegration() {
 }
 
 const nativeConstraintSchema = z.object({
-	subject: z
+	name: z
 		.string()
 		.min(8)
 		.max(20)
 		.regex(/^[0-9a-zA-Z]{8,20}$/),
 	remarks: z.string().optional(),
-	grade: z.preprocess(
+	score: z.preprocess(
 		(value) => (typeof value !== 'undefined' ? Number(value) : undefined),
 		z.number().min(1).max(100).step(10).optional(),
 	),
+	grade: z.enum(['A', 'B', 'C', 'D', 'E', 'F']).default('F'),
 });
 
 function NativeConstraintFieldset() {
-	const [fieldsetProps, { subject, remarks, grade }] = useFieldset(
+	const [fieldsetProps, { name, remarks, grade, score }] = useFieldset(
 		resolve(nativeConstraintSchema),
 	);
 
 	return (
 		<fieldset {...fieldsetProps}>
-			<Field label="Subject" error={subject.error}>
+			<Field label="Name" error={name.error}>
 				<input
 					className={styles.input}
-					{...conform.input(subject, { type: 'text' })}
+					{...conform.input(name, { type: 'text' })}
 				/>
 			</Field>
 			<Field label="Remarks" error={remarks.error}>
@@ -75,10 +76,16 @@ function NativeConstraintFieldset() {
 					{...conform.input(remarks, { type: 'text' })}
 				/>
 			</Field>
+			<Field label="Score" error={score.error}>
+				<input
+					className={styles.input}
+					{...conform.input(score, { type: 'number' })}
+				/>
+			</Field>
 			<Field label="Grade" error={grade.error}>
 				<input
 					className={styles.input}
-					{...conform.input(grade, { type: 'number' })}
+					{...conform.input(grade, { type: 'text' })}
 				/>
 			</Field>
 		</fieldset>

--- a/playground/app/routes/zod.tsx
+++ b/playground/app/routes/zod.tsx
@@ -15,6 +15,19 @@ export default function ZodIntegration() {
 	return (
 		<>
 			<Playground
+				title="Native Constraint"
+				description="Infering constraint based on the zod schema"
+				result={getResult('native', (formData) =>
+					parse(formData, nativeConstraintSchema),
+				)}
+				form="native"
+			>
+				<Form id="native" method="post" action={action} {...typeFormProps}>
+					<NativeConstraintFieldset />
+				</Form>
+			</Playground>
+			<hr className={styles.divider} />
+			<Playground
 				title="Type Conversion"
 				description="Parsing the form data based on the defined preprocess with zod"
 				result={getResult('type', (formData) =>
@@ -27,6 +40,48 @@ export default function ZodIntegration() {
 				</Form>
 			</Playground>
 		</>
+	);
+}
+
+const nativeConstraintSchema = z.object({
+	subject: z
+		.string()
+		.min(8)
+		.max(20)
+		.regex(/^[0-9a-zA-Z]{8,20}$/),
+	remarks: z.string().optional(),
+	grade: z.preprocess(
+		(value) => (typeof value !== 'undefined' ? Number(value) : undefined),
+		z.number().min(1).max(100).step(10).optional(),
+	),
+});
+
+function NativeConstraintFieldset() {
+	const [fieldsetProps, { subject, remarks, grade }] = useFieldset(
+		resolve(nativeConstraintSchema),
+	);
+
+	return (
+		<fieldset {...fieldsetProps}>
+			<Field label="Subject" error={subject.error}>
+				<input
+					className={styles.input}
+					{...conform.input(subject, { type: 'text' })}
+				/>
+			</Field>
+			<Field label="Remarks" error={remarks.error}>
+				<input
+					className={styles.input}
+					{...conform.input(remarks, { type: 'text' })}
+				/>
+			</Field>
+			<Field label="Grade" error={grade.error}>
+				<input
+					className={styles.input}
+					{...conform.input(grade, { type: 'number' })}
+				/>
+			</Field>
+		</fieldset>
 	);
 }
 

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -109,9 +109,12 @@ test.describe('Native Constraint', () => {
 
 		await clickSubmitButton(playground);
 		expect(await getFormResult(playground)).toEqual({
-			email: 'me@edmund.dev',
-			password: 'constraintvalidation',
-			age: '91',
+			state: 'accepted',
+			value: {
+				email: 'me@edmund.dev',
+				password: 'constraintvalidation',
+				age: '91',
+			},
 		});
 	});
 });
@@ -154,8 +157,11 @@ test.describe('Custom Constraint', () => {
 
 		await clickSubmitButton(playground);
 		expect(await getFormResult(playground)).toEqual({
-			number: '10',
-			accept: 'on',
+			state: 'accepted',
+			value: {
+				number: '10',
+				accept: 'on',
+			},
 		});
 	});
 

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -13,14 +13,15 @@ test.beforeEach(async ({ page }) => {
 test.describe('Native Constraint', () => {
 	test('infer constraint correctly', async ({ page }) => {
 		const playground = getPlaygroundLocator(page, 'Native Constraint');
-		const [subject, remarks, grade] = await Promise.all([
-			getConstraint(playground.locator('[name="subject"]')),
+		const [name, remarks, score, grade] = await Promise.all([
+			getConstraint(playground.locator('[name="name"]')),
 			getConstraint(playground.locator('[name="remarks"]')),
+			getConstraint(playground.locator('[name="score"]')),
 			getConstraint(playground.locator('[name="grade"]')),
 		]);
 
-		expect({ subject, remarks, grade }).toEqual({
-			subject: {
+		expect({ name, remarks, score, grade }).toEqual({
+			name: {
 				required: true,
 				minLength: 8,
 				maxLength: 20,
@@ -40,7 +41,7 @@ test.describe('Native Constraint', () => {
 				multiple: false,
 				pattern: '',
 			},
-			grade: {
+			score: {
 				required: false,
 				minLength: -1,
 				maxLength: -1,
@@ -49,6 +50,16 @@ test.describe('Native Constraint', () => {
 				step: '',
 				multiple: false,
 				pattern: '',
+			},
+			grade: {
+				required: false,
+				minLength: -1,
+				maxLength: -1,
+				min: '',
+				max: '',
+				step: '',
+				multiple: false,
+				pattern: 'A|B|C|D|E|F',
 			},
 		});
 	});

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -3,10 +3,55 @@ import {
 	getPlaygroundLocator,
 	getFormResult,
 	clickSubmitButton,
+	getConstraint,
 } from './helpers';
 
 test.beforeEach(async ({ page }) => {
 	await page.goto('/zod');
+});
+
+test.describe('Native Constraint', () => {
+	test('infer constraint correctly', async ({ page }) => {
+		const playground = getPlaygroundLocator(page, 'Native Constraint');
+		const [subject, remarks, grade] = await Promise.all([
+			getConstraint(playground.locator('[name="subject"]')),
+			getConstraint(playground.locator('[name="remarks"]')),
+			getConstraint(playground.locator('[name="grade"]')),
+		]);
+
+		expect({ subject, remarks, grade }).toEqual({
+			subject: {
+				required: true,
+				minLength: 8,
+				maxLength: 20,
+				min: '',
+				max: '',
+				step: '',
+				multiple: false,
+				pattern: '^[0-9a-zA-Z]{8,20}$',
+			},
+			remarks: {
+				required: false,
+				minLength: -1,
+				maxLength: -1,
+				min: '',
+				max: '',
+				step: '',
+				multiple: false,
+				pattern: '',
+			},
+			grade: {
+				required: false,
+				minLength: -1,
+				maxLength: -1,
+				min: '1',
+				max: '100',
+				step: '',
+				multiple: false,
+				pattern: '',
+			},
+		});
+	});
 });
 
 test.describe('Type Conversion', () => {

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -68,9 +68,12 @@ test.describe('Type Conversion', () => {
 		await clickSubmitButton(playground);
 
 		expect(await getFormResult(playground)).toEqual({
-			number: 123,
-			datetime: '2022-07-04T12:00:00.000Z',
-			boolean: true,
+			state: 'accepted',
+			value: {
+				number: 123,
+				datetime: '2022-07-04T12:00:00.000Z',
+				boolean: true,
+			},
 		});
 	});
 });


### PR DESCRIPTION
## Context

This PR improves the logic on inferring constraint based on `zod` schema.

- It should manage to unwarp ZodEffect and ZodOptional correctly when inferring constraint
- it infers the constraint based on the array element type as well (Not final)
- It will no longer infer `steps` based on the `multipleOf` checks on zod number as input steps is affected by `min`, e.g. 15 will be counted as valid when step = 10 and min = 5, instead 10 will be counted as valid when step = 10 but min = 0
- It infers pattern if the type is an enum
- It infers required as false if the type has a default value