### PR TITLE
feat(conform-react): useInputEvent API

### DIFF
--- a/docs/focus-management.md
+++ b/docs/focus-management.md
@@ -33,41 +33,30 @@ function Example() {
 
 ## Focusing on Custom Control
 
-Conform can also focus on custom control if it exposes the inner ref property, where you can pass `control.ref` provided by [useControlledInput](/packages/conform-react/README.md#usecontrolledinput). e.g. `inputRef` on `<TextField />` from Material UI.
+Conform can also focus on custom control if it exposes a ref for you to focus manually. Here is an example snippet integrating with **react-select**:
 
 ```tsx
-import { useForm, useControlledInput } from '@conform-to/react';
-import { TextField, MenuItem, Button } from '@mui/material';
-
-function Example() {
-  const [form, { language }] = useForm();
-  const [shadowInputProps, control] = useControlledInput(language.config);
+function Select({ options, ...config }: SelectProps) {
+  const [inputRef, control] = useInputEvent();
+  const ref = useRef<HTMLInputElement>(null);
 
   return (
-    <form {...form.props}>
-      <div>
-        <input {...shadowInputProps} />
-        <TextField
-          label={label}
-          inputRef={control.ref}
-          value={control.value}
-          onChange={control.onChange}
-          onBlur={control.onBlur}
-          error={Boolean(language.error)}
-          helperText={language.error}
-          select
-        >
-          <MenuItem value="">Please select</MenuItem>
-          <MenuItem value="english">English</MenuItem>
-          <MenuItem value="deutsch">Deutsch</MenuItem>
-          <MenuItem value="japanese">Japanese</MenuItem>
-        </TextField>
-        <div>{language.error}</div>
-      </div>
-      <Button>Submit</Button>
-    </form>
+    <>
+      <input
+        ref={inputRef}
+        {...conform.input(config, { hidden: true })}
+        onFocus={() => ref.current?.focus()}
+      />
+      <Select
+        innerRef={ref}
+        options={options}
+        defaultValue={config.defaultValue ?? ''}
+        onChange={control.change}
+        onBlur={control.blur}
+      />
+    </>
   );
 }
 ```
 
-Check the [integration](/docs/integrations.md) guide for more details.
+Please check the [integration](/docs/integrations.md) guide for more details.

--- a/examples/chakra-ui/README.md
+++ b/examples/chakra-ui/README.md
@@ -2,18 +2,25 @@
 
 This example shows you how to integrate [chakra-ui](https://chakra-ui.com/docs/components) forms components with Conform.
 
-| Component   | Native support | Integration required |
-| ----------- | :------------: | :------------------: |
-| Input       |      Yes       |                      |
-| Select      |      Yes       |                      |
-| Textarea    |      Yes       |                      |
-| NumberInput |                |         Yes          |
-| PinInput    |                |         Yes          |
-| Editable    |                |         Yes          |
-| Checkbox    |      Yes       |                      |
-| Switch      |      Yes       |                      |
-| Slider      |                |         Yes          |
-| Radio       |      Yes       |                      |
+## Compatibility
+
+> Based on @chakra-ui/react@2.4.2
+
+**Native support**
+
+- Input
+- Select
+- Textarea
+- Checkbox
+- Switch
+- Radio
+- Editable
+
+**Integration required**
+
+- NumberInput
+- PinInput
+- Slider
 
 <!-- sandbox src="/examples/chakra-ui" -->
 

--- a/examples/chakra-ui/src/App.tsx
+++ b/examples/chakra-ui/src/App.tsx
@@ -1,5 +1,5 @@
 import type { FieldConfig } from '@conform-to/react';
-import { useForm, useControlledInput } from '@conform-to/react';
+import { useForm, useInputControl, conform } from '@conform-to/react';
 import {
 	Stack,
 	FormControl,
@@ -31,6 +31,7 @@ import {
 	Heading,
 	Text,
 } from '@chakra-ui/react';
+import { useRef, useState } from 'react';
 
 interface Schema {
 	email: string;
@@ -184,17 +185,29 @@ export default function Example() {
 }
 
 function ExampleNumberInput(config: FieldConfig<number>) {
-	const [shadowInputProps, control] = useControlledInput(config);
+	const [value, setValue] = useState(config.defaultValue ?? '');
+	const [inputRef, control] = useInputControl({
+		onReset: () => setValue(config.defaultValue ?? ''),
+	});
+	const ref = useRef<HTMLInputElement>(null);
 
 	return (
 		<>
-			<input {...shadowInputProps} />
+			<input
+				ref={inputRef}
+				{...conform.input(config, { hidden: true })}
+				onFocus={() => inputRef.current?.focus()}
+			/>
 			<NumberInput
+				ref={ref}
 				isRequired={config.required}
-				value={control.value}
-				onChange={control.onChange}
+				value={value}
+				onChange={(value) => {
+					control.onChange(value);
+					setValue(value);
+				}}
 			>
-				<NumberInputField ref={control.ref} />
+				<NumberInputField ref={ref} />
 				<NumberInputStepper>
 					<NumberIncrementStepper />
 					<NumberDecrementStepper />
@@ -208,18 +221,29 @@ function ExamplePinInput({
 	isInvalid,
 	...config
 }: FieldConfig<string> & { isInvalid: boolean }) {
-	const [shadowInputProps, control] = useControlledInput(config);
+	const [value, setValue] = useState(config.defaultValue ?? '');
+	const [inputRef, control] = useInputControl({
+		onReset: () => setValue(config.defaultValue ?? ''),
+	});
+	const ref = useRef<HTMLInputElement>(null);
 
 	return (
 		<>
-			<input {...shadowInputProps} />
+			<input
+				ref={inputRef}
+				{...conform.input(config, { hidden: true })}
+				onFocus={() => inputRef.current?.focus()}
+			/>
 			<PinInput
 				type="alphanumeric"
-				value={control.value}
-				onChange={control.onChange}
+				value={value}
+				onChange={(value) => {
+					control.onChange(value);
+					setValue(value);
+				}}
 				isInvalid={isInvalid}
 			>
-				<PinInputField ref={control.ref} />
+				<PinInputField ref={ref} />
 				<PinInputField />
 				<PinInputField />
 				<PinInputField />
@@ -229,14 +253,27 @@ function ExamplePinInput({
 }
 
 function ExampleSlider(config: FieldConfig<number>) {
-	const [shadowInputProps, control] = useControlledInput(config);
+	const [value, setValue] = useState(
+		config.defaultValue ? Number(config.defaultValue) : undefined,
+	);
+	const [inputRef, control] = useInputControl({
+		onReset: () =>
+			setValue(config.defaultValue ? Number(config.defaultValue) : undefined),
+	});
 
 	return (
 		<>
-			<input {...shadowInputProps} />
+			<input
+				ref={inputRef}
+				{...conform.input(config, { hidden: true })}
+				onFocus={() => inputRef.current?.focus()}
+			/>
 			<Slider
-				value={control.value ? Number(control.value) : undefined}
-				onChange={(value) => control.onChange(`${value}`)}
+				value={value}
+				onChange={(value) => {
+					control.onChange(`${value}`);
+					setValue(value);
+				}}
 				onBlur={control.onBlur}
 			>
 				<SliderTrack>

--- a/examples/chakra-ui/src/App.tsx
+++ b/examples/chakra-ui/src/App.tsx
@@ -1,5 +1,5 @@
 import type { FieldConfig } from '@conform-to/react';
-import { useForm, useInputControl, conform } from '@conform-to/react';
+import { useForm, useInputEvent, conform } from '@conform-to/react';
 import {
 	Stack,
 	FormControl,
@@ -186,7 +186,7 @@ export default function Example() {
 
 function ExampleNumberInput(config: FieldConfig<number>) {
 	const [value, setValue] = useState(config.defaultValue ?? '');
-	const [inputRef, control] = useInputControl({
+	const [inputRef, control] = useInputEvent({
 		onReset: () => setValue(config.defaultValue ?? ''),
 	});
 	const ref = useRef<HTMLInputElement>(null);
@@ -203,7 +203,7 @@ function ExampleNumberInput(config: FieldConfig<number>) {
 				isRequired={config.required}
 				value={value}
 				onChange={(value) => {
-					control.onChange(value);
+					control.change(value);
 					setValue(value);
 				}}
 			>
@@ -222,7 +222,7 @@ function ExamplePinInput({
 	...config
 }: FieldConfig<string> & { isInvalid: boolean }) {
 	const [value, setValue] = useState(config.defaultValue ?? '');
-	const [inputRef, control] = useInputControl({
+	const [inputRef, control] = useInputEvent({
 		onReset: () => setValue(config.defaultValue ?? ''),
 	});
 	const ref = useRef<HTMLInputElement>(null);
@@ -238,7 +238,7 @@ function ExamplePinInput({
 				type="alphanumeric"
 				value={value}
 				onChange={(value) => {
-					control.onChange(value);
+					control.change(value);
 					setValue(value);
 				}}
 				isInvalid={isInvalid}
@@ -256,7 +256,7 @@ function ExampleSlider(config: FieldConfig<number>) {
 	const [value, setValue] = useState(
 		config.defaultValue ? Number(config.defaultValue) : undefined,
 	);
-	const [inputRef, control] = useInputControl({
+	const [inputRef, control] = useInputEvent({
 		onReset: () =>
 			setValue(config.defaultValue ? Number(config.defaultValue) : undefined),
 	});
@@ -271,10 +271,11 @@ function ExampleSlider(config: FieldConfig<number>) {
 			<Slider
 				value={value}
 				onChange={(value) => {
-					control.onChange(`${value}`);
+					control.change(`${value}`);
 					setValue(value);
 				}}
-				onBlur={control.onBlur}
+				onFocus={control.focus}
+				onBlur={control.blur}
 			>
 				<SliderTrack>
 					<SliderFilledTrack />

--- a/examples/chakra-ui/src/App.tsx
+++ b/examples/chakra-ui/src/App.tsx
@@ -196,16 +196,14 @@ function ExampleNumberInput(config: FieldConfig<number>) {
 			<input
 				ref={inputRef}
 				{...conform.input(config, { hidden: true })}
+				onChange={(e) => setValue(e.target.value)}
 				onFocus={() => inputRef.current?.focus()}
 			/>
 			<NumberInput
 				ref={ref}
 				isRequired={config.required}
 				value={value}
-				onChange={(value) => {
-					control.change(value);
-					setValue(value);
-				}}
+				onChange={control.change}
 			>
 				<NumberInputField ref={ref} />
 				<NumberInputStepper>
@@ -232,15 +230,13 @@ function ExamplePinInput({
 			<input
 				ref={inputRef}
 				{...conform.input(config, { hidden: true })}
+				onChange={(e) => setValue(e.target.value)}
 				onFocus={() => inputRef.current?.focus()}
 			/>
 			<PinInput
 				type="alphanumeric"
 				value={value}
-				onChange={(value) => {
-					control.change(value);
-					setValue(value);
-				}}
+				onChange={control.change}
 				isInvalid={isInvalid}
 			>
 				<PinInputField ref={ref} />
@@ -253,12 +249,9 @@ function ExamplePinInput({
 }
 
 function ExampleSlider(config: FieldConfig<number>) {
-	const [value, setValue] = useState(
-		config.defaultValue ? Number(config.defaultValue) : undefined,
-	);
+	const [value, setValue] = useState(config.defaultValue ?? '');
 	const [inputRef, control] = useInputEvent({
-		onReset: () =>
-			setValue(config.defaultValue ? Number(config.defaultValue) : undefined),
+		onReset: () => setValue(config.defaultValue ?? ''),
 	});
 
 	return (
@@ -266,14 +259,12 @@ function ExampleSlider(config: FieldConfig<number>) {
 			<input
 				ref={inputRef}
 				{...conform.input(config, { hidden: true })}
+				onChange={(e) => setValue(e.target.value)}
 				onFocus={() => inputRef.current?.focus()}
 			/>
 			<Slider
-				value={value}
-				onChange={(value) => {
-					control.change(`${value}`);
-					setValue(value);
-				}}
+				value={value ? Number(value) : undefined}
+				onChange={(value) => control.change(`${value}`)}
 				onFocus={control.focus}
 				onBlur={control.blur}
 			>

--- a/examples/headless-ui/README.md
+++ b/examples/headless-ui/README.md
@@ -6,12 +6,12 @@
 
 > Based on @headless-ui/react@1.7.4
 
-| Component  | Native support | Integration required |
-| ---------- | :------------: | :------------------: |
-| ListBox    |                |         Yes          |
-| Combobox   |                |         Yes          |
-| Switch     |                |         Yes          |
-| RadioGroup |                |         Yes          |
+**Integration required**
+
+- ListBox
+- Combobox
+- Switch
+- RadioGroup
 
 ## Demo
 

--- a/examples/headless-ui/src/App.tsx
+++ b/examples/headless-ui/src/App.tsx
@@ -130,15 +130,10 @@ function ExampleListBox(config: FieldConfig<string>) {
 			<input
 				ref={inputRef}
 				{...conform.input(config, { hidden: true })}
-				onFocus={() => buttonRef.current?.click()}
+				onChange={(e) => setValue(e.target.value)}
+				onFocus={() => buttonRef.current?.focus()}
 			/>
-			<Listbox
-				value={value}
-				onChange={(value) => {
-					control.change(value);
-					setValue(value);
-				}}
-			>
+			<Listbox value={value} onChange={control.change}>
 				<div className="relative mt-1">
 					<Listbox.Button
 						className="relative w-full cursor-default rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 text-left shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm"
@@ -217,17 +212,10 @@ function ExampleCombobox(config: FieldConfig<string>) {
 			<input
 				ref={ref}
 				{...conform.input(config, { hidden: true })}
+				onChange={(e) => setValue(e.target.value)}
 				onFocus={() => inputRef.current?.focus()}
 			/>
-			<Combobox
-				as="div"
-				value={value}
-				onChange={(value) => {
-					control.change(value ?? '');
-					setValue(value ?? '');
-				}}
-				nullable
-			>
+			<Combobox as="div" value={value} onChange={control.change} nullable>
 				<div className="relative mt-1">
 					<Combobox.Input
 						ref={inputRef}
@@ -302,6 +290,7 @@ function ExampleSwitch(config: FieldConfig<boolean>) {
 			<input
 				ref={ref}
 				{...conform.input(config, { hidden: true })}
+				onChange={(e) => setChecked(e.target.value === 'on')}
 				onFocus={() => inputRef.current?.focus()}
 			/>
 			<Switch
@@ -309,7 +298,6 @@ function ExampleSwitch(config: FieldConfig<boolean>) {
 				checked={checked}
 				onChange={(checked: boolean) => {
 					control.change(checked ? 'on' : '');
-					setChecked(checked);
 				}}
 				className={classNames(
 					checked ? 'bg-indigo-600' : 'bg-gray-200',
@@ -350,18 +338,14 @@ function ExampleRadioGroup(config: FieldConfig<string>) {
 		},
 	];
 
-	console.log({ value });
-
 	return (
 		<>
-			<input ref={ref} {...conform.input(config, { hidden: true })} />
-			<RadioGroup
-				value={value}
-				onChange={(value) => {
-					control.change(value);
-					setValue(value);
-				}}
-			>
+			<input
+				ref={ref}
+				{...conform.input(config, { hidden: true })}
+				onChange={(e) => setValue(e.target.value)}
+			/>
+			<RadioGroup value={value} onChange={control.change}>
 				<div className="mt-4 flex items-center space-x-3">
 					{colors.map((color) => (
 						<RadioGroup.Option

--- a/examples/headless-ui/src/App.tsx
+++ b/examples/headless-ui/src/App.tsx
@@ -1,7 +1,7 @@
 import {
 	type FieldConfig,
 	useForm,
-	useInputControl,
+	useInputEvent,
 	conform,
 } from '@conform-to/react';
 import { Listbox, Combobox, Switch, RadioGroup } from '@headlessui/react';
@@ -120,7 +120,7 @@ function classNames(...classes: Array<string | boolean>): string {
 
 function ExampleListBox(config: FieldConfig<string>) {
 	const [value, setValue] = useState(config.defaultValue ?? '');
-	const [inputRef, control] = useInputControl({
+	const [inputRef, control] = useInputEvent({
 		onReset: () => setValue(config.defaultValue ?? ''),
 	});
 	const buttonRef = useRef<HTMLButtonElement>(null);
@@ -135,8 +135,7 @@ function ExampleListBox(config: FieldConfig<string>) {
 			<Listbox
 				value={value}
 				onChange={(value) => {
-					console.log({ value });
-					control.onChange(value);
+					control.change(value);
 					setValue(value);
 				}}
 			>
@@ -202,7 +201,7 @@ function ExampleListBox(config: FieldConfig<string>) {
 function ExampleCombobox(config: FieldConfig<string>) {
 	const [value, setValue] = useState(config.defaultValue ?? '');
 	const [query, setQuery] = useState('');
-	const [ref, control] = useInputControl({
+	const [ref, control] = useInputEvent({
 		onReset: () => setValue(config.defaultValue ?? ''),
 	});
 	const inputRef = useRef<HTMLInputElement>(null);
@@ -224,7 +223,7 @@ function ExampleCombobox(config: FieldConfig<string>) {
 				as="div"
 				value={value}
 				onChange={(value) => {
-					control.onChange(value ?? '');
+					control.change(value ?? '');
 					setValue(value ?? '');
 				}}
 				nullable
@@ -293,7 +292,7 @@ function ExampleCombobox(config: FieldConfig<string>) {
 
 function ExampleSwitch(config: FieldConfig<boolean>) {
 	const [checked, setChecked] = useState(config.defaultValue === 'on');
-	const [ref, control] = useInputControl({
+	const [ref, control] = useInputEvent({
 		onReset: () => setChecked(config.defaultValue === 'on'),
 	});
 	const inputRef = useRef<HTMLButtonElement>(null);
@@ -309,7 +308,7 @@ function ExampleSwitch(config: FieldConfig<boolean>) {
 				ref={inputRef}
 				checked={checked}
 				onChange={(checked: boolean) => {
-					control.onChange(checked ? 'on' : '');
+					control.change(checked ? 'on' : '');
 					setChecked(checked);
 				}}
 				className={classNames(
@@ -332,11 +331,8 @@ function ExampleSwitch(config: FieldConfig<boolean>) {
 
 function ExampleRadioGroup(config: FieldConfig<string>) {
 	const [value, setValue] = useState(config.defaultValue ?? '');
-	const [ref, control] = useInputControl({
-		onReset: () => {
-			console.log('reset');
-			setValue(config.defaultValue ?? '');
-		},
+	const [ref, control] = useInputEvent({
+		onReset: () => setValue(config.defaultValue ?? ''),
 	});
 	const colors = [
 		{ name: 'Pink', bgColor: 'bg-pink-500', selectedColor: 'ring-pink-500' },
@@ -362,7 +358,7 @@ function ExampleRadioGroup(config: FieldConfig<string>) {
 			<RadioGroup
 				value={value}
 				onChange={(value) => {
-					control.onChange(value);
+					control.change(value);
 					setValue(value);
 				}}
 			>

--- a/examples/headless-ui/src/App.tsx
+++ b/examples/headless-ui/src/App.tsx
@@ -1,11 +1,12 @@
 import {
 	type FieldConfig,
 	useForm,
-	useControlledInput,
+	useInputControl,
+	conform,
 } from '@conform-to/react';
 import { Listbox, Combobox, Switch, RadioGroup } from '@headlessui/react';
 import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 interface Schema {
 	owner: string;
@@ -118,20 +119,34 @@ function classNames(...classes: Array<string | boolean>): string {
 }
 
 function ExampleListBox(config: FieldConfig<string>) {
-	const [inputProps, control] = useControlledInput(config);
+	const [value, setValue] = useState(config.defaultValue ?? '');
+	const [inputRef, control] = useInputControl({
+		onReset: () => setValue(config.defaultValue ?? ''),
+	});
+	const buttonRef = useRef<HTMLButtonElement>(null);
 
 	return (
 		<>
-			<input {...inputProps} />
-			<Listbox value={control.value} onChange={control.onChange}>
+			<input
+				ref={inputRef}
+				{...conform.input(config, { hidden: true })}
+				onFocus={() => buttonRef.current?.click()}
+			/>
+			<Listbox
+				value={value}
+				onChange={(value) => {
+					console.log({ value });
+					control.onChange(value);
+					setValue(value);
+				}}
+			>
 				<div className="relative mt-1">
 					<Listbox.Button
 						className="relative w-full cursor-default rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 text-left shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm"
-						ref={control.ref as any}
+						ref={buttonRef}
 					>
 						<span className="block truncate">
-							{people.find((p) => control.value === `${p.id}`)?.name ??
-								'Please select'}
+							{people.find((p) => value === `${p.id}`)?.name ?? 'Please select'}
 						</span>
 						<span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
 							<ChevronUpDownIcon
@@ -185,27 +200,38 @@ function ExampleListBox(config: FieldConfig<string>) {
 }
 
 function ExampleCombobox(config: FieldConfig<string>) {
-	const [inputProps, control] = useControlledInput(config);
+	const [value, setValue] = useState(config.defaultValue ?? '');
 	const [query, setQuery] = useState('');
+	const [ref, control] = useInputControl({
+		onReset: () => setValue(config.defaultValue ?? ''),
+	});
+	const inputRef = useRef<HTMLInputElement>(null);
 	const filteredPeople =
-		query === ''
+		value === ''
 			? people
-			: people.filter((person) => {
-					return person.name.toLowerCase().includes(query.toLowerCase());
-			  });
+			: people.filter((person) =>
+					person.name.toLowerCase().includes(query.toLowerCase()),
+			  );
 
 	return (
 		<>
-			<input {...inputProps} />
+			<input
+				ref={ref}
+				{...conform.input(config, { hidden: true })}
+				onFocus={() => inputRef.current?.focus()}
+			/>
 			<Combobox
 				as="div"
-				value={control.value}
-				onChange={(value) => control.onChange(value ?? '')}
+				value={value}
+				onChange={(value) => {
+					control.onChange(value ?? '');
+					setValue(value ?? '');
+				}}
 				nullable
 			>
 				<div className="relative mt-1">
 					<Combobox.Input
-						ref={control.ref}
+						ref={inputRef}
 						className="w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm"
 						onChange={(event) => setQuery(event.target.value)}
 						displayValue={(personId: string) =>
@@ -266,17 +292,28 @@ function ExampleCombobox(config: FieldConfig<string>) {
 }
 
 function ExampleSwitch(config: FieldConfig<boolean>) {
-	const [inputProps, control] = useControlledInput(config);
+	const [checked, setChecked] = useState(config.defaultValue === 'on');
+	const [ref, control] = useInputControl({
+		onReset: () => setChecked(config.defaultValue === 'on'),
+	});
+	const inputRef = useRef<HTMLButtonElement>(null);
 
 	return (
 		<>
-			<input {...inputProps} />
+			<input
+				ref={ref}
+				{...conform.input(config, { hidden: true })}
+				onFocus={() => inputRef.current?.focus()}
+			/>
 			<Switch
-				ref={control.ref as any}
-				checked={control.value === 'on'}
-				onChange={(checked: boolean) => control.onChange(checked ? 'on' : '')}
+				ref={inputRef}
+				checked={checked}
+				onChange={(checked: boolean) => {
+					control.onChange(checked ? 'on' : '');
+					setChecked(checked);
+				}}
 				className={classNames(
-					control.value === 'on' ? 'bg-indigo-600' : 'bg-gray-200',
+					checked ? 'bg-indigo-600' : 'bg-gray-200',
 					'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2',
 				)}
 			>
@@ -284,7 +321,7 @@ function ExampleSwitch(config: FieldConfig<boolean>) {
 				<span
 					aria-hidden="true"
 					className={classNames(
-						control.value === 'on' ? 'translate-x-5' : 'translate-x-0',
+						checked ? 'translate-x-5' : 'translate-x-0',
 						'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
 					)}
 				/>
@@ -294,7 +331,13 @@ function ExampleSwitch(config: FieldConfig<boolean>) {
 }
 
 function ExampleRadioGroup(config: FieldConfig<string>) {
-	const [inputProps, control] = useControlledInput(config);
+	const [value, setValue] = useState(config.defaultValue ?? '');
+	const [ref, control] = useInputControl({
+		onReset: () => {
+			console.log('reset');
+			setValue(config.defaultValue ?? '');
+		},
+	});
 	const colors = [
 		{ name: 'Pink', bgColor: 'bg-pink-500', selectedColor: 'ring-pink-500' },
 		{
@@ -311,10 +354,18 @@ function ExampleRadioGroup(config: FieldConfig<string>) {
 		},
 	];
 
+	console.log({ value });
+
 	return (
 		<>
-			<input {...inputProps} />
-			<RadioGroup value={control.value} onChange={control.onChange}>
+			<input ref={ref} {...conform.input(config, { hidden: true })} />
+			<RadioGroup
+				value={value}
+				onChange={(value) => {
+					control.onChange(value);
+					setValue(value);
+				}}
+			>
 				<div className="mt-4 flex items-center space-x-3">
 					{colors.map((color) => (
 						<RadioGroup.Option

--- a/examples/material-ui/README.md
+++ b/examples/material-ui/README.md
@@ -6,18 +6,21 @@
 
 > Based on @mui/material@5.10
 
-| Component             | Native support | Integration required |
-| --------------------- | :------------: | :------------------: |
-| Text Field (input)    |      Yes       |                      |
-| Text Field (textarea) |      Yes       |                      |
-| Select (native)       |      Yes       |                      |
-| Select (default)      |                |         Yes          |
-| Autocomplete          |      Yes       |                      |
-| Checkbox              |      Yes       |                      |
-| Radio Group           |      Yes       |                      |
-| Rating                |                |         Yes          |
-| Slider                |                |         Yes          |
-| Switch                |                |         Yes          |
+**Native support**
+
+- Text Field (default)
+- Text Field (multiline)
+- NativeSelect
+- Checkbox
+- Radio Group
+- Switch
+
+**Integration required**
+
+- Autocomplete
+- Select
+- Rating
+- Slider
 
 ## Demo
 

--- a/examples/material-ui/src/App.tsx
+++ b/examples/material-ui/src/App.tsx
@@ -34,7 +34,7 @@ interface Schema {
 	progress: number;
 }
 
-export default function ArticleForm() {
+export default function ExampleForm() {
 	const [form, fieldset] = useForm<Schema>({ initialReport: 'onBlur' });
 
 	return (
@@ -247,7 +247,7 @@ function ExampleRating({ label, error, ...config }: FieldProps<number>) {
 			<FormLabel>{label}</FormLabel>
 			<input
 				ref={inputRef}
-				{...conform.input(config as FieldConfig<number>, {
+				{...conform.input(config, {
 					type: 'number',
 					hidden: true,
 				})}
@@ -279,10 +279,7 @@ function ExampleSlider({ label, error, ...config }: FieldProps<number>) {
 	return (
 		<FormControl variant="standard" error={Boolean(error)} required>
 			<FormLabel>{label}</FormLabel>
-			<input
-				ref={inputRef}
-				{...conform.input(config as FieldConfig<number>, { hidden: true })}
-			/>
+			<input ref={inputRef} {...conform.input(config, { hidden: true })} />
 			<Slider
 				value={value}
 				onChange={(_, value) => {

--- a/examples/material-ui/src/App.tsx
+++ b/examples/material-ui/src/App.tsx
@@ -20,7 +20,7 @@ import {
 	Slider,
 	Switch,
 } from '@mui/material';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 interface Schema {
 	email: string;
@@ -173,36 +173,36 @@ interface FieldProps<Schema> extends FieldConfig<Schema> {
 
 function ExampleSelect({ label, error, ...config }: FieldProps<string>) {
 	const [value, setValue] = useState(config.defaultValue ?? '');
-	const [inputRef, control] = useInputEvent<{
-		node: HTMLInputElement;
-		focus: () => void;
-	}>({
-		getElement: (ref) => ref?.node,
+	const [ref, control] = useInputEvent({
 		onReset: () => setValue(config.defaultValue ?? ''),
 	});
+	const inputRef = useRef<HTMLInputElement>(null);
 
 	return (
-		<TextField
-			label={label}
-			inputRef={inputRef}
-			name={config.name}
-			value={value}
-			onChange={(event) => {
-				control.change(event);
-				setValue(event.target.value);
-			}}
-			onFocus={control.focus}
-			onBlur={control.blur}
-			error={Boolean(error)}
-			helperText={error}
-			select
-			required={config.required}
-		>
-			<MenuItem value="">Please select</MenuItem>
-			<MenuItem value="english">English</MenuItem>
-			<MenuItem value="deutsch">Deutsch</MenuItem>
-			<MenuItem value="japanese">Japanese</MenuItem>
-		</TextField>
+		<>
+			<input
+				ref={ref}
+				{...conform.input(config, { hidden: true })}
+				onChange={(e) => setValue(e.target.value)}
+				onFocus={() => inputRef.current?.focus()}
+			/>
+			<TextField
+				label={label}
+				inputRef={inputRef}
+				value={value}
+				onChange={control.change}
+				onFocus={control.focus}
+				onBlur={control.blur}
+				error={Boolean(error)}
+				helperText={error}
+				select
+			>
+				<MenuItem value="">Please select</MenuItem>
+				<MenuItem value="english">English</MenuItem>
+				<MenuItem value="deutsch">Deutsch</MenuItem>
+				<MenuItem value="japanese">Japanese</MenuItem>
+			</TextField>
+		</>
 	);
 }
 
@@ -234,12 +234,9 @@ function ExampleAutocomplete({ label, error, ...config }: FieldProps<string>) {
 }
 
 function ExampleRating({ label, error, ...config }: FieldProps<number>) {
-	const [value, setValue] = useState(
-		config.defaultValue ? Number(config.defaultValue) : null,
-	);
+	const [value, setValue] = useState(config.defaultValue ?? '');
 	const [inputRef, control] = useInputEvent({
-		onReset: () =>
-			setValue(config.defaultValue ? Number(config.defaultValue) : null),
+		onReset: () => setValue(config.defaultValue ?? ''),
 	});
 
 	return (
@@ -251,13 +248,12 @@ function ExampleRating({ label, error, ...config }: FieldProps<number>) {
 					type: 'number',
 					hidden: true,
 				})}
+				onChange={(e) => setValue(e.target.value)}
 			/>
 			<Rating
-				value={value}
+				value={value ? Number(value) : null}
 				onChange={(_, value) => {
 					control.change(`${value ?? ''}`);
-					console.log('rating', value);
-					setValue(value);
 				}}
 				onFocus={control.focus}
 				onBlur={control.blur}
@@ -268,27 +264,27 @@ function ExampleRating({ label, error, ...config }: FieldProps<number>) {
 }
 
 function ExampleSlider({ label, error, ...config }: FieldProps<number>) {
-	const [value, setValue] = useState(
-		config.defaultValue ? Number(config.defaultValue) : undefined,
-	);
+	const [value, setValue] = useState(config.defaultValue ?? '');
 	const [inputRef, control] = useInputEvent<HTMLInputElement>({
-		onReset: () =>
-			setValue(config.defaultValue ? Number(config.defaultValue) : undefined),
+		onReset: () => setValue(config.defaultValue ?? ''),
 	});
 
 	return (
 		<FormControl variant="standard" error={Boolean(error)} required>
 			<FormLabel>{label}</FormLabel>
-			<input ref={inputRef} {...conform.input(config, { hidden: true })} />
+			<input
+				ref={inputRef}
+				{...conform.input(config, { hidden: true })}
+				onChange={(e) => setValue(e.target.value)}
+			/>
 			<Slider
-				value={value}
+				value={value ? Number(value) : undefined}
 				onChange={(_, value) => {
 					if (Array.isArray(value)) {
 						return;
 					}
 
 					control.change(`${value}`);
-					setValue(value);
 				}}
 			/>
 			<FormHelperText>{error}</FormHelperText>

--- a/examples/material-ui/src/App.tsx
+++ b/examples/material-ui/src/App.tsx
@@ -1,5 +1,5 @@
 import type { FieldConfig } from '@conform-to/react';
-import { useForm, conform, useInputControl } from '@conform-to/react';
+import { useForm, conform, useInputEvent } from '@conform-to/react';
 import {
 	TextField,
 	Button,
@@ -173,7 +173,7 @@ interface FieldProps<Schema> extends FieldConfig<Schema> {
 
 function ExampleSelect({ label, error, ...config }: FieldProps<string>) {
 	const [value, setValue] = useState(config.defaultValue ?? '');
-	const [inputRef, control] = useInputControl<{
+	const [inputRef, control] = useInputEvent<{
 		node: HTMLInputElement;
 		focus: () => void;
 	}>({
@@ -188,11 +188,11 @@ function ExampleSelect({ label, error, ...config }: FieldProps<string>) {
 			name={config.name}
 			value={value}
 			onChange={(event) => {
-				control.onChange(event);
+				control.change(event);
 				setValue(event.target.value);
 			}}
-			onFocus={control.onFocus}
-			onBlur={control.onBlur}
+			onFocus={control.focus}
+			onBlur={control.blur}
 			error={Boolean(error)}
 			helperText={error}
 			select
@@ -207,7 +207,7 @@ function ExampleSelect({ label, error, ...config }: FieldProps<string>) {
 }
 
 function ExampleAutocomplete({ label, error, ...config }: FieldProps<string>) {
-	const [inputRef, control] = useInputControl();
+	const [inputRef, control] = useInputEvent();
 	const options = ['The Godfather', 'Pulp Fiction'];
 
 	return (
@@ -215,9 +215,9 @@ function ExampleAutocomplete({ label, error, ...config }: FieldProps<string>) {
 			disablePortal
 			options={options}
 			defaultValue={options.find((option) => option === config.defaultValue)}
-			onChange={(_, option) => control.onChange(`${option ?? ''}`)}
-			onFocus={control.onFocus}
-			onBlur={control.onBlur}
+			onChange={(_, option) => control.change(`${option ?? ''}`)}
+			onFocus={control.focus}
+			onBlur={control.blur}
 			renderInput={(params) => (
 				<TextField
 					{...params}
@@ -237,7 +237,7 @@ function ExampleRating({ label, error, ...config }: FieldProps<number>) {
 	const [value, setValue] = useState(
 		config.defaultValue ? Number(config.defaultValue) : null,
 	);
-	const [inputRef, control] = useInputControl({
+	const [inputRef, control] = useInputEvent({
 		onReset: () =>
 			setValue(config.defaultValue ? Number(config.defaultValue) : null),
 	});
@@ -254,13 +254,13 @@ function ExampleRating({ label, error, ...config }: FieldProps<number>) {
 			/>
 			<Rating
 				value={value}
-				onFocus={control.onFocus}
 				onChange={(_, value) => {
-					control.onChange(`${value ?? ''}`);
+					control.change(`${value ?? ''}`);
 					console.log('rating', value);
 					setValue(value);
 				}}
-				onBlur={control.onBlur}
+				onFocus={control.focus}
+				onBlur={control.blur}
 			/>
 			<FormHelperText>{error}</FormHelperText>
 		</FormControl>
@@ -271,7 +271,7 @@ function ExampleSlider({ label, error, ...config }: FieldProps<number>) {
 	const [value, setValue] = useState(
 		config.defaultValue ? Number(config.defaultValue) : undefined,
 	);
-	const [inputRef, control] = useInputControl<HTMLInputElement>({
+	const [inputRef, control] = useInputEvent<HTMLInputElement>({
 		onReset: () =>
 			setValue(config.defaultValue ? Number(config.defaultValue) : undefined),
 	});
@@ -287,7 +287,7 @@ function ExampleSlider({ label, error, ...config }: FieldProps<number>) {
 						return;
 					}
 
-					control.onChange(`${value}`);
+					control.change(`${value}`);
 					setValue(value);
 				}}
 			/>

--- a/examples/material-ui/src/App.tsx
+++ b/examples/material-ui/src/App.tsx
@@ -20,7 +20,7 @@ import {
 	Slider,
 	Switch,
 } from '@mui/material';
-import { useRef } from 'react';
+import { useState } from 'react';
 
 interface Schema {
 	email: string;
@@ -172,16 +172,25 @@ interface FieldProps<Schema> extends FieldConfig<Schema> {
 }
 
 function ExampleSelect({ label, error, ...config }: FieldProps<string>) {
-	const inputRef = useRef<{ node: HTMLInputElement; focus: () => void }>(null);
-	const control = useInputControl(() => inputRef.current?.node);
+	const [value, setValue] = useState(config.defaultValue ?? '');
+	const [inputRef, control] = useInputControl<{
+		node: HTMLInputElement;
+		focus: () => void;
+	}>({
+		getElement: (ref) => ref?.node,
+		onReset: () => setValue(config.defaultValue ?? ''),
+	});
 
 	return (
 		<TextField
 			label={label}
 			inputRef={inputRef}
 			name={config.name}
-			defaultValue={config.defaultValue ?? ''}
-			onChange={control.onChange}
+			value={value}
+			onChange={(event) => {
+				control.onChange(event);
+				setValue(event.target.value);
+			}}
 			onFocus={control.onFocus}
 			onBlur={control.onBlur}
 			error={Boolean(error)}
@@ -198,8 +207,7 @@ function ExampleSelect({ label, error, ...config }: FieldProps<string>) {
 }
 
 function ExampleAutocomplete({ label, error, ...config }: FieldProps<string>) {
-	const inputRef = useRef<HTMLInputElement>(null);
-	const control = useInputControl(() => inputRef.current);
+	const [inputRef, control] = useInputControl();
 	const options = ['The Godfather', 'Pulp Fiction'];
 
 	return (
@@ -226,8 +234,13 @@ function ExampleAutocomplete({ label, error, ...config }: FieldProps<string>) {
 }
 
 function ExampleRating({ label, error, ...config }: FieldProps<number>) {
-	const inputRef = useRef<HTMLInputElement>(null);
-	const control = useInputControl(() => inputRef.current);
+	const [value, setValue] = useState(
+		config.defaultValue ? Number(config.defaultValue) : null,
+	);
+	const [inputRef, control] = useInputControl({
+		onReset: () =>
+			setValue(config.defaultValue ? Number(config.defaultValue) : null),
+	});
 
 	return (
 		<FormControl variant="standard" error={Boolean(error)} required>
@@ -240,11 +253,13 @@ function ExampleRating({ label, error, ...config }: FieldProps<number>) {
 				})}
 			/>
 			<Rating
-				defaultValue={
-					config.defaultValue ? Number(config.defaultValue) : undefined
-				}
+				value={value}
 				onFocus={control.onFocus}
-				onChange={(_, value) => control.onChange(`${value ?? ''}`)}
+				onChange={(_, value) => {
+					control.onChange(`${value ?? ''}`);
+					console.log('rating', value);
+					setValue(value);
+				}}
 				onBlur={control.onBlur}
 			/>
 			<FormHelperText>{error}</FormHelperText>
@@ -253,8 +268,13 @@ function ExampleRating({ label, error, ...config }: FieldProps<number>) {
 }
 
 function ExampleSlider({ label, error, ...config }: FieldProps<number>) {
-	const inputRef = useRef<HTMLInputElement>(null);
-	const control = useInputControl(() => inputRef.current);
+	const [value, setValue] = useState(
+		config.defaultValue ? Number(config.defaultValue) : undefined,
+	);
+	const [inputRef, control] = useInputControl<HTMLInputElement>({
+		onReset: () =>
+			setValue(config.defaultValue ? Number(config.defaultValue) : undefined),
+	});
 
 	return (
 		<FormControl variant="standard" error={Boolean(error)} required>
@@ -264,10 +284,15 @@ function ExampleSlider({ label, error, ...config }: FieldProps<number>) {
 				{...conform.input(config as FieldConfig<number>, { hidden: true })}
 			/>
 			<Slider
-				defaultValue={
-					config.defaultValue ? Number(config.defaultValue) : undefined
-				}
-				onChange={(_, value) => control.onChange(`${value}`)}
+				value={value}
+				onChange={(_, value) => {
+					if (Array.isArray(value)) {
+						return;
+					}
+
+					control.onChange(`${value}`);
+					setValue(value);
+				}}
 			/>
 			<FormHelperText>{error}</FormHelperText>
 		</FormControl>

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -29,9 +29,9 @@ export type FieldConstraint<Schema = any> = {
 	required?: boolean;
 	minLength?: number;
 	maxLength?: number;
-	min?: Schema extends number ? number : string;
-	max?: Schema extends number ? number : string;
-	step?: Schema extends number ? number : string;
+	min?: Schema extends number ? number : string | number;
+	max?: Schema extends number ? number : string | number;
+	step?: Schema extends number ? number : string | number;
 	multiple?: boolean;
 	pattern?: string;
 };

--- a/packages/conform-react/README.md
+++ b/packages/conform-react/README.md
@@ -9,6 +9,7 @@
 - [useForm](#useform)
 - [useFieldset](#usefieldset)
 - [useFieldList](#usefieldlist)
+- [useInputEvent](#useinputevent)
 - [useControlledInput](#usecontrolledinput)
 - [conform](#conform)
 - [list](#list)
@@ -304,6 +305,7 @@ function MuiForm() {
       <input
         ref={ref}
         {...conform.input(category.config, { hidden: true })}
+        onChange={(e) => setValue(e.target.value)}
         onFocus={() => inputRef.current?.focus()}
       />
 
@@ -312,10 +314,7 @@ function MuiForm() {
         label="Category"
         inputRef={inputRef}
         value={value}
-        onChange={(event) => {
-          control.change(event.target.value);
-          setValue(event.target.value);
-        }}
+        onChange={control.change}
         onBlur={control.blur}
         select
       >

--- a/packages/conform-react/README.md
+++ b/packages/conform-react/README.md
@@ -281,14 +281,65 @@ function Example() {
 
 ---
 
+### useInputEvent
+
+It returns a ref object and a set of helpers that dispatch corresponding dom event.
+
+```tsx
+import { useForm, useInputEvent } from '@conform-to/react';
+import { Select, MenuItem } from '@mui/material';
+import { useState, useRef } from 'react';
+
+function MuiForm() {
+  const [form, { category }] = useForm();
+  const [value, setValue] = useState(category.config.defaultValue ?? '');
+  const [ref, control] = useInputEvent({
+    onReset: () => setValue(category.config.defaultValue ?? ''),
+  });
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <form {...form.props}>
+      {/* Render a shadow input somewhere */}
+      <input
+        ref={ref}
+        {...conform.input(category.config, { hidden: true })}
+        onFocus={() => inputRef.current?.focus()}
+      />
+
+      {/* MUI Select is a controlled component */}
+      <TextField
+        label="Category"
+        inputRef={inputRef}
+        value={value}
+        onChange={(event) => {
+          control.change(event.target.value);
+          setValue(event.target.value);
+        }}
+        onBlur={control.blur}
+        select
+      >
+        <MenuItem value="">Please select</MenuItem>
+        <MenuItem value="a">Category A</MenuItem>
+        <MenuItem value="b">Category B</MenuItem>
+        <MenuItem value="c">Category C</MenuItem>
+      </TextField>
+    </form>
+  );
+}
+```
+
+---
+
 ### useControlledInput
+
+> This API is deprecated and replaced with the [useInputEvent](#useinputevent) hook.
 
 It returns the properties required to configure a shadow input for validation and helper to integrate it. This is particularly useful when [integrating custom input components](/docs/integrations.md#custom-input-component) like dropdown and datepicker.
 
 ```tsx
 import { useForm, useControlledInput } from '@conform-to/react';
 import { Select, MenuItem } from '@mui/material';
-import { useRef } from 'react';
 
 function MuiForm() {
   const [form, { category }] = useForm();

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -1,5 +1,5 @@
 import type { FieldConfig } from '@conform-to/dom';
-import type { HTMLInputTypeAttribute } from 'react';
+import type { CSSProperties, HTMLInputTypeAttribute } from 'react';
 
 interface FieldProps {
 	id?: string;
@@ -7,8 +7,11 @@ interface FieldProps {
 	form?: string;
 	required?: boolean;
 	autoFocus?: boolean;
+	tabIndex?: number;
+	style?: CSSProperties;
 	'aria-invalid': boolean;
 	'aria-describedby'?: string;
+	'aria-hidden'?: boolean;
 }
 
 interface InputProps<Schema> extends FieldProps {
@@ -39,19 +42,30 @@ interface TextareaProps extends FieldProps {
 type InputOptions =
 	| {
 			type: 'checkbox' | 'radio';
+			hidden?: boolean;
 			value?: string;
 	  }
 	| {
-			type: 'file';
-			value?: never;
-	  }
-	| {
-			type?: Exclude<
-				HTMLInputTypeAttribute,
-				'button' | 'submit' | 'hidden' | 'file'
-			>;
+			type?: Exclude<HTMLInputTypeAttribute, 'button' | 'submit' | 'hidden'>;
+			hidden?: boolean;
 			value?: never;
 	  };
+
+/**
+ * Style to make the input element visually hidden
+ * Based on the `sr-only` class from tailwindcss
+ */
+const hiddenStyle: CSSProperties = {
+	position: 'absolute',
+	width: '1px',
+	height: '1px',
+	padding: 0,
+	margin: '-1px',
+	overflow: 'hidden',
+	clip: 'rect(0,0,0,0)',
+	whiteSpace: 'nowrap',
+	border: 0,
+};
 
 export function input<Schema extends File | File[]>(
 	config: FieldConfig<Schema>,
@@ -82,6 +96,12 @@ export function input<Schema>(
 		'aria-describedby': config.errorId,
 	};
 
+	if (options?.hidden) {
+		attributes.style = hiddenStyle;
+		attributes.tabIndex = -1;
+		attributes['aria-hidden'] = true;
+	}
+
 	if (config.initialError && config.initialError.length > 0) {
 		attributes.autoFocus = true;
 	}
@@ -96,7 +116,10 @@ export function input<Schema>(
 	return attributes;
 }
 
-export function select<Schema>(config: FieldConfig<Schema>): SelectProps {
+export function select<Schema>(
+	config: FieldConfig<Schema>,
+	options?: { hidden?: boolean },
+): SelectProps {
 	const attributes: SelectProps = {
 		id: config.id,
 		name: config.name,
@@ -112,6 +135,12 @@ export function select<Schema>(config: FieldConfig<Schema>): SelectProps {
 		'aria-describedby': config.errorId,
 	};
 
+	if (options?.hidden) {
+		attributes.style = hiddenStyle;
+		attributes.tabIndex = -1;
+		attributes['aria-hidden'] = true;
+	}
+
 	if (config.initialError && config.initialError.length > 0) {
 		attributes.autoFocus = true;
 	}
@@ -119,7 +148,10 @@ export function select<Schema>(config: FieldConfig<Schema>): SelectProps {
 	return attributes;
 }
 
-export function textarea<Schema>(config: FieldConfig<Schema>): TextareaProps {
+export function textarea<Schema>(
+	config: FieldConfig<Schema>,
+	options?: { hidden?: boolean },
+): TextareaProps {
 	const attributes: TextareaProps = {
 		id: config.id,
 		name: config.name,
@@ -132,6 +164,12 @@ export function textarea<Schema>(config: FieldConfig<Schema>): TextareaProps {
 		'aria-invalid': Boolean(config.initialError?.length),
 		'aria-describedby': config.errorId,
 	};
+
+	if (options?.hidden) {
+		attributes.style = hiddenStyle;
+		attributes.tabIndex = -1;
+		attributes['aria-hidden'] = true;
+	}
 
 	if (config.initialError && config.initialError.length > 0) {
 		attributes.autoFocus = true;

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -951,34 +951,45 @@ export function useInputControl<RefShape>(options?: {
 	});
 
 	useSafeLayoutEffect(() => {
-		const createFormEventListener =
-			<FormEvent extends Event>(handler: (event: FormEvent) => void) =>
-			(event: FormEvent) => {
-				const $input = (optionsRef.current?.getElement?.(ref.current) ??
-					ref.current) as FieldElement;
+		const getInputElement = () =>
+			(optionsRef.current?.getElement?.(ref.current) ?? ref.current) as
+				| FieldElement
+				| undefined;
+		const inputHandler = (event: Event) => {
+			const input = getInputElement();
 
-				if (!$input || event.target !== $input) {
-					return;
-				}
+			if (input && event.target === input) {
+				changeDispatched.current = true;
+			}
+		};
+		const focusHandler = (event: FocusEvent) => {
+			const input = getInputElement();
 
-				handler(event);
-			};
+			if (input && event.target === input) {
+				focusDispatched.current = true;
+			}
+		};
+		const blurHandler = (event: FocusEvent) => {
+			const input = getInputElement();
 
-		const inputHandler = createFormEventListener((e) => {
-			changeDispatched.current = true;
-		});
-		const focusHandler = createFormEventListener(() => {
-			focusDispatched.current = true;
-		});
-		const blurHandler = createFormEventListener(() => {
-			blurDispatched.current = true;
-		});
-		const submitHandler = createFormEventListener<SubmitEvent>((event) => {
-			optionsRef.current?.onSubmit?.(event);
-		});
-		const resetHandler = createFormEventListener((event) => {
-			optionsRef.current?.onReset?.(event);
-		});
+			if (input && event.target === input) {
+				blurDispatched.current = true;
+			}
+		};
+		const submitHandler = (event: SubmitEvent) => {
+			const input = getInputElement();
+
+			if (input?.form && event.target === input.form) {
+				optionsRef.current?.onSubmit?.(event);
+			}
+		};
+		const resetHandler = (event: Event) => {
+			const input = getInputElement();
+
+			if (input?.form && event.target === input.form) {
+				optionsRef.current?.onReset?.(event);
+			}
+		};
 
 		document.addEventListener('input', inputHandler, true);
 		document.addEventListener('focus', focusHandler, true);

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -804,6 +804,7 @@ interface LegacyInputControl<Element extends { focus: () => void }> {
  * This is particular useful when integrating dropdown and datepicker whichs
  * introduces custom input mode.
  *
+ * @deprecated Please use the `useInputEvent` hook instead
  * @see https://conform.guide/api/react#usecontrolledinput
  */
 export function useControlledInput<
@@ -932,6 +933,11 @@ interface InputControl {
 	blur: () => void;
 }
 
+/**
+ * Returns a ref object and a set of helpers that dispatch corresponding dom event.
+ *
+ * @see https://conform.guide/api/react#useinputevent
+ */
 export function useInputEvent<
 	RefShape extends FieldElement = HTMLInputElement,
 >(options?: {

--- a/playground/app/routes/input-event.tsx
+++ b/playground/app/routes/input-event.tsx
@@ -1,0 +1,116 @@
+import { useInputEvent, conform } from '@conform-to/react';
+import { useSearchParams } from '@remix-run/react';
+import { type FormEvent, useRef, useState } from 'react';
+
+export default function BaseInputText() {
+	const [searchParams] = useSearchParams();
+	const [baseRef, control] = useInputEvent({
+		onSubmit: (e) => {
+			const submitter = e.submitter as HTMLButtonElement | undefined;
+
+			e.preventDefault();
+
+			setLogsByName((prev) => {
+				const next: Record<string, string[]> = {};
+
+				if (submitter?.name === 'intent') {
+					for (const name of Object.keys(prev)) {
+						next[name] = [`--- ${submitter.value} ---`];
+					}
+				}
+
+				return next;
+			});
+		},
+		onReset: () => setValue(searchParams.get('defaultValue') ?? ''),
+	});
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [value, setValue] = useState(searchParams.get('defaultValue') ?? '');
+	const [logsByName, setLogsByName] = useState<Record<string, string[]>>({});
+	const log = (event: FormEvent<HTMLFormElement>) => {
+		const input = event.target as HTMLInputElement;
+
+		setLogsByName((logsByName) => ({
+			...logsByName,
+			[input.name]: [
+				...(logsByName[input.name] ?? []),
+				JSON.stringify({
+					eventPhase: event.eventPhase,
+					type: event.type,
+					bubbles: event.bubbles,
+					cancelable: event.cancelable,
+				}),
+			],
+		}));
+	};
+
+	return (
+		<form
+			onChange={log}
+			onInput={log}
+			onFocusCapture={log}
+			onFocus={log}
+			onBlurCapture={log}
+			onBlur={log}
+		>
+			<div className="sticky top-0 pt-4 pb-8 bg-gray-100 border-b">
+				<label>Type here</label>
+				<input
+					ref={baseRef}
+					{...conform.input(
+						{
+							name: 'base-input',
+							defaultValue: searchParams.get('defaultValue') ?? '',
+						},
+						{ hidden: true },
+					)}
+				/>
+				<div className="flex flex-row gap-4">
+					<input
+						className="p-2 flex-1"
+						name="native-input"
+						value={value}
+						ref={inputRef}
+						onChange={(e) => {
+							control.change(e.target.value);
+							setValue(e.target.value);
+						}}
+						onFocus={control.focus}
+						onBlur={control.blur}
+					/>
+					<button
+						className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+						name="intent"
+						value="clear"
+					>
+						Submit
+					</button>
+					<button
+						type="reset"
+						className="inline-flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-gray-700 bg-gray-50 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+					>
+						Reset
+					</button>
+				</div>
+			</div>
+			<div className="my-4 flex flex-row">
+				<div className="flex-1">
+					native-input logs
+					<ul id="native-input">
+						{logsByName['native-input']?.map((log, i) => (
+							<li key={i}>{log}</li>
+						))}
+					</ul>
+				</div>
+				<div className="flex-1">
+					base-input logs
+					<ul id="base-input">
+						{logsByName['base-input']?.map((log, i) => (
+							<li key={i}>{log}</li>
+						))}
+					</ul>
+				</div>
+			</div>
+		</form>
+	);
+}

--- a/tests/integrations/input-event.spec.ts
+++ b/tests/integrations/input-event.spec.ts
@@ -1,0 +1,225 @@
+import { type Page, test, expect } from '@playwright/test';
+
+async function getForm(page: Page, defaultValue?: string) {
+	await page.goto(`/input-event?defaultValue=${defaultValue ?? ''}`);
+
+	return {
+		baseInput: page.locator('[name="base-input"]'),
+		nativeInput: page.locator('[name="native-input"]'),
+		reset: page.locator('button:text("Reset")'),
+		submit: page.locator('button:text("Submit")'),
+		baseLogs: page.locator('ul#base-input > li'),
+		nativeLogs: page.locator('ul#native-input > li'),
+	};
+}
+
+function createLog(type: string, eventPhase: number) {
+	return JSON.stringify({
+		eventPhase,
+		type,
+		bubbles: true,
+		cancelable: false,
+	});
+}
+
+test.describe('input event', () => {
+	test('emits nothing on load', async ({ page }) => {
+		const form = await getForm(page);
+
+		await expect(form.nativeLogs).toHaveText([]);
+		await expect(form.baseLogs).toHaveText([]);
+	});
+
+	test('emits events as native input', async ({ page }) => {
+		const form = await getForm(page);
+		const logs1 = [createLog('focus', 1), createLog('focus', 3)];
+
+		await form.nativeInput.focus();
+		await expect(form.baseLogs).toHaveText(logs1);
+		await expect(form.nativeLogs).toHaveText(logs1);
+
+		const logs2 = [
+			createLog('focus', 1),
+			createLog('focus', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+		];
+
+		await form.nativeInput.type('test');
+		await expect(form.nativeLogs).toHaveText(logs2);
+		await expect(form.baseLogs).toHaveText(logs2);
+
+		const logs3 = [
+			createLog('focus', 1),
+			createLog('focus', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('blur', 1),
+			createLog('blur', 3),
+		];
+
+		await page.click('body');
+		await expect(form.nativeLogs).toHaveText(logs3);
+		await expect(form.baseLogs).toHaveText(logs3);
+	});
+
+	test('works with keyboard events', async ({ page }) => {
+		const form = await getForm(page);
+
+		// Change event will be emitted first before the focus event
+		// if we type without focus on webkit (headless mode only)
+		// This might be a bug from playwright
+		await form.nativeInput.focus();
+
+		// Type 'abc'
+		await form.nativeInput.type('abc');
+
+		const logs1 = [
+			createLog('focus', 1),
+			createLog('focus', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+		];
+
+		// Highlight 'c'
+		await form.nativeInput.press('Shift+ArrowLeft');
+		await expect(form.nativeLogs).toHaveText(logs1);
+		await expect(form.baseLogs).toHaveText(logs1);
+
+		const logs2 = [
+			createLog('focus', 1),
+			createLog('focus', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+		];
+
+		// Cut out 'c'
+		await form.nativeInput.press('Control+x');
+		await expect(form.nativeLogs).toHaveText(logs2);
+		await expect(form.baseLogs).toHaveText(logs2);
+
+		const logs3 = [
+			createLog('focus', 1),
+			createLog('focus', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+		];
+
+		// Paste the 'c' back
+		await form.nativeInput.press('Control+v');
+		await expect(form.nativeLogs).toHaveText(logs3);
+		await expect(form.baseLogs).toHaveText(logs3);
+
+		const logs4 = [
+			createLog('focus', 1),
+			createLog('focus', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+		];
+
+		// Select all text
+		await form.nativeInput.press('Control+a');
+		await expect(form.nativeLogs).toHaveText(logs4);
+		await expect(form.baseLogs).toHaveText(logs4);
+
+		const logs5 = [
+			createLog('focus', 1),
+			createLog('focus', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+		];
+
+		// Delete all text
+		await form.nativeInput.press('Backspace');
+		await expect(form.nativeLogs).toHaveText(logs5);
+		await expect(form.baseLogs).toHaveText(logs5);
+	});
+
+	test('works with reset event', async ({ page }) => {
+		const form = await getForm(page, 'abc');
+		const logs = [
+			createLog('focus', 1),
+			createLog('focus', 3),
+			createLog('input', 3),
+			createLog('change', 3),
+			createLog('blur', 1),
+			createLog('blur', 3),
+		];
+
+		await form.reset.click();
+		await expect(form.nativeInput).toHaveValue('abc');
+		await expect(form.nativeLogs).toHaveText([]);
+		await expect(form.baseLogs).toHaveText([]);
+
+		await form.nativeInput.focus();
+		await form.nativeInput.type('d');
+		await form.reset.click();
+		await expect(form.nativeInput).toHaveValue('abc');
+		await expect(form.nativeLogs).toHaveText(logs);
+		await expect(form.baseLogs).toHaveText(logs);
+	});
+
+	test('works with submit event', async ({ page }) => {
+		const form = await getForm(page, 'abc');
+		const logs1 = [createLog('focus', 1), createLog('focus', 3)];
+
+		await form.nativeInput.focus();
+
+		await expect(form.nativeLogs).toHaveText(logs1);
+		await expect(form.baseLogs).toHaveText(logs1);
+
+		const logs2 = ['--- clear ---'];
+
+		await form.submit.click();
+		await expect(form.nativeLogs).toHaveText(logs2);
+		await expect(form.baseLogs).toHaveText(logs2);
+	});
+});


### PR DESCRIPTION
## Introducing the `useInputEvent()` hook

This APIs has several improvements over **useControlledInput()**:
- It no longer enforces creating a shadow input element
- Use your own value instead of built-in value state
- Explicit focus forwarding for flexiblity
- Wider event type support, e.g. focus-in / focus / focus-out / change (react-only)

```tsx
// Before
function ExampleAutocomplete({ label, error, ...config }: FieldProps<string>) {
    const [shadowInput, control] = useControlledInput(config);

    return (
        <>
            <input {...shadowInput} />
            <Autocomplete
                disablePortal
                options={['The Godfather', 'Pulp Fiction']}
                value={control.value}
                onChange={(_, option) => control.change(`${option ?? ''}`)}
                renderInput={(params) => (
                    <TextField
                        {...params}
                        label={label}
                        inputRef={control.ref}
                        onBlur={control.blur}
                        error={Boolean(error)}
                        helperText={error}
                        required={config.required}
                        inputProps={{
                            ...params.inputProps,
                            // To disable error bubble caused by the constraint
                            // attribute set by mui input, e.g. `required`
                            required: false,
                        }}
                    />
                )}
            />
        </>
    );
}

// After - To achieve exactly the same features as before
function ExampleAutocomplete({ label, error, ...config }: FieldProps<string>) {
    const [value, setValue] = useState(config.defaultValue ?? '');
    const [ref, control] = useInputEvent({
        onReset: () => setValue(config.defaultValue ?? ''),
    });
    const inputRef = useRef<HTMLInputElement>();

    return (
        <>
            <input
                ref={ref}
                {...conform.input(config, { hidden: true })}
                onFoucs={() => inputRef.current?.focus()}
            />
            <Autocomplete
                disablePortal
                options={['The Godfather', 'Pulp Fiction']}
                value={value}
                onChange={(_, option) => {
                    control.change(`${option ?? ''}`);
                    setValue(option);
                }}
                onFocus={control.focus}
                onBlur={control.blur}
                renderInput={(params) => (
                    <TextField
                        {...params}
                        inputRef={inputRef}
                        label={label}
                        error={Boolean(error)}
                        helperText={error}
                        required={config.required}
                        inputProps={{
                            ...params.inputProps,
                            required: false,
                        }}
                    />
                )}
            />
        </>
    );
}

// After - To reuse existing input element if possible
function ExampleAutocomplete({ label, error, ...config }: FieldProps<string>) {
    const [value, setValue] = useState(config.defaultValue ?? '');
    const [inputRef, control] = useInputEvent({
        onReset: () => setValue(config.defaultValue ?? ''),
    });

    return (
        <Autocomplete
            disablePortal
            options={['The Godfather', 'Pulp Fiction']}
            value={value}
            onChange={(_, option) => {
                control.change(`${option ?? ''}`);
                setValue(option);
            }}
            onFocus={control.focus}
            onBlur={control.blur}
            renderInput={(params) => (
                <TextField
                    {...params}
                    inputRef={inputRef}
                    label={label}
                    error={Boolean(error)}
                    helperText={error}
                    required={config.required}
                    inputProps={{
                        ...params.inputProps,
                        required: false,
                    }}
                />
            )}
        />
    );
}

// After - If there is no need to support form reset event, you can also use the defaultValue
function ExampleAutocomplete({ label, error, ...config }: FieldProps<string>) {
    const [inputRef, control] = useInputEvent();

    return (
        <Autocomplete
            disablePortal
            options={['The Godfather', 'Pulp Fiction']}
            defaultValue={config.defaultValue ?? ''}
            onChange={(_, option) => control.change(`${option ?? ''}`)}
            onFocus={control.focus}
            onBlur={control.blur}
            renderInput={(params) => (
                <TextField
                    {...params}
                    inputRef={inputRef}
                    label={label}
                    error={Boolean(error)}
                    helperText={error}
                    required={config.required}
                    inputProps={{
                        ...params.inputProps,
                        required: false,
                    }}
                />
            )}
        />
    );
}
```