### PR TITLE
feat(react-base-input): initial release

### DIFF
--- a/examples/material-ui/package.json
+++ b/examples/material-ui/package.json
@@ -7,6 +7,7 @@
 		"@emotion/styled": "^11.10.0",
 		"@mui/material": "^5.10.2",
 		"react": "^18.2.0",
+		"react-base-input": "^0.1.0",
 		"react-dom": "^18.2.0",
 		"react-scripts": "5.0.1"
 	},

--- a/examples/material-ui/src/App.tsx
+++ b/examples/material-ui/src/App.tsx
@@ -1,5 +1,5 @@
 import type { FieldConfig } from '@conform-to/dom';
-import { useForm, useFieldset, useControlledInput } from '@conform-to/react';
+import { useForm, useFieldset } from '@conform-to/react';
 import {
 	TextField,
 	Button,
@@ -20,6 +20,8 @@ import {
 	Slider,
 	Switch,
 } from '@mui/material';
+import { useRef, useState } from 'react';
+import { BaseInput } from 'react-base-input';
 
 interface Schema {
 	email: string;
@@ -172,28 +174,33 @@ interface FieldProps<Schema> extends FieldConfig<Schema> {
 }
 
 function ExampleSelect({ label, error, ...config }: FieldProps<string>) {
-	/**
-	 * MUI Select is a non-native input and does not dispatch any DOM events (e.g. input / focus / blur).
-	 * This hooks works by dispatching DOM events manually on the shadow input and thus validated once
-	 * it is hooked up with the controlled component.
-	 */
-	const [shadowInput, control] = useControlledInput(config);
+	const baseRef = useRef<HTMLInputElement>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [value, setValue] = useState(config.defaultValue ?? '');
 
 	return (
 		<>
-			<input {...shadowInput} />
+			<BaseInput
+				ref={baseRef}
+				name={config.name}
+				value={value}
+				required={config.required}
+				onFocus={() => inputRef.current?.focus()}
+				onReset={() => setValue(config.defaultValue ?? '')}
+			/>
 			<TextField
 				label={label}
-				inputRef={control.ref}
-				value={control.value}
-				onChange={control.onChange}
-				onBlur={control.onBlur}
+				inputRef={inputRef}
+				value={value}
+				onChange={(event) => setValue(event.target.value)}
+				onFocus={() => baseRef.current?.focus()}
+				onBlur={() => baseRef.current?.blur()}
 				error={Boolean(error)}
 				helperText={error}
 				inputProps={{
-					// To disable error bubble caused by the constraint
-					// attribute set by mui input, e.g. `required`
-					onInvalid: control.onInvalid,
+					// To avoid error bubble caused by the constraint
+					// attribute set by mui input
+					required: false,
 				}}
 				select
 				required={config.required}
@@ -208,7 +215,9 @@ function ExampleSelect({ label, error, ...config }: FieldProps<string>) {
 }
 
 function ExampleAutocomplete({ label, error, ...config }: FieldProps<string>) {
-	const [shadowInput, control] = useControlledInput(config);
+	const baseRef = useRef<HTMLInputElement>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [value, setValue] = useState(config.defaultValue ?? '');
 	const options = [
 		{ label: 'The Godfather', id: 1 },
 		{ label: 'Pulp Fiction', id: 2 },
@@ -216,27 +225,32 @@ function ExampleAutocomplete({ label, error, ...config }: FieldProps<string>) {
 
 	return (
 		<>
-			<input {...shadowInput} />
+			<BaseInput
+				ref={baseRef}
+				name={config.name}
+				value={value}
+				required={config.required}
+				onFocus={() => inputRef.current?.focus()}
+				onReset={() => setValue(config.defaultValue ?? '')}
+			/>
 			<Autocomplete
 				disablePortal
 				options={options}
-				value={
-					options.find((option) => control.value === `${option.id}`) ?? null
-				}
-				onChange={(_, option) => control.onChange(`${option?.id ?? ''}`)}
+				value={options.find((option) => value === `${option.id}`) ?? null}
+				onChange={(_, option) => setValue(`${option?.id ?? ''}`)}
 				renderInput={(params) => (
 					<TextField
 						{...params}
 						label={label}
-						onBlur={control.onBlur}
+						inputRef={inputRef}
+						onFocus={() => baseRef.current?.focus()}
+						onBlur={() => baseRef.current?.blur()}
 						error={Boolean(error)}
 						helperText={error}
 						required={config.required}
 						inputProps={{
 							...params.inputProps,
-							// To disable error bubble caused by the constraint
-							// attribute set by mui input, e.g. `required`
-							onInvalid: control.onInvalid,
+							required: false,
 						}}
 					/>
 				)}
@@ -246,17 +260,28 @@ function ExampleAutocomplete({ label, error, ...config }: FieldProps<string>) {
 }
 
 function ExampleRating({ label, error, ...config }: FieldProps<number>) {
-	const [shadowInput, control] = useControlledInput(config);
+	const baseRef = useRef<HTMLInputElement>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [value, setValue] = useState(config.defaultValue ?? '');
 
 	return (
 		<>
-			<input {...shadowInput} />
+			<BaseInput
+				ref={baseRef}
+				name={config.name}
+				value={value}
+				required={config.required}
+				onFocus={() => inputRef.current?.focus()}
+				onReset={() => setValue(config.defaultValue ?? '')}
+			/>
 			<FormControl variant="standard" error={Boolean(error)} required>
 				<FormLabel>{label}</FormLabel>
 				<Rating
-					ref={control.ref}
-					value={control.value ? Number(control.value) : null}
-					onChange={(_, value) => control.onChange(`${value ?? ''}`)}
+					ref={inputRef}
+					value={value ? Number(value) : null}
+					onFocus={() => baseRef.current?.focus()}
+					onBlur={() => baseRef.current?.blur()}
+					onChange={(_, value) => setValue(`${value ?? ''}`)}
 				/>
 				<FormHelperText>{error}</FormHelperText>
 			</FormControl>
@@ -265,17 +290,24 @@ function ExampleRating({ label, error, ...config }: FieldProps<number>) {
 }
 
 function ExampleSlider({ label, error, ...config }: FieldProps<number>) {
-	const [shadowInput, control] = useControlledInput(config);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [value, setValue] = useState(config.defaultValue ?? '');
 
 	return (
 		<>
-			<input {...shadowInput} />
+			<BaseInput
+				name={config.name}
+				value={value}
+				required={config.required}
+				onFocus={() => inputRef.current?.focus()}
+				onReset={() => setValue(config.defaultValue ?? '')}
+			/>
 			<FormControl variant="standard" error={Boolean(error)} required>
 				<FormLabel>{label}</FormLabel>
 				<Slider
-					ref={control.ref}
-					value={control.value ? Number(control.value) : 0}
-					onChange={(_, value) => control.onChange(`${value}`)}
+					ref={inputRef}
+					value={value ? Number(value) : 0}
+					onChange={(_, value) => setValue(`${value}`)}
 				/>
 				<FormHelperText>{error}</FormHelperText>
 			</FormControl>

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
 				"@emotion/styled": "^11.10.0",
 				"@mui/material": "^5.10.2",
 				"react": "^18.2.0",
+				"react-base-input": "^0.1.0",
 				"react-dom": "^18.2.0",
 				"react-scripts": "5.0.1"
 			},
@@ -30174,6 +30175,7 @@
 				"@types/react": "^18.0.15",
 				"@types/react-dom": "^18.0.6",
 				"react": "^18.2.0",
+				"react-base-input": "^0.1.0",
 				"react-dom": "^18.2.0",
 				"react-scripts": "5.0.1",
 				"typescript": "^4.7.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22793,6 +22793,10 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/react-base-input": {
+			"resolved": "packages/react-base-input",
+			"link": true
+		},
 		"node_modules/react-dev-utils": {
 			"version": "12.0.1",
 			"resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -28304,6 +28308,16 @@
 				"zod": "^3.0.0"
 			}
 		},
+		"packages/react-base-input": {
+			"version": "0.1.0",
+			"license": "MIT",
+			"devDependencies": {
+				"react": "^18.2.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8"
+			}
+		},
 		"playground": {
 			"name": "@conform-to/playground",
 			"dependencies": {
@@ -28313,6 +28327,7 @@
 				"@remix-run/react": "^1.7.4",
 				"@remix-run/serve": "^1.7.4",
 				"react": "^18.2.0",
+				"react-base-input": "*",
 				"react-dom": "^18.2.0"
 			},
 			"devDependencies": {
@@ -30188,6 +30203,7 @@
 				"eslint": "^8.20.0",
 				"npm-run-all": "^4.1.5",
 				"react": "^18.2.0",
+				"react-base-input": "*",
 				"react-dom": "^18.2.0",
 				"tailwindcss": "^3.1.4",
 				"typescript": "^4.7.4"
@@ -45077,6 +45093,12 @@
 				"raf": "^3.4.1",
 				"regenerator-runtime": "^0.13.9",
 				"whatwg-fetch": "^3.6.2"
+			}
+		},
+		"react-base-input": {
+			"version": "file:packages/react-base-input",
+			"requires": {
+				"react": "^18.2.0"
 			}
 		},
 		"react-dev-utils": {

--- a/packages/react-base-input/.npmignore
+++ b/packages/react-base-input/.npmignore
@@ -1,0 +1,8 @@
+# ignore all .ts, .tsx files except .d.ts
+*.ts
+*.tsx
+!*.d.ts
+
+# config / build result
+tsconfig.json
+*.tsbuildinfo

--- a/packages/react-base-input/README.md
+++ b/packages/react-base-input/README.md
@@ -1,0 +1,13 @@
+# react-base-input
+
+A drop-in replacement of your hidden input that trigger the `onChange` handler.
+
+<!-- aside -->
+
+## API Reference
+
+- [BaseInput](#baseinput)
+
+<!-- /aside -->
+
+### BaseInput

--- a/packages/react-base-input/components.tsx
+++ b/packages/react-base-input/components.tsx
@@ -1,0 +1,183 @@
+import React, {
+	type ForwardedRef,
+	type InputHTMLAttributes,
+	forwardRef,
+	useRef,
+	useEffect,
+	useLayoutEffect,
+	useImperativeHandle,
+} from 'react';
+
+const useSafeLayoutEffect =
+	typeof document === 'undefined' ? useEffect : useLayoutEffect;
+
+/**
+ * Triggering react custom change event
+ * Solution based on dom-testing-library
+ * @see https://github.com/facebook/react/issues/10135#issuecomment-401496776
+ * @see https://github.com/testing-library/dom-testing-library/blob/main/src/events.js#L104-L123
+ */
+function setNativeValue(element: HTMLElement, value: string) {
+	const { set: valueSetter } =
+		Object.getOwnPropertyDescriptor(element, 'value') || {};
+	const prototype = Object.getPrototypeOf(element);
+	const { set: prototypeValueSetter } =
+		Object.getOwnPropertyDescriptor(prototype, 'value') || {};
+
+	if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
+		prototypeValueSetter.call(element, value);
+	} else {
+		if (valueSetter) {
+			valueSetter.call(element, value);
+		} else {
+			throw new Error('The given element does not have a value setter');
+		}
+	}
+}
+
+const hiddenStyle: React.CSSProperties = {
+	position: 'absolute',
+	width: '1px',
+	height: '1px',
+	padding: 0,
+	margin: '-1px',
+	overflow: 'hidden',
+	clip: 'rect(0,0,0,0)',
+	whiteSpace: 'nowrap',
+	borderWidth: 0,
+};
+
+export interface BaseInputProps
+	extends Omit<
+		InputHTMLAttributes<HTMLInputElement>,
+		'name' | 'value' | 'defaultValue' | 'onReset'
+	> {
+	name: string;
+	value: string;
+	onReset?: (event: Event) => void;
+}
+
+export const BaseInput = forwardRef(function BaseInput(
+	props: BaseInputProps,
+	forwardedRef: ForwardedRef<HTMLInputElement>,
+) {
+	const ref = useRef<HTMLInputElement>(null);
+	const propsRef = useRef(props);
+
+	const {
+		hidden = true,
+		tabIndex = -1,
+		className,
+		style,
+		onChange,
+		onFocus,
+		onBlur,
+		onFocusCapture,
+		onBlurCapture,
+		onReset,
+		...inputProps
+	} = props;
+
+	useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
+		forwardedRef,
+		() => {
+			const $input = ref.current;
+
+			if (!$input) {
+				return null;
+			}
+
+			return {
+				...$input,
+				focus() {
+					setTimeout(() => {
+						$input.dataset.mode = 'manual';
+						$input.dispatchEvent(
+							new FocusEvent('focusin', { bubbles: true, cancelable: true }),
+						);
+						$input.dispatchEvent(new FocusEvent('focus', { cancelable: true }));
+						delete $input.dataset.mode;
+					}, 0);
+				},
+				blur() {
+					setTimeout(() => {
+						$input.dataset.mode = 'manual';
+						$input.dispatchEvent(
+							new FocusEvent('focusout', { bubbles: true, cancelable: true }),
+						);
+						$input.dispatchEvent(new FocusEvent('blur', { cancelable: true }));
+						delete $input.dataset.mode;
+					}, 0);
+				},
+			};
+		},
+	);
+
+	useSafeLayoutEffect(() => {
+		const handleReset = (event: Event) => {
+			if (event.target === ref.current?.form) {
+				propsRef.current.onReset?.(event);
+			}
+		};
+
+		document.addEventListener('reset', handleReset);
+
+		return () => {
+			document.removeEventListener('reset', handleReset);
+		};
+	}, []);
+
+	useSafeLayoutEffect(() => {
+		const $input = ref.current;
+
+		if (!$input || !hidden) {
+			return;
+		}
+
+		const value = $input.value;
+
+		$input.value = propsRef.current.value;
+		$input.dispatchEvent(
+			new InputEvent('beforeinput', { bubbles: true, cancelable: true }),
+		);
+		setNativeValue($input, value);
+		$input.dispatchEvent(
+			new InputEvent('input', { bubbles: true, cancelable: true }),
+		);
+	}, [props.value, hidden]);
+
+	useSafeLayoutEffect(() => {
+		propsRef.current = props;
+	});
+
+	return (
+		<input
+			ref={ref}
+			className={!hidden ? className : ''}
+			style={!hidden ? style : hiddenStyle}
+			onChange={onChange ?? (() => {})}
+			onFocusCapture={(event) => {
+				if (event.target.dataset.mode !== 'manual') {
+					onFocusCapture?.(event);
+				}
+			}}
+			onFocus={(event) => {
+				if (event.target.dataset.mode !== 'manual') {
+					onFocus?.(event);
+				}
+			}}
+			onBlurCapture={(event) => {
+				if (event.target.dataset.mode !== 'manual') {
+					onBlurCapture?.(event);
+				}
+			}}
+			onBlur={(event) => {
+				if (event.target.dataset.mode !== 'manual') {
+					onBlur?.(event);
+				}
+			}}
+			tabIndex={tabIndex}
+			{...inputProps}
+		/>
+	);
+});

--- a/packages/react-base-input/components.tsx
+++ b/packages/react-base-input/components.tsx
@@ -119,12 +119,9 @@ export const BaseInput = forwardRef(function BaseInput(
 									target.dispatchEvent(
 										new FocusEvent('focusin', {
 											bubbles: true,
-											cancelable: true,
 										}),
 									);
-									target.dispatchEvent(
-										new FocusEvent('focus', { cancelable: true }),
-									);
+									target.dispatchEvent(new FocusEvent('focus'));
 								}, 0);
 						case 'blur':
 							return () =>
@@ -132,12 +129,9 @@ export const BaseInput = forwardRef(function BaseInput(
 									$input.dispatchEvent(
 										new FocusEvent('focusout', {
 											bubbles: true,
-											cancelable: true,
 										}),
 									);
-									$input.dispatchEvent(
-										new FocusEvent('blur', { cancelable: true }),
-									);
+									$input.dispatchEvent(new FocusEvent('blur'));
 								}, 0);
 						default:
 							return Reflect.get(target, prop, receiver);
@@ -187,15 +181,11 @@ export const BaseInput = forwardRef(function BaseInput(
 		}
 
 		// Dispatch beforeinput event before updating the input value
-		$input.dispatchEvent(
-			new InputEvent('beforeinput', { bubbles: true, cancelable: true }),
-		);
+		$input.dispatchEvent(new Event('beforeinput', { bubbles: true }));
 		// Update the input value to trigger a change event
 		setNativeValue($input, nextValue);
 		// Dispatch input event with the updated input value
-		$input.dispatchEvent(
-			new InputEvent('input', { bubbles: true, cancelable: true }),
-		);
+		$input.dispatchEvent(new InputEvent('input', { bubbles: true }));
 	}, [value, hidden]);
 
 	return (

--- a/packages/react-base-input/index.ts
+++ b/packages/react-base-input/index.ts
@@ -1,0 +1,1 @@
+export { type BaseInputProps, BaseInput } from './components';

--- a/packages/react-base-input/package.json
+++ b/packages/react-base-input/package.json
@@ -1,0 +1,33 @@
+{
+	"name": "react-base-input",
+	"description": "A drop-in replacement of your hidden input that trigger the onChange handler",
+	"license": "MIT",
+	"version": "0.1.0",
+	"main": "index.js",
+	"module": "module/index.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/edmundhung/conform",
+		"directory": "packages/react-base-input"
+	},
+	"author": {
+		"name": "Edmund Hung",
+		"email": "me@edmund.dev",
+		"url": "https://edmund.dev"
+	},
+	"bugs": {
+		"url": "https://github.com/edmundhung/conform/issues"
+	},
+	"peerDependencies": {
+		"react": ">=16.8"
+	},
+	"devDependencies": {
+		"react": "^18.2.0"
+	},
+	"keywords": [
+		"constraint-validation",
+		"form",
+		"react"
+	],
+	"sideEffects": false
+}

--- a/packages/react-base-input/tsconfig.json
+++ b/packages/react-base-input/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"jsx": "react",
+		"target": "ES2020",
+		"module": "ES2020",
+		"moduleResolution": "node",
+		"allowSyntheticDefaultImports": true,
+		"strict": true,
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		"composite": true,
+		"skipLibCheck": true
+	}
+}

--- a/playground/app/routes/base-input.tsx
+++ b/playground/app/routes/base-input.tsx
@@ -2,43 +2,102 @@ import { useSearchParams } from '@remix-run/react';
 import { useReducer, useRef, useState } from 'react';
 import { BaseInput } from 'react-base-input';
 
+/**
+ * Format event phase number
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Event/eventPhase
+ */
+function getEventPhaseName(phase: number) {
+	switch (phase) {
+		case 0:
+			return 'None';
+		case 1:
+			return 'Capturing';
+		case 2:
+			return 'At target';
+		case 3:
+			return 'Bubbling';
+		default:
+			throw new Error('Unknown event phase');
+	}
+}
+
 export default function BaseInputText() {
 	const [searchParams] = useSearchParams();
-	const ref = useRef<HTMLInputElement>(null);
+	const baseRef = useRef<HTMLInputElement>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
 	const [value, setValue] = useState(searchParams.get('defaultValue') ?? '');
-	const [logs, append] = useReducer(
-		(list: string[], log: string) => list.concat(log),
-		[],
+	const [logsByName, log] = useReducer(
+		(
+			logsByName: Record<string, string[]>,
+			event: { target: { name: string }; type: string; eventPhase: number },
+		) => ({
+			...logsByName,
+			[event.target.name]: [
+				...(logsByName[event.target.name] ?? []),
+				`${getEventPhaseName(event.eventPhase)}: ${event.type}`,
+			],
+		}),
+		{},
 	);
 
 	return (
 		<form
-			onChange={(e: any) => append(`${e.target.name}: ${e.type}`)}
-			onFocus={(e: any) => append(`${e.target.name}: ${e.type}`)}
-			onBlur={(e: any) => append(`${e.target.name}: ${e.type}`)}
+			onChange={(e: any) => log(e)}
+			onFocusCapture={(e: any) => log(e)}
+			onFocus={(e: any) => log(e)}
+			onBlurCapture={(e: any) => log(e)}
+			onBlur={(e: any) => log(e)}
 		>
-			<div>
+			<div className="sticky top-0 pt-4 pb-8 bg-gray-100 border-b">
 				<label>Type here</label>
-				<input
-					name="native-input"
+				<BaseInput
+					ref={baseRef}
+					name="base-input"
 					value={value}
-					onChange={(e) => {
-						setValue(e.target.value);
-					}}
-					onFocus={(e) => {
-						ref.current?.focus();
-					}}
-					onBlur={(e) => {
-						ref.current?.blur();
-					}}
+					onReset={() => setValue(searchParams.get('defaultValue') ?? '')}
 				/>
-				<BaseInput ref={ref} name="base-input" value={value} />
+				<div className="flex flex-row gap-4">
+					<input
+						className="p-2 flex-1"
+						name="native-input"
+						value={value}
+						ref={inputRef}
+						onChange={(e) => {
+							setValue(e.target.value);
+						}}
+						onFocus={(e) => {
+							baseRef.current?.focus();
+						}}
+						onBlur={(e) => {
+							baseRef.current?.blur();
+						}}
+					/>
+					<button
+						type="reset"
+						className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+					>
+						Reset
+					</button>
+				</div>
 			</div>
-			<ul>
-				{logs.map((log, i) => (
-					<li key={i}>{log}</li>
-				))}
-			</ul>
+			<div className="my-4 flex flex-row">
+				<div className="flex-1">
+					native-input logs
+					<ul id="native-input">
+						{logsByName['native-input']?.map((log, i) => (
+							<li key={i}>{log}</li>
+						))}
+					</ul>
+				</div>
+				<div className="flex-1">
+					base-input logs
+					<ul id="base-input">
+						{logsByName['base-input']?.map((log, i) => (
+							<li key={i}>{log}</li>
+						))}
+					</ul>
+				</div>
+			</div>
 		</form>
 	);
 }

--- a/playground/app/routes/base-input.tsx
+++ b/playground/app/routes/base-input.tsx
@@ -1,25 +1,6 @@
 import { useSearchParams } from '@remix-run/react';
-import { useReducer, useRef, useState } from 'react';
+import { type FormEvent, useReducer, useRef, useState } from 'react';
 import { BaseInput } from 'react-base-input';
-
-/**
- * Format event phase number
- * @see https://developer.mozilla.org/en-US/docs/Web/API/Event/eventPhase
- */
-function getEventPhaseName(phase: number) {
-	switch (phase) {
-		case 0:
-			return 'None';
-		case 1:
-			return 'Capturing';
-		case 2:
-			return 'At target';
-		case 3:
-			return 'Bubbling';
-		default:
-			throw new Error('Unknown event phase');
-	}
-}
 
 export default function BaseInputText() {
 	const [searchParams] = useSearchParams();
@@ -29,24 +10,34 @@ export default function BaseInputText() {
 	const [logsByName, log] = useReducer(
 		(
 			logsByName: Record<string, string[]>,
-			event: { target: { name: string }; type: string; eventPhase: number },
-		) => ({
-			...logsByName,
-			[event.target.name]: [
-				...(logsByName[event.target.name] ?? []),
-				`${getEventPhaseName(event.eventPhase)}: ${event.type}`,
-			],
-		}),
+			event: FormEvent<HTMLFormElement>,
+		) => {
+			const input = event.target as HTMLInputElement;
+
+			return {
+				...logsByName,
+				[input.name]: [
+					...(logsByName[input.name] ?? []),
+					JSON.stringify({
+						eventPhase: event.eventPhase,
+						type: event.type,
+						bubbles: event.bubbles,
+						cancelable: event.cancelable,
+					}),
+				],
+			};
+		},
 		{},
 	);
 
 	return (
 		<form
-			onChange={(e: any) => log(e)}
-			onFocusCapture={(e: any) => log(e)}
-			onFocus={(e: any) => log(e)}
-			onBlurCapture={(e: any) => log(e)}
-			onBlur={(e: any) => log(e)}
+			onChange={log}
+			onInput={log}
+			onFocusCapture={log}
+			onFocus={log}
+			onBlurCapture={log}
+			onBlur={log}
 		>
 			<div className="sticky top-0 pt-4 pb-8 bg-gray-100 border-b">
 				<label>Type here</label>

--- a/playground/app/routes/base-input.tsx
+++ b/playground/app/routes/base-input.tsx
@@ -1,0 +1,44 @@
+import { useSearchParams } from '@remix-run/react';
+import { useReducer, useRef, useState } from 'react';
+import { BaseInput } from 'react-base-input';
+
+export default function BaseInputText() {
+	const [searchParams] = useSearchParams();
+	const ref = useRef<HTMLInputElement>(null);
+	const [value, setValue] = useState(searchParams.get('defaultValue') ?? '');
+	const [logs, append] = useReducer(
+		(list: string[], log: string) => list.concat(log),
+		[],
+	);
+
+	return (
+		<form
+			onChange={(e: any) => append(`${e.target.name}: ${e.type}`)}
+			onFocus={(e: any) => append(`${e.target.name}: ${e.type}`)}
+			onBlur={(e: any) => append(`${e.target.name}: ${e.type}`)}
+		>
+			<div>
+				<label>Type here</label>
+				<input
+					name="native-input"
+					value={value}
+					onChange={(e) => {
+						setValue(e.target.value);
+					}}
+					onFocus={(e) => {
+						ref.current?.focus();
+					}}
+					onBlur={(e) => {
+						ref.current?.blur();
+					}}
+				/>
+				<BaseInput ref={ref} name="base-input" value={value} />
+			</div>
+			<ul>
+				{logs.map((log, i) => (
+					<li key={i}>{log}</li>
+				))}
+			</ul>
+		</form>
+	);
+}

--- a/playground/package.json
+++ b/playground/package.json
@@ -18,6 +18,7 @@
 		"@remix-run/react": "^1.7.4",
 		"@remix-run/serve": "^1.7.4",
 		"react": "^18.2.0",
+		"react-base-input": "*",
 		"react-dom": "^18.2.0"
 	},
 	"devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -72,6 +72,9 @@ export default function rollup() {
 
 		// View adapter
 		'conform-react',
+
+		// misc
+		'react-base-input',
 	];
 
 	return packages.flatMap(configurePackage);

--- a/tests/react-base-input.spec.ts
+++ b/tests/react-base-input.spec.ts
@@ -1,6 +1,8 @@
-import { type Page, test, expect } from '@playwright/test';
+import { type Page, type Locator, test, expect } from '@playwright/test';
 
-function getForm(page: Page) {
+async function getForm(page: Page, defaultValue?: string) {
+	await page.goto(`/base-input?defaultValue=${defaultValue ?? ''}`);
+
 	return {
 		baseInput: page.locator('[name="base-input"]'),
 		nativeInput: page.locator('[name="native-input"]'),
@@ -10,30 +12,155 @@ function getForm(page: Page) {
 	};
 }
 
-test.beforeEach(async ({ page }) => {
-	await page.goto('/base-input');
-});
+async function expectToHaveSameTexts(
+	baseLogs: Locator,
+	nativeLogs: Locator,
+): Promise<void> {
+	const [base, native] = await Promise.all([
+		baseLogs.allInnerTexts(),
+		nativeLogs.allInnerTexts(),
+	]);
+
+	expect(base).toEqual(native);
+}
 
 test.describe('BaseInput', () => {
 	test('emits nothing on load', async ({ page }) => {
-		const form = getForm(page);
+		const form = await getForm(page);
 
-		await expect(form.baseLogs).toHaveText(
-			await form.nativeLogs.allInnerTexts(),
-		);
+		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
 		await expect(form.nativeLogs).toHaveText([]);
 	});
 
-	test('emits focus/blur event as native input', async ({ page }) => {
-		const form = getForm(page);
+	test('emits events as native input', async ({ page }) => {
+		const form = await getForm(page);
 
 		await form.nativeInput.focus();
-		await expect(form.baseLogs).toHaveText(
-			await form.nativeLogs.allInnerTexts(),
-		);
+		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
 		await expect(form.nativeLogs).toHaveText([
 			'Capturing: focus',
 			'Bubbling: focus',
+		]);
+
+		await form.nativeInput.type('test');
+		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
+		await expect(form.nativeLogs).toHaveText([
+			'Capturing: focus',
+			'Bubbling: focus',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+		]);
+
+		await page.click('body');
+		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
+		await expect(form.nativeLogs).toHaveText([
+			'Capturing: focus',
+			'Bubbling: focus',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Capturing: blur',
+			'Bubbling: blur',
+		]);
+	});
+
+	test('works with keyboard events', async ({ page }) => {
+		const form = await getForm(page);
+
+		// Change event will be emitted first before the focus event
+		// if we type without focus on webkit (headless mode only)
+		// This might be a bug from playwright
+		await form.nativeInput.focus();
+
+		// Type 'abc'
+		await form.nativeInput.type('abc');
+
+		// Highlight 'c'
+		await form.nativeInput.press('Shift+ArrowLeft');
+		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
+		await expect(form.nativeLogs).toHaveText([
+			'Capturing: focus',
+			'Bubbling: focus',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+		]);
+
+		// Cut out 'c'
+		await form.nativeInput.press('Control+x');
+		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
+		await expect(form.nativeLogs).toHaveText([
+			'Capturing: focus',
+			'Bubbling: focus',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+		]);
+
+		// Paste the 'c' back
+		await form.nativeInput.press('Control+v');
+		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
+		await expect(form.nativeLogs).toHaveText([
+			'Capturing: focus',
+			'Bubbling: focus',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+		]);
+
+		// Select all text
+		await form.nativeInput.press('Control+a');
+		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
+		await expect(form.nativeLogs).toHaveText([
+			'Capturing: focus',
+			'Bubbling: focus',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+		]);
+
+		// Delete all text
+		await form.nativeInput.press('Backspace');
+		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
+		await expect(form.nativeLogs).toHaveText([
+			'Capturing: focus',
+			'Bubbling: focus',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+			'Bubbling: change',
+		]);
+	});
+
+	test('works with reset event', async ({ page }) => {
+		const form = await getForm(page, 'abc');
+
+		await form.reset.click();
+		await expect(form.nativeInput).toHaveValue('abc');
+		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
+		await expect(form.nativeLogs).toHaveText([]);
+
+		await form.nativeInput.focus();
+		await form.nativeInput.type('d');
+		await form.reset.click();
+		await expect(form.nativeInput).toHaveValue('abc');
+		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
+		await expect(form.nativeLogs).toHaveText([
+			'Capturing: focus',
+			'Bubbling: focus',
+			'Bubbling: change',
+			'Capturing: blur',
+			'Bubbling: blur',
 		]);
 	});
 });

--- a/tests/react-base-input.spec.ts
+++ b/tests/react-base-input.spec.ts
@@ -1,0 +1,39 @@
+import { type Page, test, expect } from '@playwright/test';
+
+function getForm(page: Page) {
+	return {
+		baseInput: page.locator('[name="base-input"]'),
+		nativeInput: page.locator('[name="native-input"]'),
+		reset: page.locator('button:text("Reset")'),
+		baseLogs: page.locator('ul#base-input > li'),
+		nativeLogs: page.locator('ul#native-input > li'),
+	};
+}
+
+test.beforeEach(async ({ page }) => {
+	await page.goto('/base-input');
+});
+
+test.describe('BaseInput', () => {
+	test('emits nothing on load', async ({ page }) => {
+		const form = getForm(page);
+
+		await expect(form.baseLogs).toHaveText(
+			await form.nativeLogs.allInnerTexts(),
+		);
+		await expect(form.nativeLogs).toHaveText([]);
+	});
+
+	test('emits focus/blur event as native input', async ({ page }) => {
+		const form = getForm(page);
+
+		await form.nativeInput.focus();
+		await expect(form.baseLogs).toHaveText(
+			await form.nativeLogs.allInnerTexts(),
+		);
+		await expect(form.nativeLogs).toHaveText([
+			'Capturing: focus',
+			'Bubbling: focus',
+		]);
+	});
+});

--- a/tests/react-base-input.spec.ts
+++ b/tests/react-base-input.spec.ts
@@ -12,6 +12,15 @@ async function getForm(page: Page, defaultValue?: string) {
 	};
 }
 
+function createLog(type: string, eventPhase: number) {
+	return JSON.stringify({
+		eventPhase,
+		type,
+		bubbles: true,
+		cancelable: false,
+	});
+}
+
 async function expectToHaveSameTexts(
 	baseLogs: Locator,
 	nativeLogs: Locator,
@@ -24,7 +33,7 @@ async function expectToHaveSameTexts(
 	expect(base).toEqual(native);
 }
 
-test.describe('BaseInput', () => {
+test.describe.only('BaseInput', () => {
 	test('emits nothing on load', async ({ page }) => {
 		const form = await getForm(page);
 
@@ -38,32 +47,40 @@ test.describe('BaseInput', () => {
 		await form.nativeInput.focus();
 		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
 		await expect(form.nativeLogs).toHaveText([
-			'Capturing: focus',
-			'Bubbling: focus',
+			createLog('focus', 1),
+			createLog('focus', 3),
 		]);
 
 		await form.nativeInput.type('test');
 		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
 		await expect(form.nativeLogs).toHaveText([
-			'Capturing: focus',
-			'Bubbling: focus',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
+			createLog('focus', 1),
+			createLog('focus', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
 		]);
 
 		await page.click('body');
 		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
 		await expect(form.nativeLogs).toHaveText([
-			'Capturing: focus',
-			'Bubbling: focus',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Capturing: blur',
-			'Bubbling: blur',
+			createLog('focus', 1),
+			createLog('focus', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('blur', 1),
+			createLog('blur', 3),
 		]);
 	});
 
@@ -82,63 +99,86 @@ test.describe('BaseInput', () => {
 		await form.nativeInput.press('Shift+ArrowLeft');
 		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
 		await expect(form.nativeLogs).toHaveText([
-			'Capturing: focus',
-			'Bubbling: focus',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
+			createLog('focus', 1),
+			createLog('focus', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
 		]);
 
 		// Cut out 'c'
 		await form.nativeInput.press('Control+x');
 		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
 		await expect(form.nativeLogs).toHaveText([
-			'Capturing: focus',
-			'Bubbling: focus',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
+			createLog('focus', 1),
+			createLog('focus', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
 		]);
 
 		// Paste the 'c' back
 		await form.nativeInput.press('Control+v');
 		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
 		await expect(form.nativeLogs).toHaveText([
-			'Capturing: focus',
-			'Bubbling: focus',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
+			createLog('focus', 1),
+			createLog('focus', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
 		]);
 
 		// Select all text
 		await form.nativeInput.press('Control+a');
 		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
 		await expect(form.nativeLogs).toHaveText([
-			'Capturing: focus',
-			'Bubbling: focus',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
+			createLog('focus', 1),
+			createLog('focus', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
 		]);
 
 		// Delete all text
 		await form.nativeInput.press('Backspace');
 		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
 		await expect(form.nativeLogs).toHaveText([
-			'Capturing: focus',
-			'Bubbling: focus',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
-			'Bubbling: change',
+			createLog('focus', 1),
+			createLog('focus', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
 		]);
 	});
 
@@ -156,11 +196,12 @@ test.describe('BaseInput', () => {
 		await expect(form.nativeInput).toHaveValue('abc');
 		await expectToHaveSameTexts(form.baseLogs, form.nativeLogs);
 		await expect(form.nativeLogs).toHaveText([
-			'Capturing: focus',
-			'Bubbling: focus',
-			'Bubbling: change',
-			'Capturing: blur',
-			'Bubbling: blur',
+			createLog('focus', 1),
+			createLog('focus', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('blur', 1),
+			createLog('blur', 3),
 		]);
 	});
 });


### PR DESCRIPTION
This is a replacement of the `useControlledInput` hook. By hooking it up with an custom component, it can emit the following events in the same order as you would expect on an native input:

- focusin
- focus
- beforeinput
- change (specific to react event system)
- input
- focusout
- blur

Here is an example based on material-ui select component:
```jsx
// before
import { useControlledInput } from '@conform-to/react';

function ExampleSelect({ label, error, name, defaultValue }) {
  const [shadowInput, control] = useControlledInput({ name, defaultValue });

  return (
    <>
      <input {...shadowInput} />
      <TextField
        label={label}
        inputRef={control.ref}
        value={control.value}
        onChange={control.onChange}
        onBlur={control.onBlur}
        error={Boolean(error)}
        helperText={error}
        select
      >
        <MenuItem value="">Please select</MenuItem>
        <MenuItem value="english">English</MenuItem>
        <MenuItem value="deutsch">Deutsch</MenuItem>
        <MenuItem value="japanese">Japanese</MenuItem>
      </TextField>
    </>
  );
}

// after (if only change / input event matters)
import { BaseInput } from 'react-base-input';

function ExampleSelect({ label, error, name, defaultValue }) {
  const [value, setValue] = useState(defaultValue ?? '');

  return (
    <>
      <BaseInput
        name={name}
        value={value}
      />
      <TextField
        label={label}
        value={value}
        onChange={e => setValue(e.target.value}
        error={Boolean(error)}
        helperText={error}
        select
      >
        <MenuItem value="">Please select</MenuItem>
        <MenuItem value="english">English</MenuItem>
        <MenuItem value="deutsch">Deutsch</MenuItem>
        <MenuItem value="japanese">Japanese</MenuItem>
      </TextField>
    </>
  );
}

// Enable focus / blue event with focus delegation
// i.e. focus on BaseInput element will be delegated to the custom input
import { BaseInput } from 'react-base-input';

function ExampleSelect({ label, error, name, defaultValue }) {
  const baseRef = useRef(null);
  const inputRef = useRef(null);
  const [value, setValue] = useState(defaultValue ?? '');

  return (
    <>
      <BaseInput
        ref={ref}
        name={name}
        value={value}
        onFocus={() => inputRef.current.focus()}
        onReset={() => setValue(defaultValue ?? ''}
      />
      <TextField
        label={label}
        inputRef={inputRef}
        value={value}
        onChange={e => setValue(e.target.value}
        onFocus={() => baseRef.current?.focus()}
        onBlur={() => baseRef.current?.blur()}
        error={Boolean(error)}
        helperText={error}
        select
      >
        <MenuItem value="">Please select</MenuItem>
        <MenuItem value="english">English</MenuItem>
        <MenuItem value="deutsch">Deutsch</MenuItem>
        <MenuItem value="japanese">Japanese</MenuItem>
      </TextField>
    </>
  );
}
```

Why should this be published on a new package?
- This simply enable event delegation on any custom input once it is integrated. It can be useful for any one that would like to do `<form onChange={handleChange} onBlur={handleBlur}>`
- It is best integrated at the design system level which does not need to coupled with conform. This can be treat as a drop-in replacement of hidden input
- This is not an ideal solution from the progressive enhancement perspective as it only works with JS. It is a workaround to integrate UI components that are not compliant to native input events.
