### PR TITLE
feat(conform-dom,conform-react): multiple file support

### DIFF
--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -13,8 +13,10 @@ export interface FieldConfig<Schema = unknown> extends FieldConstraint<Schema> {
 	form?: string;
 }
 
-export type FieldValue<Schema> = Schema extends Primitive | File
+export type FieldValue<Schema> = Schema extends Primitive
 	? string
+	: Schema extends File
+	? File
 	: Schema extends Array<infer InnerType>
 	? Array<FieldValue<InnerType>>
 	: Schema extends Record<string, any>
@@ -319,11 +321,13 @@ export function parse<Schema extends Record<string, any>>(
 				const paths = getPaths(name);
 
 				setValue(submission.value, paths, (prev) => {
-					if (prev) {
-						throw new Error('Entry with the same name is not supported');
+					if (!prev) {
+						return value;
+					} else if (Array.isArray(prev)) {
+						return prev.concat(value);
+					} else {
+						return [prev, value];
 					}
-
-					return value;
 				});
 			}
 		}

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -1,5 +1,5 @@
-import { type FieldConfig, type Primitive } from '@conform-to/dom';
-import { type HTMLInputTypeAttribute } from 'react';
+import type { FieldConfig } from '@conform-to/dom';
+import type { HTMLInputTypeAttribute } from 'react';
 
 interface FieldProps {
 	name: string;
@@ -33,13 +33,37 @@ interface TextareaProps extends FieldProps {
 	defaultValue?: string;
 }
 
-export function input<Schema extends Primitive>(
+type InputOptions =
+	| {
+			type: 'checkbox' | 'radio';
+			value?: string;
+	  }
+	| {
+			type: 'file';
+			value?: never;
+	  }
+	| {
+			type?: Exclude<
+				HTMLInputTypeAttribute,
+				'button' | 'submit' | 'hidden' | 'file'
+			>;
+			value?: never;
+	  };
+
+export function input<Schema extends File | File[]>(
 	config: FieldConfig<Schema>,
-	{ type, value }: { type?: HTMLInputTypeAttribute; value?: string } = {},
+	options: { type: 'file' },
+): InputProps<Schema>;
+export function input<Schema extends any>(
+	config: FieldConfig<Schema>,
+	options?: InputOptions,
+): InputProps<Schema>;
+export function input<Schema>(
+	config: FieldConfig<Schema>,
+	options: InputOptions = {},
 ): InputProps<Schema> {
-	const isCheckboxOrRadio = type === 'checkbox' || type === 'radio';
 	const attributes: InputProps<Schema> = {
-		type,
+		type: options.type,
 		name: config.name,
 		form: config.form,
 		required: config.required,
@@ -56,19 +80,17 @@ export function input<Schema extends Primitive>(
 		attributes.autoFocus = true;
 	}
 
-	if (isCheckboxOrRadio) {
-		attributes.value = value ?? 'on';
+	if (options.type === 'checkbox' || options.type === 'radio') {
+		attributes.value = options.value ?? 'on';
 		attributes.defaultChecked = config.defaultValue === attributes.value;
-	} else {
-		attributes.defaultValue = config.defaultValue;
+	} else if (options.type !== 'file') {
+		attributes.defaultValue = config.defaultValue as string | undefined;
 	}
 
 	return attributes;
 }
 
-export function select<Schema extends Primitive | Array<Primitive>>(
-	config: FieldConfig<Schema>,
-): SelectProps {
+export function select<Schema>(config: FieldConfig<Schema>): SelectProps {
 	const attributes: SelectProps = {
 		name: config.name,
 		form: config.form,
@@ -88,9 +110,7 @@ export function select<Schema extends Primitive | Array<Primitive>>(
 	return attributes;
 }
 
-export function textarea<Schema extends Primitive>(
-	config: FieldConfig<Schema>,
-): TextareaProps {
+export function textarea<Schema>(config: FieldConfig<Schema>): TextareaProps {
 	const attributes: TextareaProps = {
 		name: config.name,
 		form: config.form,

--- a/playground/app/routes/file-upload.tsx
+++ b/playground/app/routes/file-upload.tsx
@@ -1,0 +1,91 @@
+import { conform, parse, useFieldset, useForm } from '@conform-to/react';
+import { formatError, validate } from '@conform-to/zod';
+import type { ActionArgs, LoaderArgs } from '@remix-run/node';
+import { json } from '@remix-run/node';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { z } from 'zod';
+import { Playground, Field, Alert } from '~/components';
+
+function isEmptyFile(file: unknown): boolean {
+	return (
+		// FIXME: The empty file is presented as empty string on server side
+		// This is caused by @remix-run/web-fetch considered empty filename as non-file entry
+		file === '' ||
+		(file instanceof File &&
+			file.name === '' &&
+			file.size === 0 &&
+			file.type === 'application/octet-stream')
+	);
+}
+const JsonFile = z
+	.instanceof(File, { message: 'File is required' })
+	.refine(
+		(file) => file.type === 'application/json',
+		'Only JSON file is accepted',
+	);
+
+const schema = z.object({
+	file: z.preprocess(
+		(file) => (isEmptyFile(file) ? undefined : file),
+		JsonFile,
+	),
+	files: z
+		.preprocess(
+			(files) =>
+				isEmptyFile(files) ? [] : Array.isArray(files) ? files : [files],
+			z.array(JsonFile).min(1, 'At least 1 file is required'),
+		)
+		.refine(
+			(files) => files.reduce((size, file) => size + file.size, 0) < 5 * 1024,
+			'Total file size must be less than 5kb',
+		),
+});
+
+type Schema = z.infer<typeof schema>;
+
+export async function loader({ request }: LoaderArgs) {
+	const url = new URL(request.url);
+
+	return {
+		noClientValidate: url.searchParams.get('noClientValidate') === 'yes',
+	};
+}
+
+export async function action({ request }: ActionArgs) {
+	const formData = await request.formData();
+	const submission = parse(formData);
+
+	try {
+		schema.parse(submission.value);
+	} catch (error) {
+		submission.error.push(...formatError(error));
+	}
+
+	return json(submission);
+}
+
+export default function FileUpload() {
+	const { noClientValidate } = useLoaderData<typeof loader>();
+	const state = useActionData();
+	const form = useForm<Schema>({
+		state,
+		onValidate: !noClientValidate
+			? ({ formData }) => validate(formData, schema)
+			: undefined,
+	});
+	const { file, files } = useFieldset<Schema>(form.ref, form.config);
+
+	return (
+		<Form method="post" {...form.props} encType="multipart/form-data">
+			<Playground title="Employee Form" state={state}>
+				<Alert message={form.error} />
+				<Field label="Single file" error={file.error}>
+					<input {...conform.input(file.config, { type: 'file' })} />
+				</Field>
+				<Field label="Multiple files" error={files.error}>
+					<input {...conform.input(files.config, { type: 'file' })} multiple />
+				</Field>
+			</Playground>
+		</Form>
+	);
+}

--- a/tests/integrations/file-upload.spec.ts
+++ b/tests/integrations/file-upload.spec.ts
@@ -1,0 +1,134 @@
+import { type Page, type Locator, test, expect } from '@playwright/test';
+import { getPlayground } from '../helpers';
+
+function getFieldset(form: Locator) {
+	return {
+		file: form.locator('[name="file"]'),
+		files: form.locator('[name="files"]'),
+	};
+}
+
+interface TestFile {
+	name: string;
+	mimeType: string;
+	buffer: Buffer;
+}
+
+const testFiles: TestFile[] = [
+	{
+		name: 'zero.txt',
+		mimeType: 'plain/text',
+		buffer: Buffer.from(Array(5000).fill(0)),
+	},
+	{
+		name: 'test.json',
+		mimeType: 'application/json',
+		buffer: Buffer.from('{}'),
+	},
+	{
+		name: 'huge.json',
+		mimeType: 'application/json',
+		buffer: Buffer.from(`{ data: ${Array(5109).fill(1).join('')} }`), // 5109 + 10 < 5120
+	},
+];
+
+async function runValidationScenario(page: Page) {
+	const playground = getPlayground(page);
+	const fieldset = getFieldset(playground.form);
+
+	// Trigger form validation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'',
+		'File is required',
+		'At least 1 file is required',
+	]);
+	await fieldset.file.setInputFiles(testFiles[0]);
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'',
+		'Only JSON file is accepted',
+		'At least 1 file is required',
+	]);
+
+	await fieldset.file.setInputFiles(testFiles[1]);
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'',
+		'',
+		'At least 1 file is required',
+	]);
+
+	await fieldset.file.setInputFiles(testFiles[1]);
+	await fieldset.files.setInputFiles([testFiles[1], testFiles[2]]);
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'',
+		'',
+		'Total file size must be less than 5kb',
+	]);
+
+	await fieldset.file.setInputFiles(testFiles[1]);
+	await fieldset.files.setInputFiles(testFiles[2]);
+
+	// Trigger revalidation
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', '', '']);
+
+	expect(JSON.parse(await playground.submission.innerText())).toMatchObject({
+		type: 'submit',
+		value: {
+			file: {
+				_name: 'test.json',
+				_lastModified: expect.anything(),
+			},
+			files: {
+				_name: 'huge.json',
+				_lastModified: expect.anything(),
+			},
+		},
+		error: [],
+	});
+}
+
+test.describe('With JS', () => {
+	test('Client Validation', async ({ page }) => {
+		await page.goto('/file-upload');
+		await runValidationScenario(page);
+	});
+
+	test('Server Validation', async ({ page }) => {
+		await page.goto('/file-upload?noClientValidate=yes');
+		await runValidationScenario(page);
+	});
+
+	test('Form reset', async ({ page }) => {
+		await page.goto('/file-upload');
+
+		const playground = getPlayground(page);
+
+		await playground.submit.click();
+		await expect(playground.error).toHaveText([
+			'',
+			'File is required',
+			'At least 1 file is required',
+		]);
+
+		await playground.reset.click();
+		await expect(playground.error).toHaveText(['', '', '']);
+	});
+});
+
+test.describe('No JS', () => {
+	test.use({ javaScriptEnabled: false });
+
+	test('Validation', async ({ page }) => {
+		await page.goto('/file-upload');
+		await runValidationScenario(page);
+	});
+});


### PR DESCRIPTION
My original idea was to use `[]` to denote the type of the data and hopefully enable a better type hint on the parsed value, but then comes to realize the current types for `submission.value` is very much a lie as there is no way to guess its structure, best as `Record<string, unknown>`.

- The final solution simply removes the error thrown when there are more than one entry with the same name and convert the value to an array instead. This means the result data type will be an array **ONLY** when there are 2+ entries. It is the duty of the user to coerce the value to an array if appropriate. 
- The FormData API will generate an entry with empty file (name = '', size = 0, type = 'application/octet-stream') even no file is selected. However, there is currently a bug on `@remix-run/web-fetch` which parses the body incorrectly and returns an empty string instead on the server. Since this is a polyfill, only remix app running on node is affected and some extra logic to preprocess it is needed.
- When validating a list of files, only validation messages on the array level are accepted. Error on the item will not be captured and reported. e.g. `files` instead of `files[0]`, 

Zod example:

```ts
function isEmptyFile(file: unknown): boolean {
    return (
        // FIXME: The empty file is presented as empty string on server side
        // This is caused by @remix-run/web-fetch considered empty filename as non-file entry
        file === '' ||
        (file instanceof File &&
            file.name === '' &&
            file.size === 0 &&
            file.type === 'application/octet-stream')
    );
}

const schema = z.object({
    file: z.preprocess(
        (file) => (isEmptyFile(file) ? undefined : file),
        z.instanceof(File, { message: 'File is required' }),
    ),
    files: z
        .preprocess(
            (files) =>
                isEmptyFile(files) ? [] : Array.isArray(files) ? files : [files],
            z.instanceof(File).array().min(1, 'At least 1 file is required'),
        )
        .refine(
            (files) => files.reduce((size, file) => size + file.size, 0) < 5 * 1024,
            'Total file size must be less than 5kb',
        ),
});
```

