### PR TITLE
feat(conform-react): list validation 

### DIFF
--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -199,6 +199,10 @@ export function reportSubmission(
 			}
 		}
 	}
+
+	if (submission.type === 'submit') {
+		focusFirstInvalidField(form);
+	}
 }
 
 export function setValue<T>(

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -151,7 +151,6 @@ export function reportSubmission(
 		form.dispatchEvent(
 			new CustomEvent('conform/list', {
 				detail: submission.intent,
-				bubbles: true,
 			}),
 		);
 	}

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -120,7 +120,10 @@ export function shouldValidate(submission: Submission, name: string): boolean {
 	return (
 		submission.type === 'submit' ||
 		(submission.type === 'validate' &&
-			(submission.intent === '' || submission.intent === name))
+		(submission.intent === '' || submission.intent === name)) ||
+		(submission.type === 'list' &&
+			typeof submission.intent !== 'undefined' &&
+			parseListCommand(submission.intent).scope === name)
 	);
 }
 
@@ -366,12 +369,6 @@ export function parse<Schema extends Record<string, any>>(
 					}
 				});
 			}
-		}
-
-		switch (submission.type) {
-			case 'list':
-				submission = handleList(submission);
-				break;
 		}
 	} catch (e) {
 		submission.error.push([

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -343,7 +343,8 @@ export function useForm<Schema extends Record<string, any>>(
 							!submitter?.formNoValidate &&
 							hasError(submission.error)) ||
 						(submission.type === 'validate' &&
-							config.mode !== 'server-validation')
+							config.mode !== 'server-validation') ||
+						submission.type === 'list'
 					) {
 						event.preventDefault();
 					} else {
@@ -736,7 +737,6 @@ export function useFieldList<Payload = any>(
 					}
 				}
 			});
