### PR TITLE
docs: add reminder for sandbox container examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,41 +4,48 @@ A progressive enhancement first form validation library for [Remix](https://remi
 
 ### Highlights
 
-- Make your form progressively enhanced by default [[?]](https://codesandbox.io/s/github/edmundhung/conform/tree/main/examples/nested-list?file=/app/routes/index.tsx "Try it with JS disabled")
-- Simplifed intergration through event delegation [[?]](https://conform.guide/integrations "Learn more")
-- Server first validation [[?]](https://conform.guide/validation "Learn more")
-- Field name inference with type checking [[?]](https://conform.guide/configuration "Learn more")
-- Focus management [[?]](https://conform.guide/focus-management "Learn more")
-- Accessibility support [[?]](https://conform.guide/accessibility "Learn more")
-- About 4kb compressed [[?]](https://bundlephobia.com/package/@conform-to/react "Check the size on bundlephobia")
+- Progressively enhanced by default
+- Simplifed intergration through event delegation
+- Server first validation with Zod / Yup schema support
+- Field name inference with type checking
+- Focus management
+- Accessibility support
+- About 4kb compressed
 
-### Quickstart
+### Quick Start
 
-Here is a real world example built with [Remix](https://remix.run) and validating using [Zod](https://zod.dev).
+Here is a real world example built with [Remix](https://remix.run).
 
 ```tsx
 import { useForm, parse } from '@conform-to/react';
-import { validate, formatError } from '@conform-to/zod';
 import { Form } from '@remix-run/react';
 import { json, redirect } from '@remix-run/node';
 import { useId } from 'react';
-import { z } from 'zod';
-import { login } from '~/auth';
+import { authenticate } from '~/auth';
 
-const schema = z.object({
-  email: z.string().min(1, 'Email is required'),
-  password: z.string().min(1, 'Password is required'),
-});
+function validate(formData: FormData) {
+  const submission = parse(formData);
+
+  if (!submission.value.email) {
+    submission.error.push(['email', 'Email is required']);
+  } else if (!email.includes('@')) {
+    submission.error.push(['email', 'Email is invalid']);
+  }
+
+  if (!password) {
+    submission.error.push(['password', 'Password is required']);
+  }
+
+  return submission;
+}
 
 export async function action({ request }: ActionArgs) {
   const formData = await request.formData();
-  const submission = parse(formData);
+  const submission = validate(formData);
 
   try {
-    const data = schema.parse(submission.value);
-
-    if (submission.type === 'submit') {
-      const user = await login(data);
+    if (submission.error.length === 0 && submission.type === 'submit') {
+      const user = await authenticate(submission.value);
 
       if (!user) {
         throw new Error(
@@ -49,20 +56,20 @@ export async function action({ request }: ActionArgs) {
       return redirect('/');
     }
   } catch (error) {
-    submission.error.push(...formatError(error));
+    submission.error.push(['', error.message]);
   }
 
   return json(submission);
 }
 
 export default function LoginForm() {
-  const state = useActionData<typeof action>();
   const id = useId();
-  const [form, { email, password }] = useForm<z.infer<typeof schema>>({
+  const state = useActionData<typeof action>();
+  const [form, { email, password }] = useForm({
     id,
     state,
     onValidate({ formData }) {
-      return validate(formData, schema);
+      return validate(formData);
     },
   });
 
@@ -75,11 +82,11 @@ export default function LoginForm() {
         <div id={email.config.errorId}>{email.error}</div>
       </div>
       <div>
-        <label htmlFor={email.config.id}>Password</label>
+        <label htmlFor={password.config.id}>Password</label>
         <input {...conform.input(password.config)} />
-        <div id={email.config.errorId}>{password.error}</div>
+        <div id={password.config.errorId}>{password.error}</div>
       </div>
-      <button type="submit">Login</button>
+      <button>Login</button>
     </Form>
   );
 }

--- a/README.md
+++ b/README.md
@@ -79,12 +79,16 @@ export default function LoginForm() {
       <div>
         <label htmlFor={email.config.id}>Email</label>
         <input {...conform.input(email.config)} />
-        <div id={email.config.errorId}>{email.error}</div>
+        <div id={email.config.errorId} role="alert">
+          {email.error}
+        </div>
       </div>
       <div>
         <label htmlFor={password.config.id}>Password</label>
         <input {...conform.input(password.config)} />
-        <div id={password.config.errorId}>{password.error}</div>
+        <div id={password.config.errorId} role="alert">
+          {password.error}
+        </div>
       </div>
       <button>Login</button>
     </Form>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -291,7 +291,6 @@ export default function LoginForm() {
     initialReport: 'onBlur',
     state: result,
     onValidate({ formData }) {
-      // Run the same validation logic on client side
       return validate(formData);
     },
   });

--- a/examples/async-validation/README.md
+++ b/examples/async-validation/README.md
@@ -1,5 +1,7 @@
 # Async Validation Example
 
+> Please fork the sandbox if it is stuck in the `Initializing Sandbox Container` stage
+
 This example shows you how to how to implement async valdation with Conform.
 
 <!-- sandbox src="/examples/async-validation?module=/app/routes/index.tsx" -->

--- a/examples/async-validation/README.md
+++ b/examples/async-validation/README.md
@@ -1,6 +1,6 @@
 # Async Validation Example
 
-> Please fork the sandbox if it is stuck in the `Initializing Sandbox Container` stage
+> Please fork the sandbox if it is stuck in the _Initializing Sandbox Container_ stage
 
 This example shows you how to how to implement async valdation with Conform.
 

--- a/examples/nested-list/README.md
+++ b/examples/nested-list/README.md
@@ -1,5 +1,7 @@
 # Nested List Example
 
+> Please fork the sandbox if it is stuck in the `Initializing Sandbox Container` stage
+
 This example shows you how to build a todo list with a dynamic list of tasks.
 
 <!-- sandbox src="/examples/nested-list?module=/app/routes/index.tsx" -->

--- a/examples/nested-list/README.md
+++ b/examples/nested-list/README.md
@@ -1,6 +1,6 @@
 # Nested List Example
 
-> Please fork the sandbox if it is stuck in the `Initializing Sandbox Container` stage
+> Please fork the sandbox if it is stuck in the _Initializing Sandbox Container_ stage
 
 This example shows you how to build a todo list with a dynamic list of tasks.
 

--- a/examples/server-validation/README.md
+++ b/examples/server-validation/README.md
@@ -1,6 +1,6 @@
 # Server Validation Example
 
-> Please fork the sandbox if it is stuck in the `Initializing Sandbox Container` stage
+> Please fork the sandbox if it is stuck in the _Initializing Sandbox Container_ stage
 
 This example shows you how to implement server validation with Conform.
 

--- a/examples/server-validation/README.md
+++ b/examples/server-validation/README.md
@@ -1,5 +1,7 @@
 # Server Validation Example
 
+> Please fork the sandbox if it is stuck in the `Initializing Sandbox Container` stage
+
 This example shows you how to implement server validation with Conform.
 
 <!-- sandbox src="/examples/server-validation?module=/app/routes/index.tsx" -->

--- a/examples/yup/README.md
+++ b/examples/yup/README.md
@@ -1,6 +1,6 @@
 # Yup Example
 
-> Please fork the sandbox if it is stuck in the `Initializing Sandbox Container` stage
+> Please fork the sandbox if it is stuck in the _Initializing Sandbox Container_ stage
 
 This example shows you how to validate formData with [yup](https://github.com/jquense/yup) schema using the [validate](/packages/conform-yup/README.md#validate) helper.
 

--- a/examples/yup/README.md
+++ b/examples/yup/README.md
@@ -1,5 +1,7 @@
 # Yup Example
 
+> Please fork the sandbox if it is stuck in the `Initializing Sandbox Container` stage
+
 This example shows you how to validate formData with [yup](https://github.com/jquense/yup) schema using the [validate](/packages/conform-yup/README.md#validate) helper.
 
 <!-- sandbox src="/examples/yup?module=/app/routes/index.tsx" -->

--- a/examples/zod/README.md
+++ b/examples/zod/README.md
@@ -1,6 +1,6 @@
 # Zod Example
 
-> Please fork the sandbox if it is stuck in the `Initializing Sandbox Container` stage
+> Please fork the sandbox if it is stuck in the _Initializing Sandbox Container_ stage
 
 This example shows you how to validate formData with [zod](https://github.com/colinhacks/zod) schema using the [validate](/packages/conform-zod/README.md#validate) helper.
 

--- a/examples/zod/README.md
+++ b/examples/zod/README.md
@@ -1,5 +1,7 @@
 # Zod Example
 
+> Please fork the sandbox if it is stuck in the `Initializing Sandbox Container` stage
+
 This example shows you how to validate formData with [zod](https://github.com/colinhacks/zod) schema using the [validate](/packages/conform-zod/README.md#validate) helper.
 
 <!-- sandbox src="/examples/zod?module=/app/routes/index.tsx" -->


### PR DESCRIPTION
In order to showcases the features of Conform with Remix, I have migrated many of the examples to Remix running on sandbox container. However some of the examples seems to be stuck in `Initializing Sandbox Container` stage forever and the only way to solve it now is by forking it. Adding a reminder so users can still give it a try.