### PR TITLE
fix: radio buttons support

### DIFF
--- a/playground/app/routes/radio-buttons.tsx
+++ b/playground/app/routes/radio-buttons.tsx
@@ -1,0 +1,77 @@
+import { conform, parse, useForm } from '@conform-to/react';
+import { type LoaderArgs, type ActionArgs, json } from '@remix-run/node';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { Playground, Field } from '~/components';
+
+interface Schema {
+	answer: string;
+}
+
+function validate(formData: FormData) {
+	const submission = parse(formData);
+
+	if (!submission.value.answer) {
+		submission.error.push(['answer', 'Required']);
+	}
+
+	return submission;
+}
+
+export async function loader({ request }: LoaderArgs) {
+	const url = new URL(request.url);
+
+	return {
+		noClientValidate: url.searchParams.get('noClientValidate') === 'yes',
+	};
+}
+
+export async function action({ request }: ActionArgs) {
+	const formData = await request.formData();
+	const submission = validate(formData);
+
+	return json(submission);
+}
+
+export default function Example() {
+	const { noClientValidate } = useLoaderData<typeof loader>();
+	const state = useActionData<typeof action>();
+	const [form, { answer }] = useForm<Schema>({
+		state,
+		onValidate: !noClientValidate
+			? ({ formData }) => validate(formData)
+			: undefined,
+	});
+
+	return (
+		<Form method="post" {...form.props}>
+			<Playground title="Attributes" state={state}>
+				<Field label="Multiple Choice" {...answer}>
+					<label>
+						<input
+							{...conform.input(answer.config, { type: 'radio', value: 'a' })}
+						/>
+						<span className="p-2">A</span>
+					</label>
+					<label className="inline-block">
+						<input
+							{...conform.input(answer.config, { type: 'radio', value: 'b' })}
+						/>
+						<span className="p-2">B</span>
+					</label>
+					<label className="inline-block">
+						<input
+							{...conform.input(answer.config, { type: 'radio', value: 'c' })}
+						/>
+						<span className="p-2">C</span>
+					</label>
+					<label className="inline-block">
+						<input
+							{...conform.input(answer.config, { type: 'radio', value: 'd' })}
+						/>
+						<span className="p-2">D</span>
+					</label>
+				</Field>
+			</Playground>
+		</Form>
+	);
+}

--- a/tests/integrations/radio-buttons.spec.ts
+++ b/tests/integrations/radio-buttons.spec.ts
@@ -1,0 +1,61 @@
+import { type Page, test, expect } from '@playwright/test';
+import { getPlayground } from '../helpers';
+
+async function runValidationScenario(page: Page) {
+	const playground = getPlayground(page);
+
+	await playground.submit.click();
+
+	await expect(playground.error).toHaveText(['Required']);
+
+	await playground.container.locator('[name="answer"][value="b"]').click();
+	await playground.submit.click();
+
+	await expect(playground.error).toHaveText(['']);
+	await expect(playground.submission).toHaveText(
+		JSON.stringify(
+			{
+				type: 'submit',
+				value: {
+					answer: 'b',
+				},
+				error: [],
+			},
+			null,
+			2,
+		),
+	);
+}
+
+test.describe('With JS', () => {
+	test('Client Validation', async ({ page }) => {
+		await page.goto('/radio-buttons');
+		await runValidationScenario(page);
+	});
+
+	test('Server Validation', async ({ page }) => {
+		await page.goto('/radio-buttons?noClientValidate=yes');
+		await runValidationScenario(page);
+	});
+
+	test('Form reset', async ({ page }) => {
+		await page.goto('/radio-buttons');
+
+		const playground = getPlayground(page);
+
+		await playground.submit.click();
+		await expect(playground.error).toHaveText(['Required']);
+
+		await playground.reset.click();
+		await expect(playground.error).toHaveText(['']);
+	});
+});
+
+test.describe('No JS', () => {
+	test.use({ javaScriptEnabled: false });
+
+	test('Validation', async ({ page }) => {
+		await page.goto('/radio-buttons');
+		await runValidationScenario(page);
+	});
+});


### PR DESCRIPTION
This bug is introduced with #69 which throws an error if there are multiple fields with the exact same name. As there could be only one error message per name and so there is no way to provide a different message for each input. However, this is not a problem with radio buttons.