### PR TITLE
feat(conform-react)!: allow customizing shadow input with props

### DIFF
--- a/examples/remix/app/routes/material-ui.tsx
+++ b/examples/remix/app/routes/material-ui.tsx
@@ -34,7 +34,7 @@ export default function Integration() {
 	 * This creates a shadow input that would be used to validate against the schema instead and
 	 * let you hook it up with the controlled component life cycle
 	 */
-	const [selectInput, selectControl] = useControlledInput(select);
+	const [selectProps, selectControl] = useControlledInput(select);
 
 	return (
 		<form {...formProps}>
@@ -45,7 +45,7 @@ export default function Integration() {
 				) : null}
 			</header>
 			<fieldset className={styles.card} {...fieldsetProps}>
-				{selectInput}
+				<input {...selectProps} />
 				<Stack spacing={3}>
 					<TextField
 						label="Text"

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -1,3 +1,5 @@
+export type Primitive = null | undefined | string | number | boolean | Date;
+
 export type Constraint = {
 	required?: boolean;
 	minLength?: number;
@@ -24,12 +26,7 @@ export type Schema<Type extends Record<string, any>> = {
 /**
  * Data structure of the form value
  */
-export type FieldsetData<Type, Value> = Type extends
-	| string
-	| number
-	| Date
-	| boolean
-	| undefined
+export type FieldsetData<Type, Value> = Type extends Primitive
 	? Value
 	: Type extends Array<infer InnerType>
 	? Array<FieldsetData<InnerType, Value>>

--- a/packages/conform-react/README.md
+++ b/packages/conform-react/README.md
@@ -375,29 +375,30 @@ function BookFieldset({ name, form, defaultValue, error }) {
 
 ### useControlledInput
 
-This hooks creates a shadow input that would be used to validate against the schema. Mainly used to get around problem integrating with controlled component.
+It helps hooking up a controlled component with a shadow input for validation. This is particular useful when integrating dropdown and datepicker whichs introuces different input mode.
 
 ```tsx
 import { useControlledInput } from '@conform-to/react';
 import { Select, MenuItem } from '@mui/material';
 
-function RandomFieldset() {
+function MuiForm() {
   const [fieldsetProps, { category }] = useFieldset(schema);
-  const [input, control] = useControlledInput(category);
+  const [inputProps, control] = useControlledInput(category);
 
   return (
     <fieldset {...fieldsetProps}>
-      {/* Render the shadow input somewhere within the fieldset */}
-      {input}
+      {/* Render a shadow input somewhere */}
+      <input {...inputProps} />
 
       {/* MUI Select is a controlled component */}
       <Select
         label="Category"
-        value={control.value ?? ''}
-        onChange={(e) => control.onChange(e.target.value)}
-        onBlur={() => control.onBlur()}
-        error={Boolean(category.error)}
-        helperText={category.error}
+        value={control.value}
+        onChange={control.onChange}
+        onBlur={control.onBlur}
+        inputProps={{
+          onInvalid: control.onInvalid
+        }}
       >
         <MenuItem value="">Please select</MenuItem>
         <MenuItem value="a">Category A</MenuItem>

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -1,14 +1,12 @@
-import { type FieldProps } from '@conform-to/dom';
+import { type FieldProps, type Primitive } from '@conform-to/dom';
 import {
 	type InputHTMLAttributes,
 	type SelectHTMLAttributes,
 	type TextareaHTMLAttributes,
 } from 'react';
 
-export function input<
-	Type extends string | number | Date | boolean | undefined,
->(
-	props: FieldProps<Type>,
+export function input<Schema extends Primitive>(
+	props: FieldProps<Schema>,
 	{ type, value }: { type?: string; value?: string } = {},
 ): InputHTMLAttributes<HTMLInputElement> {
 	const isCheckboxOrRadio = type === 'checkbox' || type === 'radio';
@@ -30,14 +28,14 @@ export function input<
 		attributes.value = value ?? 'on';
 		attributes.defaultChecked = props.defaultValue === attributes.value;
 	} else {
-		attributes.defaultValue = `${props.defaultValue ?? ''}`;
+		attributes.defaultValue = props.defaultValue;
 	}
 
 	return attributes;
 }
 
-export function select<T extends any>(
-	props: FieldProps<T>,
+export function select<Schema extends Primitive>(
+	props: FieldProps<Schema>,
 ): SelectHTMLAttributes<HTMLSelectElement> {
 	return {
 		name: props.name,
@@ -52,8 +50,8 @@ export function select<T extends any>(
 	};
 }
 
-export function textarea<T extends string | undefined>(
-	props: FieldProps<T>,
+export function textarea<Schema extends Primitive>(
+	props: FieldProps<Schema>,
 ): TextareaHTMLAttributes<HTMLTextAreaElement> {
 	return {
 		name: props.name,


### PR DESCRIPTION
## Context

> This PR includes breaking changes

This makes `useControlledInput` returning the props to be applied on the input element instead of giving you an element directly, which gives users control over the shadow input in case of customization

Example:
```tsx
import { useFieldset, useControlledInput } from '@conform-to/react';
import { Select, MenuItem } from '@mui/material';

function MuiForm() {
  const [fieldsetProps, { category }] = useFieldset(schema);
  const [inputProps, control] = useControlledInput(category);

  return (
    <fieldset {...fieldsetProps}>
      {/* Render a shadow input somewhere */}
      <input {...inputProps} />

      {/* MUI Select is a controlled component */}
      <Select
        label="Category"
        value={control.value}
        onChange={control.onChange}
        onBlur={control.onBlur}
        inputProps={{
          onInvalid: control.onInvalid
        }}
      >
        <MenuItem value="">Please select</MenuItem>
        <MenuItem value="a">Category A</MenuItem>
        <MenuItem value="b">Category B</MenuItem>
        <MenuItem value="c">Category C</MenuItem>
      </TextField>
    </fieldset>
  )
}
```