### PR TITLE
feat(conform-dom,conform-react,conform-yup,conform-zod)!: make internal state uncontrolled

### DIFF
--- a/examples/remix/app/routes/index.tsx
+++ b/examples/remix/app/routes/index.tsx
@@ -44,7 +44,7 @@ export default function OrderForm() {
 		formProps.ref,
 		{
 			defaultValue: formState?.value,
-			initialError: formState?.error.details,
+			initialError: formState?.error,
 		},
 	);
 	const [taskList, control] = useFieldList(formProps.ref, tasks.config);

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -9,7 +9,7 @@ export type FieldElement =
 export interface FieldConfig<Schema = unknown> extends FieldConstraint {
 	name: string;
 	defaultValue?: FieldValue<Schema>;
-	initialError?: FieldError<Schema>['details'];
+	initialError?: Array<[string, string]>;
 	form?: string;
 }
 
@@ -20,17 +20,6 @@ export type FieldValue<Schema> = Schema extends Primitive | File
 	: Schema extends Record<string, any>
 	? { [Key in keyof Schema]?: FieldValue<Schema[Key]> }
 	: unknown;
-
-export interface FieldError<Schema> {
-	message?: string;
-	details?: Schema extends Primitive | File
-		? never
-		: Schema extends Array<infer InnerType>
-		? Array<FieldError<InnerType>>
-		: Schema extends Record<string, any>
-		? { [Key in keyof Schema]?: FieldError<Schema[Key]> }
-		: unknown;
-}
 
 export type FieldConstraint = {
 	required?: boolean;
@@ -59,7 +48,7 @@ export type Schema<Shape extends Record<string, any>, Source> = {
 
 export interface FormState<Schema extends Record<string, any>> {
 	value: FieldValue<Schema>;
-	error: FieldError<Schema>;
+	error: Array<[string, string]>;
 }
 
 export type Submission<T extends Record<string, unknown>> =
@@ -248,7 +237,7 @@ export function createSubmission(
 				state: 'modified',
 				form: {
 					value,
-					error: {},
+					error: [],
 				},
 			};
 		}
@@ -257,9 +246,7 @@ export function createSubmission(
 			state: 'rejected',
 			form: {
 				value,
-				error: {
-					message: e instanceof Error ? e.message : 'Submission failed',
-				},
+				error: [['', e instanceof Error ? e.message : 'Submission failed']],
 			},
 		};
 	}
@@ -269,7 +256,7 @@ export function createSubmission(
 		data: value,
 		form: {
 			value,
-			error: {},
+			error: [],
 		},
 	};
 }

--- a/packages/conform-yup/index.ts
+++ b/packages/conform-yup/index.ts
@@ -1,31 +1,16 @@
 import {
 	type FieldConstraint,
 	type FieldsetConstraint,
-	type FieldError,
 	type Schema,
 	type Submission,
 	createSubmission,
 	getFormData,
-	getPaths,
 	setFormError,
-	setValue,
 } from '@conform-to/dom';
 import * as yup from 'yup';
 
