### PR TITLE
feat(conform-react): capture list item error

### DIFF
--- a/playground/app/routes/simple-list.tsx
+++ b/playground/app/routes/simple-list.tsx
@@ -1,0 +1,116 @@
+import {
+	conform,
+	parse,
+	useFieldList,
+	useFieldset,
+	useForm,
+} from '@conform-to/react';
+import { formatError, validate } from '@conform-to/zod';
+import type { ActionArgs, LoaderArgs } from '@remix-run/node';
+import { json } from '@remix-run/node';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { z } from 'zod';
+import { Playground, Field, Alert } from '~/components';
+
+const schema = z.object({
+	items: z
+		.array(
+			z
+				.string()
+				.min(1, 'The field is required')
+				.regex(/^[^0-9]+$/, 'Number is not allowed'),
+		)
+		.min(1, 'At least one item is required')
+		.max(5, 'Only five items are allowed in maximum'),
+});
+
+export async function loader({ request }: LoaderArgs) {
+	const url = new URL(request.url);
+
+	return {
+		noClientValidate: url.searchParams.get('noClientValidate') === 'yes',
+	};
+}
+
+export async function action({ request }: ActionArgs) {
+	const formData = await request.formData();
+	const submission = parse(formData);
+
+	try {
+		switch (submission.type) {
+			case 'validate':
+			case 'submit':
+				schema.parse(submission.value);
+				break;
+		}
+	} catch (error) {
+		submission.error.push(...formatError(error));
+	}
+
+	return json(submission);
+}
+
+export default function SimpleList() {
+	const { noClientValidate } = useLoaderData<typeof loader>();
+	const state = useActionData();
+	const form = useForm<z.infer<typeof schema>>({
+		mode: noClientValidate ? 'server-validation' : 'client-only',
+		state,
+		onValidate: !noClientValidate
+			? ({ formData }) => validate(formData, schema)
+			: undefined,
+	});
+	const { items } = useFieldset(form.ref, form.config);
+	const [list, command] = useFieldList(form.ref, items.config);
+
+	return (
+		<Form method="post" {...form.props}>
+			<Playground title="Simple list" state={state}>
+				<Alert message={form.error} />
+				<ol>
+					{list.map((item, index) => (
+						<li key={item.key} className="border rounded-md p-4 mb-4">
+							<Field label={`Item #${index + 1}`} error={item.error}>
+								<input {...conform.input(item.config, { type: 'text' })} />
+							</Field>
+							<div className="flex flex-row gap-2">
+								<button
+									className="rounded-md border p-2 hover:border-black"
+									{...command.remove({ index })}
+								>
+									Delete
+								</button>
+								<button
+									className="rounded-md border p-2 hover:border-black"
+									{...command.reorder({ from: index, to: 0 })}
+								>
+									Move to top
+								</button>
+								<button
+									className="rounded-md border p-2 hover:border-black"
+									{...command.replace({ index, defaultValue: '' })}
+								>
+									Clear
+								</button>
+							</div>
+						</li>
+					))}
+				</ol>
+				<div className="flex flex-row gap-2">
+					<button
+						className="rounded-md border p-2 hover:border-black"
+						{...command.prepend({ defaultValue: '' })}
+					>
+						Insert top
+					</button>
+					<button
+						className="rounded-md border p-2 hover:border-black"
+						{...command.append({ defaultValue: '' })}
+					>
+						Insert bottom
+					</button>
+				</div>
+			</Playground>
+		</Form>
+	);
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -239,4 +239,16 @@ export function getTaskFieldset(list: Locator, name: string, index: number) {
 	};
 }
 
+export function getPlayground(page: Page) {
+	const form = page.locator('section');
+
+	return {
+		form,
+		submit: form.locator('footer button[type="submit"]'),
+		reset: form.locator('footer button[type="reset"]'),
+		submission: form.locator('pre'),
+		error: form.locator('label > p'),
+	};
+}
+
 export const expectNonEmptyString = expect.stringMatching(/\w+/);

