### PR TITLE
feat(conform-zod)!: merge parse into schema to streamline form setup

### DIFF
--- a/examples/remix/app/routes/material-ui.tsx
+++ b/examples/remix/app/routes/material-ui.tsx
@@ -5,26 +5,26 @@ import { useState } from 'react';
 import { z } from 'zod';
 import { styles } from '~/helpers';
 
-const muiFields = z.object({
-	text: z.string(),
-	select: z.enum(['a', 'b', 'c']),
-	textarea: z.string().min(10),
-});
-
-const { validate, fields } = resolve(muiFields);
+const muiFields = resolve(
+	z.object({
+		text: z.string(),
+		select: z.enum(['a', 'b', 'c']),
+		textarea: z.string().min(10),
+	}),
+);
 
 export default function Integration() {
 	const [query, setQuery] = useState<any>(null);
 	const formProps = useForm({
 		initialReport: 'onBlur',
-		validate,
+		validate: muiFields.validate,
 		onSubmit(e) {
 			e.preventDefault();
 			setQuery(Object.fromEntries(new FormData(e.currentTarget)));
 		},
 	});
 	const { text, select, textarea } = useFieldset(formProps.ref, {
-		constraint: fields,
+		constraint: muiFields.constraint,
 	});
 
 	/**

--- a/examples/remix/app/routes/search.tsx
+++ b/examples/remix/app/routes/search.tsx
@@ -11,51 +11,10 @@ import { styles } from '~/helpers';
 /**
  * Define the schema of the fieldset manually
  */
-const schema: Schema<{
+interface Search {
 	keyword?: string;
 	category: string;
-}> = {
-	/**
-	 * Required - Define the fields and coresponding constraint
-	 * All keys will be used as the name of the field
-	 */
-	fields: {
-		keyword: {
-			minLength: 4,
-		},
-		category: {
-			required: true,
-		},
-	},
-
-	/**
-	 * Optional - Customise validation behaviour
-	 * Fallbacks to native validation message provided by the browser vendors
-	 */
-	validate: createValidate((field) => {
-		switch (field.name) {
-			case 'keyword': {
-				if (field.validity.tooShort) {
-					// Native constraint (minLength) with custom message
-					field.setCustomValidity('Please fill in at least 4 characters');
-				} else if (field.value === 'something') {
-					// Custom constraint
-					field.setCustomValidity('Be a little more specific please');
-				} else {
-					// Reset the custom error state of the field (Important!)
-					field.setCustomValidity('');
-				}
-				break;
-			}
-			case 'category': {
-				// Here we didn't call setCustomValidity for category
-				// So it fallbacks to native validation message
-				// These messages varies based on browser vendors
-				break;
-			}
-		}
-	}),
-};
+}
 
 export default function SearchForm() {
 	const [searchParams, setSearchParams] = useSearchParams();
@@ -80,6 +39,30 @@ export default function SearchForm() {
 		 */
 		noValidate: false,
 
+		validate: createValidate((field) => {
+			switch (field.name) {
+				case 'keyword': {
+					if (field.validity.tooShort) {
+						// Native constraint (minLength) with custom message
+						field.setCustomValidity('Please fill in at least 4 characters');
+					} else if (field.value === 'something') {
+						// Custom constraint
+						field.setCustomValidity('Be a little more specific please');
+					} else {
+						// Reset the custom error state of the field (Important!)
+						field.setCustomValidity('');
+					}
+					break;
+				}
+				case 'category': {
+					// Here we didn't call setCustomValidity for category
+					// So it fallbacks to native validation message
+					// These messages varies based on browser vendors
+					break;
+				}
+			}
+		}),
+
 		/**
 		 * Form submit handler
 		 *
@@ -101,7 +84,14 @@ export default function SearchForm() {
 		},
 	});
 	const { keyword, category } = useFieldset(formProps.ref, {
-		constraint: schema.fields,
+		constraint: {
+			keyword: {
+				minLength: 4,
+			},
+			category: {
+				required: true,
+			},
+		},
 		defaultValue: {
 			keyword: searchParams.get('keyword') ?? '',
 			category: searchParams.get('category') ?? '',

--- a/examples/remix/app/routes/signup.tsx
+++ b/examples/remix/app/routes/signup.tsx
@@ -1,6 +1,5 @@
 import {
 	type Submission,
-	type InferSchema,
 	useForm,
 	useFieldset,
 	conform,

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -47,12 +47,14 @@ export type FieldsetConstraint<Schema extends Record<string, any>> = {
 	[Key in keyof Schema]?: FieldConstraint;
 };
 
-export type Schema<Type extends Record<string, any>> = {
-	fields: FieldsetConstraint<Type>;
-	validate?: (
+export type Schema<Shape extends Record<string, any>, Source> = {
+	source: Source;
+	constraint: FieldsetConstraint<Shape>;
+	validate: (
 		element: HTMLFormElement,
 		submitter?: HTMLInputElement | HTMLButtonElement | null,
 	) => void;
+	parse: (payload: FormData | URLSearchParams) => Submission<Shape>;
 };
 
 export interface FormState<Schema extends Record<string, any>> {

--- a/playground/app/routes/basic.tsx
+++ b/playground/app/routes/basic.tsx
@@ -1,4 +1,4 @@
-import { type Schema, createValidate } from '@conform-to/react';
+import { type FieldsetConstraint, createValidate } from '@conform-to/react';
 import {
 	type Movie,
 	type LoginForm,
@@ -13,92 +13,81 @@ import { action, Form, Playground } from '~/playground';
 export { action };
 
 export default function Basic() {
-	const movieSchema: Schema<Movie> = {
-		fields: {
-			title: {
-				required: true,
-				pattern: '[0-9a-zA-Z ]{1,20}',
-			},
-			description: {
-				minLength: 30,
-				maxLength: 200,
-			},
-			genres: {
-				required: true,
-				multiple: true,
-			},
-			rating: {
-				min: '0.5',
-				max: '5',
-				step: '0.5',
-			},
+	const movieConstraint: FieldsetConstraint<Movie> = {
+		title: {
+			required: true,
+			pattern: '[0-9a-zA-Z ]{1,20}',
+		},
+		description: {
+			minLength: 30,
+			maxLength: 200,
+		},
+		genres: {
+			required: true,
+			multiple: true,
+		},
+		rating: {
+			min: '0.5',
+			max: '5',
+			step: '0.5',
 		},
 	};
-	const movieSchemaWithCustomMessage: Schema<Movie> = {
-		fields: movieSchema.fields,
-		validate: createValidate((field) => {
-			switch (field.name) {
-				case 'title':
-					if (field.validity.valueMissing) {
-						field.setCustomValidity('Title is required');
-					} else if (field.validity.patternMismatch) {
-						field.setCustomValidity('Please enter a valid title');
-					} else {
-						field.setCustomValidity('');
-					}
-					break;
-				case 'description':
-					if (field.validity.tooShort) {
-						field.setCustomValidity('Please provides more details');
-					} else {
-						field.setCustomValidity('');
-					}
-					break;
-				case 'genres':
-					if (field.validity.valueMissing) {
-						field.setCustomValidity('Genre is required');
-					} else {
-						field.setCustomValidity('');
-					}
-					break;
-				case 'rating':
-					if (field.validity.stepMismatch) {
-						field.setCustomValidity('The provided rating is invalid');
-					} else {
-						field.setCustomValidity('');
-					}
-					break;
-			}
-		}),
-	};
-	const loginSchema: Schema<LoginForm> = {
-		fields: {
-			email: {
-				required: true,
-			},
-			password: {
-				required: true,
-				minLength: 8,
-			},
+	const movieValidate = createValidate((field) => {
+		switch (field.name) {
+			case 'title':
+				if (field.validity.valueMissing) {
+					field.setCustomValidity('Title is required');
+				} else if (field.validity.patternMismatch) {
+					field.setCustomValidity('Please enter a valid title');
+				} else {
+					field.setCustomValidity('');
+				}
+				break;
+			case 'description':
+				if (field.validity.tooShort) {
+					field.setCustomValidity('Please provides more details');
+				} else {
+					field.setCustomValidity('');
+				}
+				break;
+			case 'genres':
+				if (field.validity.valueMissing) {
+					field.setCustomValidity('Genre is required');
+				} else {
+					field.setCustomValidity('');
+				}
+				break;
+			case 'rating':
+				if (field.validity.stepMismatch) {
+					field.setCustomValidity('The provided rating is invalid');
+				} else {
+					field.setCustomValidity('');
+				}
+				break;
+		}
+	});
+	const loginConstraint: FieldsetConstraint<LoginForm> = {
+		email: {
+			required: true,
+		},
+		password: {
+			required: true,
+			minLength: 8,
 		},
 	};
-	const checklistSchmea: Schema<Checklist> = {
-		fields: {
-			title: {
-				required: true,
-			},
-			tasks: {
-				required: true,
-			},
+	const checklistConstraint: FieldsetConstraint<Checklist> = {
+		title: {
+			required: true,
+		},
+		tasks: {
+			required: true,
 		},
 	};
-	const taskSchema: Schema<Task> = {
-		fields: {
-			content: {
-				required: true,
-			},
-			completed: {},
+	const taskConstraint: FieldsetConstraint<Task> = {
+		content: {
+			required: true,
 		},
+		completed: {},
 	};
 
 	return (
@@ -108,8 +97,8 @@ export default function Basic() {
 				description="Reporting error messages provided by the browser vendor"
 				form="native"
 			>
-				<Form id="native" method="post" validate={movieSchema.validate}>
-					<MovieFieldset constraint={movieSchema.fields} />
+				<Form id="native" method="post">
+					<MovieFieldset constraint={movieConstraint} />
 				</Form>
 			</Playground>
 			<Playground
@@ -117,12 +106,8 @@ export default function Basic() {
 				description="Setting up custom validation rules with user-defined error messages"
 				form="custom"
 			>
-				<Form
-					id="custom"
-					method="post"
-					validate={movieSchemaWithCustomMessage.validate}
-				>
-					<MovieFieldset constraint={movieSchemaWithCustomMessage.fields} />
+				<Form id="custom" method="post" validate={movieValidate}>
+					<MovieFieldset constraint={movieConstraint} />
 				</Form>
 			</Playground>
 			<Playground
@@ -130,13 +115,8 @@ export default function Basic() {
 				description="Disabling validation by using the `noValidate` option"
 				form="disable"
 			>
-				<Form
-					id="disable"
-					method="post"
-					validate={loginSchema.validate}
-					noValidate
-				>
-					<LoginFieldset constraint={loginSchema.fields} />
+				<Form id="disable" method="post" noValidate>
+					<LoginFieldset constraint={loginConstraint} />
 				</Form>
 			</Playground>
 			<Playground
@@ -144,13 +124,8 @@ export default function Basic() {
 				description="No error would be reported before users try submitting the form"
 				form="onsubmit"
 			>
-				<Form
-					id="onsubmit"
-					method="post"
-					initialReport="onSubmit"
-					validate={loginSchema.validate}
-				>
-					<LoginFieldset constraint={loginSchema.fields} />
+				<Form id="onsubmit" method="post" initialReport="onSubmit">
+					<LoginFieldset constraint={loginConstraint} />
 				</Form>
 			</Playground>
 			<Playground
@@ -158,13 +133,8 @@ export default function Basic() {
 				description="Error would be reported once the users type something on the field"
 				form="onchange"
 			>
-				<Form
-					id="onchange"
-					method="post"
-					initialReport="onChange"
-					validate={loginSchema.validate}
-				>
-					<LoginFieldset constraint={loginSchema.fields} />
+				<Form id="onchange" method="post" initialReport="onChange">
+					<LoginFieldset constraint={loginConstraint} />
 				</Form>
 			</Playground>
 			<Playground
@@ -172,13 +142,8 @@ export default function Basic() {
 				description="Error would not be reported until the users leave the field"
 				form="onblur"
 			>
-				<Form
-					id="onblur"
-					method="post"
-					initialReport="onBlur"
-					validate={loginSchema.validate}
-				>
-					<LoginFieldset constraint={loginSchema.fields} />
+				<Form id="onblur" method="post" initialReport="onBlur">
+					<LoginFieldset constraint={loginConstraint} />
 				</Form>
 			</Playground>
 			<Playground
@@ -186,18 +151,18 @@ export default function Basic() {
 				description="Connecting the form and fieldset using the `form` attribute"
 				form="remote"
 			>
-				<Form id="remote" method="post" validate={loginSchema.validate} />
-				<LoginFieldset form="remote" constraint={loginSchema.fields} />
+				<Form id="remote" method="post" />
+				<LoginFieldset form="remote" constraint={loginConstraint} />
 			</Playground>
 			<Playground
 				title="Nested list"
 				description="Constructing a nested array using useFieldList"
 				form="nested-list"
 			>
-				<Form id="nested-list" method="post" validate={loginSchema.validate}>
+				<Form id="nested-list" method="post">
 					<ChecklistFieldset
-						constraint={checklistSchmea.fields}
-						taskConstraint={taskSchema.fields}
+						constraint={checklistConstraint}
+						taskConstraint={taskConstraint}
 					/>
 				</Form>
 			</Playground>

--- a/playground/app/routes/zod.tsx
+++ b/playground/app/routes/zod.tsx
@@ -1,4 +1,4 @@
-import { parse, resolve } from '@conform-to/zod';
+import { resolve } from '@conform-to/zod';
 import { z } from 'zod';
 import { action, Playground, Form } from '~/playground';
 import { PaymentFieldset, StudentFieldset } from '~/fieldset';
@@ -6,64 +6,60 @@ import { PaymentFieldset, StudentFieldset } from '~/fieldset';
 export { action };
 
 export default function ZodIntegration() {
-	const StudentSchema = z.object({
-		name: z
-			.string()
-			.min(8)
-			.max(20)
-			.regex(/^[0-9a-zA-Z]{8,20}$/),
-		remarks: z.string().optional(),
-		score: z.preprocess(
-			(value) => (typeof value !== 'undefined' ? Number(value) : undefined),
-			z.number().min(0).max(100).step(0.5).optional(),
-		),
-		grade: z.enum(['A', 'B', 'C', 'D', 'E', 'F']).default('F'),
-	});
-	const paymentSchema = z.object({
-		account: z.string(),
-		amount: z.preprocess(
-			(value) => (typeof value !== 'undefined' ? Number(value) : value),
-			z.number(),
-		),
-		timestamp: z.preprocess(
-			(value) =>
-				typeof value !== 'undefined' ? new Date(value as any) : value,
-			z.date(),
-		),
-		verified: z.preprocess(
-			(value) => (typeof value !== 'undefined' ? value === 'Yes' : value),
-			z.boolean(),
-		),
-	});
+	const studentSchema = resolve(
+		z.object({
+			name: z
+				.string()
+				.min(8)
+				.max(20)
+				.regex(/^[0-9a-zA-Z]{8,20}$/),
+			remarks: z.string().optional(),
+			score: z.preprocess(
+				(value) => (typeof value !== 'undefined' ? Number(value) : undefined),
+				z.number().min(0).max(100).step(0.5).optional(),
+			),
+			grade: z.enum(['A', 'B', 'C', 'D', 'E', 'F']).default('F'),
+		}),
+	);
+	const paymentSchema = resolve(
+		z.object({
+			account: z.string(),
+			amount: z.preprocess(
+				(value) => (typeof value !== 'undefined' ? Number(value) : value),
+				z.number(),
+			),
+			timestamp: z.preprocess(
+				(value) =>
+					typeof value !== 'undefined' ? new Date(value as any) : value,
+				z.date(),
+			),
+			verified: z.preprocess(
+				(value) => (typeof value !== 'undefined' ? value === 'Yes' : value),
+				z.boolean(),
+			),
+		}),
+	);
 
 	return (
 		<>
 			<Playground
 				title="Native Constraint"
 				description="Infering constraint based on the zod schema"
-				parse={(payload) => parse(payload, StudentSchema)}
+				parse={studentSchema.parse}
 				form="native"
 			>
-				<Form
-					id="native"
-					method="post"
-					validate={resolve(StudentSchema).validate}
-				>
-					<StudentFieldset constraint={resolve(StudentSchema).fields} />
+				<Form id="native" method="post" validate={studentSchema.validate}>
+					<StudentFieldset constraint={studentSchema.constraint} />
 				</Form>
 			</Playground>
 			<Playground
 				title="Type Conversion"
 				description="Parsing the form data based on the defined preprocess with zod"
-				parse={(payload) => parse(payload, paymentSchema)}
+				parse={paymentSchema.parse}
 				form="type"
 			>
-				<Form
-					id="type"
-					method="post"
-					validate={resolve(paymentSchema).validate}
-				>
-					<PaymentFieldset constraint={resolve(paymentSchema).fields} />
+				<Form id="type" method="post" validate={paymentSchema.validate}>
+					<PaymentFieldset constraint={paymentSchema.constraint} />
 				</Form>
 			</Playground>
 		</>


### PR DESCRIPTION
## Context

> This PR includes breaking changes

This is a follow-up from #21 as now none of our hooks accept the schema directly but instead expect individual pieces of what schema provided. There are 2 ways to handle this:
1) Make 3 independent function that parse the schema and convert it to the corresponding structure we want.
2) Generate all 3 things in 1 function.

Although (1) is good for reducing the size of the package (since `parse` might only be needed on BE and the `constraint` is optional), I don't like having to call so many functions again and again. This PR goes with option 2 instead.