### PR TITLE
feat(conform-zod): add preprocess helper

### DIFF
--- a/examples/remix/README.md
+++ b/examples/remix/README.md
@@ -10,3 +10,5 @@ It works without JS.
 
 - [useForm](../../packages/conform-react/README.md#useForm)
 - [useFieldset](../../packages/conform-react/README.md#useFieldset)
+- [resolve](../../packages/conform-zod/README.md#resolve)
+- [ifNonEmptyString](../../packages/conform-zod/README.md#ifNonEmptyString)

--- a/examples/remix/app/routes/index.tsx
+++ b/examples/remix/app/routes/index.tsx
@@ -4,7 +4,7 @@ import {
 	useFieldset,
 	useFieldList,
 } from '@conform-to/react';
-import { resolve } from '@conform-to/zod';
+import { ifNonEmptyString, resolve } from '@conform-to/zod';
 import { type ActionArgs } from '@remix-run/node';
 import { Form, useActionData } from '@remix-run/react';
 import { useRef } from 'react';
@@ -13,7 +13,10 @@ import { z } from 'zod';
 const Task = resolve(
 	z.object({
 		content: z.string(),
-		completed: z.preprocess((value) => value === 'yes', z.boolean()),
+		completed: z.preprocess(
+			ifNonEmptyString((value) => value === 'yes'),
+			z.boolean(),
+		),
 	}),
 );
 

--- a/examples/zod/README.md
+++ b/examples/zod/README.md
@@ -9,3 +9,4 @@ This example shows you how to resolve form data with custom validation logic usi
 - [useForm](../../packages/conform-react/README.md#useForm)
 - [useFieldset](../../packages/conform-react/README.md#useFieldset)
 - [resolve](../../packages/conform-zod/README.md#resolve)
+- [ifNonEmptyString](../../packages/conform-zod/README.md#ifNonEmptyString)

--- a/packages/conform-zod/README.md
+++ b/packages/conform-zod/README.md
@@ -5,6 +5,7 @@
 ## API Reference
 
 - [resolve](#resolve)
+- [ifNonEmptyString](#ifNonEmptyString)
 
 ### resolve
 
@@ -88,4 +89,38 @@ export default function ExampleRoute() {
   // to populate inital value of each fields with
   // the intital error
 }
+```
+
+### ifNonEmptyString
+
+As `zod` does not have specific logic for handling form data, there are some common cases need to be handled by the users. For example,
+
+1. it does not treat empty string as invalid for a requried field
+2. it has no type coercion support (e.g. '1' -> 1)
+
+The zod schema resolver currently does an extra cleanup step to transform empty string to undefined internally. But users are still required to do convert the data to their desired type themselves.
+
+```tsx
+import { z } from 'zod';
+import { resolve, ifNonEmptyString } from '@conform-to/zod';
+
+const schema = resolve(
+  z.object({
+    // No preprocess is needed for string as empty string
+    // is already converted to undefined by the resolver
+    text: z.string({ required_error: 'This field is required' }),
+
+    // Cast to number manually
+    number: z.preprocess(
+      ifNonEmptyString(Number),
+      z.number({ required_error: 'This field is required' }),
+    ),
+
+    // This is how you will do it without the helper
+    date: z.preprocess(
+      (value) => (typeof value === 'string' ? new Date(value) : value),
+      z.date({ required_error: 'This field is required' }),
+    ),
+  }),
+);
 ```

--- a/playground/app/routes/zod.tsx
+++ b/playground/app/routes/zod.tsx
@@ -1,4 +1,4 @@
-import { resolve } from '@conform-to/zod';
+import { resolve, ifNonEmptyString } from '@conform-to/zod';
 import { z } from 'zod';
 import { action, Playground, Form } from '~/playground';
 import { PaymentFieldset, StudentFieldset } from '~/fieldset';
@@ -15,7 +15,7 @@ export default function ZodIntegration() {
 				.regex(/^[0-9a-zA-Z]{8,20}$/),
 			remarks: z.string().optional(),
 			score: z.preprocess(
-				(value) => (typeof value !== 'undefined' ? Number(value) : undefined),
+				ifNonEmptyString(Number),
 				z.number().min(0).max(100).step(0.5).optional(),
 			),
 			grade: z.enum(['A', 'B', 'C', 'D', 'E', 'F']).default('F'),
@@ -24,17 +24,13 @@ export default function ZodIntegration() {
 	const paymentSchema = resolve(
 		z.object({
 			account: z.string(),
-			amount: z.preprocess(
-				(value) => (typeof value !== 'undefined' ? Number(value) : value),
-				z.number(),
-			),
+			amount: z.preprocess(ifNonEmptyString(Number), z.number()),
 			timestamp: z.preprocess(
-				(value) =>
-					typeof value !== 'undefined' ? new Date(value as any) : value,
+				ifNonEmptyString((value) => new Date(value)),
 				z.date(),
 			),
 			verified: z.preprocess(
-				(value) => (typeof value !== 'undefined' ? value === 'Yes' : value),
+				ifNonEmptyString((value) => value === 'Yes'),
 				z.boolean(),
 			),
 		}),


### PR DESCRIPTION
## Context

As `zod` does not have specific logic for handling form data, there are some common cases need to be handled by the users. For example,

1. it does not treat empty string as invalid for a requried field
2. it has no type coercion support (e.g. '1' -> 1)

The zod schema resolver currently does an extra cleanup step to transform empty string to undefined internally. But users are still required to do convert the data to their desired type themselves.

```tsx
import { z } from 'zod';
import { resolve, ifNonEmptyString } from '@conform-to/zod';

const schema = resolve(
  z.object({
    // No preprocess is needed for string as empty string
    // is already converted to undefined by the resolver
    text: z.string({ required_error: 'This field is required' }),

    // Cast to number manually
    number: z.preprocess(
      ifNonEmptyString(Number),
      z.number({ required_error: 'This field is required' }),
    ),

    // This is how you will do it without the helper
    date: z.preprocess(
      (value) => (typeof value === 'string' ? new Date(value) : value),
      z.date({ required_error: 'This field is required' }),
    ),
  }),
);
```