### PR TITLE
feat(conform-dom,conform-react): file upload support

### DIFF
--- a/examples/chakra-ui/src/App.tsx
+++ b/examples/chakra-ui/src/App.tsx
@@ -1,9 +1,5 @@
-import {
-	type FieldConfig,
-	useForm,
-	useFieldset,
-	useControlledInput,
-} from '@conform-to/react';
+import type { FieldConfig } from '@conform-to/react';
+import { useForm, useFieldset, useControlledInput } from '@conform-to/react';
 import {
 	Stack,
 	FormControl,

--- a/examples/material-ui/src/App.tsx
+++ b/examples/material-ui/src/App.tsx
@@ -1,9 +1,5 @@
-import {
-	type FieldConfig,
-	useForm,
-	useFieldset,
-	useControlledInput,
-} from '@conform-to/react';
+import type { FieldConfig } from '@conform-to/react';
+import { useForm, useFieldset, useControlledInput } from '@conform-to/react';
 import {
 	TextField,
 	Button,

--- a/guide/app/routes/_guide.tsx
+++ b/guide/app/routes/_guide.tsx
@@ -33,8 +33,9 @@ const navigations: Navigation[] = [
 	{
 		title: 'Examples',
 		menus: [
-			{ title: 'Material UI', to: '/examples/material-ui' },
+			{ title: 'Chakra UI', to: '/examples/chakra-ui' },
 			{ title: 'Headless UI', to: '/examples/headless-ui' },
+			{ title: 'Material UI', to: '/examples/material-ui' },
 			{ title: 'Yup', to: '/examples/yup' },
 			{ title: 'Zod', to: '/examples/zod' },
 		],

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -142,28 +142,21 @@ export function reportSubmission(
 			let item = form.elements.namedItem(elementName);
 
 			if (item === null) {
-				const paths = getPaths(name);
-				const lastPath = paths.pop();
+				item = form.elements.namedItem(`${name}[]`);
+			}
 
-				if (typeof lastPath === 'number') {
-					item = form.elements.namedItem(getName([...paths, NaN]));
+			if (item instanceof RadioNodeList) {
+				throw new Error('Repeated name field is not supported');
+			}
 
-					if (item instanceof RadioNodeList) {
-						item = item.item(lastPath) as Element | null;
-					} else {
-						// Skip linking list item error if the multiple attribute is set
-						// ie. multiple file input / multiple select
-						if (
-							(item as HTMLInputElement | HTMLSelectElement | null)?.multiple
-						) {
-							item = null;
-						}
-
-						item = lastPath === 0 ? item : null;
-					}
-				} else {
-					item = form.elements.namedItem(`${name}[]`);
-				}
+			if (
+				item !== null &&
+				(item as FieldElement).name.endsWith('[]') &&
+				!(item as HTMLInputElement | HTMLSelectElement).multiple
+			) {
+				throw new Error(
+					`The multiple attribute is not set on ${(item as FieldElement).name}`,
+				);
 			}
 
 			if (item === null) {
@@ -178,14 +171,7 @@ export function reportSubmission(
 				form.appendChild(button);
 			}
 
-			if (item instanceof RadioNodeList) {
-				// This assumes all inputs have no multiple attribute set
-				for (const node of item) {
-					nameByInput.set(node as FieldElement, name);
-				}
-			} else {
-				nameByInput.set(item as FieldElement, name);
-			}
+			nameByInput.set(item as FieldElement, name);
 		}
 	}
 

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -143,10 +143,10 @@ export function reportSubmission(
 
 			if (item === null) {
 				const paths = getPaths(name);
-				const lastPath = paths[paths.length - 1];
+				const lastPath = paths.pop();
 
 				if (typeof lastPath === 'number') {
-					item = form.elements.namedItem(getName(paths.slice(0, -1)));
+					item = form.elements.namedItem(getName([...paths, NaN]));
 
 					if (item instanceof RadioNodeList) {
 						item = item.item(lastPath) as Element | null;

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -13,8 +13,10 @@ export interface FieldConfig<Schema = unknown> extends FieldConstraint<Schema> {
 	form?: string;
 }
 
-export type FieldValue<Schema> = Schema extends Primitive | File
+export type FieldValue<Schema> = Schema extends Primitive
 	? string
+	: Schema extends File
+	? File
 	: Schema extends Array<infer InnerType>
 	? Array<FieldValue<InnerType>>
 	: Schema extends Record<string, any>

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -151,6 +151,14 @@ export function reportSubmission(
 					if (item instanceof RadioNodeList) {
 						item = item.item(lastPath) as Element | null;
 					} else {
+						// Skip linking list item error if the multiple attribute is set
+						// ie. multiple file input / multiple select
+						if (
+							(item as HTMLInputElement | HTMLSelectElement | null)?.multiple
+						) {
+							item = null;
+						}
+
 						item = lastPath === 0 ? item : null;
 					}
 				} else {
@@ -171,6 +179,7 @@ export function reportSubmission(
 			}
 
 			if (item instanceof RadioNodeList) {
+				// This assumes all inputs have no multiple attribute set
 				for (const node of item) {
 					nameByInput.set(node as FieldElement, name);
 				}

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -33,10 +33,6 @@ interface TextareaProps extends FieldProps {
 	defaultValue?: string;
 }
 
-export function input<Schema extends File | File[]>(
-	config: FieldConfig<Schema>,
-	{ type }: { type: 'file' },
-): InputProps<Schema>;
 export function input<Schema extends Primitive | File | File[]>(
 	config: FieldConfig<Schema>,
 	{ type, value }: { type?: HTMLInputTypeAttribute; value?: string } = {},

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -33,14 +33,17 @@ interface TextareaProps extends FieldProps {
 	defaultValue?: string;
 }
 
-export function input<Schema extends Primitive>(
+export function input<Schema extends File | File[]>(
+	config: FieldConfig<Schema>,
+	{ type }: { type: 'file' },
+): InputProps<Schema>;
+export function input<Schema extends Primitive | File | File[]>(
 	config: FieldConfig<Schema>,
 	{ type, value }: { type?: HTMLInputTypeAttribute; value?: string } = {},
 ): InputProps<Schema> {
-	const isCheckboxOrRadio = type === 'checkbox' || type === 'radio';
 	const attributes: InputProps<Schema> = {
 		type,
-		name: config.name,
+		name: config.multiple ? `${config.name}[]` : config.name,
 		form: config.form,
 		required: config.required,
 		minLength: config.minLength,
@@ -56,11 +59,11 @@ export function input<Schema extends Primitive>(
 		attributes.autoFocus = true;
 	}
 
-	if (isCheckboxOrRadio) {
+	if (type === 'checkbox' || type === 'radio') {
 		attributes.value = value ?? 'on';
 		attributes.defaultChecked = config.defaultValue === attributes.value;
-	} else {
-		attributes.defaultValue = config.defaultValue;
+	} else if (type !== 'file') {
+		attributes.defaultValue = config.defaultValue as string | undefined;
 	}
 
 	return attributes;

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -203,7 +203,7 @@ export function useForm<Schema extends Record<string, any>>(
 				!form ||
 				!isFieldElement(field) ||
 				field.form !== form ||
-				field.name !== ''
+				field.name !== '__form__'
 			) {
 				return;
 			}

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -6,7 +6,6 @@ import {
 	type ListCommand,
 	type Primitive,
 	type Submission,
-	focusFirstInvalidField,
 	getFormData,
 	getFormElement,
 	getName,
@@ -15,11 +14,11 @@ import {
 	isFieldElement,
 	parse,
 	parseListCommand,
-	requestSubmit,
 	requestValidate,
 	setFormError,
 	updateList,
 	hasError,
+	reportSubmission,
 } from '@conform-to/dom';
 import {
 	type InputHTMLAttributes,
@@ -156,13 +155,7 @@ export function useForm<Schema extends Record<string, any>>(
 			return;
 		}
 
-		setFormError(form, config.state);
-
-		if (!form.reportValidity()) {
-			focusFirstInvalidField(form);
-		}
-
-		requestSubmit(form);
+		reportSubmission(form, config.state);
 	}, [config.state]);
 
 	useEffect(() => {
@@ -278,25 +271,13 @@ export function useForm<Schema extends Record<string, any>>(
 					| HTMLInputElement
 					| null;
 
-				for (const element of form.elements) {
-					if (
-						isFieldElement(element) &&
-						element.name === '' &&
-						element.willValidate
-					) {
-						setError(element.validationMessage);
-						break;
-					}
-				}
-
 				/**
 				 * It checks defaultPrevented to confirm if the submission is intentional
 				 * This is utilized by `useFieldList` to modify the list state when the submit
 				 * event is captured and revalidate the form with new fields without triggering
 				 * a form submission at the same time.
 				 */
-				if (!submitter || event.defaultPrevented) {
-					event.preventDefault();
+				if (event.defaultPrevented) {
 					return;
 				}
 
@@ -343,7 +324,7 @@ export function useForm<Schema extends Record<string, any>>(
 
 					if (
 						(!config.noValidate &&
-							!submitter.formNoValidate &&
+							!submitter?.formNoValidate &&
 							hasError(submission.error)) ||
 						(submission.type === 'validate' &&
 							config.mode !== 'server-validation')
@@ -354,11 +335,7 @@ export function useForm<Schema extends Record<string, any>>(
 					}
 
 					if (event.defaultPrevented) {
-						setFormError(form, submission);
-
-						if (!form.reportValidity()) {
-							focusFirstInvalidField(form);
-						}
+						reportSubmission(form, submission);
 					}
 				} catch (e) {
 					console.warn(e);
@@ -520,44 +497,6 @@ export function useFieldset<Schema extends Record<string, any>>(
 				event.preventDefault();
 			}
 		};
-		const submitHandler = (event: SubmitEvent) => {
-			const form = getFormElement(ref.current);
-
-			if (!form || event.target !== form) {
-				return;
-			}
-
-			/**
-			 * Reset the error state of each field if its validity is changed.
-			 *
-			 * This is a workaround as no official way is provided to notify
-			 * when the validity of the field is changed from `invalid` to `valid`.
-			 */
-			setError((prev) => {
-				let next = prev;
-
-				const fieldsetName = configRef.current.name ?? '';
-
-				for (const field of form.elements) {
-					if (isFieldElement(field) && field.name.startsWith(fieldsetName)) {
-						const key = fieldsetName
-							? field.name.slice(fieldsetName.length + 1)
-							: field.name;
-						const prevMessage = next?.[key] ?? '';
-						const nextMessage = field.validationMessage;
-
-						if (prevMessage !== '' && nextMessage === '') {
-							next = {
-								...next,
-								[key]: '',
-							};
-						}
-					}
-				}
-
-				return next;
-			});
-		};
 		const resetHandler = (event: Event) => {
 			const form = getFormElement(ref.current);
 
@@ -579,12 +518,10 @@ export function useFieldset<Schema extends Record<string, any>>(
 
 		// The invalid event does not bubble and so listening on the capturing pharse is needed
 		document.addEventListener('invalid', invalidHandler, true);
-		document.addEventListener('submit', submitHandler);
 		document.addEventListener('reset', resetHandler);
 
 		return () => {
 			document.removeEventListener('invalid', invalidHandler, true);
-			document.removeEventListener('submit', submitHandler);
 			document.removeEventListener('reset', resetHandler);
 		};
 	}, [ref]);

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -843,7 +843,7 @@ interface InputControl<Element extends { focus: () => void }> {
  */
 export function useControlledInput<
 	Element extends { focus: () => void } = HTMLInputElement,
-	Schema extends Primitive = Primitive,
+	Schema = any,
 >(config: FieldConfig<Schema>): [ShadowInputProps, InputControl<Element>] {
 	const ref = useRef<HTMLInputElement>(null);
 	const inputRef = useRef<Element>(null);

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -155,6 +155,8 @@ export function useForm<Schema extends Record<string, any>>(
 			return;
 		}
 
+		console.log('last submission', config.state);
+
 		reportSubmission(form, config.state);
 	}, [config.state]);
 
@@ -478,7 +480,11 @@ export function useFieldset<Schema extends Record<string, any>>(
 			);
 
 			// Update the error only if the field belongs to the fieldset
-			if (typeof key === 'string' && paths.length === 0) {
+			if (
+				typeof key === 'string' &&
+				(paths.length === 0 ||
+					(paths.length === 1 && Number.isNaN(paths[paths.length - 1])))
+			) {
 				if (field.dataset.conformTouched) {
 					setError((prev) => {
 						const prevMessage = prev?.[key] ?? '';
@@ -837,6 +843,7 @@ export function useControlledInput<
 			onFocus() {
 				inputRef.current?.focus();
 			},
+			// @ts-expect-error
 			...input({ ...config, ...uncontrolledState }),
 		},
 		{

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -699,18 +699,30 @@ export function useFieldList<Payload = any>(
 				typeof key === 'number' &&
 				paths.every((path) => Number.isNaN(path))
 			) {
+				let index = key;
+
+				if (Number.isNaN(index)) {
+					const item = form.elements.namedItem(field.name);
+
+					if (item instanceof RadioNodeList) {
+						index = Array.from(item.values()).indexOf(field);
+					} else {
+						index = 0;
+					}
+				}
+
 				if (field.dataset.conformTouched) {
 					setError((prev) => {
-						const prevMessage = prev?.[key] ?? '';
+						const prevMessage = prev?.[index] ?? '';
 
 						if (prevMessage === field.validationMessage) {
 							return prev;
 						}
 
 						return [
-							...prev.slice(0, key),
+							...prev.slice(0, index),
 							field.validationMessage,
-							...prev.slice(key + 1),
+							...prev.slice(index + 1),
 						];
 					});
 				}

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -155,8 +155,6 @@ export function useForm<Schema extends Record<string, any>>(
 			return;
 		}
 
-		console.log('last submission', config.state);
-
 		reportSubmission(form, config.state);
 	}, [config.state]);
 
@@ -588,6 +586,7 @@ export function useFieldList<Payload = any>(
 ): [
 	Array<{
 		key: string;
+		error: string | undefined;
 		config: FieldConfig<Payload>;
 	}>,
 	{
@@ -631,20 +630,26 @@ export function useFieldList<Payload = any>(
 			initialError,
 		};
 	});
+	const [error, setError] = useState(() =>
+		uncontrolledState.initialError.map((error) => error?.[0][1]),
+	);
 	const [entries, setEntries] = useState<
 		Array<[string, FieldValue<Payload> | undefined]>
 	>(() => Object.entries(config.defaultValue ?? [undefined]));
-	const list = entries.map<{ key: string; config: FieldConfig<Payload> }>(
-		([key, defaultValue], index) => ({
-			key,
-			config: {
-				name: `${config.name}[${index}]`,
-				form: config.form,
-				defaultValue: defaultValue ?? uncontrolledState.defaultValue[index],
-				initialError: uncontrolledState.initialError[index],
-			},
-		}),
-	);
+	const list = entries.map<{
+		key: string;
+		error: string | undefined;
+		config: FieldConfig<Payload>;
+	}>(([key, defaultValue], index) => ({
+		key,
+		error: error[index],
+		config: {
+			name: `${config.name}[${index}]`,
+			form: config.form,
+			defaultValue: defaultValue ?? uncontrolledState.defaultValue[index],
+			initialError: uncontrolledState.initialError[index],
+		},
+	}));
 
 	/***
 	 * This use proxy to capture all information about the command and
@@ -671,6 +676,48 @@ export function useFieldList<Payload = any>(
 	});
 
 	useEffect(() => {
+		const invalidHandler = (event: Event) => {
+			const form = getFormElement(ref.current);
+			const field = event.target;
+			const prefix = configRef.current.name ?? '';
+
+			if (
+				!form ||
+				!isFieldElement(field) ||
+				field.form !== form ||
+				!field.name.startsWith(prefix)
+			) {
+				return;
+			}
+
+			const [key, ...paths] = getPaths(
+				prefix.length > 0 ? field.name.slice(prefix.length) : field.name,
+			);
+
+			// Update the error only if the field belongs to the fieldset
+			if (
+				typeof key === 'number' &&
+				paths.every((path) => Number.isNaN(path))
+			) {
+				if (field.dataset.conformTouched) {
+					setError((prev) => {
+						const prevMessage = prev?.[key] ?? '';
+
+						if (prevMessage === field.validationMessage) {
+							return prev;
+						}
+
+						return [
+							...prev.slice(0, key),
+							field.validationMessage,
+							...prev.slice(key + 1),
+						];
+					});
+				}
+
+				event.preventDefault();
+			}
+		};
 		const submitHandler = (event: SubmitEvent) => {
 			const form = getFormElement(ref.current);
 
@@ -709,6 +756,23 @@ export function useFieldList<Payload = any>(
 					}
 				}
 			});
+			setError((error) => {
+				switch (command.type) {
+					case 'append':
+					case 'prepend':
+					case 'replace':
+						return updateList([...error], {
+							...command,
+							payload: {
+								...command.payload,
+								defaultValue: undefined,
+							},
+						} as ListCommand<string | undefined>);
+					default: {
+						return updateList([...error], command);
+					}
+				}
+			});
 			event.preventDefault();
 		};
 		const resetHandler = (event: Event) => {
@@ -725,13 +789,16 @@ export function useFieldList<Payload = any>(
 				initialError: [],
 			});
 			setEntries(Object.entries(fieldConfig.defaultValue ?? [undefined]));
+			setError([]);
 		};
 
 		document.addEventListener('submit', submitHandler, true);
+		document.addEventListener('invalid', invalidHandler, true);
 		document.addEventListener('reset', resetHandler);
 
 		return () => {
 			document.removeEventListener('submit', submitHandler, true);
+			document.removeEventListener('invalid', invalidHandler, true);
 			document.removeEventListener('reset', resetHandler);
 		};
 	}, [ref]);
@@ -843,7 +910,6 @@ export function useControlledInput<
 			onFocus() {
 				inputRef.current?.focus();
 			},
-			// @ts-expect-error
 			...input({ ...config, ...uncontrolledState }),
 		},
 		{

--- a/playground/app/routes/file-upload.tsx
+++ b/playground/app/routes/file-upload.tsx
@@ -1,0 +1,77 @@
+import { conform, parse, useFieldset, useForm } from '@conform-to/react';
+import { formatError, validate } from '@conform-to/zod';
+import type { ActionArgs, LoaderArgs } from '@remix-run/node';
+import { json } from '@remix-run/node';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { z } from 'zod';
+import { Playground, Field, Alert } from '~/components';
+import { parseConfig } from '~/config';
+
+const schema = z.object({
+	files: z
+		.array(z.instanceof(File, { message: 'Please select at least one file' }))
+		.refine(
+			(files) => files.every((file) => file.type === 'application/json'),
+			'All files must be JSON',
+		),
+});
+
+type Schema = z.infer<typeof schema>;
+
+export let loader = async ({ request }: LoaderArgs) => {
+	return parseConfig(request);
+};
+
+export let action = async ({ request }: ActionArgs) => {
+	const formData = await request.formData();
+	const submission = parse(formData);
+
+	try {
+		const data = schema.parse(submission.value);
+
+		console.log(data);
+	} catch (error) {
+		submission.error.push(...formatError(error));
+	}
+
+	return json(submission);
+};
+
+export default function EmployeeForm() {
+	const config = useLoaderData();
+	const state = useActionData();
+	const form = useForm<Schema>({
+		...config,
+		state,
+		onValidate: config.validate
+			? ({ formData }) => validate(formData, schema)
+			: undefined,
+		onSubmit:
+			config.mode === 'server-validation'
+				? (event, { submission }) => {
+						if (submission.type === 'validate') {
+							event.preventDefault();
+						}
+				  }
+				: undefined,
+	});
+	const { files } = useFieldset<Schema>(form.ref, {
+		...form.config,
+		constraint: {
+			files: {
+				multiple: true,
+			},
+		},
+	});
+
+	return (
+		<Form method="post" {...form.props} encType="multipart/form-data">
+			<Playground title="Employee Form" state={state}>
+				<Alert message={form.error} />
+				<Field label="Files" error={files.error}>
+					<input {...conform.input(files.config, { type: 'file' })} />
+				</Field>
+			</Playground>
+		</Form>
+	);
+}

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -87,6 +87,7 @@ export default function LoginForm() {
 				<Field label="Password" error={password.error}>
 					<input {...conform.input(password.config, { type: 'password' })} />
 				</Field>
+				<button type="button">Non-submit button</button>
 			</Playground>
 		</Form>
 	);

--- a/playground/app/routes/simple-list.tsx
+++ b/playground/app/routes/simple-list.tsx
@@ -14,7 +14,10 @@ import { Playground, Field, Alert } from '~/components';
 import { parseConfig } from '~/config';
 
 const schema = z.object({
-	sections: z.array(z.string().min(1, 'The field is required')),
+	sections: z
+		.array(z.string().min(1, 'The field is required'))
+		.min(1, 'At least one section is required')
+		.max(5, 'Maximum 5 sections are accepted'),
 });
 
 type Schema = z.infer<typeof schema>;
@@ -28,9 +31,14 @@ export let action = async ({ request }: ActionArgs) => {
 	const submission = parse(formData);
 
 	try {
-		const data = schema.parse(submission.value);
-
-		console.log(data);
+		switch (submission.type) {
+			case 'validate':
+			case 'submit':
+			default:
+				const data = schema.parse(submission.value);
+				console.log(data);
+				break;
+		}
 	} catch (error) {
 		submission.error.push(...formatError(error));
 	}
@@ -99,13 +107,13 @@ export default function EmployeeForm() {
 				<div className="flex flex-row gap-2">
 					<button
 						className="rounded-md border p-2 hover:border-black"
-						{...command.prepend()}
+						{...command.prepend({ defaultValue: '' })}
 					>
 						Insert top
 					</button>
 					<button
 						className="rounded-md border p-2 hover:border-black"
-						{...command.append()}
+						{...command.append({ defaultValue: '' })}
 					>
 						Insert bottom
 					</button>

--- a/playground/app/routes/simple-list.tsx
+++ b/playground/app/routes/simple-list.tsx
@@ -1,0 +1,116 @@
+import {
+	conform,
+	parse,
+	useFieldList,
+	useFieldset,
+	useForm,
+} from '@conform-to/react';
+import { formatError, validate } from '@conform-to/zod';
+import type { ActionArgs, LoaderArgs } from '@remix-run/node';
+import { json } from '@remix-run/node';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { z } from 'zod';
+import { Playground, Field, Alert } from '~/components';
+import { parseConfig } from '~/config';
+
+const schema = z.object({
+	sections: z.array(z.string().min(1, 'The field is required')),
+});
+
+type Schema = z.infer<typeof schema>;
+
+export let loader = async ({ request }: LoaderArgs) => {
+	return parseConfig(request);
+};
+
+export let action = async ({ request }: ActionArgs) => {
+	const formData = await request.formData();
+	const submission = parse(formData);
+
+	try {
+		const data = schema.parse(submission.value);
+
+		console.log(data);
+	} catch (error) {
+		submission.error.push(...formatError(error));
+	}
+
+	return json(submission);
+};
+
+export default function EmployeeForm() {
+	const config = useLoaderData();
+	const state = useActionData();
+	const form = useForm<Schema>({
+		...config,
+		state,
+		onValidate: config.validate
+			? ({ formData }) => validate(formData, schema)
+			: undefined,
+		onSubmit:
+			config.mode === 'server-validation'
+				? (event, { submission }) => {
+						if (submission.type === 'validate') {
+							event.preventDefault();
+						}
+				  }
+				: undefined,
+	});
+	const { sections } = useFieldset(form.ref, form.config);
+	const [sectionList, command] = useFieldList(form.ref, sections.config);
+
+	return (
+		<Form method="post" {...form.props} encType="multipart/form-data">
+			<Playground title="Simple list" state={state}>
+				<Alert message={form.error} />
+				<ol>
+					{sectionList.map((section, index) => (
+						<li key={section.key} className="border rounded-md p-4 mb-4">
+							<Field
+								key={section.key}
+								label={`Section #${index + 1}`}
+								error={section.error}
+							>
+								<textarea {...conform.input(section.config)} />
+							</Field>
+							<div className="flex flex-row gap-2">
+								<button
+									className="rounded-md border p-2 hover:border-black"
+									{...command.remove({ index })}
+								>
+									Delete
+								</button>
+								<button
+									className="rounded-md border p-2 hover:border-black"
+									{...command.reorder({ from: index, to: 0 })}
+								>
+									Move to top
+								</button>
+								<button
+									className="rounded-md border p-2 hover:border-black"
+									{...command.replace({ index, defaultValue: '' })}
+								>
+									Clear
+								</button>
+							</div>
+						</li>
+					))}
+				</ol>
+				<div className="flex flex-row gap-2">
+					<button
+						className="rounded-md border p-2 hover:border-black"
+						{...command.prepend()}
+					>
+						Insert top
+					</button>
+					<button
+						className="rounded-md border p-2 hover:border-black"
+						{...command.append()}
+					>
+						Insert bottom
+					</button>
+				</div>
+			</Playground>
+		</Form>
+	);
+}

--- a/tests/conform-dom.spec.ts
+++ b/tests/conform-dom.spec.ts
@@ -322,6 +322,7 @@ test.describe('conform-dom', () => {
 			expect(getPaths('')).toEqual([]);
 			expect(getPaths('[0]')).toEqual([0]);
 			expect(getPaths('title')).toEqual(['title']);
+			expect(getPaths('file[]')).toEqual(['file', NaN]);
 			expect(getPaths('amount.currency')).toEqual(['amount', 'currency']);
 			expect(getPaths('tasks[0]')).toEqual(['tasks', 0]);
 			expect(getPaths('tasks[1].completed')).toEqual(['tasks', 1, 'completed']);
@@ -332,6 +333,7 @@ test.describe('conform-dom', () => {
 		test('Expected inputs', () => {
 			expect(getName([])).toEqual('');
 			expect(getName([0])).toEqual('[0]');
+			expect(getName(['file', NaN])).toEqual('file[]');
 			expect(getName(['title'])).toEqual('title');
 			expect(getName(['amount', 'currency'])).toEqual('amount.currency');
 			expect(getName(['tasks', 0])).toEqual('tasks[0]');

--- a/tests/conform-yup.spec.ts
+++ b/tests/conform-yup.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from '@playwright/test';
+import { formatError, getFieldsetConstraint, validate } from '@conform-to/yup';
+import * as yup from 'yup';
+import { parse } from '@conform-to/dom';
+import { installGlobals } from '@remix-run/node';
+
+function createFormData(entries: Array<[string, string | File]>): FormData {
+	const formData = new FormData();
+
+	for (const [name, value] of entries) {
+		formData.append(name, value);
+	}
+
+	return formData;
+}
+
+test.beforeAll(() => {
+	installGlobals();
+});
+
+test.describe('conform-yup', () => {
+	const schema = yup
+		.object({
+			text: yup
+				.string()
+				.min(1, 'min')
+				.max(100, 'max')
+				.matches(/^[A-Z]{1-100}$/, 'regex'),
+			tag: yup.string().required('required').oneOf(['x', 'y', 'z'], 'invalid'),
+			number: yup.number().required().min(1, 'min').max(10, 'max'),
+			timestamp: yup
+				.date()
+				.min(new Date(1), 'min')
+				.max(new Date(), 'max')
+				.default(new Date()),
+			options: yup
+				.array(yup.string().oneOf(['a', 'b', 'c'], 'invalid'))
+				.min(3, 'min'),
+			nested: yup
+				.object({
+					key: yup.string().required('required'),
+				})
+				.test('nested', 'error', () => false),
+			list: yup
+				.array(
+					yup
+						.object({
+							key: yup.string().required('required'),
+						})
+						.test('list-object', 'error', () => false),
+				)
+				.max(0, 'max'),
+		})
+		.test('root', 'error', () => false);
+
+	const value = {
+		text: '',
+		tag: '',
+		number: '99',
+		timestamp: new Date(0).toISOString(),
+		options: ['a', 'd'],
+		nested: { key: '' },
+		list: [{ key: '' }],
+	};
+	const error = [
+		['text', 'min'],
+		['text', 'regex'],
+		['tag', 'required'],
+		['tag', 'invalid'],
+		['number', 'max'],
+		['timestamp', 'min'],
+		['options[1]', 'invalid'],
+		['options', 'min'],
+		['nested.key', 'required'],
+		['nested', 'error'],
+		['list[0].key', 'required'],
+		['list[0]', 'error'],
+		['list', 'max'],
+		['', 'error'],
+	];
+
+	test('formatError', () => {
+		expect(formatError(null)).toEqual([['', 'Oops! Something went wrong.']]);
+		expect(formatError(null, 'Error found')).toEqual([['', 'Error found']]);
+		expect(formatError(new Error('Test error'))).toEqual([['', 'Test error']]);
+
+		try {
+			schema.validateSync(value, {
+				abortEarly: false,
+			});
+			throw new Error('Validation should be failed');
+		} catch (exception) {
+			expect(formatError(exception)).toEqual(error);
+		}
+	});
+
+	test('getFieldsetConstraint', () => {
+		expect(getFieldsetConstraint(schema)).toEqual({
+			text: {
+				minLength: 1,
+				maxLength: 100,
+				pattern: '^[A-Z]{1-100}$',
+			},
+			tag: {
+				required: true,
+				pattern: 'x|y|z',
+			},
+			number: {
+				required: true,
+				min: 1,
+				max: 10,
+			},
+			timestamp: {},
+			options: {},
+			nested: {},
+			list: {},
+		});
+	});
+
+	test('validate', () => {
+		const formData = createFormData([
+			['text', value.text],
+			['tag', value.tag],
+			['number', value.number],
+			['timestamp', value.timestamp],
+			['options[0]', value.options[0]],
+			['options[1]', value.options[1]],
+			['nested.key', value.nested.key],
+			['list[0].key', value.list[0].key],
+		]);
+		const submission = parse(formData);
+
+		expect(submission.value).toEqual(value);
+		expect(validate(formData, schema)).toEqual({
+			...submission,
+			error,
+		});
+
+		// TODO: Fallback to server validation when non zod error is caught on client validation
+		// expect(() => validate(formData, undefined as any)).toThrow();
+	});
+});

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -1,0 +1,166 @@
+import { test, expect } from '@playwright/test';
+import {
+	formatError,
+	getFieldsetConstraint,
+	validate,
+	ifNonEmptyString,
+} from '@conform-to/zod';
+import { z } from 'zod';
+import { parse } from '@conform-to/dom';
+import { installGlobals } from '@remix-run/node';
+
+function createFormData(entries: Array<[string, string | File]>): FormData {
+	const formData = new FormData();
+
+	for (const [name, value] of entries) {
+		formData.append(name, value);
+	}
+
+	return formData;
+}
+
+test.beforeAll(() => {
+	installGlobals();
+});
+
+test.describe('conform-zod', () => {
+	const schema = z
+		.object({
+			text: z
+				.string()
+				.min(1, 'min')
+				.max(100, 'max')
+				.regex(/^[A-Z]{1-100}$/, 'regex')
+				.refine(() => false, 'refine'),
+			number: z.preprocess(
+				ifNonEmptyString(Number),
+				z.number().min(1, 'min').max(10, 'max').step(2, 'step'),
+			),
+			timestamp: z.preprocess(
+				ifNonEmptyString((value) => new Date(value)),
+				z
+					.date()
+					.min(new Date(1), 'min')
+					.max(new Date(), 'max')
+					.default(new Date()),
+			),
+			flag: z.preprocess(
+				ifNonEmptyString((value) => value === 'Yes'),
+				z.boolean().optional(),
+			),
+			options: z
+				.array(z.enum(['a', 'b', 'c']).refine(() => false, 'refine'))
+				.min(3, 'min'),
+			nested: z
+				.object({
+					key: z.string().refine(() => false, 'refine'),
+				})
+				.refine(() => false, 'refine'),
+			list: z
+				.array(
+					z
+						.object({
+							key: z.string().refine(() => false, 'refine'),
+						})
+						.refine(() => false, 'refine'),
+				)
+				.max(0, 'max'),
+		})
+		.refine(() => false, 'refine');
+
+	const value = {
+		text: '',
+		number: '3',
+		timestamp: new Date(0).toISOString(),
+		flag: 'no',
+		options: ['a', 'b'],
+		nested: { key: '' },
+		list: [{ key: '' }],
+	};
+	const error = [
+		['text', 'min'],
+		['text', 'regex'],
+		['text', 'refine'],
+		['number', 'step'],
+		['timestamp', 'min'],
+		['options', 'min'],
+		['options[0]', 'refine'],
+		['options[1]', 'refine'],
+		['nested.key', 'refine'],
+		['nested', 'refine'],
+		['list', 'max'],
+		['list[0].key', 'refine'],
+		['list[0]', 'refine'],
+		['', 'refine'],
+	];
+
+	test('formatError', () => {
+		const result = schema.safeParse(value);
+
+		if (result.success) {
+			throw new Error('Validation should be failed');
+		}
+
+		expect(formatError(null)).toEqual([['', 'Oops! Something went wrong.']]);
+		expect(formatError(null, 'Error found')).toEqual([['', 'Error found']]);
+		expect(formatError(new Error('Test error'))).toEqual([['', 'Test error']]);
+		expect(formatError(result.error)).toEqual(error);
+	});
+
+	test('getFieldsetConstraint', () => {
+		expect(getFieldsetConstraint(schema)).toEqual({
+			text: {
+				required: true,
+				minLength: 1,
+				maxLength: 100,
+				pattern: '^[A-Z]{1-100}$',
+			},
+			number: {
+				required: true,
+				min: 1,
+				max: 10,
+			},
+			timestamp: {
+				required: false,
+			},
+			flag: {
+				required: false,
+			},
+			options: {
+				required: true,
+				pattern: 'a|b|c',
+				multiple: true,
+			},
+			nested: {
+				required: true,
+			},
+			list: {
+				required: true,
+				multiple: true,
+			},
+		});
+	});
+
+	test('validate', () => {
+		const formData = createFormData([
+			['text', value.text],
+			['number', value.number],
+			['timestamp', value.timestamp],
+			['flag', value.flag],
+			['options[0]', value.options[0]],
+			['options[1]', value.options[1]],
+			['nested.key', value.nested.key],
+			['list[0].key', value.list[0].key],
+		]);
+		const submission = parse(formData);
+
+		expect(submission.value).toEqual(value);
+		expect(validate(formData, schema)).toEqual({
+			...submission,
+			error,
+		});
+
+		// TODO: Fallback to server validation when non zod error is caught on client validation
+		// expect(() => validate(formData, undefined as any)).toThrow();
+	});
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -239,4 +239,16 @@ export function getTaskFieldset(list: Locator, name: string, index: number) {
 	};
 }
 
+export function getPlayground(page: Page) {
+	const form = page.locator('section');
+
+	return {
+		form,
+		submit: form.locator('footer button[type="submit"]'),
+		reset: form.locator('footer button[type="reset"]'),
+		submission: form.locator('pre'),
+		error: form.locator('label > p'),
+	};
+}
+
 export const expectNonEmptyString = expect.stringMatching(/\w+/);

--- a/tests/integrations/file-upload.spec.ts
+++ b/tests/integrations/file-upload.spec.ts
@@ -1,0 +1,136 @@
+import { type Page, type Locator, test, expect } from '@playwright/test';
+import { getPlayground } from '../helpers';
+
+function getFieldset(form: Locator) {
+	return {
+		file: form.locator('[name="file"]'),
+		files: form.locator('[name="files[]"]'),
+	};
+}
+
+interface TestFile {
+	name: string;
+	mimeType: string;
+	buffer: Buffer;
+}
+
+const testFiles: TestFile[] = [
+	{
+		name: 'zero.txt',
+		mimeType: 'plain/text',
+		buffer: Buffer.from(Array(5000).fill(0)),
+	},
+	{
+		name: 'test.json',
+		mimeType: 'application/json',
+		buffer: Buffer.from('{}'),
+	},
+	{
+		name: 'huge.json',
+		mimeType: 'application/json',
+		buffer: Buffer.from(`{ data: ${Array(5109).fill(1).join('')} }`), // 5109 + 10 < 5120
+	},
+];
+
+async function runValidationScenario(page: Page) {
+	const playground = getPlayground(page);
+	const fieldset = getFieldset(playground.form);
+
+	// Trigger form validation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'',
+		'File is required',
+		'At least 1 file is required',
+	]);
+	await fieldset.file.setInputFiles(testFiles[0]);
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'',
+		'Only JSON file is accepted',
+		'At least 1 file is required',
+	]);
+
+	await fieldset.file.setInputFiles(testFiles[1]);
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'',
+		'',
+		'At least 1 file is required',
+	]);
+
+	await fieldset.file.setInputFiles(testFiles[1]);
+	await fieldset.files.setInputFiles([testFiles[1], testFiles[2]]);
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'',
+		'',
+		'Total file size must be less than 5kb',
+	]);
+
+	await fieldset.file.setInputFiles(testFiles[1]);
+	await fieldset.files.setInputFiles(testFiles[2]);
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', '', '']);
+
+	expect(JSON.parse(await playground.submission.innerText())).toMatchObject({
+		type: 'submit',
+		value: {
+			file: {
+				_name: 'test.json',
+				_lastModified: expect.anything(),
+			},
+			files: [
+				{
+					_name: 'huge.json',
+					_lastModified: expect.anything(),
+				},
+			],
+		},
+		error: [],
+	});
+}
+
+test.describe('With JS', () => {
+	test('Client Validation', async ({ page }) => {
+		await page.goto('/file-upload');
+		await runValidationScenario(page);
+	});
+
+	test('Server Validation', async ({ page }) => {
+		await page.goto('/file-upload?noClientValidate=yes');
+		await runValidationScenario(page);
+	});
+
+	test('Form reset', async ({ page }) => {
+		await page.goto('/file-upload');
+
+		const playground = getPlayground(page);
+
+		await playground.submit.click();
+		await expect(playground.error).toHaveText([
+			'',
+			'File is required',
+			'At least 1 file is required',
+		]);
+
+		await playground.reset.click();
+		await expect(playground.error).toHaveText(['', '', '']);
+	});
+});
+
+test.describe('No JS', () => {
+	test.use({ javaScriptEnabled: false });
+
+	test('Validation', async ({ page }) => {
+		await page.goto('/file-upload');
+		await runValidationScenario(page);
+	});
+});

--- a/tests/integrations/simple-list.spec.ts
+++ b/tests/integrations/simple-list.spec.ts
@@ -1,0 +1,167 @@
+import { type Page, type Locator, test, expect } from '@playwright/test';
+import { getPlayground } from '../helpers';
+
+function getFieldset(form: Locator) {
+	return {
+		items: form.locator('ol > li'),
+		insertTop: form.locator('button:text("Insert top")'),
+		insertBottom: form.locator('button:text("Insert bottom")'),
+	};
+}
+
+function getItemFieldset(list: Locator, index: number) {
+	return {
+		content: list.nth(index).locator(`[name="items[${index}]"]`),
+		delete: list.nth(index).locator('button:text("Delete")'),
+		clear: list.nth(index).locator('button:text("Clear")'),
+		moveToTop: list.nth(index).locator('button:text("Move to top")'),
+	};
+}
+
+async function runValidationScenario(page: Page) {
+	const playground = getPlayground(page);
+	const fieldset = getFieldset(playground.form);
+	const item0 = getItemFieldset(fieldset.items, 0);
+	const item1 = getItemFieldset(fieldset.items, 1);
+	const item2 = getItemFieldset(fieldset.items, 2);
+
+	await expect(fieldset.items).toHaveCount(1);
+	await expect(playground.error).toHaveText(['', '']);
+
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', 'The field is required']);
+
+	// Type `First Item` on first row
+	await item0.content.type('First item');
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', '']);
+
+	// Insert a new row on top
+	await fieldset.insertTop.click();
+	await expect(fieldset.items).toHaveCount(2);
+	await expect(item0.content).toHaveValue('');
+	await expect(item1.content).toHaveValue('First item');
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', 'The field is required', '']);
+
+	// Insert a new row at the bottom
+	await fieldset.insertBottom.click();
+	await expect(fieldset.items).toHaveCount(3);
+	await expect(item0.content).toHaveValue('');
+	await expect(item1.content).toHaveValue('First item');
+	await expect(item2.content).toHaveValue('');
+
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'',
+		'The field is required',
+		'',
+		'The field is required',
+	]);
+
+	// Delete the first row
+	await item0.delete.click();
+	await expect(fieldset.items).toHaveCount(2);
+	await expect(item0.content).toHaveValue('First item');
+	await expect(item1.content).toHaveValue('');
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', '', 'The field is required']);
+
+	// Type something on 2nd item
+	await item1.content.type('2nd item');
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', '', 'Number is not allowed']);
+
+	// Clear 2nd row
+	await item1.clear.click();
+	await expect(fieldset.items).toHaveCount(2);
+	await expect(item0.content).toHaveValue('First item');
+	await expect(item1.content).toHaveValue('');
+	await expect(playground.error).toHaveText(['', '', '']);
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', '', 'The field is required']);
+
+	// Move 2nd row to top
+	await item1.moveToTop.click();
+	await expect(fieldset.items).toHaveCount(2);
+	await expect(item0.content).toHaveValue('');
+	await expect(item1.content).toHaveValue('First item');
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', 'The field is required', '']);
+
+	await item0.content.type('Top item');
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', '', '']);
+	await expect(playground.submission).toHaveText(
+		JSON.stringify(
+			{
+				type: 'submit',
+				value: {
+					items: ['Top item', 'First item'],
+				},
+				error: [],
+			},
+			null,
+			2,
+		),
+	);
+}
+
+test.describe('With JS', () => {
+	test('Client Validation', async ({ page }) => {
+		await page.goto('/simple-list');
+		await runValidationScenario(page);
+	});
+
+	test('Server Validation', async ({ page }) => {
+		await page.goto('/simple-list?noClientValidate=yes');
+		await runValidationScenario(page);
+	});
+
+	test('Form reset', async ({ page }) => {
+		await page.goto('/simple-list');
+
+		const playground = getPlayground(page);
+		const fieldset = getFieldset(playground.form);
+
+		await fieldset.insertBottom.click();
+		await playground.submit.click();
+
+		// Before reset
+		await expect(fieldset.items).toHaveCount(2);
+		await expect(playground.error).toHaveText([
+			'',
+			'The field is required',
+			'The field is required',
+		]);
+
+		await playground.reset.click();
+
+		// After reset
+		await expect(fieldset.items).toHaveCount(1);
+		await expect(playground.error).toHaveText(['', '']);
+	});
+});
+
+test.describe('No JS', () => {
+	test.use({ javaScriptEnabled: false });
+
+	test('Validation', async ({ page }) => {
+		await page.goto('/simple-list');
+		await runValidationScenario(page);
+	});
+});


### PR DESCRIPTION
> WIP. This might be split to several PRs later

This PR introduces a new naming convention to denote repeated field names by using the array notation without number, i.e. `[]`. This is particular useful for file input with multiple set to `true`.

This is achieved by an additional mapping logic that look up input by mapping name path on the validation error to the input based on its order on the DOM. e.g. Conform will look up an input with `files[0]` first, and if it is not available, search for the first input with name `file[]`.

More details will be provided later.