### PR TITLE
feat(conform-react)!: return fieldset on useForm hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Conform is a form validation library built on top of the [Constraint Validation]
 <!-- sandbox src="/examples/basic" -->
 
 ```tsx
-import { useForm, useFieldset } from '@conform-to/react';
+import { useForm } from '@conform-to/react';
 
 export default function LoginForm() {
-  const form = useForm({
+  const [form, { email, password }] = useForm({
     onSubmit(event) {
       event.preventDefault();
 
@@ -24,7 +24,6 @@ export default function LoginForm() {
       console.log(value);
     },
   });
-  const { email, password } = useFieldset(form.ref, form.config);
 
   return (
     <form {...form.props}>

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -77,10 +77,10 @@ Conform utilizes these APIs internally. For example, form errors are reported by
 
 With the help of Constraint Validation, users will see [error bubbles](https://codesandbox.io/s/cocky-fermi-zwjort?file=/src/App.js) popping up when they try to submit a form with invalid fields. These bubbles are not customizable unfortunately. What if we can capture the error messages and decide where to put them ourselves?
 
-Let's introduce the [useForm](/packages/conform-react/README.md#useform) and [useFieldset](/packages/conform-react/README.md#usefieldset) hooks.
+Let's introduce the [useForm](/packages/conform-react/README.md#useform) hook.
 
 ```tsx