-			event.preventDefault();
 		};
 		const resetHandler = (event: Event) => {
 			const form = getFormElement(ref.current);

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -342,9 +342,8 @@ export function useForm<Schema extends Record<string, any>>(
 						(!config.noValidate &&
 							!submitter?.formNoValidate &&
 							hasError(submission.error)) ||
-						(submission.type === 'validate' &&
-							config.mode !== 'server-validation') ||
-						submission.type === 'list'
+						((submission.type === 'validate' || submission.type === 'list') &&
+							config.mode !== 'server-validation')
 					) {
 						event.preventDefault();
 					} else {

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -681,20 +681,15 @@ export function useFieldList<Payload = any>(
 				event.preventDefault();
 			}
 		};
-		const submitHandler = (event: SubmitEvent) => {
+		const listHandler = (event: CustomEvent) => {
 			const form = getFormElement(ref.current);
 
-			if (
-				!form ||
-				event.target !== form ||
-				!(event.submitter instanceof HTMLButtonElement) ||
-				event.submitter.name !== 'conform/list'
-			) {
+			if (!form || event.target !== form) {
 				return;
 			}
 
 			const command = parseListCommand<ListCommand<FieldValue<Payload>>>(
-				event.submitter.value,
+				event.detail,
 			);
 
 			if (command.scope !== configRef.current.name) {
@@ -754,12 +749,14 @@ export function useFieldList<Payload = any>(
 			setError([]);
 		};
 
-		document.addEventListener('submit', submitHandler, true);
+		// @ts-expect-error Custom event: conform/list
+		document.addEventListener('conform/list', listHandler);
 		document.addEventListener('invalid', invalidHandler, true);
 		document.addEventListener('reset', resetHandler);
 
 		return () => {
-			document.removeEventListener('submit', submitHandler, true);
+			// @ts-expect-error Custom event: conform/list
+			document.removeEventListener('conform/list', listHandler);
 			document.removeEventListener('invalid', invalidHandler, true);
 			document.removeEventListener('reset', resetHandler);
 		};

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -750,13 +750,13 @@ export function useFieldList<Payload = any>(
 		};
 
 		// @ts-expect-error Custom event: conform/list
-		document.addEventListener('conform/list', listHandler);
+		document.addEventListener('conform/list', listHandler, true);
 		document.addEventListener('invalid', invalidHandler, true);
 		document.addEventListener('reset', resetHandler);
 
 		return () => {
 			// @ts-expect-error Custom event: conform/list
-			document.removeEventListener('conform/list', listHandler);
+			document.removeEventListener('conform/list', listHandler, true);
 			document.removeEventListener('invalid', invalidHandler, true);
 			document.removeEventListener('reset', resetHandler);
 		};

--- a/playground/app/routes/simple-list.tsx
+++ b/playground/app/routes/simple-list.tsx
@@ -8,14 +8,12 @@ import { Playground, Field, Alert } from '~/components';
 
 const schema = z.object({
 	items: z
-		.array(
-			z
-				.string()
-				.min(1, 'The field is required')
-				.regex(/^[^0-9]+$/, 'Number is not allowed'),
-		)
+		.string()
+		.min(1, 'The field is required')
+		.regex(/^[^0-9]+$/, 'Number is not allowed')
+		.array()
 		.min(1, 'At least one item is required')
-		.max(5, 'Only five items are allowed in maximum'),
+		.max(2, 'Maximum 2 items are allowed'),
 });
 
 export async function loader({ request }: LoaderArgs) {
@@ -54,7 +52,6 @@ export default function SimpleList() {
 	return (
 		<Form method="post" {...form.props}>
 			<Playground title="Simple list" state={state}>
-				<Alert message={form.error} />
 				<Alert message={items.error ?? ''} />
 				<ol>
 					{itemsList.map((item, index) => (

--- a/playground/app/routes/simple-list.tsx
+++ b/playground/app/routes/simple-list.tsx
@@ -1,3 +1,4 @@
+import { handleList } from '@conform-to/dom';
 import {
 	conform,
 	parse,
@@ -38,6 +39,8 @@ export async function action({ request }: ActionArgs) {
 
 	try {
 		switch (submission.type) {
+			case 'list':
+				return handleList(submission);
 			case 'validate':
 			case 'submit':
 				schema.parse(submission.value);

--- a/playground/app/routes/simple-list.tsx
+++ b/playground/app/routes/simple-list.tsx
@@ -1,11 +1,4 @@
-import { handleList } from '@conform-to/dom';
-import {
-	conform,
-	parse,
-	useFieldList,
-	useForm,
-	list,
-} from '@conform-to/react';
+import { conform, parse, useFieldList, useForm, list } from '@conform-to/react';
 import { formatError, validate } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
@@ -38,14 +31,7 @@ export async function action({ request }: ActionArgs) {
 	const submission = parse(formData);
 
 	try {
-		switch (submission.type) {
-			case 'list':
-				return handleList(submission);
-			case 'validate':
-			case 'submit':
-				schema.parse(submission.value);
-				break;
-		}
+		schema.parse(submission.value);
 	} catch (error) {
 		submission.error.push(...formatError(error));
 	}
@@ -69,6 +55,7 @@ export default function SimpleList() {
 		<Form method="post" {...form.props}>
 			<Playground title="Simple list" state={state}>
 				<Alert message={form.error} />
+				<Alert message={items.error ?? ''} />
 				<ol>
 					{itemsList.map((item, index) => (
 						<li key={item.key} className="border rounded-md p-4 mb-4">

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -1,4 +1,3 @@
-import { handleList } from '@conform-to/dom';
 import type { FieldsetConfig } from '@conform-to/react';
 import {
 	conform,
@@ -46,10 +45,6 @@ export let action = async ({ request }: ActionArgs) => {
 	let submission = parse<Schema>(formData);
 
 	try {
-		if (submission.type === 'list') {
-			submission = handleList(submission);
-		}
-
 		schema.parse(submission.value);
 	} catch (error) {
 		submission.error.push(...formatError(error));

--- a/tests/integrations/simple-list.spec.ts
+++ b/tests/integrations/simple-list.spec.ts
@@ -28,6 +28,14 @@ async function runValidationScenario(page: Page) {
 	await expect(fieldset.items).toHaveCount(1);
 	await expect(playground.error).toHaveText(['', '']);
 
+	// Delete the first row
+	await item0.delete.click();
+	await expect(playground.error).toHaveText(['At least one item is required']);
+
+	// Insert back first row
+	await fieldset.insertBottom.click();
+	await expect(playground.error).toHaveText(['', '']);
+
 	await playground.submit.click();
 	await expect(playground.error).toHaveText(['', 'The field is required']);
 
@@ -50,6 +58,12 @@ async function runValidationScenario(page: Page) {
 
 	// Insert a new row at the bottom
 	await fieldset.insertBottom.click();
+	await expect(playground.error).toHaveText([
+		'Maximum 2 items are allowed',
+		'The field is required',
+		'',
+		'',
+	]);
 	await expect(fieldset.items).toHaveCount(3);
 	await expect(item0.content).toHaveValue('');
 	await expect(item1.content).toHaveValue('First item');
@@ -57,7 +71,7 @@ async function runValidationScenario(page: Page) {
 
 	await playground.submit.click();
 	await expect(playground.error).toHaveText([
-		'',
+		'Maximum 2 items are allowed',
 		'The field is required',
 		'',
 		'The field is required',

--- a/tests/integrations/simple-list.spec.ts
+++ b/tests/integrations/simple-list.spec.ts
@@ -52,19 +52,15 @@ async function runValidationScenario(page: Page) {
 	await expect(item0.content).toHaveValue('');
 	await expect(item1.content).toHaveValue('First item');
 
-	// Trigger revalidation
-	await playground.submit.click();
-	await expect(playground.error).toHaveText(['', 'The field is required', '']);
-
 	// Insert a new row at the bottom
 	await fieldset.insertBottom.click();
+	await expect(fieldset.items).toHaveCount(3);
 	await expect(playground.error).toHaveText([
 		'Maximum 2 items are allowed',
-		'The field is required',
+		'',
 		'',
 		'',
 	]);
-	await expect(fieldset.items).toHaveCount(3);
 	await expect(item0.content).toHaveValue('');
 	await expect(item1.content).toHaveValue('First item');
 	await expect(item2.content).toHaveValue('');


### PR DESCRIPTION
> Draft. It might very likely includes a breaking change..

Tasks:
- [x] Server Validation (No JS)
- [x] Client Validation
- [x] Remote Validation (Server validation without page refresh)

~~I might need an alternative solution here as the current solution removes the button before the form is submitted when deleting a row. Remix is unhappy about it and throw an error as the form submitter is no longer belongs to the form since it is unmounted.~~

close #62 