--- a/tests/integrations/simple-list.spec.ts
+++ b/tests/integrations/simple-list.spec.ts
@@ -1,0 +1,167 @@
+import { type Page, type Locator, test, expect } from '@playwright/test';
+import { getPlayground } from '../helpers';
+
+function getFieldset(form: Locator) {
+	return {
+		items: form.locator('ol > li'),
+		insertTop: form.locator('button:text("Insert top")'),
+		insertBottom: form.locator('button:text("Insert bottom")'),
+	};
+}
+
+function getItemFieldset(list: Locator, index: number) {
+	return {
+		content: list.nth(index).locator(`[name="items[${index}]"]`),
+		delete: list.nth(index).locator('button:text("Delete")'),
+		clear: list.nth(index).locator('button:text("Clear")'),
+		moveToTop: list.nth(index).locator('button:text("Move to top")'),
+	};
+}
+
+async function runValidationScenario(page: Page) {
+	const playground = getPlayground(page);
+	const fieldset = getFieldset(playground.form);
+	const item0 = getItemFieldset(fieldset.items, 0);
+	const item1 = getItemFieldset(fieldset.items, 1);
+	const item2 = getItemFieldset(fieldset.items, 2);
+
+	await expect(fieldset.items).toHaveCount(1);
+	await expect(playground.error).toHaveText(['', '']);
+
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', 'The field is required']);
+
+	// Type `First Item` on first row
+	await item0.content.type('First item');
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', '']);
+
+	// Insert a new row on top
+	await fieldset.insertTop.click();
+	await expect(fieldset.items).toHaveCount(2);
+	await expect(item0.content).toHaveValue('');
+	await expect(item1.content).toHaveValue('First item');
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', 'The field is required', '']);
+
+	// Insert a new row at the bottom
+	await fieldset.insertBottom.click();
+	await expect(fieldset.items).toHaveCount(3);
+	await expect(item0.content).toHaveValue('');
+	await expect(item1.content).toHaveValue('First item');
+	await expect(item2.content).toHaveValue('');
+
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'',
+		'The field is required',
+		'',
+		'The field is required',
+	]);
+
+	// Delete the first row
+	await item0.delete.click();
+	await expect(fieldset.items).toHaveCount(2);
+	await expect(item0.content).toHaveValue('First item');
+	await expect(item1.content).toHaveValue('');
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', '', 'The field is required']);
+
+	// Type something on 2nd item
+	await item1.content.type('2nd item');
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', '', 'Number is not allowed']);
+
+	// Clear 2nd row
+	await item1.clear.click();
+	await expect(fieldset.items).toHaveCount(2);
+	await expect(item0.content).toHaveValue('First item');
+	await expect(item1.content).toHaveValue('');
+	await expect(playground.error).toHaveText(['', '', '']);
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', '', 'The field is required']);
+
+	// Move 2nd row to top
+	await item1.moveToTop.click();
+	await expect(fieldset.items).toHaveCount(2);
+	await expect(item0.content).toHaveValue('');
+	await expect(item1.content).toHaveValue('First item');
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', 'The field is required', '']);
+
+	await item0.content.type('Top item');
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', '', '']);
+	await expect(playground.submission).toHaveText(
+		JSON.stringify(
+			{
+				type: 'submit',
+				value: {
+					items: ['Top item', 'First item'],
+				},
+				error: [],
+			},
+			null,
+			2,
+		),
+	);
+}
+
+test.describe('With JS', () => {
+	test('Client Validation', async ({ page }) => {
+		await page.goto('/simple-list');
+		await runValidationScenario(page);
+	});
+
+	test('Server Validation', async ({ page }) => {
+		await page.goto('/simple-list?noClientValidate=yes');
+		await runValidationScenario(page);
+	});
+
+	test('Form reset', async ({ page }) => {
+		await page.goto('/simple-list');
+
+		const playground = getPlayground(page);
+		const fieldset = getFieldset(playground.form);
+
+		await fieldset.insertBottom.click();
+		await playground.submit.click();
+
+		// Before reset
+		await expect(fieldset.items).toHaveCount(2);
+		await expect(playground.error).toHaveText([
+			'',
+			'The field is required',
+			'The field is required',
+		]);
+
+		await playground.reset.click();
+
+		// After reset
+		await expect(fieldset.items).toHaveCount(1);
+		await expect(playground.error).toHaveText(['', '']);
+	});
+});
+
+test.describe('No JS', () => {
+	test.use({ javaScriptEnabled: false });
+
+	test('Validation', async ({ page }) => {
+		await page.goto('/simple-list');
+		await runValidationScenario(page);
+	});
+});


### PR DESCRIPTION
This PR adds error capturing logic for each list item, which is useful when dealing with simple array structure like `string[]`

```tsx
function Example() {
  const [list, command] = useFieldList(form.ref, items.config);

  return (
    <ol>
      {list.map(item => (
        <li key={item.key}>
          <input {...conform.input(item.config)} />
          {item.error}
        </li>
      )}
    </ol>
  );
}