-import { useForm, useFieldset } from '@conform-to/react';
+import { useForm } from '@conform-to/react';
 
 export default function LoginForm() {
   /**
@@ -88,20 +88,13 @@ export default function LoginForm() {
    * validation flow and customize it. The submit event
    * handler will be called only when the form is valid.
    */
-  const form = useForm({
+  const [form, { email, password }] = useForm({
     onSubmit(event, { formData }) {
       event.preventDefault();
 
       console.log(Object.fromEntries(formData));
     },
   });
-
-  /**
-   * The useFieldset hook helps you configure each field and
-   * subscribe to its state. The properties accessed should
-   * match the name of the inputs.
-   */
-  const { email, password } = useFieldset(form.ref, form.config);
 
   return (
     <form {...form.props}>
@@ -137,7 +130,7 @@ Although we haven't define any error messages yet, the form above should be able
 import { useForm, parse, getFormElements } from '@conform-to/react';
 
 export default function LoginForm() {
-  const form = useForm({
+  const [form] = useForm({
     onValidate({ form, formData }) {
       /**
        * By parsing the formData, you will be able to access:
@@ -205,7 +198,7 @@ Currently, form error is reported only when a submission is made. If you want it
 import { useForm } from '@conform-to/react';
 
 export default function LoginForm() {
-  const form = useForm({
+  const [form] = useForm({
     /**
      * Define when the error should be reported initially.
      * Support "onSubmit", "onChange", "onBlur".

--- a/docs/submission.md
+++ b/docs/submission.md
@@ -51,7 +51,7 @@ The first approach is to setup manually:
 
 ```tsx
 export default function TodoForm() {
-  const form = useForm();
+  const [form] = useForm();
 
   return (
     <form {...form.props}>
@@ -95,13 +95,7 @@ export default function TodoForm() {
   /**
    * For better type safety, you can provide a schema to `useForm`
    */
-  const form = useForm<Todo>();
-
-  /**
-   * useFieldset handles object structure. It warns if you are
-   * accessing fields not defined in the schema
-   */
-  const { title, tasks } = useFieldset(form.ref, form.config);
+  const [form, { title, tasks }] = useForm<Todo>();
 
   /**
    * useFieldList handles array structure. It warns if the field
@@ -170,7 +164,7 @@ Unfortunately, the FormData API is not able to capture the submitter information
 
 ```tsx
 function Product() {
-  const form = useForm({
+  const [form] = useForm({
     onSubmit(event, { formData }) {
       event.preventDefault();
 
@@ -222,7 +216,7 @@ However, this polutes the form data with information used for controlling form b
 import { useForm } from '@conform-to/react';
 
 function Product() {
-  const form = useForm({
+  const [form] = useForm({
     onSubmit(event, { submission }) {
       event.preventDefault();
 
@@ -257,8 +251,7 @@ The [useFieldList](/packages/conform-react/README.md#usefieldlist) hook provide 
 
 ```tsx
 export default function Todos() {
-  const form = useForm();
-  const { title, tasks } = useFieldset<Todo>(form.ref, form.config);
+  const [form, { title, tasks }] = useForm<Todo>();
   const [taskList, command] = useFieldList(form.ref, tasks.config);
 
   return (

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -28,7 +28,7 @@ Now, client validation can be treated as a way to shorten the feedback loop. You
 **Conform** tries to makes it easy to validate the form data on the server. For example, you can validate a login form **fully server side** with Remix as shown below:
 
 ```tsx
-import { parse, useFieldset, useForm } from '@conform-to/react';
+import { parse, useForm } from '@conform-to/react';
 
 interface SignupForm {
   email: string;
@@ -99,7 +99,7 @@ export async function action({ request }: ActionArgs) {
 export default function Signup() {
   // Last submission returned by the server
   const state = useActionData<typeof action>();
-  const form = useForm<SignupForm>({
+  const [form] = useForm<SignupForm>({
     // Enable server validation mode
     mode: 'server-validation',
 
@@ -187,7 +187,7 @@ export async function action({ request }: ActionArgs) {
 
 export default function Signup() {
   const state = useActionData();
-  const form = useForm({
+  const [form] = useForm({
     /**
      * Changing the mode to `client-only` as the client
      * validation does exactly the same checks as the
@@ -235,7 +235,7 @@ export function action() {
 
 export default function Signup() {
   const state = useActionData();
-  const form = useForm({
+  const [form] = useForm({
     /**
      * Changing the mode back to `server-validation`
      * as you want to confirm with the server now.

--- a/examples/basic/src/App.tsx
+++ b/examples/basic/src/App.tsx
@@ -1,12 +1,7 @@
-import {
-	useForm,
-	useFieldset,
-	parse,
-	getFormElements,
-} from '@conform-to/react';
+import { useForm, parse, getFormElements } from '@conform-to/react';
 
 export default function LoginForm() {
-	const form = useForm({
+	const [form, { email, password }] = useForm({
 		initialReport: 'onBlur',
 		onValidate({ form, formData }) {
 			const submission = parse(formData);
@@ -40,7 +35,6 @@ export default function LoginForm() {
 			console.log(Object.fromEntries(formData));
 		},
 	});
-	const { email, password } = useFieldset(form.ref, form.config);
 
 	return (
 		<form {...form.props}>

--- a/examples/chakra-ui/src/App.tsx
+++ b/examples/chakra-ui/src/App.tsx
@@ -1,5 +1,5 @@
 import type { FieldConfig } from '@conform-to/react';
-import { useForm, useFieldset, useControlledInput } from '@conform-to/react';
+import { useForm, useControlledInput } from '@conform-to/react';
 import {
 	Stack,
 	FormControl,

--- a/examples/chakra-ui/src/App.tsx
+++ b/examples/chakra-ui/src/App.tsx
@@ -47,8 +47,7 @@ interface Schema {
 }
 
 export default function Example() {
-	const form = useForm<Schema>();
-	const fieldset = useFieldset(form.ref, form.config);
+	const [form, fieldset] = useForm<Schema>();
 
 	return (
 		<Container maxW="container.sm" paddingY={8}>

--- a/examples/headless-ui/src/App.tsx
+++ b/examples/headless-ui/src/App.tsx
@@ -1,7 +1,6 @@
 import {
 	type FieldConfig,
 	useForm,
-	useFieldset,
 	useControlledInput,
 } from '@conform-to/react';
 import { Listbox, Combobox, Switch, RadioGroup } from '@headlessui/react';
@@ -16,8 +15,7 @@ interface Schema {
 }
 
 export default function Example() {
-	const form = useForm<Schema>();
-	const fieldset = useFieldset(form.ref, form.config);
+	const [form, fieldset] = useForm<Schema>();
 
 	return (
 		<main className="max-w-lg mx-auto py-8 px-4">

--- a/examples/material-ui/src/App.tsx
+++ b/examples/material-ui/src/App.tsx
@@ -1,5 +1,5 @@
 import type { FieldConfig } from '@conform-to/react';
-import { useForm, useFieldset, useControlledInput } from '@conform-to/react';
+import { useForm, useControlledInput } from '@conform-to/react';
 import {
 	TextField,
 	Button,
@@ -34,8 +34,7 @@ interface Schema {
 }
 
 export default function ArticleForm() {
-	const form = useForm<Schema>();
-	const fieldset = useFieldset(form.ref, form.config);
+	const [form, fieldset] = useForm<Schema>();
 
 	return (
 		<Container maxWidth="sm">

--- a/examples/remix-run/app/routes/async-validation.tsx
+++ b/examples/remix-run/app/routes/async-validation.tsx
@@ -1,7 +1,6 @@
 import {
 	conform,
 	parse,
-	useFieldset,
 	useForm,
 	hasError,
 	shouldValidate,
@@ -87,7 +86,7 @@ export async function action({ request }: ActionArgs) {
 
 export default function Signup() {
 	const state = useActionData<typeof action>();
-	const form = useForm({
+	const [form, { email, username, password, confirmPassword }] = useForm({
 		mode: 'server-validation',
 		initialReport: 'onBlur',
 		state,
@@ -106,10 +105,6 @@ export default function Signup() {
 			}
 		},
 	});
-	const { email, username, password, confirmPassword } = useFieldset(
-		form.ref,
-		form.config,
-	);
 
 	return (
 		<Form method="post" {...form.props}>

--- a/examples/remix-run/app/routes/server-validation.tsx
+++ b/examples/remix-run/app/routes/server-validation.tsx
@@ -1,10 +1,4 @@
-import {
-	conform,
-	parse,
-	hasError,
-	useFieldset,
-	useForm,
-} from '@conform-to/react';
+import { conform, parse, hasError, useForm } from '@conform-to/react';
 import type { ActionArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import { Form, useActionData } from '@remix-run/react';
@@ -13,10 +7,6 @@ interface SignupForm {
 	email: string;
 	password: string;
 	confirmPassword: string;
-}
-
-async function signup(data: unknown) {
-	throw new Error('Not implemented');
 }
 
 export async function action({ request }: ActionArgs) {
@@ -55,7 +45,7 @@ export async function action({ request }: ActionArgs) {
 				 * and no error found
 				 */
 				if (submission.type === 'submit' && !hasError(submission.error)) {
-					return await signup(submission.value);
+					throw new Error('Not implemented');
 				}
 
 				break;
@@ -82,7 +72,7 @@ export async function action({ request }: ActionArgs) {
 export default function Signup() {
 	// Last submission returned by the server
 	const state = useActionData<typeof action>();
-	const form = useForm<SignupForm>({
+	const [form, { email, password, confirmPassword }] = useForm<SignupForm>({
 		// Enable server validation mode
 		mode: 'server-validation',
 
@@ -92,10 +82,6 @@ export default function Signup() {
 		// Sync the result of last submission
 		state,
 	});
-	const { email, password, confirmPassword } = useFieldset(
-		form.ref,
-		form.config,
-	);
 
 	return (
 		<Form method="post" {...form.props}>

--- a/examples/remix-run/app/routes/todos.tsx
+++ b/examples/remix-run/app/routes/todos.tsx
@@ -23,22 +23,20 @@ const todosSchema = z.object({
 	tasks: z.array(taskSchema).min(1),
 });
 
-function createTodos(data: unknown) {
-	throw new Error('Not implemented');
-}
+type Schema = z.infer<typeof todosSchema>;
 
 export let action = async ({ request }: ActionArgs) => {
 	const formData = await request.formData();
-	const submission = parse(formData);
+	const submission = parse<Schema>(formData);
 
 	try {
 		switch (submission.type) {
 			case 'submit':
 			case 'validate': {
-				const data = todosSchema.parse(submission.value);
+				todosSchema.parse(submission.value);
 
 				if (submission.type === 'submit') {
-					return await createTodos(data);
+					throw new Error('Not implemented');
 				}
 			}
 		}
@@ -51,14 +49,13 @@ export let action = async ({ request }: ActionArgs) => {
 
 export default function TodoForm() {
 	const state = useActionData<typeof action>();
-	const form = useForm<z.infer<typeof todosSchema>>({
+	const [form, { title, tasks }] = useForm<Schema>({
 		initialReport: 'onBlur',
 		state,
 		onValidate({ formData }) {
 			return validate(formData, todosSchema);
 		},
 	});
-	const { title, tasks } = useFieldset(form.ref, form.config);
 	const [taskList, command] = useFieldList(form.ref, tasks.config);
 
 	return (

--- a/examples/remix-run/app/routes/zod.tsx
+++ b/examples/remix-run/app/routes/zod.tsx
@@ -1,4 +1,4 @@
-import { conform, parse, useFieldset, useForm } from '@conform-to/react';
+import { conform, parse, useForm } from '@conform-to/react';
 import { formatError } from '@conform-to/zod';
 import type { ActionArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
@@ -16,10 +16,6 @@ const schema = z
 		path: ['confirmPassword'],
 	});
 
-async function signup(data: unknown) {
-	throw new Error('Not implemented');
-}
-
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parse<z.infer<typeof schema>>(formData);
@@ -28,10 +24,10 @@ export async function action({ request }: ActionArgs) {
 		switch (submission.type) {
 			case 'validate':
 			case 'submit': {
-				const data = schema.parse(submission.value);
+				schema.parse(submission.value);
 
 				if (submission.type === 'submit') {
-					return await signup(data);
+					throw new Error('Not implemented');
 				}
 
 				break;
@@ -51,15 +47,13 @@ export async function action({ request }: ActionArgs) {
 
 export default function Signup() {
 	const state = useActionData<typeof action>();
-	const form = useForm<z.infer<typeof schema>>({
+	const [form, { email, password, confirmPassword }] = useForm<
+		z.infer<typeof schema>
+	>({
 		mode: 'server-validation',
 		initialReport: 'onBlur',
 		state,
 	});
-	const { email, password, confirmPassword } = useFieldset(
-		form.ref,
-		form.config,
-	);
 
 	return (
 		<Form method="post" {...form.props}>

--- a/examples/todos/src/App.tsx
+++ b/examples/todos/src/App.tsx
@@ -13,7 +13,7 @@ interface Todo {
 }
 
 export default function TodoForm() {
-	const form = useForm<Todo>({
+	const [form, { title, tasks }] = useForm<Todo>({
 		initialReport: 'onBlur',
 		onSubmit(event, { submission }) {
 			event.preventDefault();
@@ -21,7 +21,6 @@ export default function TodoForm() {
 			console.log(submission);
 		},
 	});
-	const { title, tasks } = useFieldset(form.ref, form.config);
 	const [taskList, command] = useFieldList(form.ref, tasks.config);
 
 	return (

--- a/examples/yup/src/App.tsx
+++ b/examples/yup/src/App.tsx
@@ -18,21 +18,17 @@ const schema = yup.object({
 });
 
 export default function SignupForm() {
-	const form = useForm({
-		onValidate({ formData }) {
-			return validate(formData, schema);
-		},
-		onSubmit(event, { submission }) {
-			event.preventDefault();
+	const [form, { email, password, 'confirm-password': confirmPassword }] =
+		useForm({
+			onValidate({ formData }) {
+				return validate(formData, schema);
+			},
+			onSubmit(event, { submission }) {
+				event.preventDefault();
 
-			console.log(submission);
-		},
-	});
-	const {
-		email,
-		password,
-		'confirm-password': confirmPassword,
-	} = useFieldset(form.ref, form.config);
+				console.log(submission);
+			},
+		});
 
 	return (
 		<form {...form.props}>

--- a/examples/yup/src/App.tsx
+++ b/examples/yup/src/App.tsx
@@ -1,4 +1,4 @@
-import { useFieldset, useForm } from '@conform-to/react';
+import { useForm } from '@conform-to/react';
 import { validate } from '@conform-to/yup';
 import * as yup from 'yup';
 

--- a/examples/zod/src/App.tsx
+++ b/examples/zod/src/App.tsx
@@ -1,4 +1,4 @@
-import { useFieldset, useForm } from '@conform-to/react';
+import { useForm } from '@conform-to/react';
 import { validate } from '@conform-to/zod';
 import { z } from 'zod';
 
@@ -20,21 +20,17 @@ const schema = z
 	});
 
 export default function SignupForm() {
-	const form = useForm<z.infer<typeof schema>>({
-		onValidate({ formData }) {
-			return validate(formData, schema);
-		},
-		onSubmit(event, { submission }) {
-			event.preventDefault();
+	const [form, { email, password, 'confirm-password': confirmPassword }] =
+		useForm<z.infer<typeof schema>>({
+			onValidate({ formData }) {
+				return validate(formData, schema);
+			},
+			onSubmit(event, { submission }) {
+				event.preventDefault();
 
-			console.log(submission);
-		},
-	});
-	const {
-		email,
-		password,
-		'confirm-password': confirmPassword,
-	} = useFieldset(form.ref, form.config);
+				console.log(submission);
+			},
+		});
 
 	return (
 		<form {...form.props}>

--- a/packages/conform-react/README.md
+++ b/packages/conform-react/README.md
@@ -32,7 +32,7 @@ This hook enhances the form validation behaviour in 3 parts:
 import { useForm } from '@conform-to/react';
 
 function LoginForm() {
-  const form = useForm({
+  const [form] = useForm({
     /**
      * Validation mode.
      * Support "client-only" or "server-validation".
@@ -58,6 +58,11 @@ function LoginForm() {
      * An object describing the state from the last submission
      */
     state: undefined;
+
+    /**
+     * An object describing the constraint of each field
+     */
+    constraint: undefined;
 
     /**
      * Enable native validation before hydation.
@@ -100,7 +105,7 @@ It is a group of properties properties required to hook into form events. They c
 
 ```tsx
 function RandomForm() {
-  const form = useForm();
+  const [form] = useForm();
 
   return (
     <form
@@ -126,7 +131,7 @@ import { useFrom } from '@conform-to/react';
 import { Form } from '@remix-run/react';
 
 function LoginForm() {
-  const form = useForm();
+  const [form] = useForm();
 
   return (
     <Form method="post" action="/login" {...form.props}>
@@ -144,11 +149,10 @@ function LoginForm() {
 The `onValidate` function is not required if the validation logic can be fully covered by the [native constraints](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Constraint_validation#validation-related_attributes), e.g. **required** / **min** / **pattern** etc.
 
 ```tsx
-import { useForm, useFieldset } from '@conform-to/react';
+import { useForm } from '@conform-to/react';
 
 function LoginForm() {
-  const form = useForm();
-  const { email, password } = useFieldset(form.ref);
+  const [form, { email, password }] = useForm();
 
   return (
     <form {...form.props}>
@@ -189,7 +193,7 @@ type Book = {
 };
 
 function BookFieldset() {
-  const form = useForm();
+  const [form] = useForm();
   const { name, isbn } = useFieldset<Book>(
     /**
      * A ref object of the form element or fieldset element
@@ -562,7 +566,7 @@ It returns all _input_ / _select_ / _textarea_ or _button_ in the forms. Useful 
 import { useForm, parse, getFormElements } from '@conform-to/react';
 
 export default function LoginForm() {
-  const form = useForm({
+  const [form] = useForm({
     onValidate({ form, formData }) {
       const submission = parse(formData);
 

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -54,6 +54,11 @@ export interface FormConfig<Schema extends Record<string, any>> {
 	state?: Submission<Schema>;
 
 	/**
+	 * An object describing the constraint of each field
+	 */
+	constraint?: FieldsetConstraint<Schema>;
+
+	/**
 	 * Enable native validation before hydation.
 	 *
 	 * Default to `false`.
@@ -115,7 +120,7 @@ interface Form<Schema extends Record<string, any>> {
  */
 export function useForm<Schema extends Record<string, any>>(
 	config: FormConfig<Schema> = {},
-): Form<Schema> {
+): [Form<Schema>, Fieldset<Schema>] {
 	const configRef = useRef(config);
 	const ref = useRef<HTMLFormElement>(null);
 	const [error, setError] = useState<string>(() => {
@@ -132,9 +137,11 @@ export function useForm<Schema extends Record<string, any>>(
 				initialError: error.filter(
 					([name]) => name !== '' && getSubmissionType(name) === null,
 				),
+				constraint: config.constraint,
 			};
 		},
 	);
+	const fieldset = useFieldset(ref, fieldsetConfig);
 	const [noValidate, setNoValidate] = useState(
 		config.noValidate || !config.fallbackNative,
 	);
@@ -256,7 +263,7 @@ export function useForm<Schema extends Record<string, any>>(
 		};
 	}, []);
 
-	return {
+	const form: Form<Schema> = {
 		ref,
 		error,
 		props: {
@@ -342,6 +349,8 @@ export function useForm<Schema extends Record<string, any>>(
 		},
 		config: fieldsetConfig,
 	};
+
+	return [form, fieldset];
 }
 
 /**

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -239,6 +239,7 @@ export function useForm<Schema extends Record<string, any>>(
 			setError('');
 			setFieldsetConfig({
 				defaultValue: formConfig.defaultValue,
+				constraint: formConfig.constraint,
 				initialError: [],
 			});
 		};

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -128,19 +128,22 @@ export function useForm<Schema extends Record<string, any>>(
 
 		return message ?? '';
 	});
-	const [fieldsetConfig, setFieldsetConfig] = useState<FieldsetConfig<Schema>>(
-		() => {
-			const error = config.state?.error ?? [];
+	const [uncontrolledState, setUncontrolledState] = useState<
+		FieldsetConfig<Schema>
+	>(() => {
+		const error = config.state?.error ?? [];
 
-			return {
-				defaultValue: config.state?.value ?? config.defaultValue,
-				initialError: error.filter(
-					([name]) => name !== '' && getSubmissionType(name) === null,
-				),
-				constraint: config.constraint,
-			};
-		},
-	);
+		return {
+			defaultValue: config.state?.value ?? config.defaultValue,
+			initialError: error.filter(
+				([name]) => name !== '' && getSubmissionType(name) === null,
+			),
+		};
+	});
+	const fieldsetConfig = {
+		...uncontrolledState,
+		constraint: config.constraint,
+	};
 	const fieldset = useFieldset(ref, fieldsetConfig);
 	const [noValidate, setNoValidate] = useState(
 		config.noValidate || !config.fallbackNative,
@@ -237,9 +240,8 @@ export function useForm<Schema extends Record<string, any>>(
 			}
 
 			setError('');
-			setFieldsetConfig({
+			setUncontrolledState({
 				defaultValue: formConfig.defaultValue,
-				constraint: formConfig.constraint,
 				initialError: [],
 			});
 		};

--- a/packages/conform-yup/README.md
+++ b/packages/conform-yup/README.md
@@ -30,7 +30,7 @@ const schema = yup.object({
 });
 
 function ExampleForm() {
-  const form = useForm<yup.InferType<typeof schema>>({
+  const [form] = useForm<yup.InferType<typeof schema>>({
     onValidate({ formData }) {
       const submission = parse(formData);
 
@@ -90,7 +90,7 @@ export let action = async ({ request }) => {
 
 export default function ExampleRoute() {
   const state = useActionData();
-  const form = useForm({
+  const [form] = useForm({
     mode: 'server-validation',
     state,
   });
@@ -110,9 +110,7 @@ This tries to infer constraint of each field based on the yup schema. This is us
 import { getFieldsetConstraint } from '@conform-to/yup';
 
 function LoginFieldset() {
-  const form = useForm();
-  const { email, password } = useFieldset(ref, {
-    ...form.config,
+  const [form, { email, password }] = useForm({
     constraint: getFieldsetConstraint(schema),
   });
 
@@ -135,7 +133,7 @@ const schema = yup.object({
 });
 
 function ExampleForm() {
-  const form = useForm({
+  const [form] = useForm({
     onValidate({ formData }) {
       return validate(formData, schema, {
         // Optional

--- a/packages/conform-zod/README.md
+++ b/packages/conform-zod/README.md
@@ -30,7 +30,7 @@ const schema = z.object({
 });
 
 function ExampleForm() {
-  const form = useForm<z.infer<typeof schema>>({
+  const [form] = useForm<z.infer<typeof schema>>({
     onValidate({ formData }) {
       // Only sync validation is allowed on the client side
       const submission = parse(formData);
@@ -90,7 +90,7 @@ export let action = async ({ request }) => {
 
 export default function ExampleRoute() {
   const state = useActionData();
-  const form = useForm({
+  const [form] = useForm({
     mode: 'server-validation',
     state,
   });
@@ -133,7 +133,7 @@ const schema = z.object({
 });
 
 function ExampleForm() {
-  const form = useForm({
+  const [form] = useForm({
     onValidate({ formData }) {
       return validate(formData, schema, {
         // Optional

--- a/playground/app/routes/employee.tsx
+++ b/playground/app/routes/employee.tsx
@@ -3,7 +3,6 @@ import {
 	hasError,
 	parse,
 	shouldValidate,
-	useFieldset,
 	useForm,
 } from '@conform-to/react';
 import { formatError, validate } from '@conform-to/zod';
@@ -59,7 +58,7 @@ export let action = async ({ request }: ActionArgs) => {
 export default function EmployeeForm() {
 	const config = useLoaderData();
 	const state = useActionData();
-	const form = useForm<Schema>({
+	const [form, { name, email, title }] = useForm<Schema>({
 		...config,
 		state,
 		onValidate({ formData }) {
@@ -78,7 +77,6 @@ export default function EmployeeForm() {
 				  }
 				: undefined,
 	});
-	const { name, email, title } = useFieldset(form.ref, form.config);
 
 	return (
 		<Form method="post" {...form.props}>

--- a/playground/app/routes/file-upload.tsx
+++ b/playground/app/routes/file-upload.tsx
@@ -1,4 +1,4 @@
-import { conform, parse, useFieldset, useForm } from '@conform-to/react';
+import { conform, parse, useForm } from '@conform-to/react';
 import { formatError, validate } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
@@ -67,13 +67,12 @@ export async function action({ request }: ActionArgs) {
 export default function FileUpload() {
 	const { noClientValidate } = useLoaderData<typeof loader>();
 	const state = useActionData();
-	const form = useForm<Schema>({
+	const [form, { file, files }] = useForm<Schema>({
 		state,
 		onValidate: !noClientValidate
 			? ({ formData }) => validate(formData, schema)
 			: undefined,
 	});
-	const { file, files } = useFieldset<Schema>(form.ref, form.config);
 
 	return (
 		<Form method="post" {...form.props} encType="multipart/form-data">

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -1,10 +1,4 @@
-import {
-	type Submission,
-	conform,
-	useFieldset,
-	useForm,
-	parse,
-} from '@conform-to/react';
+import { type Submission, conform, useForm, parse } from '@conform-to/react';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { Playground, Field, Alert } from '~/components';
@@ -57,7 +51,7 @@ export let action = async ({ request }: ActionArgs) => {
 export default function LoginForm() {
 	const config = useLoaderData();
 	const state = useActionData();
-	const form = useForm<Login>({
+	const [form, { email, password }] = useForm<Login>({
 		...config,
 		state,
 		onValidate: config.validate
@@ -72,7 +66,6 @@ export default function LoginForm() {
 				  }
 				: undefined,
 	});
-	const { email, password } = useFieldset(form.ref, form.config);
 
 	return (
 		<Form method="post" {...form.props}>

--- a/playground/app/routes/movie.tsx
+++ b/playground/app/routes/movie.tsx
@@ -1,11 +1,4 @@
-import type { FieldsetConstraint } from '@conform-to/react';
-import {
-	conform,
-	getFormElements,
-	parse,
-	useFieldset,
-	useForm,
-} from '@conform-to/react';
+import { conform, getFormElements, parse, useForm } from '@conform-to/react';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { Playground, Field } from '~/components';
@@ -17,33 +10,6 @@ interface Movie {
 	genre: string;
 	rating?: number;
 }
-
-const constraint: FieldsetConstraint<Movie> = {
-	title: {
-		required: true,
-		pattern: '[0-9a-zA-Z ]{1,20}',
-	},
-	description: {
-		minLength: 30,
-		maxLength: 200,
-	},
-	genre: {
-		required: true,
-		/**
-		 * No value from multiple select will be included in the FormData
-		 * when nothing is selected. This makes it hard to know the field
-		 * exist and add it to part of the scope. As native select is
-		 * uncommon (especially with `multiple`) due to lack of customization
-		 * capablity. This is considered a limitation for now.
-		 */
-		// multiple: true,
-	},
-	rating: {
-		min: '0.5',
-		max: '5',
-		step: '0.5',
-	},
-};
 
 export let loader = async ({ request }: LoaderArgs) => {
 	return parseConfig(request);
@@ -80,9 +46,35 @@ export let action = async ({ request }: ActionArgs) => {
 export default function MovieForm() {
 	const config = useLoaderData();
 	const state = useActionData();
-	const form = useForm<Movie>({
+	const [form, { title, description, genre, rating }] = useForm<Movie>({
 		...config,
 		state,
+		constraint: {
+			title: {
+				required: true,
+				pattern: '[0-9a-zA-Z ]{1,20}',
+			},
+			description: {
+				minLength: 30,
+				maxLength: 200,
+			},
+			genre: {
+				required: true,
+				/**
+				 * No value from multiple select will be included in the FormData
+				 * when nothing is selected. This makes it hard to know the field
+				 * exist and add it to part of the scope. As native select is
+				 * uncommon (especially with `multiple`) due to lack of customization
+				 * capablity. This is considered a limitation for now.
+				 */
+				// multiple: true,
+			},
+			rating: {
+				min: '0.5',
+				max: '5',
+				step: '0.5',
+			},
+		},
 		onValidate: config.validate
 			? ({ form, formData }) => {
 					const submission = parse(formData);
@@ -134,10 +126,6 @@ export default function MovieForm() {
 						}
 				  }
 				: undefined,
-	});
-	const { title, description, genre, rating } = useFieldset(form.ref, {
-		...form.config,
-		constraint,
 	});
 
 	return (

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -49,9 +49,10 @@ export let action = async ({ request }: ActionArgs) => {
 export default function PaymentForm() {
 	const config = useLoaderData();
 	const state = useActionData();
-	const form = useForm({
+	const [form, { iban, amount, timestamp, verified }] = useForm({
 		...config,
 		state,
+		constraint: getFieldsetConstraint(schema),
 		onValidate: config.validate
 			? ({ formData }) => validate(formData, schema)
 			: undefined,
@@ -63,10 +64,6 @@ export default function PaymentForm() {
 						}
 				  }
 				: undefined,
-	});
-	const { iban, amount, timestamp, verified } = useFieldset(form.ref, {
-		...form.config,
-		constraint: getFieldsetConstraint(schema),
 	});
 	const { currency, value } = useFieldset(form.ref, {
 		...amount.config,

--- a/playground/app/routes/signup.tsx
+++ b/playground/app/routes/signup.tsx
@@ -1,5 +1,5 @@
 import type { Submission } from '@conform-to/react';
-import { conform, parse, useFieldset, useForm } from '@conform-to/react';
+import { conform, parse, useForm } from '@conform-to/react';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { Playground, Field } from '~/components';
@@ -59,7 +59,7 @@ export let action = async ({ request }: ActionArgs) => {
 export default function SignupForm() {
 	const config = useLoaderData();
 	const state = useActionData();
-	const form = useForm<Signup>({
+	const [form, { email, password, confirmPassword }] = useForm<Signup>({
 		...config,
 		state,
 		onValidate: config.validate
@@ -74,10 +74,6 @@ export default function SignupForm() {
 				  }
 				: undefined,
 	});
-	const { email, password, confirmPassword } = useFieldset(form.ref, {
-		...form.config,
-		form: 'signup',
-	});
 
 	return (
 		<Playground title="Signup Form" form="signup" state={state}>
@@ -86,14 +82,19 @@ export default function SignupForm() {
 				<input
 					{...conform.input(email.config, { type: 'email' })}
 					autoComplete="off"
+					form="signup"
 				/>
 			</Field>
 			<Field label="Password" error={password.error}>
-				<input {...conform.input(password.config, { type: 'password' })} />
+				<input
+					{...conform.input(password.config, { type: 'password' })}
+					form="signup"
+				/>
 			</Field>
 			<Field label="Confirm password" error={confirmPassword.error}>
 				<input
 					{...conform.input(confirmPassword.config, { type: 'password' })}
+					form="signup"
 				/>
 			</Field>
 		</Playground>

--- a/playground/app/routes/simple-list.tsx
+++ b/playground/app/routes/simple-list.tsx
@@ -1,10 +1,4 @@
-import {
-	conform,
-	parse,
-	useFieldList,
-	useFieldset,
-	useForm,
-} from '@conform-to/react';
+import { conform, parse, useFieldList, useForm } from '@conform-to/react';
 import { formatError, validate } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
@@ -53,14 +47,13 @@ export async function action({ request }: ActionArgs) {
 export default function SimpleList() {
 	const { noClientValidate } = useLoaderData<typeof loader>();
 	const state = useActionData();
-	const form = useForm<z.infer<typeof schema>>({
+	const [form, { items }] = useForm<z.infer<typeof schema>>({
 		mode: noClientValidate ? 'server-validation' : 'client-only',
 		state,
 		onValidate: !noClientValidate
 			? ({ formData }) => validate(formData, schema)
 			: undefined,
 	});
-	const { items } = useFieldset(form.ref, form.config);
 	const [list, command] = useFieldList(form.ref, items.config);
 
 	return (

--- a/playground/app/routes/student.tsx
+++ b/playground/app/routes/student.tsx
@@ -1,4 +1,4 @@
-import { conform, useFieldset, useForm } from '@conform-to/react';
+import { conform, useForm } from '@conform-to/react';
 import { getFieldsetConstraint, validate } from '@conform-to/yup';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
@@ -32,9 +32,12 @@ export let action = async ({ request }: ActionArgs) => {
 export default function StudentForm() {
 	const config = useLoaderData();
 	const state = useActionData();
-	const form = useForm<Schema>({
+	const [form, { name, remarks, grade, score }] = useForm<
+		yup.InferType<typeof schema>
+	>({
 		...config,
 		state,
+		constraint: getFieldsetConstraint(schema),
 		onValidate: config.validate
 			? ({ formData }) => validate(formData, schema)
 			: undefined,
@@ -46,10 +49,6 @@ export default function StudentForm() {
 						}
 				  }
 				: undefined,
-	});
-	const { name, remarks, grade, score } = useFieldset(form.ref, {
-		...form.config,
-		constraint: getFieldsetConstraint(schema),
 	});
 
 	return (

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -55,7 +55,7 @@ export let action = async ({ request }: ActionArgs) => {
 export default function TodosForm() {
 	const config = useLoaderData();
 	const state = useActionData();
-	const form = useForm<z.infer<typeof schema>>({
+	const [form] = useForm<z.infer<typeof schema>>({
 		...config,
 		state,
 		onValidate: config.validate


### PR DESCRIPTION
This is a change I have been considering since v0.3. What changed is just calling `useFieldset()` inside `useForm()` and return the data as a tuple:

```tsx
// Before
export default function LoginForm() {
    const form = useForm({
        onValidate({ form, formData }) {
            return validate(formData, schema);
        },
    });
    const { email, password } = useFieldset(form.ref, form.config);

    return (
        <form {...form.props}>
            {/* ... */}
        </form>
    );
}

// After the changes
export default function LoginForm() {
    const [form, { email, password }] = useForm({
        onValidate({ form, formData }) {
            return validate(formData, schema);
        },
    });

    return (
        <form {...form.props}>
            {/* ... */}
        </form>
    );
}
```

