### PR TITLE
feat!: finialize server validation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,13 @@ import { useForm, useFieldset } from '@conform-to/react';
 
 export default function LoginForm() {
   const form = useForm({
-    onValidate({ form }) {
-      return form.reportValidity();
-    },
     onSubmit(event, { submission }) {
       event.preventDefault();
 
       console.log(submission);
     },
   });
-  const { email, password } = useFieldset(form.ref, form.config);
+  const { email, password } = useFieldset(form.ref);
 
   return (
     <form {...form.props}>

--- a/examples/basics/README.md
+++ b/examples/basics/README.md
@@ -76,9 +76,6 @@ import { useForm, useFieldset } from '@conform-to/react';
 
 export default function LoginForm() {
   const form = useForm({
-    onValidate({ form }) {
-      return form.reportValidity();
-    }
     onSubmit(event) {
       event.preventDefault();
 

--- a/examples/basics/src/App.tsx
+++ b/examples/basics/src/App.tsx
@@ -2,16 +2,13 @@ import { useForm, useFieldset } from '@conform-to/react';
 
 export default function LoginForm() {
 	const form = useForm({
-		onValidate({ form }) {
-			return form.reportValidity();
-		},
 		onSubmit(event, { submission }) {
 			event.preventDefault();
 
 			console.log(submission);
 		},
 	});
-	const { email, password } = useFieldset(form.ref, form.config);
+	const { email, password } = useFieldset(form.ref);
 
 	return (
 		<form {...form.props}>

--- a/examples/list/src/App.tsx
+++ b/examples/list/src/App.tsx
@@ -15,9 +15,6 @@ interface Todo {
 export default function TodoForm() {
 	const form = useForm<Todo>({
 		initialReport: 'onBlur',
-		onValidate({ form }) {
-			return form.reportValidity();
-		},
 		async onSubmit(event, { submission }) {
 			event.preventDefault();
 

--- a/examples/list/src/App.tsx
+++ b/examples/list/src/App.tsx
@@ -15,7 +15,7 @@ interface Todo {
 export default function TodoForm() {
 	const form = useForm<Todo>({
 		initialReport: 'onBlur',
-		async onSubmit(event, { submission }) {
+		onSubmit(event, { submission }) {
 			event.preventDefault();
 
 			console.log(submission);

--- a/examples/material-ui/src/App.tsx
+++ b/examples/material-ui/src/App.tsx
@@ -10,9 +10,6 @@ interface Article {
 export default function ArticleForm() {
 	const form = useForm<Article>({
 		initialReport: 'onBlur',
-		onValidate({ form }) {
-			return form.reportValidity();
-		},
 		onSubmit: (event, { submission }) => {
 			event.preventDefault();
 

--- a/examples/nested/src/App.tsx
+++ b/examples/nested/src/App.tsx
@@ -11,9 +11,6 @@ interface Payment {
 
 export default function PaymentForm() {
 	const form = useForm<Payment>({
-		onValidate({ form }) {
-			return form.reportValidity();
-		},
 		onSubmit(event, { submission }) {
 			event.preventDefault();
 

--- a/examples/remix/app/routes/index.tsx
+++ b/examples/remix/app/routes/index.tsx
@@ -5,7 +5,7 @@ import {
 	useFieldList,
 	conform,
 	parse,
-	reportValidity,
+	setFormError,
 } from '@conform-to/react';
 import { getError } from '@conform-to/zod';
 import type { ActionArgs } from '@remix-run/node';
@@ -64,7 +64,7 @@ export default function TodoForm() {
 				submission.error = submission.error.concat(getError(result.error));
 			}
 
-			return reportValidity(form, submission);
+			setFormError(form, submission);
 		},
 		onSubmit(event, { submission }) {
 			switch (submission.type) {

--- a/examples/remix/app/routes/index.tsx
+++ b/examples/remix/app/routes/index.tsx
@@ -59,11 +59,12 @@ export default function TodoForm() {
 		state,
 		onValidate({ form, submission }) {
 			const result = todoSchema.safeParse(submission.value);
-			const error = !result.success
-				? submission.error.concat(getError(result.error))
-				: submission.error;
 
-			return reportValidity(form, error);
+			if (!result.success) {
+				submission.error = submission.error.concat(getError(result.error));
+			}
+
+			return reportValidity(form, submission);
 		},
 		onSubmit(event, { submission }) {
 			switch (submission.type) {

--- a/examples/remix/app/routes/index.tsx
+++ b/examples/remix/app/routes/index.tsx
@@ -29,7 +29,7 @@ export let action = async ({ request }: ActionArgs) => {
 	const submission = parse(formData);
 	const result = todoSchema.safeParse(submission.value);
 	const error = !result.success
-		? submission.error.concat(getError(result.error, submission.scope))
+		? submission.error.concat(getError(result.error))
 		: submission.error;
 
 	switch (submission.type) {
@@ -60,13 +60,10 @@ export default function TodoForm() {
 		onValidate({ form, submission }) {
 			const result = todoSchema.safeParse(submission.value);
 			const error = !result.success
-				? submission.error.concat(getError(result.error, submission.scope))
+				? submission.error.concat(getError(result.error))
 				: submission.error;
 
-			return reportValidity(form, {
-				...submission,
-				error,
-			});
+			return reportValidity(form, error);
 		},
 		onSubmit(event, { submission }) {
 			switch (submission.type) {

--- a/examples/remix/app/routes/index.tsx
+++ b/examples/remix/app/routes/index.tsx
@@ -28,9 +28,7 @@ export let action = async ({ request }: ActionArgs) => {
 	const formData = await request.formData();
 	const submission = parse(formData);
 	const result = todoSchema.safeParse(submission.value);
-	const error = !result.success
-		? submission.error.concat(getError(result.error))
-		: submission.error;
+	const error = submission.error.concat(getError(result));
 
 	switch (submission.type) {
 		case 'validate': {

--- a/examples/server-validation/app/routes/index.tsx
+++ b/examples/server-validation/app/routes/index.tsx
@@ -68,9 +68,7 @@ export let action = async ({ request }: ActionArgs) => {
 	if (!result.success || submission.type === 'validate') {
 		return json({
 			value: submission.value,
-			error: submission.error.concat(
-				!result.success ? getError(result.error) : [],
-			),
+			error: submission.error.concat(getError(result)),
 		});
 	}
 

--- a/examples/server-validation/app/routes/index.tsx
+++ b/examples/server-validation/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import type { FormState } from '@conform-to/react';
+import type { Submission } from '@conform-to/react';
 import {
 	conform,
 	parse,
@@ -79,8 +79,8 @@ export let action = async ({ request }: ActionArgs) => {
 };
 
 export default function EmployeeForm() {
-	// FormState returned from the server
-	const state = useActionData<FormState<Schema>>();
+	// Last submission returned from the server
+	const state = useActionData<Submission<Schema>>();
 
 	/**
 	 * The useForm hook now returns a `Form` object
@@ -115,9 +115,8 @@ export default function EmployeeForm() {
 			const hasEmailError = hasError(error, 'email');
 
 			if (
-				submission.type === 'validate' &&
-				submission.data === 'email' &&
-				!hasEmailError
+				(submission.type !== 'validate' || submission.metadata === 'email') &&
+				!hasError(error, 'email')
 			) {
 				// Consider the submission to be valid
 				return true;
@@ -136,7 +135,7 @@ export default function EmployeeForm() {
 			return reportValidity(form, error);
 		},
 		async onSubmit(event, { submission }) {
-			if (submission.type === 'validate' && submission.data !== 'email') {
+			if (submission.type === 'validate' && submission.metadata !== 'email') {
 				event.preventDefault();
 			}
 		},

--- a/examples/server-validation/app/routes/index.tsx
+++ b/examples/server-validation/app/routes/index.tsx
@@ -114,13 +114,14 @@ export default function EmployeeForm() {
 		onValidate({ form, submission }) {
 			// Similar to server validation without the extra refine()
 			const result = schema.safeParse(submission.value);
-			const error = submission.error.concat(
-				!result.success ? getError(result.error) : [],
-			);
+
+			if (!result.success) {
+				submission.error = submission.error.concat(getError(result.error));
+			}
 
 			if (
 				(submission.type !== 'validate' || submission.metadata === 'email') &&
-				!hasError(error, 'email')
+				!hasError(submission.error, 'email')
 			) {
 				// Consider the submission to be valid
 				return true;
@@ -131,7 +132,7 @@ export default function EmployeeForm() {
 			 * (1) Set all error to the dom and trigger the `invalid` event through `form.reportValidity()`
 			 * (2) Return whether the form is valid or not. If the form is invalid, stop it.
 			 */
-			return reportValidity(form, error);
+			return reportValidity(form, submission);
 		},
 		async onSubmit(event, { submission }) {
 			if (submission.type === 'validate' && submission.metadata !== 'email') {

--- a/examples/server-validation/app/routes/index.tsx
+++ b/examples/server-validation/app/routes/index.tsx
@@ -131,7 +131,7 @@ export default function EmployeeForm() {
 			 */
 			setFormError(form, submission);
 		},
-		async onSubmit(event, { submission }) {
+		onSubmit(event, { submission }) {
 			if (submission.type === 'validate' && submission.metadata !== 'email') {
 				event.preventDefault();
 			}

--- a/examples/server-validation/app/routes/index.tsx
+++ b/examples/server-validation/app/routes/index.tsx
@@ -5,6 +5,7 @@ import {
 	useFieldset,
 	useForm,
 	hasError,
+	shouldValidate,
 	reportValidity,
 } from '@conform-to/react';
 import { getError } from '@conform-to/zod';
@@ -120,7 +121,7 @@ export default function EmployeeForm() {
 			}
 
 			if (
-				(submission.type !== 'validate' || submission.metadata === 'email') &&
+				shouldValidate(submission, 'email') &&
 				!hasError(submission.error, 'email')
 			) {
 				// Consider the submission to be valid

--- a/examples/server-validation/app/routes/index.tsx
+++ b/examples/server-validation/app/routes/index.tsx
@@ -92,9 +92,14 @@ export default function EmployeeForm() {
 	 * (4) form.error: Form error. Set when an error with an empty string name is provided by the form state.
 	 */
 	const form = useForm<Schema>({
+		// Begin validating on blur
+		initialReport: 'onBlur',
+
+		// Enable server validation mode
+		mode: 'server-validation',
+
 		// Just hook it up with the result from useActionData()
 		state,
-		initialReport: 'onBlur',
 
 		/**
 		 * The validate hook - `onValidate(context: FormContext): boolean`
@@ -112,18 +117,12 @@ export default function EmployeeForm() {
 			const error = submission.error.concat(
 				!result.success ? getError(result.error) : [],
 			);
-			const hasEmailError = hasError(error, 'email');
 
 			if (
 				(submission.type !== 'validate' || submission.metadata === 'email') &&
 				!hasError(error, 'email')
 			) {
 				// Consider the submission to be valid
-				return true;
-			}
-
-			if (typeof submission.type === 'undefined' && !hasEmailError) {
-				// Consider the submission to be valid too
 				return true;
 			}
 

--- a/examples/server-validation/app/routes/index.tsx
+++ b/examples/server-validation/app/routes/index.tsx
@@ -6,7 +6,7 @@ import {
 	useForm,
 	hasError,
 	shouldValidate,
-	reportValidity,
+	setFormError,
 } from '@conform-to/react';
 import { getError } from '@conform-to/zod';
 import type { ActionArgs } from '@remix-run/node';
@@ -90,14 +90,14 @@ export default function EmployeeForm() {
 	 * (2) form.config: Fieldset config to be passed to the useFieldset hook.
 	 * 	   [Optional] Needed only if the fields have default value / nojs support is needed)
 	 * (3) form.ref: Ref object of the form element. Same as `form.props.ref`
-	 * (4) form.error: Form error. Set when an error with an empty string name is provided by the form state.
+	 * (4) form.error: Form error. Set when an error with an empty string name is provided.
 	 */
 	const form = useForm<Schema>({
-		// Begin validating on blur
-		initialReport: 'onBlur',
-
 		// Enable server validation mode
 		mode: 'server-validation',
+
+		// Begin validating on blur
+		initialReport: 'onBlur',
 
 		// Just hook it up with the result from useActionData()
 		state,
@@ -124,16 +124,14 @@ export default function EmployeeForm() {
 				shouldValidate(submission, 'email') &&
 				!hasError(submission.error, 'email')
 			) {
-				// Consider the submission to be valid
-				return true;
+				// Skip reporting client error
+				throw form;
 			}
 
 			/**
-			 * The `reportValidity` helper does 2 things for you:
-			 * (1) Set all error to the dom and trigger the `invalid` event through `form.reportValidity()`
-			 * (2) Return whether the form is valid or not. If the form is invalid, stop it.
+			 * Set the submission error to the dom
 			 */
-			return reportValidity(form, submission);
+			setFormError(form, submission);
 		},
 		async onSubmit(event, { submission }) {
 			if (submission.type === 'validate' && submission.metadata !== 'email') {

--- a/examples/server-validation/app/routes/index.tsx
+++ b/examples/server-validation/app/routes/index.tsx
@@ -44,8 +44,9 @@ export let action = async ({ request }: ActionArgs) => {
 	 * (1) `submission.value`: Structured form value based on the name (path)
 	 * (2) `submission.error`: Error (if any) while parsing the FormData object,
 	 * (3) `submission.type` : Type of the submission.
-	 * 		Set only when the user click on named button with pattern (`conform/${type}`),
-	 * 		e.g. `validate`
+	 * 		The type would be `undefined` when user click on any normal submit button.
+	 * 		It would be set only when the user click on named button with pattern (`conform/${type}`),
+	 * 		e.g. Conform is clicking on a button with name `conform/validate` when validating, so the type would be `valdiate`.
 	 */
 	const submission = parse(formData);
 	const result = await schema
@@ -67,7 +68,7 @@ export let action = async ({ request }: ActionArgs) => {
 	// Return the state to the client if the submission is made for validation purpose
 	if (!result.success || submission.type === 'validate') {
 		return json({
-			value: submission.value,
+			...submission,
 			error: submission.error.concat(getError(result)),
 		});
 	}
@@ -106,7 +107,6 @@ export default function EmployeeForm() {
 		 *
 		 * (1) Renamed from `validate` to `onValidate`
 		 * (2) Changed the function signature with a new context object, including `form`, `formData` and `submission`
-		 * (3) It should now returns a boolean indicating if the server validation is needed
 		 *
 		 * If both `onValidate` and `onSubmit` are commented out, then it will validate the form completely by server validation
 		 */

--- a/examples/validation/src/App.tsx
+++ b/examples/validation/src/App.tsx
@@ -10,7 +10,7 @@ export default function SignupForm() {
 	const form = useForm<Signup>({
 		onValidate({ form, submission }) {
 			for (const field of Array.from(form.elements)) {
-				if (isFieldElement(field) && submission.scope.includes(field.name)) {
+				if (isFieldElement(field)) {
 					switch (field.name) {
 						case 'email':
 							if (field.validity.valueMissing) {

--- a/examples/yup/src/App.tsx
+++ b/examples/yup/src/App.tsx
@@ -26,9 +26,7 @@ export default function SignupForm() {
 				});
 			} catch (error) {
 				if (error instanceof yup.ValidationError) {
-					submission.error = submission.error.concat(
-						getError(error, submission.scope),
-					);
+					submission.error = submission.error.concat(getError(error));
 				} else {
 					submission.error = submission.error.concat([
 						['', 'Validation failed'],
@@ -36,7 +34,7 @@ export default function SignupForm() {
 				}
 			}
 
-			return reportValidity(form, submission);
+			return reportValidity(form, submission.error);
 		},
 		onSubmit: async (event, { submission }) => {
 			event.preventDefault();

--- a/examples/yup/src/App.tsx
+++ b/examples/yup/src/App.tsx
@@ -34,7 +34,7 @@ export default function SignupForm() {
 				}
 			}
 
-			return reportValidity(form, submission.error);
+			return reportValidity(form, submission);
 		},
 		onSubmit: async (event, { submission }) => {
 			event.preventDefault();

--- a/examples/yup/src/App.tsx
+++ b/examples/yup/src/App.tsx
@@ -1,4 +1,4 @@
-import { useFieldset, useForm, reportValidity } from '@conform-to/react';
+import { useFieldset, useForm, setFormError } from '@conform-to/react';
 import { getError } from '@conform-to/yup';
 import * as yup from 'yup';
 
@@ -34,7 +34,7 @@ export default function SignupForm() {
 				}
 			}
 
-			return reportValidity(form, submission);
+			setFormError(form, submission);
 		},
 		onSubmit: async (event, { submission }) => {
 			event.preventDefault();

--- a/examples/zod/src/App.tsx
+++ b/examples/zod/src/App.tsx
@@ -23,11 +23,12 @@ export default function SignupForm() {
 	const form = useForm<z.infer<typeof schema>>({
 		onValidate({ form, submission }) {
 			const result = schema.safeParse(submission.value);
-			const error = submission.error.concat(
-				!result.success ? getError(result.error) : [],
-			);
 
-			return reportValidity(form, error);
+			if (!result.success) {
+				submission.error = submission.error.concat(getError(result.error));
+			}
+
+			return reportValidity(form, submission);
 		},
 		onSubmit: async (event, { submission }) => {
 			event.preventDefault();

--- a/examples/zod/src/App.tsx
+++ b/examples/zod/src/App.tsx
@@ -23,13 +23,11 @@ export default function SignupForm() {
 	const form = useForm<z.infer<typeof schema>>({
 		onValidate({ form, submission }) {
 			const result = schema.safeParse(submission.value);
+			const error = submission.error.concat(
+				!result.success ? getError(result.error) : [],
+			);
 
-			return reportValidity(form, {
-				...submission,
-				error: !result.success
-					? submission.error.concat(getError(result.error, submission.scope))
-					: submission.error,
-			});
+			return reportValidity(form, error);
 		},
 		onSubmit: async (event, { submission }) => {
 			event.preventDefault();

--- a/examples/zod/src/App.tsx
+++ b/examples/zod/src/App.tsx
@@ -1,4 +1,4 @@
-import { reportValidity, useFieldset, useForm } from '@conform-to/react';
+import { setFormError, useFieldset, useForm } from '@conform-to/react';
 import { getError } from '@conform-to/zod';
 import { z } from 'zod';
 
@@ -28,7 +28,7 @@ export default function SignupForm() {
 				submission.error = submission.error.concat(getError(result.error));
 			}
 
-			return reportValidity(form, submission);
+			setFormError(form, submission);
 		},
 		onSubmit: async (event, { submission }) => {
 			event.preventDefault();

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -108,6 +108,10 @@ export function getName(paths: Array<string | number>): string {
 	}, '');
 }
 
+export function shouldValidate(submission: Submission, name: string): boolean {
+	return submission.type !== 'validate' || submission.metadata === name;
+}
+
 export function hasError(
 	error: Array<[string, string]>,
 	name: string,
@@ -130,9 +134,8 @@ export function reportValidity(
 			const error = firstErrorByName[element.name];
 
 			if (
-				error ||
-				submission.type !== 'validate' ||
-				submission.metadata === element.name
+				typeof error !== 'undefined' ||
+				shouldValidate(submission, element.name)
 			) {
 				element.setCustomValidity(error ?? '');
 			}

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -123,10 +123,10 @@ export function hasError(
 	);
 }
 
-export function reportValidity(
+export function setFormError(
 	form: HTMLFormElement,
 	submission: Submission,
-): boolean {
+): void {
 	const firstErrorByName = Object.fromEntries([...submission.error].reverse());
 
 	for (const element of form.elements) {
@@ -141,8 +141,6 @@ export function reportValidity(
 			}
 		}
 	}
-
-	return form.reportValidity();
 }
 
 export function setValue<T>(

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -121,16 +121,22 @@ export function hasError(
 
 export function reportValidity(
 	form: HTMLFormElement,
-	error: Array<[string, string]>,
+	submission: Submission,
 ): boolean {
-	const firstErrorByName = Object.fromEntries([...error].reverse());
+	const firstErrorByName = Object.fromEntries([...submission.error].reverse());
 
 	for (const element of form.elements) {
-		if (!isFieldElement(element)) {
-			continue;
-		}
+		if (isFieldElement(element)) {
+			const error = firstErrorByName[element.name];
 
-		element.setCustomValidity(firstErrorByName[element.name] ?? '');
+			if (
+				error ||
+				submission.type !== 'validate' ||
+				submission.metadata === element.name
+			) {
+				element.setCustomValidity(error ?? '');
+			}
+		}
 	}
 
 	return form.reportValidity();

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -36,21 +36,18 @@ export type FieldsetConstraint<Schema extends Record<string, any>> = {
 	[Key in keyof Schema]?: FieldConstraint;
 };
 
-export type FormState<Schema = unknown> = {
-	value: FieldValue<Schema>;
-	error: Array<[string, string]>;
-};
-
-export type Submission<Schema = unknown> = FormState<Schema> &
-	(
-		| {
-				type?: undefined;
-		  }
-		| {
-				type: string;
-				data: string;
-		  }
-	);
+export type Submission<Schema = unknown> =
+	| {
+			type?: undefined;
+			value: FieldValue<Schema>;
+			error: Array<[string, string]>;
+	  }
+	| {
+			type: string;
+			metadata: string;
+			value: FieldValue<Schema>;
+			error: Array<[string, string]>;
+	  };
 
 export function isFieldElement(element: unknown): element is FieldElement {
 	return (
@@ -268,7 +265,7 @@ export function parse<Schema extends Record<string, any>>(
 				submission = {
 					...submission,
 					type: submissionType,
-					data: value,
+					metadata: value,
 				};
 			} else {
 				const paths = getPaths(name);
@@ -376,7 +373,7 @@ export function handleList<Schema>(
 		return submission;
 	}
 
-	const command = parseListCommand(submission.data);
+	const command = parseListCommand(submission.metadata);
 	const paths = getPaths(command.scope);
 
 	setValue(submission.value, paths, (list) => {

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -16,8 +16,8 @@ import {
 	parse,
 	parseListCommand,
 	requestSubmit,
-	reportValidity,
 	requestValidate,
+	setFormError,
 	updateList,
 } from '@conform-to/dom';
 import {
@@ -77,7 +77,7 @@ export interface FormConfig<Schema extends Record<string, any>> {
 	/**
 	 * A function to be called when the form should be (re)validated.
 	 */
-	onValidate?: (context: FormContext<Schema>) => boolean;
+	onValidate?: (context: FormContext<Schema>) => void;
 
 	/**
 	 * The submit event handler of the form. It will be called
@@ -152,7 +152,9 @@ export function useForm<Schema extends Record<string, any>>(
 			return;
 		}
 
-		if (!reportValidity(form, config.state)) {
+		setFormError(form, config.state);
+
+		if (!form.reportValidity()) {
 			focusFirstInvalidField(form);
 		}
 
@@ -310,27 +312,28 @@ export function useForm<Schema extends Record<string, any>>(
 
 				try {
 					if (!config.noValidate && !submitter.formNoValidate) {
-						const isValid =
-							config.onValidate?.(context) ?? form.reportValidity();
+						config.onValidate?.(context);
 
-						if (!isValid) {
+						if (!form.reportValidity()) {
 							focusFirstInvalidField(form);
 							event.preventDefault();
 						}
 					}
-
-					if (!event.defaultPrevented) {
-						if (
-							config.mode !== 'server-validation' &&
-							submission.type === 'validate'
-						) {
-							event.preventDefault();
-						} else {
-							config.onSubmit?.(event, context);
-						}
-					}
 				} catch (e) {
-					console.warn(e);
+					if (e !== form) {
+						console.warn(e);
+					}
+				}
+
+				if (!event.defaultPrevented) {
+					if (
+						config.mode !== 'server-validation' &&
+						submission.type === 'validate'
+					) {
+						event.preventDefault();
+					} else {
+						config.onSubmit?.(event, context);
+					}
 				}
 			},
 		},

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -3,7 +3,6 @@ import {
 	type FieldElement,
 	type FieldValue,
 	type FieldsetConstraint,
-	type FormState,
 	type ListCommand,
 	type Primitive,
 	type Submission,
@@ -54,7 +53,7 @@ export interface FormConfig<Schema extends Record<string, any>> {
 	/**
 	 * An object describing the state from the last submission
 	 */
-	state?: FormState<Schema>;
+	state?: Submission<Schema>;
 
 	/**
 	 * Enable native validation before hydation.

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -152,7 +152,7 @@ export function useForm<Schema extends Record<string, any>>(
 			return;
 		}
 
-		if (!reportValidity(form, config.state.error)) {
+		if (!reportValidity(form, config.state)) {
 			focusFirstInvalidField(form);
 		}
 

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -509,13 +509,16 @@ export function useFieldset<Schema extends Record<string, any>>(
 
 				for (const field of form.elements) {
 					if (isFieldElement(field) && field.name.startsWith(fieldsetName)) {
-						const prevMessage = next?.[field.name] ?? '';
+						const key = fieldsetName
+							? field.name.slice(fieldsetName.length + 1)
+							: field.name;
+						const prevMessage = next?.[key] ?? '';
 						const nextMessage = field.validationMessage;
 
 						if (prevMessage !== '' && nextMessage === '') {
 							next = {
 								...next,
-								[field.name]: '',
+								[key]: '',
 							};
 						}
 					}

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -2,6 +2,7 @@ export {
 	type FieldsetConstraint,
 	type Submission,
 	hasError,
+	shouldValidate,
 	isFieldElement,
 	parse,
 	reportValidity,

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -1,6 +1,5 @@
 export {
 	type FieldsetConstraint,
-	type FormState,
 	type Submission,
 	hasError,
 	isFieldElement,

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -2,10 +2,10 @@ export {
 	type FieldsetConstraint,
 	type Submission,
 	hasError,
-	shouldValidate,
 	isFieldElement,
 	parse,
-	reportValidity,
+	setFormError,
+	shouldValidate,
 } from '@conform-to/dom';
 export * from './hooks';
 export * as conform from './helpers';

--- a/packages/conform-yup/index.ts
+++ b/packages/conform-yup/index.ts
@@ -84,15 +84,10 @@ export function getFieldsetConstraint<Source extends yup.AnyObjectSchema>(
 
 export function getError(
 	error: yup.ValidationError | null,
-	scope?: string[],
 ): Array<[string, string]> {
 	return (
 		error?.inner.reduce<Array<[string, string]>>((result, e) => {
-			const name = e.path ?? '';
-
-			if (!scope || scope.includes(name)) {
-				result.push([name, e.message]);
-			}
+			result.push([e.path ?? '', e.message]);
 
 			return result;
 		}, []) ?? []

--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -110,15 +110,10 @@ export function getFieldsetConstraint<Source extends z.ZodTypeAny>(
 
 export function getError(
 	error: z.ZodError<any> | null,
-	scope?: string[],
 ): Array<[string, string]> {
 	return (
 		error?.errors.reduce<Array<[string, string]>>((result, e) => {
-			const name = getName(e.path);
-
-			if (!scope || scope.includes(name)) {
-				result.push([name, e.message]);
-			}
+			result.push([getName(e.path), e.message]);
 
 			return result;
 		}, []) ?? []

--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -108,16 +108,25 @@ export function getFieldsetConstraint<Source extends z.ZodTypeAny>(
 	return result;
 }
 
-export function getError(
-	error: z.ZodError<any> | null,
+export function getError<Schema>(
+	result: z.SafeParseReturnType<unknown, Schema> | z.ZodError<Schema>,
 ): Array<[string, string]> {
-	return (
-		error?.errors.reduce<Array<[string, string]>>((result, e) => {
-			result.push([getName(e.path), e.message]);
+	const issues =
+		result instanceof z.ZodError
+			? result.errors
+			: !result.success
+			? result.error.errors
+			: null;
 
-			return result;
-		}, []) ?? []
-	);
+	if (!issues) {
+		return [];
+	}
+
+	return issues.reduce<Array<[string, string]>>((result, e) => {
+		result.push([getName(e.path), e.message]);
+
+		return result;
+	}, []);
 }
 
 export function ifNonEmptyString(

--- a/playground/app/components.tsx
+++ b/playground/app/components.tsx
@@ -1,4 +1,4 @@
-import type { FormState } from '@conform-to/react';
+import type { Submission } from '@conform-to/react';
 import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 
@@ -6,7 +6,7 @@ interface PlaygroundProps {
 	title: string;
 	description?: string;
 	form?: string;
-	state?: FormState<Record<string, unknown>>;
+	state?: Submission<Record<string, unknown>>;
 	children: ReactNode;
 }
 
@@ -17,10 +17,10 @@ export function Playground({
 	state,
 	children,
 }: PlaygroundProps) {
-	const [status, setFormState] = useState(state ?? null);
+	const [submission, setSubmission] = useState(state ?? null);
 
 	useEffect(() => {
-		setFormState(state ?? null);
+		setSubmission(state ?? null);
 	}, [state]);
 
 	return (
@@ -35,17 +35,17 @@ export function Playground({
 					</h3>
 					<p className="mt-1 mb-2 text-sm text-gray-600">{description}</p>
 				</header>
-				{status ? (
+				{submission ? (
 					<details open={true}>
 						<summary>Submission</summary>
 						<pre
 							className={`m-4 border-l-4 overflow-x-scroll ${
-								status.error.length > 0
+								submission.error.length > 0
 									? 'border-pink-600'
 									: 'border-emerald-500'
 							} pl-4 py-2 mt-4`}
 						>
-							{JSON.stringify(status, null, 2)}
+							{JSON.stringify(submission, null, 2)}
 						</pre>
 					</details>
 				) : null}
@@ -59,7 +59,7 @@ export function Playground({
 						<button
 							type="submit"
 							className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-							onClick={() => setFormState(null)}
+							onClick={() => setSubmission(null)}
 							form={form}
 						>
 							Submit
@@ -67,7 +67,7 @@ export function Playground({
 						<button
 							type="reset"
 							className="inline-flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-gray-700 bg-gray-50 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-							onClick={() => setFormState(null)}
+							onClick={() => setSubmission(null)}
 							form={form}
 						>
 							Reset

--- a/playground/app/config.ts
+++ b/playground/app/config.ts
@@ -2,6 +2,7 @@ import { ifNonEmptyString } from '@conform-to/zod';
 import { z } from 'zod';
 
 const formConfig = z.object({
+	mode: z.enum(['client-only', 'server-validation']).optional(),
 	initialReport: z.enum(['onSubmit', 'onChange', 'onBlur']).optional(),
 	defaultValue: z
 		.preprocess((value) => (value ? JSON.stringify(value) : undefined), z.any())

--- a/playground/app/routes/employee.tsx
+++ b/playground/app/routes/employee.tsx
@@ -64,20 +64,21 @@ export default function EmployeeForm() {
 		state,
 		onValidate({ form, submission }) {
 			const result = schema.safeParse(submission.value);
-			const error = submission.error.concat(
-				!result.success ? getError(result.error) : [],
-			);
+
+			if (!result.success) {
+				submission.error = submission.error.concat(getError(result.error));
+			}
 
 			if (config.mode === 'server-validation') {
 				if (
 					(submission.type !== 'validate' || submission.metadata === 'email') &&
-					!hasError(error, 'email')
+					!hasError(submission.error, 'email')
 				) {
 					return true;
 				}
 			}
 
-			return reportValidity(form, error);
+			return reportValidity(form, submission);
 		},
 		onSubmit:
 			config.mode === 'server-validation'

--- a/playground/app/routes/employee.tsx
+++ b/playground/app/routes/employee.tsx
@@ -4,7 +4,7 @@ import {
 	useFieldset,
 	useForm,
 	hasError,
-	reportValidity,
+	setFormError,
 	shouldValidate,
 } from '@conform-to/react';
 import { getError } from '@conform-to/zod';
@@ -75,11 +75,11 @@ export default function EmployeeForm() {
 					shouldValidate(submission, 'email') &&
 					!hasError(submission.error, 'email')
 				) {
-					return true;
+					throw form;
 				}
 			}
 
-			return reportValidity(form, submission);
+			setFormError(form, submission);
 		},
 		onSubmit:
 			config.mode === 'server-validation'

--- a/playground/app/routes/employee.tsx
+++ b/playground/app/routes/employee.tsx
@@ -68,20 +68,28 @@ export default function EmployeeForm() {
 				!result.success ? getError(result.error) : [],
 			);
 
-			if (
-				(submission.type !== 'validate' || submission.metadata === 'email') &&
-				!hasError(error, 'email')
-			) {
-				return true;
+			if (config.mode === 'server-validation') {
+				if (
+					(submission.type !== 'validate' || submission.metadata === 'email') &&
+					!hasError(error, 'email')
+				) {
+					return true;
+				}
 			}
 
 			return reportValidity(form, error);
 		},
-		async onSubmit(event, { submission }) {
-			if (submission.type === 'validate' && submission.metadata !== 'email') {
-				event.preventDefault();
-			}
-		},
+		onSubmit:
+			config.mode === 'server-validation'
+				? (event, { submission }) => {
+						if (
+							submission.type === 'validate' &&
+							submission.metadata !== 'email'
+						) {
+							event.preventDefault();
+						}
+				  }
+				: undefined,
 	});
 	const { name, email, title } = useFieldset(form.ref, form.config);
 

--- a/playground/app/routes/employee.tsx
+++ b/playground/app/routes/employee.tsx
@@ -5,6 +5,7 @@ import {
 	useForm,
 	hasError,
 	reportValidity,
+	shouldValidate,
 } from '@conform-to/react';
 import { getError } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
@@ -71,7 +72,7 @@ export default function EmployeeForm() {
 
 			if (config.mode === 'server-validation') {
 				if (
-					(submission.type !== 'validate' || submission.metadata === 'email') &&
+					shouldValidate(submission, 'email') &&
 					!hasError(submission.error, 'email')
 				) {
 					return true;

--- a/playground/app/routes/employee.tsx
+++ b/playground/app/routes/employee.tsx
@@ -31,10 +31,7 @@ export let action = async ({ request }: ActionArgs) => {
 	const result = await schema
 		.refine(
 			async (employee) => {
-				if (
-					(submission.type === 'validate' && submission.data === 'email') ||
-					typeof submission.type === 'undefined'
-				) {
+				if (submission.type !== 'validate' || submission.metadata === 'email') {
 					return new Promise((resolve) => {
 						setTimeout(() => {
 							resolve(employee.email === 'hey@conform.guide');
@@ -70,31 +67,18 @@ export default function EmployeeForm() {
 			const error = submission.error.concat(
 				!result.success ? getError(result.error) : [],
 			);
-			const hasEmailError = hasError(error, 'email');
 
 			if (
-				submission.type === 'validate' &&
-				submission.data === 'email' &&
-				!hasEmailError
+				(submission.type !== 'validate' || submission.metadata === 'email') &&
+				!hasError(error, 'email')
 			) {
-				// Consider the submission to be valid
 				return true;
 			}
 
-			if (typeof submission.type === 'undefined' && !hasEmailError) {
-				// Consider the submission to be valid too
-				return true;
-			}
-
-			/**
-			 * The `reportValidity` helper does 2 things for you:
-			 * (1) Set all error to the dom and trigger the `invalid` event through `form.reportValidity()`
-			 * (2) Return whether the form is valid or not. If the form is invalid, stop it.
-			 */
 			return reportValidity(form, error);
 		},
 		async onSubmit(event, { submission }) {
-			if (submission.type === 'validate' && submission.data !== 'email') {
+			if (submission.type === 'validate' && submission.metadata !== 'email') {
 				event.preventDefault();
 			}
 		},

--- a/playground/app/routes/employee.tsx
+++ b/playground/app/routes/employee.tsx
@@ -51,9 +51,7 @@ export let action = async ({ request }: ActionArgs) => {
 
 	return {
 		...submission,
-		error: submission.error.concat(
-			!result.success ? getError(result.error) : [],
-		),
+		error: submission.error.concat(getError(result)),
 	};
 };
 

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -1,5 +1,4 @@
 import {
-	type FormState,
 	type Submission,
 	conform,
 	useFieldset,
@@ -17,7 +16,7 @@ interface Login {
 	password: string;
 }
 
-function validate(submission: Submission<Login>): FormState<Login> {
+function validate(submission: Submission<Login>): Submission<Login> {
 	if (!submission.value.email) {
 		submission.error.push(['email', 'Email is required']);
 	}

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -18,14 +18,11 @@ interface Login {
 }
 
 function validate(submission: Submission<Login>): FormState<Login> {
-	if (submission.scope.includes('email') && submission.value.email === '') {
+	if (!submission.value.email) {
 		submission.error.push(['email', 'Email is required']);
 	}
 
-	if (
-		submission.scope.includes('password') &&
-		submission.value.password === ''
-	) {
+	if (!submission.value.password) {
 		submission.error.push(['password', 'Password is required']);
 	}
 
@@ -68,7 +65,7 @@ export default function LoginForm() {
 			? ({ form, submission }) => {
 					const state = validate(submission);
 
-					return reportValidity(form, state);
+					return reportValidity(form, state.error);
 			  }
 			: undefined,
 		onSubmit(event, { submission }) {

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -64,7 +64,7 @@ export default function LoginForm() {
 			? ({ form, submission }) => {
 					const state = validate(submission);
 
-					return reportValidity(form, state.error);
+					return reportValidity(form, state);
 			  }
 			: undefined,
 		onSubmit:

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -67,14 +67,14 @@ export default function LoginForm() {
 					return reportValidity(form, state.error);
 			  }
 			: undefined,
-		onSubmit(event, { submission }) {
-			switch (submission.type) {
-				case 'validate': {
-					event.preventDefault();
-					break;
-				}
-			}
-		},
+		onSubmit:
+			config.mode === 'server-validation'
+				? (event, { submission }) => {
+						if (submission.type === 'validate') {
+							event.preventDefault();
+						}
+				  }
+				: undefined,
 	});
 	const { email, password } = useFieldset(form.ref, form.config);
 

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -4,7 +4,7 @@ import {
 	useFieldset,
 	useForm,
 	parse,
-	reportValidity,
+	setFormError,
 } from '@conform-to/react';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
@@ -64,7 +64,7 @@ export default function LoginForm() {
 			? ({ form, submission }) => {
 					const state = validate(submission);
 
-					return reportValidity(form, state);
+					setFormError(form, state);
 			  }
 			: undefined,
 		onSubmit:

--- a/playground/app/routes/movie.tsx
+++ b/playground/app/routes/movie.tsx
@@ -128,14 +128,14 @@ export default function MovieForm() {
 					return form.reportValidity();
 			  }
 			: undefined,
-		onSubmit(event, { submission }) {
-			switch (submission.type) {
-				case 'validate': {
-					event.preventDefault();
-					break;
-				}
-			}
-		},
+		onSubmit:
+			config.mode === 'server-validation'
+				? (event, { submission }) => {
+						if (submission.type === 'validate') {
+							event.preventDefault();
+						}
+				  }
+				: undefined,
 	});
 	const { title, description, genre, rating } = useFieldset(form.ref, {
 		...form.config,

--- a/playground/app/routes/movie.tsx
+++ b/playground/app/routes/movie.tsx
@@ -89,10 +89,7 @@ export default function MovieForm() {
 		onValidate: config.validate
 			? ({ form, submission }) => {
 					for (const field of form.elements) {
-						if (
-							isFieldElement(field) &&
-							submission.scope.includes(field.name)
-						) {
+						if (isFieldElement(field)) {
 							switch (field.name) {
 								case 'title':
 									if (field.validity.valueMissing) {

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -53,7 +53,7 @@ export let action = async ({ request }: ActionArgs) => {
 	if (!result.success) {
 		return {
 			...submission,
-			error: getError(result.error),
+			error: submission.error.concat(getError(result.error)),
 		};
 	}
 

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -43,7 +43,7 @@ export let action = async ({ request }: ActionArgs) => {
 	if (!result.success) {
 		return {
 			...submission,
-			error: getError(result.error, submission.scope),
+			error: getError(result.error),
 		};
 	}
 

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -56,14 +56,14 @@ export default function PaymentForm() {
 	const form = useForm<z.infer<typeof schema>>({
 		...config,
 		state,
-		onSubmit(event, { submission }) {
-			switch (submission.type) {
-				case 'validate': {
-					event.preventDefault();
-					break;
-				}
-			}
-		},
+		onSubmit:
+			config.mode === 'server-validation'
+				? (event, { submission }) => {
+						if (submission.type === 'validate') {
+							event.preventDefault();
+						}
+				  }
+				: undefined,
 	});
 	const { iban, amount, timestamp, verified } = useFieldset(form.ref, {
 		...form.config,

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -69,11 +69,12 @@ export default function PaymentForm() {
 		onValidate: config.validate
 			? ({ form, submission }) => {
 					const result = schema.safeParse(submission.value);
-					const error = submission.error.concat(
-						!result.success ? getError(result.error) : [],
-					);
 
-					return reportValidity(form, error);
+					if (!result.success) {
+						submission.error = submission.error.concat(getError(result.error));
+					}
+
+					return reportValidity(form, submission);
 			  }
 			: undefined,
 		onSubmit:

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -1,7 +1,7 @@
 import {
 	conform,
 	parse,
-	reportValidity,
+	setFormError,
 	useFieldset,
 	useForm,
 } from '@conform-to/react';
@@ -74,7 +74,7 @@ export default function PaymentForm() {
 						submission.error = submission.error.concat(getError(result.error));
 					}
 
-					return reportValidity(form, submission);
+					setFormError(form, submission);
 			  }
 			: undefined,
 		onSubmit:

--- a/playground/app/routes/signup.tsx
+++ b/playground/app/routes/signup.tsx
@@ -4,7 +4,7 @@ import {
 	parse,
 	useFieldset,
 	useForm,
-	reportValidity,
+	setFormError,
 } from '@conform-to/react';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
@@ -70,7 +70,7 @@ export default function SignupForm() {
 			? ({ form, submission }) => {
 					const state = validate(submission);
 
-					return reportValidity(form, state);
+					setFormError(form, state);
 			  }
 			: undefined,
 		onSubmit:

--- a/playground/app/routes/signup.tsx
+++ b/playground/app/routes/signup.tsx
@@ -73,11 +73,14 @@ export default function SignupForm() {
 					return reportValidity(form, state.error);
 			  }
 			: undefined,
-		async onSubmit(event, { submission }) {
-			if (submission.type === 'validate') {
-				event.preventDefault();
-			}
-		},
+		onSubmit:
+			config.mode === 'server-validation'
+				? (event, { submission }) => {
+						if (submission.type === 'validate') {
+							event.preventDefault();
+						}
+				  }
+				: undefined,
 	});
 	const { email, password, confirmPassword } = useFieldset(form.ref, {
 		...form.config,

--- a/playground/app/routes/signup.tsx
+++ b/playground/app/routes/signup.tsx
@@ -1,4 +1,4 @@
-import type { FormState, Submission } from '@conform-to/react';
+import type { Submission } from '@conform-to/react';
 import {
 	conform,
 	parse,
@@ -17,7 +17,7 @@ interface Signup {
 	confirmPassword: string;
 }
 
-function validate(submission: Submission<Signup>): FormState<Signup> {
+function validate(submission: Submission<Signup>): Submission<Signup> {
 	const error = [...submission.error];
 	const { email, password, confirmPassword } = submission.value;
 

--- a/playground/app/routes/signup.tsx
+++ b/playground/app/routes/signup.tsx
@@ -18,48 +18,25 @@ interface Signup {
 }
 
 function validate(submission: Submission<Signup>): FormState<Signup> {
-	const scope = new Set(submission.scope);
 	const error = [...submission.error];
 	const { email, password, confirmPassword } = submission.value;
 
-	for (const field of scope) {
-		switch (field) {
-			case 'email': {
-				if (typeof email === 'undefined' || email === '') {
-					error.push([field, 'Email is required']);
-				} else if (!email.match(/^[^()@\s]+@[\w\d.]+$/)) {
-					error.push([field, 'Email is invalid']);
-				}
-				break;
-			}
-			case 'password': {
-				if (!scope.has('confirmPassword')) {
-					scope.add('confirmPassword');
-				}
+	if (!email) {
+		error.push(['email', 'Email is required']);
+	} else if (!email.match(/^[^()@\s]+@[\w\d.]+$/)) {
+		error.push(['email', 'Email is invalid']);
+	}
 
-				if (typeof password === 'undefined' || password === '') {
-					error.push(['password', 'Password is required']);
-				} else if (`${password}`.length < 8) {
-					error.push(['password', 'Password is too short']);
-				}
-				break;
-			}
-			case 'confirmPassword': {
-				if (!scope.has('password')) {
-					scope.add('password');
-				}
+	if (!password) {
+		error.push(['password', 'Password is required']);
+	} else if (password.length < 8) {
+		error.push(['password', 'Password is too short']);
+	}
 
-				if (typeof confirmPassword === 'undefined' || confirmPassword === '') {
-					error.push(['confirmPassword', 'Confirm password is required']);
-				} else if (confirmPassword !== password) {
-					error.push([
-						'confirmPassword',
-						'The password provided does not match',
-					]);
-				}
-				break;
-			}
-		}
+	if (!confirmPassword) {
+		error.push(['confirmPassword', 'Confirm password is required']);
+	} else if (confirmPassword !== password) {
+		error.push(['confirmPassword', 'The password provided does not match']);
 	}
 
 	return {
@@ -67,7 +44,6 @@ function validate(submission: Submission<Signup>): FormState<Signup> {
 			email,
 			// Never send the password back to the client
 		},
-		scope: Array.from(scope),
 		error,
 	};
 }
@@ -94,17 +70,12 @@ export default function SignupForm() {
 			? ({ form, submission }) => {
 					const state = validate(submission);
 
-					return reportValidity(form, state);
+					return reportValidity(form, state.error);
 			  }
 			: undefined,
 		async onSubmit(event, { submission }) {
-			switch (submission.type) {
-				case 'validate': {
-					if (submission.data !== 'username') {
-						event.preventDefault();
-					}
-					break;
-				}
+			if (submission.type === 'validate') {
+				event.preventDefault();
 			}
 		},
 	});

--- a/playground/app/routes/signup.tsx
+++ b/playground/app/routes/signup.tsx
@@ -70,7 +70,7 @@ export default function SignupForm() {
 			? ({ form, submission }) => {
 					const state = validate(submission);
 
-					return reportValidity(form, state.error);
+					return reportValidity(form, state);
 			  }
 			: undefined,
 		onSubmit:

--- a/playground/app/routes/student.tsx
+++ b/playground/app/routes/student.tsx
@@ -34,9 +34,7 @@ function validate(submission: Submission<Schema>): FormState<Schema> {
 		});
 	} catch (error) {
 		if (error instanceof yup.ValidationError) {
-			submission.error = submission.error.concat(
-				getError(error, submission.scope),
-			);
+			submission.error = submission.error.concat(getError(error));
 		} else {
 			submission.error = submission.error.concat([['', 'Validation failed']]);
 		}
@@ -66,7 +64,7 @@ export default function StudentForm() {
 			? ({ form, submission }) => {
 					const state = validate(submission);
 
-					return reportValidity(form, state);
+					return reportValidity(form, state.error);
 			  }
 			: undefined,
 		onSubmit(event, { submission }) {

--- a/playground/app/routes/student.tsx
+++ b/playground/app/routes/student.tsx
@@ -67,14 +67,14 @@ export default function StudentForm() {
 					return reportValidity(form, state.error);
 			  }
 			: undefined,
-		onSubmit(event, { submission }) {
-			switch (submission.type) {
-				case 'validate': {
-					event.preventDefault();
-					break;
-				}
-			}
-		},
+		onSubmit:
+			config.mode === 'server-validation'
+				? (event, { submission }) => {
+						if (submission.type === 'validate') {
+							event.preventDefault();
+						}
+				  }
+				: undefined,
 	});
 	const { name, remarks, grade, score } = useFieldset(form.ref, {
 		...form.config,

--- a/playground/app/routes/student.tsx
+++ b/playground/app/routes/student.tsx
@@ -64,7 +64,7 @@ export default function StudentForm() {
 			? ({ form, submission }) => {
 					const state = validate(submission);
 
-					return reportValidity(form, state.error);
+					return reportValidity(form, state);
 			  }
 			: undefined,
 		onSubmit:

--- a/playground/app/routes/student.tsx
+++ b/playground/app/routes/student.tsx
@@ -1,4 +1,4 @@
-import type { FormState, Submission } from '@conform-to/react';
+import type { Submission } from '@conform-to/react';
 import {
 	conform,
 	useFieldset,
@@ -27,7 +27,7 @@ const schema = yup.object({
 
 type Schema = yup.InferType<typeof schema>;
 
-function validate(submission: Submission<Schema>): FormState<Schema> {
+function validate(submission: Submission<Schema>): Submission<Schema> {
 	try {
 		schema.validateSync(submission.value, {
 			abortEarly: false,

--- a/playground/app/routes/student.tsx
+++ b/playground/app/routes/student.tsx
@@ -4,7 +4,7 @@ import {
 	useFieldset,
 	useForm,
 	parse,
-	reportValidity,
+	setFormError,
 } from '@conform-to/react';
 import { getFieldsetConstraint, getError } from '@conform-to/yup';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
@@ -64,7 +64,7 @@ export default function StudentForm() {
 			? ({ form, submission }) => {
 					const state = validate(submission);
 
-					return reportValidity(form, state);
+					setFormError(form, state);
 			  }
 			: undefined,
 		onSubmit:

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -56,11 +56,12 @@ export default function TodosForm() {
 		onValidate: config.validate
 			? ({ form, submission }) => {
 					const result = schema.safeParse(submission.value);
-					const error = submission.error.concat(
-						!result.success ? getError(result.error) : [],
-					);
 
-					return reportValidity(form, error);
+					if (!result.success) {
+						submission.error = submission.error.concat(getError(result.error));
+					}
+
+					return reportValidity(form, submission);
 			  }
 			: undefined,
 		onSubmit:

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -40,7 +40,7 @@ export let action = async ({ request }: ActionArgs) => {
 	if (!result.success) {
 		return {
 			...submission,
-			error: submission.error.concat(getError(result.error, submission.scope)),
+			error: submission.error.concat(getError(result.error)),
 		};
 	}
 
@@ -56,11 +56,11 @@ export default function TodosForm() {
 		onValidate: config.validate
 			? ({ form, submission }) => {
 					const result = schema.safeParse(submission.value);
+					const error = submission.error.concat(
+						!result.success ? getError(result.error) : [],
+					);
 
-					return reportValidity(form, {
-						...submission,
-						error: !result.success ? getError(result.error) : submission.error,
-					});
+					return reportValidity(form, error);
 			  }
 			: undefined,
 		onSubmit(event, { submission }) {

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -63,14 +63,14 @@ export default function TodosForm() {
 					return reportValidity(form, error);
 			  }
 			: undefined,
-		onSubmit(event, { submission }) {
-			switch (submission.type) {
-				case 'validate': {
-					event.preventDefault();
-					break;
-				}
-			}
-		},
+		onSubmit:
+			config.mode === 'server-validation'
+				? (event, { submission }) => {
+						if (submission.type === 'validate') {
+							event.preventDefault();
+						}
+				  }
+				: undefined,
 	});
 
 	return (

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -5,7 +5,7 @@ import {
 	useFieldset,
 	useForm,
 	parse,
-	reportValidity,
+	setFormError,
 } from '@conform-to/react';
 import { getError, getFieldsetConstraint } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
@@ -61,7 +61,7 @@ export default function TodosForm() {
 						submission.error = submission.error.concat(getError(result.error));
 					}
 
-					return reportValidity(form, submission);
+					setFormError(form, submission);
 			  }
 			: undefined,
 		onSubmit:

--- a/tests/conform-dom.spec.ts
+++ b/tests/conform-dom.spec.ts
@@ -27,7 +27,6 @@ test.describe('conform-dom', () => {
 					]),
 				),
 			).toEqual({
-				scope: ['', 'title', 'description'],
 				value: {
 					title: 'The cat',
 					description: 'Once upon a time...',
@@ -44,14 +43,6 @@ test.describe('conform-dom', () => {
 					]),
 				),
 			).toEqual({
-				scope: [
-					'',
-					'account',
-					'amount',
-					'amount.currency',
-					'amount.value',
-					'reference',
-				],
 				value: {
 					account: 'AB00 1111 2222 3333 4444',
 					amount: {
@@ -72,16 +63,6 @@ test.describe('conform-dom', () => {
 					]),
 				),
 			).toEqual({
-				scope: [
-					'',
-					'title',
-					'tasks',
-					'tasks[0]',
-					'tasks[0].content',
-					'tasks[0].completed',
-					'tasks[1]',
-					'tasks[1].content',
-				],
 				value: {
 					title: '',
 					tasks: [
@@ -102,7 +83,6 @@ test.describe('conform-dom', () => {
 					]),
 				),
 			).toEqual({
-				scope: ['', 'title', 'description'],
 				value: {
 					title: 'The cat',
 					description: 'Once upon a time...',
@@ -122,7 +102,6 @@ test.describe('conform-dom', () => {
 			).toEqual({
 				type: 'test',
 				data: 'command value',
-				scope: ['', 'title'],
 				value: {
 					title: 'Test command',
 				},
@@ -138,7 +117,6 @@ test.describe('conform-dom', () => {
 			).toEqual({
 				type: 'list',
 				data: JSON.stringify({ greeting: 'Hello World' }),
-				scope: ['', 'title'],
 				value: {
 					title: '',
 				},
@@ -158,7 +136,6 @@ test.describe('conform-dom', () => {
 			];
 			const result = {
 				type: 'list',
-				scope: ['tasks'],
 				value: {
 					tasks: [{ content: 'Test some stuffs', completed: 'Yes' }],
 				},

--- a/tests/conform-dom.spec.ts
+++ b/tests/conform-dom.spec.ts
@@ -101,7 +101,7 @@ test.describe('conform-dom', () => {
 				),
 			).toEqual({
 				type: 'test',
-				data: 'command value',
+				metadata: 'command value',
 				value: {
 					title: 'Test command',
 				},
@@ -116,7 +116,7 @@ test.describe('conform-dom', () => {
 				),
 			).toEqual({
 				type: 'list',
-				data: JSON.stringify({ greeting: 'Hello World' }),
+				metadata: JSON.stringify({ greeting: 'Hello World' }),
 				value: {
 					title: '',
 				},
@@ -154,7 +154,11 @@ test.describe('conform-dom', () => {
 				),
 			).toEqual({
 				...result,
-				data: JSON.stringify({ type: 'prepend', scope: 'tasks', payload: {} }),
+				metadata: JSON.stringify({
+					type: 'prepend',
+					scope: 'tasks',
+					payload: {},
+				}),
 				value: {
 					tasks: [undefined, ...result.value.tasks],
 				},
@@ -175,7 +179,7 @@ test.describe('conform-dom', () => {
 				),
 			).toEqual({
 				...result,
-				data: JSON.stringify({
+				metadata: JSON.stringify({
 					type: 'prepend',
 					scope: 'tasks',
 					payload: { defaultValue: { content: 'Something' } },
@@ -196,7 +200,11 @@ test.describe('conform-dom', () => {
 				),
 			).toEqual({
 				...result,
-				data: JSON.stringify({ type: 'append', scope: 'tasks', payload: {} }),
+				metadata: JSON.stringify({
+					type: 'append',
+					scope: 'tasks',
+					payload: {},
+				}),
 				value: {
 					tasks: [...result.value.tasks, undefined],
 				},
@@ -217,7 +225,7 @@ test.describe('conform-dom', () => {
 				),
 			).toEqual({
 				...result,
-				data: JSON.stringify({
+				metadata: JSON.stringify({
 					type: 'append',
 					scope: 'tasks',
 					payload: { defaultValue: { content: 'Something' } },
@@ -242,7 +250,7 @@ test.describe('conform-dom', () => {
 				),
 			).toEqual({
 				...result,
-				data: JSON.stringify({
+				metadata: JSON.stringify({
 					type: 'replace',
 					scope: 'tasks',
 					payload: { defaultValue: { content: 'Something' }, index: 0 },
@@ -267,7 +275,7 @@ test.describe('conform-dom', () => {
 				),
 			).toEqual({
 				...result,
-				data: JSON.stringify({
+				metadata: JSON.stringify({
 					type: 'remove',
 					scope: 'tasks',
 					payload: { index: 0 },
@@ -293,7 +301,7 @@ test.describe('conform-dom', () => {
 				),
 			).toEqual({
 				...result,
-				data: JSON.stringify({
+				metadata: JSON.stringify({
 					type: 'reorder',
 					scope: 'tasks',
 					payload: { from: 0, to: 1 },

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -3,7 +3,7 @@ import type { Page, Locator, Response } from '@playwright/test';
 import { expect } from '@playwright/test';
 
 interface FormConfig {
-	mode: 'client-only' | 'server-validation';
+	mode?: 'client-only' | 'server-validation';
 	initialReport?: 'onSubmit' | 'onChange' | 'onBlur';
 	defaultValue?: any;
 	fallbackNative?: boolean;

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -3,6 +3,7 @@ import type { Page, Locator, Response } from '@playwright/test';
 import { expect } from '@playwright/test';
 
 interface FormConfig {
+	mode: 'client-only' | 'server-validation';
 	initialReport?: 'onSubmit' | 'onChange' | 'onBlur';
 	defaultValue?: any;
 	fallbackNative?: boolean;
@@ -16,6 +17,10 @@ export async function gotoForm(
 	config?: FormConfig,
 ): Promise<Locator> {
 	const searchParams = new URLSearchParams();
+
+	if (typeof config?.mode !== 'undefined') {
+		searchParams.set('mode', config.mode);
+	}
 
 	if (typeof config?.initialReport !== 'undefined') {
 		searchParams.set('initialReport', config.initialReport);

--- a/tests/react.spec.ts
+++ b/tests/react.spec.ts
@@ -126,7 +126,6 @@ test.describe('Client Validation', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
-			scope: ['', 'title', 'description', 'genre', 'rating'],
 			value: {
 				title: 'The Dark Knight',
 				description: 'When the menace known as the Joker wreaks havoc...',
@@ -203,7 +202,6 @@ test.describe('Client Validation', () => {
 
 		await clickSubmitButton(form);
 		expect(await getSubmission(form)).toEqual({
-			scope: ['', 'title', 'description', 'genre', 'rating'],
 			value: {
 				title: 'The Matrix',
 				description:
@@ -240,7 +238,6 @@ test.describe('Client Validation', () => {
 		await clickSubmitButton(playground);
 
 		expect(await getSubmission(playground)).toEqual({
-			scope: ['', 'email', 'password', 'confirmPassword'],
 			value: {
 				email: 'me@edmund.dev',
 			},
@@ -306,7 +303,6 @@ test.describe('Client Validation', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
-			scope: ['', 'email', 'password'],
 			value: {
 				email: '',
 			},
@@ -321,7 +317,6 @@ test.describe('Client Validation', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
-			scope: ['', 'email', 'password'],
 			value: {
 				email: 'invalid email',
 			},
@@ -422,7 +417,6 @@ test.describe('Server Validation', () => {
 				body: JSON.stringify({
 					value: {},
 					error: [['', 'Request forbidden']],
-					scope: [''],
 				}),
 			});
 		});
@@ -649,17 +643,6 @@ test.describe('Field list', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
-			scope: [
-				'',
-				'title',
-				'tasks',
-				'tasks[0]',
-				'tasks[0].content',
-				'tasks[1]',
-				'tasks[1].content',
-				'tasks[2]',
-				'tasks[2].content',
-			],
 			value: {
 				title: 'My schedule',
 				tasks: [
@@ -726,16 +709,6 @@ test.describe('Field list', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
-			scope: [
-				'',
-				'title',
-				'tasks',
-				'tasks[0]',
-				'tasks[0].content',
-				'tasks[1]',
-				'tasks[1].content',
-				'tasks[1].completed',
-			],
 			value: {
 				title: 'Testing plan',
 				tasks: [

--- a/tests/react.spec.ts
+++ b/tests/react.spec.ts
@@ -373,7 +373,9 @@ test.describe('Server Validation', () => {
 	});
 
 	test('Async validation', async ({ page }) => {
-		const form = await gotoForm(page, '/employee');
+		const form = await gotoForm(page, '/employee', {
+			mode: 'server-validation',
+		});
 		const { name, email, title } = getEmployeeFieldset(form);
 
 		await page.route('**', (route) => {

--- a/tests/react.spec.ts
+++ b/tests/react.spec.ts
@@ -544,15 +544,18 @@ test.describe('Server Validation', () => {
 			.poll(() => getErrorMessages(form))
 			.toEqual(['', '', 'Email is already used', 'Title is required']);
 
-		await email.type('e');
-
-		await expect
-			.poll(() => getErrorMessages(form))
-			.toEqual(['', '', '', 'Title is required']);
-
 		await title.type('Software Developer');
 
-		expect(await getErrorMessages(form)).toEqual(['', '', '', '']);
+		expect(await getErrorMessages(form)).toEqual([
+			'',
+			'',
+			'Email is already used',
+			'',
+		]);
+
+		await email.type('e');
+
+		await expect.poll(() => getErrorMessages(form)).toEqual(['', '', '', '']);
 
 		await Promise.all([waitForDataResponse(page), clickSubmitButton(form)]);
 


### PR DESCRIPTION
Time to settle on an API and ship it.

#### What's changed?

1. Introduce validation `mode` config on the `useForm` hook Default to `client-only`, which calls `even.preventDefault()` for you and prevent the `onSubmit` from being triggered by validation. This helps removing unnecessary boileplate when no server-validation is needed. 
2. Simplified the submission interface by removing the concept of `scope`
3. New `shouldValidate(submission: Submission): boolean` helper. Mainly used for server validation
4. The `onValidate()` function no longer need to returns a boolean. The official way to skip reporting client error is to `throw`. For now, throwing the `form` element will avoid conform form reporting the exception caught on console. (Not sure how to make this better yet...)

#### Updated example

```tsx
import type { Submission } from '@conform-to/react';
import {
  conform,
  parse,
  useFieldset,
  useForm,
  hasError,
  shouldValidate,
  setFormError,
} from '@conform-to/react';
import { getError } from '@conform-to/zod';
import type { ActionArgs } from '@remix-run/node';
import { json, redirect } from '@remix-run/node';
import { Form, useActionData } from '@remix-run/react';
import { z } from 'zod';

/**
 * Some changes on the parsing logic that will affect your zod schema:
 *
 * Before v0.4, empty field value are removed from the form data before passing to the schema
 * This allows empty string being treated as `undefiend` by zod to utilise `required_error`
 * e.g. `z.string({ required_error: 'Required' })`
 *
 * However, due to my lack of experience with zod, this introduced an unexpected behaviour
 * which stop the schema from running `.refine()` calls until all the defined fields are filled with at least 1 characters
 *
 * In short, please use `z.string().min(1, 'Required')` instead of `z.string({ required_error: 'Required' })` now
 */
const schema = z.object({
  name: z.string().min(1, 'Name is required'),
  email: z.string().min(1, 'Email is required').email('Email is invalid'),
  title: z.string().min(1, 'Title is required').max(20, 'Title is too long'),
});

type Schema = z.infer<typeof schema>;

export let action = async ({ request }: ActionArgs) => {
  const formData = await request.formData();

  /**
   * The `schema.parse(formData: FormData)` helper is no longer available.
   * Instead, you need to use `parse(formData: FormData)` to find out the submission details.
   * It includes:
   * (1) `submission.value`: Structured form value based on the name (path)
   * (2) `submission.error`: Error (if any) while parsing the FormData object,
   * (3) `submission.type` : Type of the submission.
   *     The type would be `undefined` when user click on any normal submit button.
   *     It would be set only when the user click on named button with pattern (`conform/${type}`),
   *     e.g. Conform is clicking on a button with name `conform/validate` when validating, so the type would be `valdiate`.
   */
  const submission = parse(formData);
  const result = await schema
    // Async validation. e.g. checking uniqueness
    .refine(
      async (employee) =>
        new Promise((resolve) => {
          setTimeout(() => {
            resolve(employee.email === 'hey@conform.guide');
          }, Math.random() * 100);
        }),
      {
        message: 'Email is already used',
        path: ['email'],
      },
    )
    .safeParseAsync(submission.value);

  // Return the state to the client if the submission is made for validation purpose
  if (!result.success || submission.type === 'validate') {
    return json({
      ...submission,
      error: submission.error.concat(getError(result)),
    });
  }

  console.log('Result:', result.data);

  return redirect('/');
};

export default function EmployeeForm() {
  // Last submission returned from the server
  const state = useActionData<Submission<Schema>>();

  /**
   * The useForm hook now returns a `Form` object
   * It includes:
   * (1) form.props: Properties to be passed to the form element
   * (2) form.config: Fieldset config to be passed to the useFieldset hook.
   *      [Optional] Needed only if the fields have default value / nojs support is needed)
   * (3) form.ref: Ref object of the form element. Same as `form.props.ref`
   * (4) form.error: Form error. Set when an error with an empty string name is provided.
   */
  const form = useForm<Schema>({
    // Enable server validation mode
    mode: 'server-validation',

    // Begin validating on blur
    initialReport: 'onBlur',

    // Just hook it up with the result from useActionData()
    state,

    /**
     * The validate hook - `onValidate(context: FormContext): boolean`
     * Changes includes:
     *
     * (1) Renamed from `validate` to `onValidate`
     * (2) Changed the function signature with a new context object, including `form`, `formData` and `submission`
     *
     * If both `onValidate` and `onSubmit` are commented out, then it will validate the form completely by server validation
     */
    onValidate({ form, submission }) {
      // Similar to server validation without the extra refine()
      const result = schema.safeParse(submission.value);

      if (!result.success) {
        submission.error = submission.error.concat(getError(result.error));
      }

      if (
        shouldValidate(submission, 'email') &&
        !hasError(submission.error, 'email')
      ) {
        // Skip reporting client error
        throw form;
      }

      /**
       * Set the submission error to the dom
       */
      setFormError(form, submission);
    },
    async onSubmit(event, { submission }) {
      if (submission.type === 'validate' && submission.metadata !== 'email') {
        event.preventDefault();
      }
    },
  });
  const { name, email, title } = useFieldset(form.ref, form.config);

  return (
    <Form method="post" {...form.props}>
      <fieldset>
        <label>
          <div>Name</div>
          <input
            className={name.error ? 'error' : ''}
            {...conform.input(name.config)}
          />
          <div>{name.error}</div>
        </label>
        <label>
          <div>Email</div>
          <input
            className={email.error ? 'error' : ''}
            {...conform.input(email.config)}
          />
          <div>{email.error}</div>
        </label>
        <label>
          <div>Title</div>
          <input
            className={title.error ? 'error' : ''}
            {...conform.input(title.config)}
          />
          <div>{title.error}</div>
        </label>
      </fieldset>
      <button type="submit">Save</button>
    </Form>
  );
}
```