### PR TITLE
feat!: redesign form result structure

### DIFF
--- a/examples/remix/app/routes/order.tsx
+++ b/examples/remix/app/routes/order.tsx
@@ -1,5 +1,6 @@
 import {
 	type FieldsetConfig,
+	type Submission,
 	useForm,
 	useFieldset,
 	useFieldList,
@@ -8,7 +9,7 @@ import {
 import { parse, resolve } from '@conform-to/zod';
 import { type ActionFunction } from '@remix-run/node';
 import { Form, useActionData } from '@remix-run/react';
-import * as z from 'zod';
+import { z } from 'zod';
 import { styles } from '~/helpers';
 
 const product = z.object({
@@ -34,19 +35,19 @@ const order = z.object({
 
 export let action: ActionFunction = async ({ request }) => {
 	const formData = await request.formData();
-	const formResult = parse(formData, order);
+	const submission = parse(formData, order);
 
-	return formResult;
+	return submission;
 };
 
 export default function OrderForm() {
-	const formResult = useActionData();
+	const submission = useActionData<Submission<z.infer<typeof order>>>();
 	const formProps = useForm({ initialReport: 'onBlur' });
 	const [fieldsetProps, { products, shipping, remarks }] = useFieldset(
 		resolve(order),
 		{
-			defaultValue: formResult?.value,
-			error: formResult?.error,
+			defaultValue: submission?.form.value,
+			error: submission?.form.error,
 		},
 	);
 	const [productList, control] = useFieldList(products);
@@ -55,9 +56,9 @@ export default function OrderForm() {
 		<Form method="post" {...formProps}>
 			<header className={styles.header}>
 				<h1>Order Form</h1>
-				{formResult?.state === 'accepted' ? (
+				{submission?.state === 'accepted' ? (
 					<pre className={styles.result}>
-						{JSON.stringify(formResult?.value, null, 2)}
+						{JSON.stringify(submission?.data, null, 2)}
 					</pre>
 				) : null}
 			</header>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"build": "run-s build:*",
 		"build:js": "rollup -c",
 		"build:ts": "tsc -b",
+		"build:playground": "npm run build --workspace=playground",
 		"watch": "run-p watch:*",
 		"watch:js": "npm run build:js -- --watch",
 		"watch:ts": "npm run build:ts -- --watch",

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -1,6 +1,8 @@
 export {
 	type FieldProps,
+	type FormState,
 	type Schema,
+	type Submission,
 	parse,
 	getFieldElements,
 } from '@conform-to/dom';

--- a/playground/app/components.tsx
+++ b/playground/app/components.tsx
@@ -1,4 +1,4 @@
-import type { FormResult } from '@conform-to/dom';
+import type { Submission } from '@conform-to/dom';
 import type { ReactElement } from 'react';
 
 interface FieldProps {
@@ -30,7 +30,7 @@ interface PlaygroundProps {
 	title: string;
 	description?: string;
 	form: string;
-	result?: FormResult<unknown>;
+	submission?: Submission<Record<string, unknown>>;
 	children: ReactElement;
 }
 
@@ -38,7 +38,7 @@ export function Playground({
 	title,
 	description,
 	form,
-	result,
+	submission,
 	children,
 }: PlaygroundProps) {
 	return (
@@ -50,17 +50,17 @@ export function Playground({
 					</h3>
 					<p className="mt-1 mb-2 text-sm text-gray-600">{description}</p>
 				</header>
-				{result ? (
+				{submission ? (
 					<details open={true}>
-						<summary>Result</summary>
+						<summary>Submission</summary>
 						<pre
 							className={`m-4 border-l-4 ${
-								result.state === 'rejected'
+								submission.state === 'rejected'
 									? 'border-pink-600'
 									: 'border-emerald-500'
 							} pl-4 py-2 mt-4`}
 						>
-							{JSON.stringify(result, null, 2)}
+							{JSON.stringify(submission, null, 2)}
 						</pre>
 					</details>
 				) : null}

--- a/playground/app/routes/basic.tsx
+++ b/playground/app/routes/basic.tsx
@@ -12,7 +12,7 @@ import { action, loader, useActionData } from '~/playground';
 export { loader, action };
 
 export default function Basic() {
-	const { config, action, getResult } = useActionData();
+	const { config, action, getSubmission } = useActionData();
 	const nativeFormProps = useForm(config);
 	const customFormProps = useForm(config);
 
@@ -21,7 +21,7 @@ export default function Basic() {
 			<Playground
 				title="Native Constraint"
 				description="Reporting error messages provided by the browser vendor"
-				result={getResult('native')}
+				submission={getSubmission('native')}
 				form="native"
 			>
 				<Form id="native" method="post" action={action} {...nativeFormProps}>
@@ -32,7 +32,7 @@ export default function Basic() {
 			<Playground
 				title="Custom Constraint"
 				description="Setting up custom validation rules with user-defined error messages"
-				result={getResult('custom')}
+				submission={getSubmission('custom')}
 				form="custom"
 			>
 				<Form id="custom" method="post" action={action} {...customFormProps}>

--- a/playground/app/routes/zod.tsx
+++ b/playground/app/routes/zod.tsx
@@ -9,7 +9,7 @@ import { loader, action, useActionData } from '~/playground';
 export { loader, action };
 
 export default function ZodIntegration() {
-	const { config, action, getResult } = useActionData();
+	const { config, action, getSubmission } = useActionData();
 	const typeFormProps = useForm(config);
 
 	return (
@@ -17,7 +17,7 @@ export default function ZodIntegration() {
 			<Playground
 				title="Native Constraint"
 				description="Infering constraint based on the zod schema"
-				result={getResult('native', (formData) =>
+				submission={getSubmission('native', (formData) =>
 					parse(formData, nativeConstraintSchema),
 				)}
 				form="native"
@@ -30,7 +30,7 @@ export default function ZodIntegration() {
 			<Playground
 				title="Type Conversion"
 				description="Parsing the form data based on the defined preprocess with zod"
-				result={getResult('type', (formData) =>
+				submission={getSubmission('type', (formData) =>
 					parse(formData, typeConversionSchema),
 				)}
 				form="type"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -102,7 +102,7 @@ const config: PlaywrightTestConfig = {
 
 	/* Run your local dev server before starting the tests */
 	webServer: {
-		command: 'npm run playground',
+		command: 'npm start --workspace=playground',
 		port: process.env.PORT ? Number(process.env.PORT) : 3000,
 	},
 };

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -110,10 +110,18 @@ test.describe('Native Constraint', () => {
 		await clickSubmitButton(playground);
 		expect(await getFormResult(playground)).toEqual({
 			state: 'accepted',
-			value: {
+			data: {
 				email: 'me@edmund.dev',
 				password: 'constraintvalidation',
 				age: '91',
+			},
+			form: {
+				value: {
+					email: 'me@edmund.dev',
+					password: 'constraintvalidation',
+					age: '91',
+				},
+				error: {},
 			},
 		});
 	});
@@ -158,9 +166,16 @@ test.describe('Custom Constraint', () => {
 		await clickSubmitButton(playground);
 		expect(await getFormResult(playground)).toEqual({
 			state: 'accepted',
-			value: {
+			data: {
 				number: '10',
 				accept: 'on',
+			},
+			form: {
+				value: {
+					number: '10',
+					accept: 'on',
+				},
+				error: {},
 			},
 		});
 	});

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -80,10 +80,18 @@ test.describe('Type Conversion', () => {
 
 		expect(await getFormResult(playground)).toEqual({
 			state: 'accepted',
-			value: {
+			data: {
 				number: 123,
 				datetime: '2022-07-04T12:00:00.000Z',
 				boolean: true,
+			},
+			form: {
+				value: {
+					number: '123',
+					datetime: '2022-07-04T12:00Z',
+					boolean: 'Yes',
+				},
+				error: {},
 			},
 		});
 	});


### PR DESCRIPTION
## Context

Conform zod resolver provides a `parse` function which lets you parse the `FormData` or `URLSearchParams` object based on the schema. The result was called `FormResult` and it has a slightly different structure based on the `state`.

The main problem here is the `value` types varies between `accepted` state and the rest. Before we let zod parse the data, we first transform the payload to a object structure based on the key of each entry. This structure should allows conform to recreate a shape similar to the expected data type except the value is always a string. This is represented by a type called
`FieldsetData<T, string>`.

```tsx
import { parse } from '@conform-to/zod';

const formData = await request.formData();
const result = parse(formData, schema);
const acceptedValue = result.state === 'accepted' ? result.value : null;
const rejectedValue = result.state === 'rejected' ? result.value : null;

// typeof acceptedValue = T
// typeof rejectedValue = FieldsetData<T> 
```

This makes it hard to work with especially if the developer want to send the current form state back to the frontend.

To simplify this, the structure is slightly changed and renamed to reflect the original intention:

```tsx
// New type to represent current form state
interface FormState<T> {
  value: FieldsetData<T, string>;
  error: FieldsetData<T, string>;
}

// New name of `FormResult`
interface Submission<T> {
  // `processed` is renamed to `modified` 
  state: 'accepted' | 'rejected' | 'modified';
  // Only available if state = accepted
  data: T;
  // This will be always available regardless of state
  form: FormState<T>;
}

// Example usage
let action = async ({ request }) => {
  const formData = await request.formData();
  const submission = parse(formData, schema);

  if (submission.state !== 'accepted') {
    return json(submission.form);
  }

  // ... do something else
};

export default function RandomForm() {
  const formState = useActionData();
  const formProps = useFieldset(schema, {
    defaultValue: formState.value,
    error: formState.error,
  });

  // ....
}
```

  
