### PR TITLE
feat(conform-react)!: support list reset through reset event

### DIFF
--- a/examples/remix/app/routes/order.tsx
+++ b/examples/remix/app/routes/order.tsx
@@ -50,7 +50,7 @@ export default function OrderForm() {
 			error: submission?.form.error,
 		},
 	);
-	const [productList, control] = useFieldList(products);
+	const [productList, control] = useFieldList(formProps.ref, products);
 
 	return (
 		<Form method="post" {...formProps}>
@@ -75,7 +75,7 @@ export default function OrderForm() {
 							<button
 								className={styles.buttonWarning}
 								disabled={productList.length === 1}
-								{...control.remove(index)}
+								{...control.remove({ index })}
 							>
 								⨯
 							</button>

--- a/packages/conform-dom/README.md
+++ b/packages/conform-dom/README.md
@@ -4,7 +4,6 @@
 
 ## API Reference
 
-- [getControlButtonProps](#getControlButtonProps)
 - [getFieldProps](#getFieldProps)
 - [getFieldsetData](#getFieldsetData)
 - [getName](#getName)
@@ -17,8 +16,6 @@
 - [setFieldsetError](#setFieldsetError)
 - [shouldSkipValidate](#shouldSkipValidate)
 - [transform](#transform)
-
-### getControlButtonProps
 
 ### getFieldProps
 

--- a/packages/conform-react/README.md
+++ b/packages/conform-react/README.md
@@ -308,7 +308,7 @@ import { useFieldset, useFieldList } from '@conform-to/react';
 
 function CollectionForm() {
   const [fieldsetProps, { books }] = useFieldset(collectionSchema);
-  const [bookList, control] = useFieldList(books);
+  const [bookList, control] = useFieldList(fieldsetProps.ref, books);
 
   return (
     <fieldset {...fieldsetProps}>
@@ -318,7 +318,7 @@ function CollectionForm() {
           <BookFieldset {...book.props}>
 
           {/* To setup a delete button */}
-          <button {...control.remove(index)}>Delete</button>
+          <button {...control.remove({ index })}>Delete</button>
         </div>
       ))}
 
@@ -354,19 +354,19 @@ function BookFieldset({ name, form, defaultValue, error }) {
 
 ```tsx
 // To append a new row with optional defaultValue
-<button {...controls.append(defaultValue)}>Append</button>;
+<button {...controls.append({ defaultValue })}>Append</button>;
 
 // To prepend a new row with optional defaultValue
-<button {...controls.prepend(defaultValue)}>Prepend</button>;
+<button {...controls.prepend({ defaultValue })}>Prepend</button>;
 
 // To remove a row by index
-<button {...controls.remove(index)}>Remove</button>;
+<button {...controls.remove({ index })}>Remove</button>;
 
 // To replace a row with another defaultValue
-<button {...controls.replace(index, defaultValue)}>Replace</button>;
+<button {...controls.replace({ index, defaultValue })}>Replace</button>;
 
 // To reorder a particular row to an another index
-<button {...controls.reorder(fromIndex, toIndex)}>Reorder</button>;
+<button {...controls.reorder({ from, to })}>Reorder</button>;
 ```
 
 </details>

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -34,7 +34,7 @@ export function input<Schema extends Primitive>(
 	return attributes;
 }
 
-export function select<Schema extends Primitive>(
+export function select<Schema extends Primitive | Array<Primitive>>(
 	props: FieldProps<Schema>,
 ): SelectHTMLAttributes<HTMLSelectElement> {
 	return {

--- a/playground/app/fieldset.tsx
+++ b/playground/app/fieldset.tsx
@@ -170,7 +170,7 @@ export function ChecklistFieldset({
 	...config
 }: FieldsetProps<Checklist> & { taskSchema: Schema<Task> }) {
 	const [fieldsetProps, { title, tasks }] = useFieldset(schema, config);
-	const [taskList, control] = useFieldList(tasks);
+	const [taskList, control] = useFieldList(fieldsetProps.ref, tasks);
 
 	return (
 		<fieldset {...fieldsetProps}>
@@ -184,19 +184,19 @@ export function ChecklistFieldset({
 						<div className="flex flex-row gap-2">
 							<button
 								className="rounded-md border p-2 hover:border-black"
-								{...control.remove(index)}
+								{...control.remove({ index })}
 							>
 								Delete
 							</button>
 							<button
 								className="rounded-md border p-2 hover:border-black"
-								{...control.reorder(index, 0)}
+								{...control.reorder({ from: index, to: 0 })}
 							>
 								Move to top
 							</button>
 							<button
 								className="rounded-md border p-2 hover:border-black"
-								{...control.replace(index, { content: '' })}
+								{...control.replace({ index, defaultValue: { content: '' } })}
 							>
 								Clear
 							</button>

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -253,9 +253,15 @@ test.describe('Skip Validation', () => {
 
 		expect(await getSubmission(playground)).toEqual({
 			state: 'accepted',
-			data: {},
+			data: {
+				email: '',
+				password: '',
+			},
 			form: {
-				value: {},
+				value: {
+					email: '',
+					password: '',
+				},
 				error: {},
 			},
 		});
@@ -268,10 +274,12 @@ test.describe('Skip Validation', () => {
 			state: 'accepted',
 			data: {
 				email: 'invalid email',
+				password: '',
 			},
 			form: {
 				value: {
 					email: 'invalid email',
+					password: '',
 				},
 				error: {},
 			},


### PR DESCRIPTION
## Context

> This PR includes breaking changes

This allows `useFieldList` to listen to the form event and reset its internal state upon receiving the reset event with implementation refactored.

The signature of the control button is also updated.

Example:
```tsx
function CollectionForm() {
  const [fieldsetProps, { books }] = useFieldset(collectionSchema);
  const [bookList, control] = useFieldList(fieldsetProps.ref, books);

  return (
    <fieldset {...fieldsetProps}>
      {bookList.map((book, index) => (
        <div key={book.key}>
          {/* `book.props` is a FieldProps object similar to `books` */}
          <BookFieldset {...book.props}>

          {/* To setup a delete button */}
          <button {...control.remove({ index })}>Delete</button>
        </div>
      ))}

      {/* To setup a button that can append a new row */}
      <button {...control.append()}>add</button>
    </fieldset>
  );
}
```