-function formatError<Schema>(error: yup.ValidationError): FieldError<Schema> {
-	const result: FieldError<Schema> = {};
-
-	for (const validationError of error.inner) {
-		setValue<string>(
-			result,
-			getPaths(validationError.path)
-				.flatMap((path) => ['details', path])
-				.concat('message'),
-			(prev) => (prev ? prev : validationError.message),
-		);
-	}
-
-	return result;
+function formatError(yupError: yup.ValidationError): Array<[string, string]> {
+	return yupError.inner.map((error) => [error.path ?? '', error.message]);
 }
 
 export function resolve<Source extends yup.AnyObjectSchema>(

--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -1,14 +1,12 @@
 import {
 	type FieldConstraint,
 	type FieldsetConstraint,
-	type FieldError,
 	type Schema,
 	type Submission,
 	createSubmission,
 	getFormData,
 	getName,
 	setFormError,
-	setValue,
 } from '@conform-to/dom';
 import * as z from 'zod';
 
@@ -34,18 +32,13 @@ function cleanup(data: unknown): unknown {
 	}
 }
 
-function formatError<Schema>(error: z.ZodError<Schema>): FieldError<Schema> {
-	const result: FieldError<Schema> = {};
-
-	for (const issue of error.errors) {
-		setValue<string>(
-			result,
-			issue.path.flatMap((path) => ['details', path]).concat('message'),
-			(prev) => (prev ? prev : issue.message),
-		);
-	}
-
-	return result;
+function formatError<Schema>(
+	zodError: z.ZodError<Schema>,
+): Array<[string, string]> {
+	return zodError.errors.map<[string, string]>((e) => [
+		getName(e.path),
+		e.message,
+	]);
 }
 
 function inferConstraint<T>(schema: z.ZodType<T>): FieldConstraint {

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -501,7 +501,7 @@ test.describe('Nested list', () => {
 		const playground = getPlaygroundLocator(page, 'Nested list');
 		const tasks = playground.locator('ol > li');
 
-		expect(tasks).toHaveCount(1);
+		await expect(tasks).toHaveCount(1);
 
 		const task0 = getTaskFieldset(tasks.nth(0), 'tasks[0]');
 		const task1 = getTaskFieldset(tasks.nth(1), 'tasks[1]');
@@ -576,14 +576,14 @@ test.describe('Nested list', () => {
 		const playground = getPlaygroundLocator(page, 'Nested list');
 		const tasks = playground.locator('ol > li');
 
-		expect(tasks).toHaveCount(1);
+		await expect(tasks).toHaveCount(1);
 
 		await playground.locator('button:text("Insert bottom")').click();
 
-		expect(tasks).toHaveCount(2);
+		await expect(tasks).toHaveCount(2);
 
 		await clickResetButton(playground);
 
-		expect(tasks).toHaveCount(1);
+		await expect(tasks).toHaveCount(1);
 	});
 });

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -97,7 +97,7 @@ test.describe('Native Constraint', () => {
 					genres: 'action',
 					rating: '4.5',
 				},
-				error: {},
+				error: [],
 			},
 		});
 	});
@@ -186,7 +186,7 @@ test.describe('Custom Constraint', () => {
 					genres: 'sci-fi',
 					rating: '4.0',
 				},
-				error: {},
+				error: [],
 			},
 		});
 	});
@@ -263,7 +263,7 @@ test.describe('Skip Validation', () => {
 					email: '',
 					password: '',
 				},
-				error: {},
+				error: [],
 			},
 		});
 
@@ -282,7 +282,7 @@ test.describe('Skip Validation', () => {
 					email: 'invalid email',
 					password: '',
 				},
-				error: {},
+				error: [],
 			},
 		});
 	});
@@ -397,7 +397,7 @@ test.describe('Remote form', () => {
 					email: 'me@edmund.dev',
 					password: 'secretpassword',
 				},
-				error: {},
+				error: [],
 			},
 		});
 	});
@@ -490,7 +490,7 @@ test.describe('Nested list', () => {
 						{ content: 'Ad hoc task' },
 					],
 				},
-				error: {},
+				error: [],
 			},
 		});
 	});
@@ -567,7 +567,7 @@ test.describe('Nested list', () => {
 						{ content: 'Write tests for nested list', completed: 'on' },
 					],
 				},
-				error: {},
+				error: [],
 			},
 		});
 	});

--- a/tests/yup.spec.ts
+++ b/tests/yup.spec.ts
@@ -70,7 +70,7 @@ test.describe('Type Conversion', () => {
 					timestamp: '2022-07-04T12:00Z',
 					verified: 'Yes',
 				},
-				error: {},
+				error: [],
 			},
 		});
 	});

--- a/tests/zod.spec.ts
+++ b/tests/zod.spec.ts
@@ -70,7 +70,7 @@ test.describe('Type Conversion', () => {
 					timestamp: '2022-07-04T12:00Z',
 					verified: 'Yes',
 				},
-				error: {},
+				error: [],
 			},
 		});
 	});


### PR DESCRIPTION
## Context

> This PR includes breaking changes

This is the first step for the upcoming server validation feature. It stops syncing error with useEffect whenever the reference for `initialError` is changed with the error object simplified to a name-message pair array (i.e. `Array<[string, string]>`). It also makes sure a stable reference for `defaultValue`.

The usage of the new error structure will be covered in another PR.

These values will not be refreshed unless a form `reset` event is captured.  

