### PR TITLE
feat(conform-react)!: api consolidation

### DIFF
--- a/examples/remix/app/routes/material-ui.tsx
+++ b/examples/remix/app/routes/material-ui.tsx
@@ -11,18 +11,21 @@ const muiFields = z.object({
 	textarea: z.string().min(10),
 });
 
+const { validate, fields } = resolve(muiFields);
+
 export default function Integration() {
 	const [query, setQuery] = useState<any>(null);
 	const formProps = useForm({
 		initialReport: 'onBlur',
+		validate,
 		onSubmit(e) {
 			e.preventDefault();
 			setQuery(Object.fromEntries(new FormData(e.currentTarget)));
 		},
 	});
-	const [fieldsetProps, { text, select, textarea }] = useFieldset(
-		resolve(muiFields),
-	);
+	const { text, select, textarea } = useFieldset(formProps.ref, {
+		constraint: fields,
+	});
 
 	/**
 	 * MUI Select is a controlled component and behaves very different from native input/select.
@@ -34,7 +37,7 @@ export default function Integration() {
 	 * This creates a shadow input that would be used to validate against the schema instead and
 	 * let you hook it up with the controlled component life cycle
 	 */
-	const [selectProps, selectControl] = useControlledInput(select);
+	const [selectProps, selectControl] = useControlledInput(select.config);
 
 	return (
 		<form {...formProps}>
@@ -44,14 +47,14 @@ export default function Integration() {
 					<pre className={styles.result}>{JSON.stringify(query, null, 2)}</pre>
 				) : null}
 			</header>
-			<fieldset className={styles.card} {...fieldsetProps}>
+			<fieldset className={styles.card}>
 				<input {...selectProps} />
 				<Stack spacing={3}>
 					<TextField
 						label="Text"
-						name={text.name}
-						defaultValue={text.defaultValue}
-						required={text.required}
+						name={text.config.name}
+						defaultValue={text.config.defaultValue}
+						required={text.config.required}
 						error={Boolean(text.error)}
 						helperText={text.error}
 						fullWidth
@@ -73,9 +76,9 @@ export default function Integration() {
 					</TextField>
 					<TextField
 						label="Textarea"
-						name={textarea.name}
-						defaultValue={textarea.defaultValue}
-						required={textarea.required}
+						name={textarea.config.name}
+						defaultValue={textarea.config.defaultValue}
+						required={textarea.config.required}
 						error={Boolean(textarea.error)}
 						helperText={textarea.error}
 						multiline

--- a/examples/remix/app/routes/signup.tsx
+++ b/examples/remix/app/routes/signup.tsx
@@ -39,13 +39,11 @@ export default function SignupForm() {
 			setSubmission(submission);
 		},
 	});
-	const [fieldsetProps, { email, password, confirm, remember }] = useFieldset(
-		resolve(signup),
-		{
-			defaultValue: submission?.form.value,
-			error: submission?.form.error,
-		},
-	);
+	const { email, password, confirm, remember } = useFieldset(formProps.ref, {
+		constraint: resolve(signup).fields,
+		defaultValue: submission?.form.value,
+		initialError: submission?.form.error.details,
+	});
 
 	return (
 		<form {...formProps}>
@@ -57,12 +55,12 @@ export default function SignupForm() {
 					</pre>
 				) : null}
 			</header>
-			<fieldset className={styles.card} {...fieldsetProps}>
+			<fieldset className={styles.card}>
 				<label className={styles.block}>
 					<div className={styles.label}>Email</div>
 					<input
 						className={email.error ? styles.invalidInput : styles.input}
-						{...conform.input(email)}
+						{...conform.input(email.config)}
 					/>
 					<p className={styles.errorMessage}>{email.error}</p>
 				</label>
