### PR TITLE
fix(conform-react): remove unwanted state sync in useFieldList

### DIFF
--- a/examples/remix/app/routes/index.tsx
+++ b/examples/remix/app/routes/index.tsx
@@ -47,11 +47,10 @@ export default function OrderForm() {
 			initialError: formState?.error.details,
 		},
 	);
-	const [taskList, control] = useFieldList(formProps.ref, tasks.config);
-
-	console.log('error', formState?.error);
-	console.log('title', title.config);
-	console.log('tasks', tasks.config);
+	const [taskList, control] = useFieldList(formProps.ref, {
+		...tasks.config,
+		defaultValue: [],
+	});
 
 	return (
 		<Form method="post" {...formProps}>

--- a/examples/remix/app/routes/index.tsx
+++ b/examples/remix/app/routes/index.tsx
@@ -47,10 +47,7 @@ export default function OrderForm() {
 			initialError: formState?.error.details,
 		},
 	);
-	const [taskList, control] = useFieldList(formProps.ref, {
-		...tasks.config,
-		defaultValue: [],
-	});
+	const [taskList, control] = useFieldList(formProps.ref, tasks.config);
 
 	return (
 		<Form method="post" {...formProps}>

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -543,26 +543,6 @@ export function useFieldList<Payload = any>(
 	) as ListControl<Payload>;
 
 	useEffect(() => {
-		setEntries((prevEntries) => {
-			const nextEntries = Object.entries(config.defaultValue ?? [undefined]);
-
-			if (prevEntries.length !== nextEntries.length) {
-				return nextEntries;
-			}
-
-			for (let i = 0; i < prevEntries.length; i++) {
-				const [prevKey, prevValue] = prevEntries[i];
-				const [nextKey, nextValue] = nextEntries[i];
-
-				if (prevKey !== nextKey || prevValue !== nextValue) {
-					return nextEntries;
-				}
-			}
-
-			// No need to rerender in this case
-			return prevEntries;
-		});
-
 		const submitHandler = (event: SubmitEvent) => {
 			const form = getFormElement(ref.current);
 

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -588,7 +588,7 @@ export function useFieldList<Payload = any>(
 				return;
 			}
 
-			setEntries(Object.entries(config.defaultValue ?? []));
+			setEntries(Object.entries(config.defaultValue ?? [undefined]));
 		};
 
 		document.addEventListener('submit', submitHandler, true);

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -571,4 +571,19 @@ test.describe('Nested list', () => {
 			},
 		});
 	});
+
+	test('reset internal state properly', async ({ page }) => {
+		const playground = getPlaygroundLocator(page, 'Nested list');
+		const tasks = playground.locator('ol > li');
+
+		expect(tasks).toHaveCount(1);
+
+		await playground.locator('button:text("Insert bottom")').click();
+
+		expect(tasks).toHaveCount(2);
+
+		await clickResetButton(playground);
+
+		expect(tasks).toHaveCount(1);
+	});
 });


### PR DESCRIPTION
This fix make `defaultValue` works consistently simialr to native input fields: Once set, any changes will be ignored until reset.

This should make customizing the default value of the field list easier. For example:
 
```tsx
function TodoForm() {
  const formProps = useForm();
  const { title, tasks } = useFieldset<Todo>(formProps.ref);
  const [taskList, control] = useFieldList(formProps.ref, {
    ...tasks.config,
    defaultValue: tasks.config.defaultValue ?? [], // default to empty list
  });

  return (
    <form {...formProps}>
      {/* ... */}
    </form>
  );
}
```

You can also default to different size with this:
```tsx
const [taskList, control] = useFieldList(formProps.ref, {
    ...tasks.config,
    // default to array of size 3 with `undefined` items
    defaultValue: tasks.config.defaultValue ?? Array(3).fill(),
});
```
