### PR TITLE
refactor: simplify zod resolver setup

### DIFF
--- a/packages/conform-dom/README.md
+++ b/packages/conform-dom/README.md
@@ -30,7 +30,7 @@
 
 ### isFieldElement
 
-### isFieldsetElement
+### isFieldsetField
 
 ### parse
 

--- a/packages/conform-dom/README.md
+++ b/packages/conform-dom/README.md
@@ -6,22 +6,23 @@
 
 - [getControlButtonProps](#getControlButtonProps)
 - [getFieldProps](#getFieldProps)
-- [getFieldElements](#getFieldElements)
+- [getFieldsetData](#getFieldsetData)
 - [getName](#getName)
 - [getPaths](#getPaths)
 - [isFieldElement](#isFieldElement)
+- [isFieldsetField](#isFieldsetField)
 - [parse](#parse)
 - [reportValidity](#reportValidity)
 - [setFieldState](#setFieldState)
+- [setFieldsetError](#setFieldsetError)
 - [shouldSkipValidate](#shouldSkipValidate)
-- [setFieldState](#setFieldState)
 - [transform](#transform)
 
 ### getControlButtonProps
 
 ### getFieldProps
 
-### getFieldElements
+### getFieldsetData
 
 ### getName
 
@@ -36,6 +37,8 @@
 ### reportValidity
 
 ### setFieldState
+
+### setFieldsetError
 
 ### shouldSkipValidate
 

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -38,12 +38,6 @@ export type FieldsetData<Type, Value> = Type extends
 	: unknown;
 
 /**
- * Element that maintains a list of fields
- * i.e. fieldset.elements
- */
-export type FieldsetElement = HTMLFormElement | HTMLFieldSetElement;
-
-/**
  * Element type that might be a candiate of Constraint Validation
  */
 export type FieldElement =
@@ -87,15 +81,6 @@ export interface ControlAction<T = unknown> {
 	reorder: { from: number; to: number };
 }
 
-export function isFieldsetElement(
-	element: unknown,
-): element is FieldsetElement {
-	return (
-		element instanceof Element &&
-		(element.tagName === 'FORM' || element.tagName === 'FIELDSET')
-	);
-}
-
 export function isFieldElement(element: unknown): element is FieldElement {
 	return (
 		element instanceof Element &&
@@ -110,15 +95,7 @@ export function setFieldState(
 	field: unknown,
 	state: { touched: boolean },
 ): void {
-	if (isFieldsetElement(field)) {
-		for (let element of field.elements) {
-			setFieldState(element, state);
-		}
-		return;
-	}
-
 	if (!isFieldElement(field)) {
-		console.warn('Only input/select/textarea/button element can be touched');
 		return;
 	}
 
@@ -129,7 +106,7 @@ export function setFieldState(
 	}
 }
 
-export function reportValidity(fieldset: FieldsetElement): boolean {
+export function reportValidity(fieldset: HTMLFormElement): boolean {
 	let isValid = true;
 
 	for (const field of fieldset.elements) {
@@ -428,7 +405,7 @@ export function parse(
  * @deprecated
  */
 export function getFieldElements(
-	fieldset: FieldsetElement,
+	fieldset: HTMLFieldSetElement,
 	key: string,
 ): FieldElement[] {
 	const name = getName([fieldset.name ?? '', key]);

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -319,13 +319,13 @@ export function useFieldset<Type extends Record<string, any>>(
 			ref,
 			name: config.name,
 			form: config.form,
-			onInput(e: FormEvent<FieldsetElement>) {
+			onInput(e: FormEvent<HTMLFieldSetElement>) {
 				const fieldset = e.currentTarget;
 
 				schema.validate?.(fieldset);
 				dispatch({ type: 'cleanup', payload: { fieldset } });
 			},
-			onInvalid(e: FormEvent<FieldsetElement>) {
+			onInvalid(e: FormEvent<HTMLFieldSetElement>) {
 				const element = isFieldElement(e.target) ? e.target : null;
 				const key = Object.keys(schema.fields).find(
 					(key) => element?.name === getName([e.currentTarget.name, key]),

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -1,5 +1,4 @@
 import {
-	type FieldsetElement,
 	type FieldProps,
 	type Schema,
 	type FieldsetData,
@@ -75,7 +74,9 @@ export function useForm({
 	);
 	const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
 		if (!noValidate) {
-			setFieldState(event.currentTarget, { touched: true });
+			for (let element of event.currentTarget.elements) {
+				setFieldState(element, { touched: true });
+			}
 
 			if (
 				!shouldSkipValidate(event.nativeEvent as SubmitEvent) &&
@@ -88,7 +89,9 @@ export function useForm({
 		onSubmit?.(event);
 	};
 	const handleReset: FormEventHandler<HTMLFormElement> = (event) => {
-		setFieldState(event.currentTarget, { touched: false });
+		for (let element of event.currentTarget.elements) {
+			setFieldState(element, { touched: false });
+		}
 
 		onReset?.(event);
 	};
@@ -178,7 +181,7 @@ export function useFieldset<Type extends Record<string, any>>(
 							error: FieldsetData<Type, string> | undefined;
 						};
 				  }
-				| { type: 'cleanup'; payload: { fieldset: FieldsetElement } }
+				| { type: 'cleanup'; payload: { fieldset: HTMLFieldSetElement } }
 				| { type: 'report'; payload: { key: string; message: string } }
 				| { type: 'reset' },
 		) => {

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -253,15 +253,9 @@ test.describe('Skip Validation', () => {
 
 		expect(await getSubmission(playground)).toEqual({
 			state: 'accepted',
-			data: {
-				email: '',
-				password: '',
-			},
+			data: {},
 			form: {
-				value: {
-					email: '',
-					password: '',
-				},
+				value: {},
 				error: {},
 			},
 		});
@@ -274,12 +268,10 @@ test.describe('Skip Validation', () => {
 			state: 'accepted',
 			data: {
 				email: 'invalid email',
-				password: '',
 			},
 			form: {
 				value: {
 					email: 'invalid email',
-					password: '',
 				},
 				error: {},
 			},


### PR DESCRIPTION
## Context

This PR refactors the setup in the zod resolver for the upcoming yup resolver (#15). Technically, this also introduces several breaking changes on the `conform-dom` package. Considering none of the APIs are documented. This PR would be treat as a fix instead. 