@@ -70,7 +68,7 @@ export default function SignupForm() {
 					<div className={styles.label}>Password</div>
 					<input
 						className={password.error ? styles.invalidInput : styles.input}
-						{...conform.input(password, { type: 'password' })}
+						{...conform.input(password.config, { type: 'password' })}
 					/>
 					<p className={styles.errorMessage}>{password.error}</p>
 				</label>
@@ -78,14 +76,14 @@ export default function SignupForm() {
 					<div className={styles.label}>Confirm Password</div>
 					<input
 						className={confirm.error ? styles.invalidInput : styles.input}
-						{...conform.input(confirm, { type: 'password' })}
+						{...conform.input(confirm.config, { type: 'password' })}
 					/>
 					<p className={styles.errorMessage}>{confirm.error}</p>
 				</label>
 				<label className={styles.optionLabel}>
 					<input
 						className={styles.optionInput}
-						{...conform.input(remember, {
+						{...conform.input(remember.config, {
 							type: 'checkbox',
 							value: 'yes',
 						})}

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -1,4 +1,4 @@
-import { type FieldProps, type Primitive } from '@conform-to/dom';
+import { type FieldConfig, type Primitive } from '@conform-to/dom';
 import {
 	type InputHTMLAttributes,
 	type SelectHTMLAttributes,
@@ -6,59 +6,59 @@ import {
 } from 'react';
 
 export function input<Schema extends Primitive>(
-	props: FieldProps<Schema>,
+	config: FieldConfig<Schema>,
 	{ type, value }: { type?: string; value?: string } = {},
 ): InputHTMLAttributes<HTMLInputElement> {
 	const isCheckboxOrRadio = type === 'checkbox' || type === 'radio';
 	const attributes: InputHTMLAttributes<HTMLInputElement> = {
 		type,
-		name: props.name,
-		form: props.form,
-		required: props.required,
-		minLength: props.minLength,
-		maxLength: props.maxLength,
-		min: props.min,
-		max: props.max,
-		step: props.step,
-		pattern: props.pattern,
-		multiple: props.multiple,
+		name: config.name,
+		form: config.form,
+		required: config.required,
+		minLength: config.minLength,
+		maxLength: config.maxLength,
+		min: config.min,
+		max: config.max,
+		step: config.step,
+		pattern: config.pattern,
+		multiple: config.multiple,
 	};
 
 	if (isCheckboxOrRadio) {
 		attributes.value = value ?? 'on';
-		attributes.defaultChecked = props.defaultValue === attributes.value;
+		attributes.defaultChecked = config.defaultValue === attributes.value;
 	} else {
-		attributes.defaultValue = props.defaultValue;
+		attributes.defaultValue = config.defaultValue;
 	}
 
 	return attributes;
 }
 
 export function select<Schema extends Primitive | Array<Primitive>>(
-	props: FieldProps<Schema>,
+	config: FieldConfig<Schema>,
 ): SelectHTMLAttributes<HTMLSelectElement> {
 	return {
-		name: props.name,
-		form: props.form,
-		defaultValue: props.multiple
-			? Array.isArray(props.defaultValue)
-				? props.defaultValue
+		name: config.name,
+		form: config.form,
+		defaultValue: config.multiple
+			? Array.isArray(config.defaultValue)
+				? config.defaultValue
 				: []
-			: `${props.defaultValue ?? ''}`,
-		required: props.required,
-		multiple: props.multiple,
+			: `${config.defaultValue ?? ''}`,
+		required: config.required,
+		multiple: config.multiple,
 	};
 }
 
 export function textarea<Schema extends Primitive>(
-	props: FieldProps<Schema>,
+	config: FieldConfig<Schema>,
 ): TextareaHTMLAttributes<HTMLTextAreaElement> {
 	return {
-		name: props.name,
-		form: props.form,
-		defaultValue: `${props.defaultValue ?? ''}`,
-		required: props.required,
-		minLength: props.minLength,
-		maxLength: props.maxLength,
+		name: config.name,
+		form: config.form,
+		defaultValue: `${config.defaultValue ?? ''}`,
+		required: config.required,
+		minLength: config.minLength,
+		maxLength: config.maxLength,
 	};
 }

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -29,17 +29,21 @@ export interface FormConfig {
 	 * Define when the error should be reported initially.
 	 * Support "onSubmit", "onChange", "onBlur".
 	 *
-	 * Default to `onSubmit`
+	 * Default to `onSubmit`.
 	 */
 	initialReport?: 'onSubmit' | 'onChange' | 'onBlur';
 
 	/**
-	 * Fallback native validation before hydation.
+	 * Enable native validation before hydation.
+	 *
+	 * Default to `false`.
 	 */
 	fallbackNative?: boolean;
 
 	/**
 	 * Accept form submission regardless of the form validity.
+	 *
+	 * Default to `false`.
 	 */
 	noValidate?: boolean;
 
@@ -247,7 +251,7 @@ export interface FieldsetConfig<Schema extends Record<string, any>> {
 	defaultValue?: FieldValue<Schema>;
 
 	/**
-	 * An object describing the error of each field
+	 * An object describing the initial error of each field
 	 */
 	initialError?: FieldError<Schema>['details'];
 

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -1,10 +1,10 @@
 export {
-	type FieldProps,
 	type FormState,
+	type FieldsetConstraint,
 	type Schema,
 	type Submission,
-	parse,
-	getFieldElements,
+	createSubmission,
+	createValidate,
 } from '@conform-to/dom';
 export * from './hooks';
 export * as conform from './helpers';

--- a/playground/app/fieldset.tsx
+++ b/playground/app/fieldset.tsx
@@ -1,15 +1,12 @@
-import { type Schema } from '@conform-to/dom';
 import {
 	type FieldsetConfig,
+	type FieldsetConstraint,
 	useFieldset,
 	conform,
 	useFieldList,
 } from '@conform-to/react';
+import { useRef } from 'react';
 import { Field } from './playground';
-
-interface FieldsetProps<T> extends FieldsetConfig<T> {
-	schema: Schema<T>;
-}
 
 export interface Student {
 	name: string;
@@ -18,25 +15,23 @@ export interface Student {
 	grade: string;
 }
 
-export function StudentFieldset({ schema, ...config }: FieldsetProps<Student>) {
-	const [fieldsetProps, { name, remarks, grade, score }] = useFieldset(
-		schema,
-		config,
-	);
+export function StudentFieldset(config: FieldsetConfig<Student>) {
+	const ref = useRef<HTMLFieldSetElement>(null);
+	const { name, remarks, grade, score } = useFieldset(ref, config);
 
 	return (
-		<fieldset {...fieldsetProps}>
+		<fieldset ref={ref} form={config.form}>
 			<Field label="Name" error={name.error}>
-				<input {...conform.input(name, { type: 'text' })} />
+				<input {...conform.input(name.config, { type: 'text' })} />
 			</Field>
 			<Field label="Remarks" error={remarks.error}>
-				<input {...conform.input(remarks, { type: 'text' })} />
+				<input {...conform.input(remarks.config, { type: 'text' })} />
 			</Field>
 			<Field label="Score" error={score.error}>
-				<input {...conform.input(score, { type: 'number' })} />
+				<input {...conform.input(score.config, { type: 'number' })} />
 			</Field>
 			<Field label="Grade" error={grade.error}>
-				<input {...conform.input(grade, { type: 'text' })} />
+				<input {...conform.input(grade.config, { type: 'text' })} />
 			</Field>
 		</fieldset>
 	);
@@ -49,19 +44,17 @@ export interface Movie {
 	rating?: number;
 }
 
-export function MovieFieldset({ schema, ...config }: FieldsetProps<Movie>) {
-	const [fieldsetProps, { title, description, genres, rating }] = useFieldset(
-		schema,
-		config,
-	);
+export function MovieFieldset(config: FieldsetConfig<Movie>) {
+	const ref = useRef<HTMLFieldSetElement>(null);
+	const { title, description, genres, rating } = useFieldset(ref, config);
 
 	return (
-		<fieldset {...fieldsetProps}>
+		<fieldset ref={ref} form={config.form}>
 			<Field label="Title" error={title.error}>
-				<input {...conform.input(title, { type: 'text' })} />
+				<input {...conform.input(title.config, { type: 'text' })} />
 			</Field>
 			<Field label="Description" error={description.error}>
-				<textarea {...conform.textarea(description)} />
+				<textarea {...conform.textarea(description.config)} />
 			</Field>
 			<Field
 				label="Genres"
@@ -69,7 +62,7 @@ export function MovieFieldset({ schema, ...config }: FieldsetProps<Movie>) {
 					Array.isArray(genres.error) ? genres.error.join(', ') : genres.error
 				}
 			>
-				<select {...conform.select(genres)}>
+				<select {...conform.select(genres.config)}>
 					<option value="action">Action</option>
 					<option value="adventure">Adventure</option>
 					<option value="comedy">Comedy</option>
@@ -80,7 +73,7 @@ export function MovieFieldset({ schema, ...config }: FieldsetProps<Movie>) {
 				</select>
 			</Field>
 			<Field label="Rating" error={rating.error}>
-				<input {...conform.input(rating, { type: 'number' })} />
+				<input {...conform.input(rating.config, { type: 'number' })} />
 			</Field>
 		</fieldset>
 	);
@@ -93,26 +86,27 @@ export interface Payment {
 	verified: boolean;
 }
 
-export function PaymentFieldset({ schema, ...config }: FieldsetProps<Payment>) {
-	const [fieldsetProps, { account, amount, timestamp, verified }] = useFieldset(
-		schema,
-		config,
-	);
+export function PaymentFieldset(config: FieldsetConfig<Payment>) {
+	const ref = useRef<HTMLFieldSetElement>(null);
+	const { account, amount, timestamp, verified } = useFieldset(ref, config);
 
 	return (
-		<fieldset {...fieldsetProps}>
+		<fieldset ref={ref} form={config.form}>
 			<Field label="Account" error={account.error}>
-				<input {...conform.input(account, { type: 'text' })} />
+				<input {...conform.input(account.config, { type: 'text' })} />
 			</Field>
 			<Field label="Amount" error={amount.error}>
-				<input {...conform.input(amount, { type: 'number' })} />
+				<input {...conform.input(amount.config, { type: 'number' })} />
 			</Field>
 			<Field label="Timestamp" error={timestamp.error}>
-				<input {...conform.input(timestamp, { type: 'text' })} />
+				<input {...conform.input(timestamp.config, { type: 'text' })} />
 			</Field>
 			<Field label="Verified" error={verified.error} inline>
 				<input
-					{...conform.input(verified, { type: 'checkbox', value: 'Yes' })}
+					{...conform.input(verified.config, {
+						type: 'checkbox',
+						value: 'Yes',
+					})}
 				/>
 			</Field>
 		</fieldset>
@@ -124,16 +118,16 @@ export interface LoginForm {
 	password: string;
 }
 
-export function LoginFieldset({ schema, ...config }: FieldsetProps<LoginForm>) {
-	const [fieldsetProps, { email, password }] = useFieldset(schema, config);
-
+export function LoginFieldset(config: FieldsetConfig<LoginForm>) {
+	const ref = useRef<HTMLFieldSetElement>(null);
+	const { email, password } = useFieldset(ref, config);
 	return (
-		<fieldset {...fieldsetProps}>
+		<fieldset ref={ref} form={config.form}>
 			<Field label="Email" error={email.error}>
-				<input {...conform.input(email, { type: 'email' })} />
+				<input {...conform.input(email.config, { type: 'email' })} />
 			</Field>
 			<Field label="Password" error={password.error}>
-				<input {...conform.input(password, { type: 'password' })} />
+				<input {...conform.input(password.config, { type: 'password' })} />
 			</Field>
 		</fieldset>
 	);
@@ -144,16 +138,16 @@ export interface Task {
 	completed: boolean;
 }
 
-export function TaskFieldset({ schema, ...config }: FieldsetProps<Task>) {
-	const [fieldsetProps, { content, completed }] = useFieldset(schema, config);
-
+export function TaskFieldset(config: FieldsetConfig<Task>) {
+	const ref = useRef<HTMLFieldSetElement>(null);
+	const { content, completed } = useFieldset(ref, config);
 	return (
-		<fieldset {...fieldsetProps}>
+		<fieldset ref={ref} form={config.form}>
 			<Field label="Content" error={content.error}>
-				<input {...conform.input(content, { type: 'text' })} />
+				<input {...conform.input(content.config, { type: 'text' })} />
 			</Field>
 			<Field label="Completed" error={completed.error} inline>
-				<input {...conform.input(completed, { type: 'checkbox' })} />
+				<input {...conform.input(completed.config, { type: 'checkbox' })} />
 			</Field>
 		</fieldset>
 	);
@@ -165,22 +159,22 @@ export interface Checklist {
 }
 
 export function ChecklistFieldset({
-	schema,
-	taskSchema,
+	taskConstraint,
 	...config
-}: FieldsetProps<Checklist> & { taskSchema: Schema<Task> }) {
-	const [fieldsetProps, { title, tasks }] = useFieldset(schema, config);
-	const [taskList, control] = useFieldList(fieldsetProps.ref, tasks);
+}: FieldsetConfig<Checklist> & { taskConstraint: FieldsetConstraint<Task> }) {
+	const ref = useRef<HTMLFieldSetElement>(null);
+	const { title, tasks } = useFieldset(ref, config);
+	const [taskList, control] = useFieldList(ref, tasks.config);
 
 	return (
-		<fieldset {...fieldsetProps}>
+		<fieldset ref={ref} form={config.form}>
 			<Field label="Title" error={title.error}>
-				<input {...conform.input(title, { type: 'text' })} />
+				<input {...conform.input(title.config, { type: 'text' })} />
 			</Field>
 			<ol>
 				{taskList.map((task, index) => (
 					<li key={task.key} className="border rounded-md p-4 mb-4">
-						<TaskFieldset schema={taskSchema} {...task.props} />
+						<TaskFieldset constraint={taskConstraint} {...task.config} />
 						<div className="flex flex-row gap-2">
 							<button
 								className="rounded-md border p-2 hover:border-black"

--- a/playground/app/playground.tsx
+++ b/playground/app/playground.tsx
@@ -1,6 +1,6 @@
 import { type ActionFunction } from '@remix-run/node';
 import { useActionData, Form as RemixForm } from '@remix-run/react';
-import { parse as baseParse, type Submission } from '@conform-to/dom';
+import { createSubmission, type Submission } from '@conform-to/dom';
 import { useState, useEffect, type ReactNode } from 'react';
 import { type FormConfig, useForm } from '@conform-to/react';
 
@@ -73,7 +73,7 @@ export function Playground({
 	title,
 	description,
 	form,
-	parse = baseParse,
+	parse = createSubmission,
 	children,
 }: PlaygroundProps) {
 	const actionData = useActionData();

--- a/playground/app/routes/basic.tsx
+++ b/playground/app/routes/basic.tsx
@@ -1,4 +1,4 @@
-import { type Schema, getFieldElements } from '@conform-to/react';
+import { type Schema, createValidate } from '@conform-to/react';
 import {
 	type Movie,
 	type LoginForm,
@@ -36,38 +36,40 @@ export default function Basic() {
 	};
 	const movieSchemaWithCustomMessage: Schema<Movie> = {
 		fields: movieSchema.fields,
-		validate(element) {
-			const [title] = getFieldElements(element, 'title');
-			const [description] = getFieldElements(element, 'description');
-			const [genres] = getFieldElements(element, 'genres');
-			const [rating] = getFieldElements(element, 'rating');
-
-			if (title.validity.valueMissing) {
-				title.setCustomValidity('Title is required');
-			} else if (title.validity.patternMismatch) {
-				title.setCustomValidity('Please enter a valid title');
-			} else {
-				title.setCustomValidity('');
+		validate: createValidate((field) => {
+			switch (field.name) {
+				case 'title':
+					if (field.validity.valueMissing) {
+						field.setCustomValidity('Title is required');
+					} else if (field.validity.patternMismatch) {
+						field.setCustomValidity('Please enter a valid title');
+					} else {
+						field.setCustomValidity('');
+					}
+					break;
+				case 'description':
+					if (field.validity.tooShort) {
+						field.setCustomValidity('Please provides more details');
+					} else {
+						field.setCustomValidity('');
+					}
+					break;
+				case 'genres':
+					if (field.validity.valueMissing) {
+						field.setCustomValidity('Genre is required');
+					} else {
+						field.setCustomValidity('');
+					}
+					break;
+				case 'rating':
+					if (field.validity.stepMismatch) {
+						field.setCustomValidity('The provided rating is invalid');
+					} else {
+						field.setCustomValidity('');
+					}
+					break;
 			}
-
-			if (description.validity.tooShort) {
-				description.setCustomValidity('Please provides more details');
-			} else {
-				description.setCustomValidity('');
-			}
-
-			if (genres.validity.valueMissing) {
-				genres.setCustomValidity('Genre is required');
-			} else {
-				genres.setCustomValidity('');
-			}
-
-			if (rating.validity.stepMismatch) {
-				rating.setCustomValidity('The provided rating is invalid');
-			} else {
-				rating.setCustomValidity('');
-			}
-		},
+		}),
 	};
 	const loginSchema: Schema<LoginForm> = {
 		fields: {
@@ -106,8 +108,8 @@ export default function Basic() {
 				description="Reporting error messages provided by the browser vendor"
 				form="native"
 			>
-				<Form id="native" method="post">
-					<MovieFieldset schema={movieSchema} />
+				<Form id="native" method="post" validate={movieSchema.validate}>
+					<MovieFieldset constraint={movieSchema.fields} />
 				</Form>
 			</Playground>
 			<Playground
@@ -115,8 +117,12 @@ export default function Basic() {
 				description="Setting up custom validation rules with user-defined error messages"
 				form="custom"
 			>
-				<Form id="custom" method="post">
-					<MovieFieldset schema={movieSchemaWithCustomMessage} />
+				<Form
+					id="custom"
+					method="post"
+					validate={movieSchemaWithCustomMessage.validate}
+				>
+					<MovieFieldset constraint={movieSchemaWithCustomMessage.fields} />
 				</Form>
 			</Playground>
 			<Playground
@@ -124,8 +130,13 @@ export default function Basic() {
 				description="Disabling validation by using the `noValidate` option"
 				form="disable"
 			>
-				<Form id="disable" method="post" noValidate>
-					<LoginFieldset schema={loginSchema} />
+				<Form
+					id="disable"
+					method="post"
+					validate={loginSchema.validate}
+					noValidate
+				>
+					<LoginFieldset constraint={loginSchema.fields} />
 				</Form>
 			</Playground>
 			<Playground
@@ -133,8 +144,13 @@ export default function Basic() {
 				description="No error would be reported before users try submitting the form"
 				form="onsubmit"
 			>
-				<Form id="onsubmit" method="post" initialReport="onSubmit">
-					<LoginFieldset schema={loginSchema} />
+				<Form
+					id="onsubmit"
+					method="post"
+					initialReport="onSubmit"
+					validate={loginSchema.validate}
+				>
+					<LoginFieldset constraint={loginSchema.fields} />
 				</Form>
 			</Playground>
 			<Playground
@@ -142,8 +158,13 @@ export default function Basic() {
 				description="Error would be reported once the users type something on the field"
 				form="onchange"
 			>
-				<Form id="onchange" method="post" initialReport="onChange">
-					<LoginFieldset schema={loginSchema} />
+				<Form
+					id="onchange"
+					method="post"
+					initialReport="onChange"
+					validate={loginSchema.validate}
+				>
+					<LoginFieldset constraint={loginSchema.fields} />
 				</Form>
 			</Playground>
 			<Playground
@@ -151,8 +172,13 @@ export default function Basic() {
 				description="Error would not be reported until the users leave the field"
 				form="onblur"
 			>
-				<Form id="onblur" method="post" initialReport="onBlur">
-					<LoginFieldset schema={loginSchema} />
+				<Form
+					id="onblur"
+					method="post"
+					initialReport="onBlur"
+					validate={loginSchema.validate}
+				>
+					<LoginFieldset constraint={loginSchema.fields} />
 				</Form>
 			</Playground>
 			<Playground
@@ -160,16 +186,19 @@ export default function Basic() {
 				description="Connecting the form and fieldset using the `form` attribute"
 				form="remote"
 			>
-				<Form id="remote" method="post" />
-				<LoginFieldset form="remote" schema={loginSchema} />
+				<Form id="remote" method="post" validate={loginSchema.validate} />
+				<LoginFieldset form="remote" constraint={loginSchema.fields} />
 			</Playground>
 			<Playground
 				title="Nested list"
 				description="Constructing a nested array using useFieldList"
 				form="nested-list"
 			>
-				<Form id="nested-list" method="post">
-					<ChecklistFieldset schema={checklistSchmea} taskSchema={taskSchema} />
+				<Form id="nested-list" method="post" validate={loginSchema.validate}>
+					<ChecklistFieldset
+						constraint={checklistSchmea.fields}
+						taskConstraint={taskSchema.fields}
+					/>
 				</Form>
 			</Playground>
 		</>

--- a/playground/app/routes/zod.tsx
+++ b/playground/app/routes/zod.tsx
@@ -44,8 +44,12 @@ export default function ZodIntegration() {
 				parse={(payload) => parse(payload, StudentSchema)}
 				form="native"
 			>
-				<Form id="native" method="post">
-					<StudentFieldset schema={resolve(StudentSchema)} />
+				<Form
+					id="native"
+					method="post"
+					validate={resolve(StudentSchema).validate}
+				>
+					<StudentFieldset constraint={resolve(StudentSchema).fields} />
 				</Form>
 			</Playground>
 			<Playground
@@ -54,8 +58,12 @@ export default function ZodIntegration() {
 				parse={(payload) => parse(payload, paymentSchema)}
 				form="type"
 			>
-				<Form id="type" method="post">
-					<PaymentFieldset schema={resolve(paymentSchema)} />
+				<Form
+					id="type"
+					method="post"
+					validate={resolve(paymentSchema).validate}
+				>
+					<PaymentFieldset constraint={resolve(paymentSchema).fields} />
 				</Form>
 			</Playground>
 		</>

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -25,7 +25,7 @@ export async function isTouched(field: Locator): Promise<boolean> {
 	return field.evaluate<
 		boolean,
 		HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-	>((field) => typeof field.dataset.touched !== 'undefined');
+	>((field) => typeof field.dataset.conformTouched !== 'undefined');
 }
 
 export async function getErrorMessages(playground: Locator): Promise<string[]> {


### PR DESCRIPTION
## Context

> This PR includes breaking changes

As mentioned in #18, I was unhappy with the `useForm` hook as its purpose is not clear. It is not that useful without `useFieldset`. After trying out several new designs for almost a month, I think it's time to settled on one of them.

The idea is:
1) `useForm` is the core of conform which covers all the validation logic
2) `useFieldset` is now only responsible for monitoring field state and act as a helper for configuring fields

The API signature is almost the same comparing with the current one, except:
- `useForm` no longer accept the `onReset` property. Just use the form `onReset` event listener if needed
- `useFieldset` no longer returns the `FieldsetProps`, instead it expect a ref object of the form or fieldset element.
- The field information returned from `useFieldset` now groups all of the data as `config` except `error` as it is a field state 

The API doucmentation is updated. I have also prepared a list of examples to be added to the repository very soon. 