### PR TITLE
feat(conform-react)!: simplify intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ export async function action({ request }: ActionArgs) {
   const submission = validate(formData);
 
   try {
-    if (submission.error.length === 0 && submission.type === 'submit') {
+    if (submission.error.length === 0 && submission.intent === 'submit') {
       const user = await authenticate(submission.value);
 
       if (!user) {

--- a/docs/intent-button.md
+++ b/docs/intent-button.md
@@ -45,10 +45,10 @@ function Product() {
 }
 ```
 
-In **Conform**, if the name of a button is configured with `conform.intent`, its value will be treated as the intent of the submission (`submission.intent`) instead.
+In **Conform**, if the name of a button is configured with `conform.intent`, its value will be treated as the intent of the submission instead.
 
 ```tsx
-import { useForm } from '@conform-to/react';
+import { useForm, conform } from '@conform-to/react';
 
 function Product() {
   const [form] = useForm({

--- a/docs/intent-button.md
+++ b/docs/intent-button.md
@@ -1,4 +1,4 @@
-# Commands
+# Intent button
 
 A submit button can contribute to the form data when it triggers the submission as a [submitter](https://developer.mozilla.org/en-US/docs/Web/API/SubmitEvent/submitter).
 
@@ -6,19 +6,31 @@ A submit button can contribute to the form data when it triggers the submission 
 
 ## On this page
 
-- [Command button](#command-button)
+- [Submission Intent](#submission-intent)
 - [Modifying a list](#modifying-a-list)
 - [Validation](#validation)
 - [Triggering a command](#triggering-a-command)
 
 <!-- /aside -->
 
-### Command button
+### Submission Intent
 
-The submitter allows us to extend the form with different behaviour based on the intent. However, it pollutes the form data with information used for controlling form behaviour.
+The submitter allows us to extend the form with different behaviour based on the intent. However, it pollutes the form value with data that are used to control form behaviour.
 
 ```tsx
+import { useForm } from '@conform-to/react';
+
 function Product() {
+  const [form] = useForm({
+    onSubmit(event, { submission }) {
+      event.preventDefault();
+
+      // This will log `{ productId: 'rf23g43', intent: 'add-to-cart' }`
+      // or `{ productId: 'rf23g43', intent: 'buy-now' }`
+      console.log(submission.value);
+    },
+  });
+
   return (
     <form>
       <input type="hidden" name="productId" value="rf23g43" />
@@ -33,7 +45,7 @@ function Product() {
 }
 ```
 
-**Conform** introduces this pattern as a **command button**. If you name the button with a prefix `conform/`, e.g. `conform/submit`, its name and value will be used to populate the type and intent of the submission instead of the form value.
+In **Conform**, if the name of a button is configured with `conform.intent`, its value will be treated as the intent of the submission (`submission.intent`) instead.
 
 ```tsx
 import { useForm } from '@conform-to/react';
@@ -42,9 +54,6 @@ function Product() {
   const [form] = useForm({
     onSubmit(event, { submission }) {
       event.preventDefault();
-
-      // This will log `submit`
-      console.log(submission.type);
 
       // This will log `add-to-cart` or `buy-now`
       console.log(submission.intent);
@@ -57,10 +66,10 @@ function Product() {
   return (
     <form {...form.props}>
       <input type="hidden" name="productId" value="rf23g43" />
-      <button type="submit" name="conform/submit" value="add-to-cart">
+      <button type="submit" name={conform.intent} value="add-to-cart">
         Add to Cart
       </button>
-      <button type="submit" name="conform/submit" value="buy-now">
+      <button type="submit" name={conform.intent} value="buy-now">
         Buy now
       </button>
     </form>
@@ -70,7 +79,7 @@ function Product() {
 
 ### Modifying a list
 
-Conform provides built-in [list](/packages/conform-react/README.md#list) command button builder for you to modify a list of fields.
+Conform provides built-in [list](/packages/conform-react/README.md#list) intent button builder for you to modify a list of fields.
 
 ```tsx
 import { useForm, useFieldList, conform, list } from '@conform-to/react';
@@ -102,7 +111,7 @@ export default function Todos() {
 
 ## Validation
 
-A validation can be triggered by configuring a button with the [validate](/packages/conform-react/README.md#validate) command button builder.
+A validation can be triggered by configuring a button with the [validate](/packages/conform-react/README.md#validate) intent button builder.
 
 ```tsx
 import { useForm, conform, validate } from '@conform-to/react';
@@ -123,9 +132,9 @@ export default function Todos() {
 }
 ```
 
-## Triggering a command
+## Triggering an intent
 
-Sometimes, it could be useful to trigger a command without requiring users to click on the command button. We can do this by capturing the button element with `useRef` and triggering the command with `.click()`
+Sometimes, it could be useful to trigger an intent without requiring users to click on the intent button. We can do this by capturing the button element with `useRef` and triggering the intent with `.click()`
 
 ```tsx
 import { useForm, useFieldList, conform, list } from '@conform-to/react';
@@ -164,7 +173,7 @@ export default function Todos() {
 }
 ```
 
-However, if the command button can not be pre-configured easily, like drag and drop an item on the list with dynamic `from` / `to` index, a command can be triggered by using the [requestCommand](/packages/conform-react/README.md#requestCommand) helper.
+However, if the intent button can not be pre-configured easily, like drag and drop an item on the list with dynamic `from` / `to` index, an intent can be triggered by using the [requestIntent](/packages/conform-react/README.md#requestintent) helper.
 
 ```tsx
 import {
@@ -172,7 +181,7 @@ import {
   useFieldList,
   conform,
   list,
-  requestCommand,
+  requestIntent,
 } from '@conform-to/react';
 import DragAndDrop from 'awesome-dnd-example';
 
@@ -181,7 +190,7 @@ export default function Todos() {
   const taskList = useFieldList(form.ref, tasks.config);
 
   const handleDrop = (from, to) =>
-    requestCommand(form.ref.current, list.reorder({ from, to }));
+    requestIntent(form.ref.current, list.reorder({ from, to }));
 
   return (
     <form {...form.props}>
@@ -198,4 +207,4 @@ export default function Todos() {
 }
 ```
 
-Conform also utilises this helper to trigger the validate command based on the event received and its event target, e.g. blur / input event on each field.
+Conform also utilises this helper to trigger the validate intent based on the event received and its event target, e.g. blur / input event on each field.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -257,8 +257,9 @@ export default function Signup() {
        * the username field and no error found on the client
        */
       if (
-        submission.type === 'validate' &&
-        (submission.intent !== 'username' || hasError(error, 'username'))
+        submission.intent !== 'submit' &&
+        (submission.intent !== 'validate/username' ||
+          hasError(submission.error, 'username'))
       ) {
         event.preventDefault();
       }
@@ -299,7 +300,7 @@ export async function action({ request }: ActionArgs) {
       )
       .parseAsync(submission.value);
 
-    if (!submission.intent) {
+    if (submission.intent === 'submit') {
       return await signup(data);
     }
   } catch (error) {

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -53,60 +53,41 @@ export async function action({ request }: ActionArgs) {
   const formData = await request.formData();
   const submission = parse<SignupForm>(formData);
 
-  try {
-    switch (submission.type) {
-      // The type will be `submit` by default
-      case 'submit':
-      // The type will be `validate` for validation
-      case 'validate':
-        if (!submission.value.email) {
-          submission.error.push(['email', 'Email is required']);
-        } else if (!submission.value.email.includes('@')) {
-          submission.error.push(['email', 'Email is invalid']);
-        }
-
-        if (!submission.value.password) {
-          submission.error.push(['password', 'Password is required']);
-        }
-
-        if (!submission.value.confirmPassword) {
-          submission.error.push([
-            'confirmPassword',
-            'Confirm password is required',
-          ]);
-        } else if (
-          submission.value.confirmPassword !== submission.value.password
-        ) {
-          submission.error.push(['confirmPassword', 'Password does not match']);
-        }
-
-        /**
-         * Signup only when the user click on the submit button
-         * and no error found
-         */
-        if (submission.type === 'submit' && !hasError(submission.error)) {
-          return await signup(submission.value);
-        }
-
-        break;
-    }
-  } catch (error) {
-    /**
-     * By specifying the key as '', the message will be
-     * treated as a form-level error and populated
-     * on the client side as `form.error`
-     */
-    submission.error.push(['', 'Oops! Something went wrong.']);
+  if (!submission.value.email) {
+    submission.error.push(['email', 'Email is required']);
+  } else if (!submission.value.email.includes('@')) {
+    submission.error.push(['email', 'Email is invalid']);
   }
 
-  // Always sends the submission state back to client until the user is signed up
-  return json({
-    ...submission,
-    value: {
-      // Never send the password back to client
-      email: submission.value.email,
-    },
-  });
+  if (!submission.value.password) {
+    submission.error.push(['password', 'Password is required']);
+  }
+
+  if (!submission.value.confirmPassword) {
+    submission.error.push(['confirmPassword', 'Confirm password is required']);
+  } else if (submission.value.confirmPassword !== submission.value.password) {
+    submission.error.push(['confirmPassword', 'Password does not match']);
+  }
+
+  if (hasError(submission.error) || submission.intent !== 'submit') {
+    return json(submission);
+  }
+
+  try {
+    return await signup(submission.value);
+  } catch (error) {
+    return json({
+      ...submission,
+      error: [
+        /**
+         * By specifying the key as '', the message will be
+         * treated as a form-level error and populated
+         * on the client side as `form.error`
+         */
+        ['', 'Oops! Something went wrong.'],
+      ],
+    });
+  }
 }
 
 export default function Signup() {
@@ -151,17 +132,10 @@ export async function action({ request }: ActionArgs) {
   const submission = parse(formData);
 
   try {
-    switch (submission.type) {
-      case 'validate':
-      case 'submit': {
-        const data = schema.parse(submission.value);
+    const data = schema.parse(submission.value);
 
-        if (submission.type === 'submit') {
-          return await signup(data);
-        }
-
-        break;
-      }
+    if (submission.intent === 'submit') {
+      return await signup(data);
     }
   } catch (error) {
     submission.error.push(...formatError(error));

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -281,33 +281,26 @@ export async function action({ request }: ActionArgs) {
   const submission = parse(formData);
 
   try {
-    switch (submission.type) {
-      case 'validate':
-      case 'submit': {
-        const data = await schema
-          .refine(
-            async ({ username }) => {
-              // Continue checking only if necessary
-              if (!shouldValidate(submission, 'username')) {
-                return true;
-              }
+    const data = await schema
+      .refine(
+        async ({ username }) => {
+          // Continue checking only if necessary
+          if (!shouldValidate(submission.intent, 'username')) {
+            return true;
+          }
 
-              // Verifying if the username is already registed
-              return await isUsernameUnique(username);
-            },
-            {
-              message: 'Username is already used',
-              path: ['username'],
-            },
-          )
-          .parseAsync(submission.value);
+          // Verifying if the username is already registed
+          return await isUsernameUnique(username);
+        },
+        {
+          message: 'Username is already used',
+          path: ['username'],
+        },
+      )
+      .parseAsync(submission.value);
 
-        if (submission.type === 'submit') {
-          return await signup(data);
-        }
-
-        break;
-      }
+    if (!submission.intent) {
+      return await signup(data);
     }
   } catch (error) {
     submission.error.push(...formatError(error));

--- a/examples/async-validation/app/routes/index.tsx
+++ b/examples/async-validation/app/routes/index.tsx
@@ -46,31 +46,24 @@ export async function action({ request }: ActionArgs) {
 	const submission = parse(formData);
 
 	try {
-		switch (submission.type) {
-			case 'validate':
-			case 'submit': {
-				const data = await schema
-					.refine(
-						async ({ username }) => {
-							if (!shouldValidate(submission, 'username')) {
-								return true;
-							}
+		const data = await schema
+			.refine(
+				async ({ username }) => {
+					if (!shouldValidate(submission.intent, 'username')) {
+						return true;
+					}
 
-							return await isUsernameUnique(username);
-						},
-						{
-							message: 'Username is already used',
-							path: ['username'],
-						},
-					)
-					.parseAsync(submission.value);
+					return await isUsernameUnique(username);
+				},
+				{
+					message: 'Username is already used',
+					path: ['username'],
+				},
+			)
+			.parseAsync(submission.value);
 
-				if (submission.type === 'submit') {
-					return await signup(data);
-				}
-
-				break;
-			}
+		if (!submission.intent) {
+			return await signup(data);
 		}
 	} catch (error) {
 		submission.error.push(...formatError(error));

--- a/examples/async-validation/app/routes/index.tsx
+++ b/examples/async-validation/app/routes/index.tsx
@@ -62,7 +62,7 @@ export async function action({ request }: ActionArgs) {
 			)
 			.parseAsync(submission.value);
 
-		if (!submission.intent) {
+		if (submission.intent === 'submit') {
 			return await signup(data);
 		}
 	} catch (error) {
@@ -90,8 +90,8 @@ export default function Signup() {
 			// Only the email field requires additional validation from the server
 			// We trust the client result otherwise
 			if (
-				submission.type === 'validate' &&
-				(submission.intent !== 'username' ||
+				submission.intent !== 'submit' &&
+				(submission.intent !== 'validate/username' ||
 					hasError(submission.error, 'username'))
 			) {
 				event.preventDefault();

--- a/examples/nested-list/app/routes/index.tsx
+++ b/examples/nested-list/app/routes/index.tsx
@@ -31,15 +31,10 @@ export let action = async ({ request }: ActionArgs) => {
 	const submission = parse<Schema>(formData);
 
 	try {
-		switch (submission.type) {
-			case 'submit':
-			case 'validate': {
-				todosSchema.parse(submission.value);
+		todosSchema.parse(submission.value);
 
-				if (submission.type === 'submit') {
-					throw new Error('Not implemented');
-				}
-			}
+		if (submission.intent === 'submit') {
+			throw new Error('Not implemented');
 		}
 	} catch (error) {
 		submission.error.push(...formatError(error));

--- a/examples/server-validation/app/routes/index.tsx
+++ b/examples/server-validation/app/routes/index.tsx
@@ -13,42 +13,29 @@ export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parse<SignupForm>(formData);
 
+	if (!submission.value.email) {
+		submission.error.push(['email', 'Email is required']);
+	} else if (!submission.value.email.includes('@')) {
+		submission.error.push(['email', 'Email is invalid']);
+	}
+
+	if (!submission.value.password) {
+		submission.error.push(['password', 'Password is required']);
+	}
+
+	if (!submission.value.confirmPassword) {
+		submission.error.push(['confirmPassword', 'Confirm password is required']);
+	} else if (submission.value.confirmPassword !== submission.value.password) {
+		submission.error.push(['confirmPassword', 'Password does not match']);
+	}
+
 	try {
-		switch (submission.type) {
-			// The type will be `submit` by default
-			case 'submit':
-			// The type will be `validate` on validation
-			case 'validate':
-				if (!submission.value.email) {
-					submission.error.push(['email', 'Email is required']);
-				} else if (!submission.value.email.includes('@')) {
-					submission.error.push(['email', 'Email is invalid']);
-				}
-
-				if (!submission.value.password) {
-					submission.error.push(['password', 'Password is required']);
-				}
-
-				if (!submission.value.confirmPassword) {
-					submission.error.push([
-						'confirmPassword',
-						'Confirm password is required',
-					]);
-				} else if (
-					submission.value.confirmPassword !== submission.value.password
-				) {
-					submission.error.push(['confirmPassword', 'Password does not match']);
-				}
-
-				/**
-				 * Signup only when the user click on the submit button
-				 * and no error found
-				 */
-				if (submission.type === 'submit' && !hasError(submission.error)) {
-					throw new Error('Not implemented');
-				}
-
-				break;
+		/**
+		 * Signup only when the user click on the submit button
+		 * and no error found
+		 */
+		if (submission.intent === 'submit' && !hasError(submission.error)) {
+			throw new Error('Not implemented');
 		}
 	} catch (error) {
 		/**

--- a/examples/yup/app/routes/index.tsx
+++ b/examples/yup/app/routes/index.tsx
@@ -29,7 +29,7 @@ export async function action({ request }: ActionArgs) {
 			abortEarly: false,
 		});
 
-		if (submission.type === 'submit') {
+		if (submission.intent === 'submit') {
 			console.log(data);
 			throw new Error('Not implemented');
 		}

--- a/examples/zod/app/routes/index.tsx
+++ b/examples/zod/app/routes/index.tsx
@@ -29,7 +29,7 @@ export async function action({ request }: ActionArgs) {
 	try {
 		const data = schema.parse(submission.value);
 
-		if (submission.type === 'submit') {
+		if (submission.intent === 'submit') {
 			console.log(data);
 			throw new Error('Not implemented');
 		}

--- a/guide/app/routes/_guide.tsx
+++ b/guide/app/routes/_guide.tsx
@@ -24,7 +24,7 @@ const navigations: Navigation[] = [
 			{ title: 'Validation', to: '/validation' },
 			{ title: 'Integrations', to: '/integrations' },
 			{ title: 'Nested object and Array', to: '/configuration' },
-			{ title: 'Commands', to: '/commands' },
+			{ title: 'Intent button', to: '/intent-button' },
 			{ title: 'File Upload', to: '/file-upload' },
 			{ title: 'Focus management', to: '/focus-management' },
 			{ title: 'Accessibility', to: '/accessibility' },

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -260,11 +260,14 @@ export function requestSubmit(
 }
 
 /**
- * Creates a command button on demand and trigger a form submit by clicking it.
+ * Creates an intent button on demand and trigger a form submit by clicking it.
  */
-export function requestCommand(
+export function requestIntent(
 	form: HTMLFormElement | undefined,
-	buttonProps: IntentButtonProps,
+	buttonProps: {
+		value: string;
+		formNoValidate?: boolean;
+	},
 ): void {
 	if (!form) {
 		console.warn('No form element is provided');
@@ -273,7 +276,7 @@ export function requestCommand(
 
 	const button = document.createElement('button');
 
-	button.name = buttonProps.name;
+	button.name = '__intent__';
 	button.value = buttonProps.value;
 	button.hidden = true;
 

--- a/packages/conform-react/README.md
+++ b/packages/conform-react/README.md
@@ -624,20 +624,15 @@ This helper checks if the scope of validation includes a specific field by check
 import { shouldValidate } from '@conform-to/react';
 
 /**
- * The submission type and intent give us hint on what should be valdiated.
- * If the type is 'validate', only the field with name matching the metadata must be validated.
- * If the type is 'submit', everything should be validated (Default submission)
+ * The submission intent give us hint on what should be valdiated.
+ * If the intent is 'validate/:field', only the field with name matching must be validated.
+ * If the intent is undefined, everything should be validated (Default submission)
  */
-const submission = {
-  context: 'validate',
-  intent: 'email',
-  value: {},
-  error: [],
-};
+const intent = 'validate/email';
 
 // This will log 'true'
-console.log(shouldValidate(submission, 'email'));
+console.log(shouldValidate(intent, 'email'));
 
 // This will log 'false'
-console.log(shouldValidate(submission, 'password'));
+console.log(shouldValidate(intent, 'password'));
 ```

--- a/packages/conform-react/README.md
+++ b/packages/conform-react/README.md
@@ -14,7 +14,7 @@
 - [conform](#conform)
 - [list](#list)
 - [validate](#validate)
-- [requestCommand](#requestcommand)
+- [requestIntent](#requestintent)
 - [getFormElements](#getformelements)
 - [hasError](#haserror)
 - [parse](#parse)
@@ -499,9 +499,9 @@ function Example() {
 
 ---
 
-### requestCommand
+### requestIntent
 
-It lets you [trigger a command](/docs/commands.md#triggering-a-command) without requiring users to click on a button. It supports both [list](#list) and [validate](#validate) command.
+It lets you [trigger an intent](/docs/commands.md#triggering-an-intent) without requiring users to click on a button. It supports both [list](#list) and [validate](#validate) intent.
 
 ```tsx
 import {
@@ -509,7 +509,7 @@ import {
   useFieldList,
   conform,
   list,
-  requestCommand,
+  requestIntent,
 } from '@conform-to/react';
 import DragAndDrop from 'awesome-dnd-example';
 
@@ -518,7 +518,7 @@ export default function Todos() {
   const taskList = useFieldList(form.ref, tasks.config);
 
   const handleDrop = (from, to) =>
-    requestCommand(form.ref.current, list.reorder({ from, to }));
+    requestIntent(form.ref.current, list.reorder({ from, to }));
 
   return (
     <form {...form.props}>

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -177,3 +177,5 @@ export function textarea<Schema>(
 
 	return attributes;
 }
+
+export const intent = '__intent__';

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -153,7 +153,7 @@ export function useForm<Schema extends Record<string, any>>(
 		return {
 			defaultValue: submission.value,
 			initialError: submission.error.filter(
-				([name]) => name !== '' && shouldValidate(submission, name),
+				([name]) => name !== '' && shouldValidate(submission.intent, name),
 			),
 		};
 	});
@@ -342,7 +342,8 @@ export function useForm<Schema extends Record<string, any>>(
 						(!config.noValidate &&
 							!submitter?.formNoValidate &&
 							hasError(submission.error)) ||
-						((submission.type === 'validate' || submission.type === 'list') &&
+						((submission.intent?.startsWith('validate/') ||
+							submission.intent?.startsWith('list/')) &&
 							config.mode !== 'server-validation')
 					) {
 						event.preventDefault();
@@ -692,7 +693,7 @@ export function useFieldList<Payload = any>(
 				event.detail,
 			);
 
-			if (command.scope !== configRef.current.name) {
+			if (command?.scope !== configRef.current.name) {
 				// Ensure the scope of the listener are limited to specific field name
 				return;
 			}

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -342,8 +342,8 @@ export function useForm<Schema extends Record<string, any>>(
 						(!config.noValidate &&
 							!submitter?.formNoValidate &&
 							hasError(submission.error)) ||
-						((submission.intent?.startsWith('validate/') ||
-							submission.intent?.startsWith('list/')) &&
+						((submission.intent.startsWith('validate/') ||
+							submission.intent.startsWith('list/')) &&
 							config.mode !== 'server-validation')
 					) {
 						event.preventDefault();

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -17,7 +17,7 @@ import {
 	hasError,
 	reportSubmission,
 	validate,
-	requestCommand,
+	requestIntent,
 	shouldValidate,
 } from '@conform-to/dom';
 import {
@@ -200,7 +200,7 @@ export function useForm<Schema extends Record<string, any>>(
 				field.dataset.conformTouched ||
 				formConfig.initialReport === 'onChange'
 			) {
-				requestCommand(form, validate(field.name));
+				requestIntent(form, validate(field.name));
 			}
 		};
 		const handleBlur = (event: FocusEvent) => {
@@ -216,7 +216,7 @@ export function useForm<Schema extends Record<string, any>>(
 				formConfig.initialReport === 'onBlur' &&
 				!field.dataset.conformTouched
 			) {
-				requestCommand(form, validate(field.name));
+				requestIntent(form, validate(field.name));
 			}
 		};
 		const handleInvalid = (event: Event) => {

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -6,7 +6,7 @@ export {
 	hasError,
 	list,
 	validate,
-	requestCommand,
+	requestIntent,
 	requestSubmit,
 	parse,
 	shouldValidate,

--- a/packages/conform-yup/README.md
+++ b/packages/conform-yup/README.md
@@ -71,7 +71,7 @@ export let action = async ({ request }) => {
       abortEarly: false,
     });
 
-    if (submission.type !== 'validate') {
+    if (submission.intent === 'submit') {
       return await handleFormData(data);
     }
   } catch (error) {

--- a/packages/conform-zod/README.md
+++ b/packages/conform-zod/README.md
@@ -72,7 +72,7 @@ export let action = async ({ request }) => {
   try {
     const data = await schema.parseAsync(submission.value);
 
-    if (submission.type === 'submit') {
+    if (submission.intent === 'submit') {
       return await handleFormData(data);
     }
   } catch (error) {

--- a/playground/app/routes/employee.tsx
+++ b/playground/app/routes/employee.tsx
@@ -67,11 +67,10 @@ export default function EmployeeForm() {
 		onSubmit:
 			config.mode === 'server-validation'
 				? (event, { submission }) => {
-						const [type, scope] = submission.intent?.split('/') ?? [];
-
 						if (
-							type === 'validate' &&
-							(scope !== 'email' || hasError(submission.error, 'email'))
+							submission.intent !== 'submit' &&
+							(submission.intent !== 'validate/email' ||
+								hasError(submission.error, 'email'))
 						) {
 							event.preventDefault();
 						}

--- a/playground/app/routes/employee.tsx
+++ b/playground/app/routes/employee.tsx
@@ -30,7 +30,7 @@ export let action = async ({ request }: ActionArgs) => {
 	const submission = parse(formData);
 	const serverSchema = schema.refine(
 		async (employee) => {
-			if (!shouldValidate(submission, 'email')) {
+			if (!shouldValidate(submission.intent, 'email')) {
 				return true;
 			}
 
@@ -67,10 +67,11 @@ export default function EmployeeForm() {
 		onSubmit:
 			config.mode === 'server-validation'
 				? (event, { submission }) => {
+						const [type, scope] = submission.intent?.split('/') ?? [];
+
 						if (
-							submission.type === 'validate' &&
-							(submission.intent !== 'email' ||
-								hasError(submission.error, 'email'))
+							type === 'validate' &&
+							(scope !== 'email' || hasError(submission.error, 'email'))
 						) {
 							event.preventDefault();
 						}

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -63,7 +63,7 @@ export default function LoginForm() {
 		onSubmit:
 			config.mode === 'server-validation'
 				? (event, { submission }) => {
-						if (submission.intent?.startsWith('validate/')) {
+						if (submission.intent.startsWith('validate/')) {
 							event.preventDefault();
 						}
 				  }

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -63,7 +63,7 @@ export default function LoginForm() {
 		onSubmit:
 			config.mode === 'server-validation'
 				? (event, { submission }) => {
-						if (submission.type === 'validate') {
+						if (submission.intent?.startsWith('validate/')) {
 							event.preventDefault();
 						}
 				  }

--- a/playground/app/routes/movie.tsx
+++ b/playground/app/routes/movie.tsx
@@ -121,7 +121,7 @@ export default function MovieForm() {
 		onSubmit:
 			config.mode === 'server-validation'
 				? (event, { submission }) => {
-						if (submission.intent?.startsWith('validate/')) {
+						if (submission.intent.startsWith('validate/')) {
 							event.preventDefault();
 						}
 				  }

--- a/playground/app/routes/movie.tsx
+++ b/playground/app/routes/movie.tsx
@@ -121,7 +121,7 @@ export default function MovieForm() {
 		onSubmit:
 			config.mode === 'server-validation'
 				? (event, { submission }) => {
-						if (submission.type === 'validate') {
+						if (submission.intent?.startsWith('validate/')) {
 							event.preventDefault();
 						}
 				  }

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -59,7 +59,7 @@ export default function PaymentForm() {
 		onSubmit:
 			config.mode === 'server-validation'
 				? (event, { submission }) => {
-						if (submission.intent?.startsWith('validate/')) {
+						if (submission.intent.startsWith('validate/')) {
 							event.preventDefault();
 						}
 				  }

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -59,7 +59,7 @@ export default function PaymentForm() {
 		onSubmit:
 			config.mode === 'server-validation'
 				? (event, { submission }) => {
-						if (submission.type === 'validate') {
+						if (submission.intent?.startsWith('validate/')) {
 							event.preventDefault();
 						}
 				  }

--- a/playground/app/routes/signup.tsx
+++ b/playground/app/routes/signup.tsx
@@ -69,7 +69,7 @@ export default function SignupForm() {
 		onSubmit:
 			config.mode === 'server-validation'
 				? (event, { submission }) => {
-						if (submission.type === 'validate') {
+						if (submission.intent?.startsWith('validate/')) {
 							event.preventDefault();
 						}
 				  }

--- a/playground/app/routes/signup.tsx
+++ b/playground/app/routes/signup.tsx
@@ -69,7 +69,7 @@ export default function SignupForm() {
 		onSubmit:
 			config.mode === 'server-validation'
 				? (event, { submission }) => {
-						if (submission.intent?.startsWith('validate/')) {
+						if (submission.intent.startsWith('validate/')) {
 							event.preventDefault();
 						}
 				  }

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -65,7 +65,7 @@ export default function TodosForm() {
 		onSubmit:
 			config.mode === 'server-validation'
 				? (event, { submission }) => {
-						if (submission.intent?.startsWith('validate/')) {
+						if (submission.intent.startsWith('validate/')) {
 							event.preventDefault();
 						}
 				  }

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -65,7 +65,7 @@ export default function TodosForm() {
 		onSubmit:
 			config.mode === 'server-validation'
 				? (event, { submission }) => {
-						if (submission.type === 'validate') {
+						if (submission.intent?.startsWith('validate/')) {
 							event.preventDefault();
 						}
 				  }

--- a/playground/app/routes/validate.tsx
+++ b/playground/app/routes/validate.tsx
@@ -24,12 +24,7 @@ export async function action({ request }: ActionArgs) {
 	const submission = parse(formData);
 
 	try {
-		switch (submission.type) {
-			case 'validate':
-			case 'submit':
-				schema.parse(submission.value);
-				break;
-		}
+		schema.parse(submission.value);
 	} catch (error) {
 		submission.error.push(...formatError(error));
 	}

--- a/tests/conform-dom.spec.ts
+++ b/tests/conform-dom.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { parse, getPaths, getName } from '@conform-to/dom';
+import { parse, getPaths, getName, list } from '@conform-to/dom';
 import { installGlobals } from '@remix-run/node';
 
 function createFormData(entries: Array<[string, string | File]>): FormData {
@@ -27,7 +27,6 @@ test.describe('conform-dom', () => {
 					]),
 				),
 			).toEqual({
-				type: 'submit',
 				value: {
 					title: 'The cat',
 					description: 'Once upon a time...',
@@ -44,7 +43,6 @@ test.describe('conform-dom', () => {
 					]),
 				),
 			).toEqual({
-				type: 'submit',
 				value: {
 					account: 'AB00 1111 2222 3333 4444',
 					amount: {
@@ -65,7 +63,6 @@ test.describe('conform-dom', () => {
 					]),
 				),
 			).toEqual({
-				type: 'submit',
 				value: {
 					title: '',
 					tasks: [
@@ -86,7 +83,6 @@ test.describe('conform-dom', () => {
 					]),
 				),
 			).toEqual({
-				type: 'submit',
 				value: {
 					title: 'The cat',
 					description: 'Once upon a time...',
@@ -100,11 +96,10 @@ test.describe('conform-dom', () => {
 				parse(
 					createFormData([
 						['title', 'Test command'],
-						['conform/test', 'command value'],
+						['__intent__', 'command value'],
 					]),
 				),
 			).toEqual({
-				type: 'test',
 				intent: 'command value',
 				value: {
 					title: 'Test command',
@@ -115,21 +110,15 @@ test.describe('conform-dom', () => {
 				parse(
 					createFormData([
 						['title', ''],
-						['conform/list', JSON.stringify({ greeting: 'Hello World' })],
+						['__intent__', 'list/helloworld'],
 					]),
 				),
 			).toEqual({
-				type: 'list',
-				intent: JSON.stringify({ greeting: 'Hello World' }),
+				intent: 'list/helloworld',
 				value: {
 					title: '',
 				},
-				error: [
-					[
-						'',
-						'Invalid list command: "{"greeting":"Hello World"}"; Error: Unknown list command received: undefined',
-					],
-				],
+				error: [],
 			});
 		});
 
@@ -139,177 +128,104 @@ test.describe('conform-dom', () => {
 				['tasks[0].completed', 'Yes'],
 			];
 			const result = {
-				type: 'list',
 				value: {
 					tasks: [{ content: 'Test some stuffs', completed: 'Yes' }],
 				},
 				error: [],
 			};
 
+			const command1 = list.prepend('tasks');
+
 			expect(
-				parse(
-					createFormData([
-						...entries,
-						[
-							'conform/list',
-							JSON.stringify({ type: 'prepend', scope: 'tasks', payload: {} }),
-						],
-					]),
-				),
+				parse(createFormData([...entries, [command1.name, command1.value]])),
 			).toEqual({
 				...result,
-				intent: JSON.stringify({
-					type: 'prepend',
-					scope: 'tasks',
-					payload: {},
-				}),
+				intent: command1.value,
 				value: {
 					tasks: [undefined, ...result.value.tasks],
 				},
 			});
+
+			const command2 = list.prepend('tasks', {
+				defaultValue: { content: 'Something' },
+			});
+
 			expect(
-				parse(
-					createFormData([
-						...entries,
-						[
-							'conform/list',
-							JSON.stringify({
-								type: 'prepend',
-								scope: 'tasks',
-								payload: { defaultValue: { content: 'Something' } },
-							}),
-						],
-					]),
-				),
+				parse(createFormData([...entries, [command2.name, command2.value]])),
 			).toEqual({
 				...result,
-				intent: JSON.stringify({
-					type: 'prepend',
-					scope: 'tasks',
-					payload: { defaultValue: { content: 'Something' } },
-				}),
+				intent: command2.value,
 				value: {
 					tasks: [{ content: 'Something' }, ...result.value.tasks],
 				},
 			});
+
+			const command3 = list.append('tasks');
+
 			expect(
-				parse(
-					createFormData([
-						...entries,
-						[
-							'conform/list',
-							JSON.stringify({ type: 'append', scope: 'tasks', payload: {} }),
-						],
-					]),
-				),
+				parse(createFormData([...entries, [command3.name, command3.value]])),
 			).toEqual({
 				...result,
-				intent: JSON.stringify({
-					type: 'append',
-					scope: 'tasks',
-					payload: {},
-				}),
+				intent: command3.value,
 				value: {
 					tasks: [...result.value.tasks, undefined],
 				},
 			});
+
+			const command4 = list.append('tasks', {
+				defaultValue: { content: 'Something' },
+			});
+
 			expect(
-				parse(
-					createFormData([
-						...entries,
-						[
-							'conform/list',
-							JSON.stringify({
-								type: 'append',
-								scope: 'tasks',
-								payload: { defaultValue: { content: 'Something' } },
-							}),
-						],
-					]),
-				),
+				parse(createFormData([...entries, [command4.name, command4.value]])),
 			).toEqual({
 				...result,
-				intent: JSON.stringify({
-					type: 'append',
-					scope: 'tasks',
-					payload: { defaultValue: { content: 'Something' } },
-				}),
+				intent: command4.value,
 				value: {
 					tasks: [...result.value.tasks, { content: 'Something' }],
 				},
 			});
+
+			const command5 = list.replace('tasks', {
+				defaultValue: { content: 'Something' },
+				index: 0,
+			});
+
 			expect(
-				parse(
-					createFormData([
-						...entries,
-						[
-							'conform/list',
-							JSON.stringify({
-								type: 'replace',
-								scope: 'tasks',
-								payload: { defaultValue: { content: 'Something' }, index: 0 },
-							}),
-						],
-					]),
-				),
+				parse(createFormData([...entries, [command5.name, command5.value]])),
 			).toEqual({
 				...result,
-				intent: JSON.stringify({
-					type: 'replace',
-					scope: 'tasks',
-					payload: { defaultValue: { content: 'Something' }, index: 0 },
-				}),
+				intent: command5.value,
 				value: {
 					tasks: [{ content: 'Something' }],
 				},
 			});
+
+			const command6 = list.remove('tasks', { index: 0 });
+
 			expect(
-				parse(
-					createFormData([
-						...entries,
-						[
-							'conform/list',
-							JSON.stringify({
-								type: 'remove',
-								scope: 'tasks',
-								payload: { index: 0 },
-							}),
-						],
-					]),
-				),
+				parse(createFormData([...entries, [command6.name, command6.value]])),
 			).toEqual({
 				...result,
-				intent: JSON.stringify({
-					type: 'remove',
-					scope: 'tasks',
-					payload: { index: 0 },
-				}),
+				intent: command6.value,
 				value: {
 					tasks: [],
 				},
 			});
+
+			const command7 = list.reorder('tasks', { from: 0, to: 1 });
+
 			expect(
 				parse(
 					createFormData([
 						...entries,
 						['tasks[1].content', 'Test more stuffs'],
-						[
-							'conform/list',
-							JSON.stringify({
-								type: 'reorder',
-								scope: 'tasks',
-								payload: { from: 0, to: 1 },
-							}),
-						],
+						[command7.name, command7.value],
 					]),
 				),
 			).toEqual({
 				...result,
-				intent: JSON.stringify({
-					type: 'reorder',
-					scope: 'tasks',
-					payload: { from: 0, to: 1 },
-				}),
+				intent: command7.value,
 				value: {
 					tasks: [{ content: 'Test more stuffs' }, ...result.value.tasks],
 				},

--- a/tests/conform-dom.spec.ts
+++ b/tests/conform-dom.spec.ts
@@ -27,6 +27,7 @@ test.describe('conform-dom', () => {
 					]),
 				),
 			).toEqual({
+				intent: 'submit',
 				value: {
 					title: 'The cat',
 					description: 'Once upon a time...',
@@ -43,6 +44,7 @@ test.describe('conform-dom', () => {
 					]),
 				),
 			).toEqual({
+				intent: 'submit',
 				value: {
 					account: 'AB00 1111 2222 3333 4444',
 					amount: {
@@ -63,6 +65,7 @@ test.describe('conform-dom', () => {
 					]),
 				),
 			).toEqual({
+				intent: 'submit',
 				value: {
 					title: '',
 					tasks: [
@@ -83,6 +86,7 @@ test.describe('conform-dom', () => {
 					]),
 				),
 			).toEqual({
+				intent: 'submit',
 				value: {
 					title: 'The cat',
 					description: 'Once upon a time...',

--- a/tests/integrations/file-upload.spec.ts
+++ b/tests/integrations/file-upload.spec.ts
@@ -81,7 +81,6 @@ async function runValidationScenario(page: Page) {
 	await expect(playground.error).toHaveText(['', '', '']);
 
 	expect(JSON.parse(await playground.submission.innerText())).toMatchObject({
-		type: 'submit',
 		value: {
 			file: {
 				_name: 'test.json',

--- a/tests/integrations/radio-buttons.spec.ts
+++ b/tests/integrations/radio-buttons.spec.ts
@@ -15,6 +15,7 @@ async function runValidationScenario(page: Page) {
 	await expect(playground.submission).toHaveText(
 		JSON.stringify(
 			{
+				intent: 'submit',
 				value: {
 					answer: 'b',
 				},

--- a/tests/integrations/radio-buttons.spec.ts
+++ b/tests/integrations/radio-buttons.spec.ts
@@ -15,7 +15,6 @@ async function runValidationScenario(page: Page) {
 	await expect(playground.submission).toHaveText(
 		JSON.stringify(
 			{
-				type: 'submit',
 				value: {
 					answer: 'b',
 				},

--- a/tests/integrations/simple-list.spec.ts
+++ b/tests/integrations/simple-list.spec.ts
@@ -119,7 +119,6 @@ async function runValidationScenario(page: Page) {
 	await expect(playground.submission).toHaveText(
 		JSON.stringify(
 			{
-				type: 'submit',
 				value: {
 					items: ['Top item', 'First item'],
 				},

--- a/tests/integrations/simple-list.spec.ts
+++ b/tests/integrations/simple-list.spec.ts
@@ -119,6 +119,7 @@ async function runValidationScenario(page: Page) {
 	await expect(playground.submission).toHaveText(
 		JSON.stringify(
 			{
+				intent: 'submit',
 				value: {
 					items: ['Top item', 'First item'],
 				},

--- a/tests/integrations/validate.spec.ts
+++ b/tests/integrations/validate.spec.ts
@@ -37,6 +37,7 @@ async function runValidationScenario(page: Page) {
 	await expect(playground.submission).toHaveText(
 		JSON.stringify(
 			{
+				intent: 'submit',
 				value: {
 					name: 'Conform',
 					message: 'A form validation library',

--- a/tests/integrations/validate.spec.ts
+++ b/tests/integrations/validate.spec.ts
@@ -37,7 +37,6 @@ async function runValidationScenario(page: Page) {
 	await expect(playground.submission).toHaveText(
 		JSON.stringify(
 			{
-				type: 'submit',
 				value: {
 					name: 'Conform',
 					message: 'A form validation library',

--- a/tests/react.spec.ts
+++ b/tests/react.spec.ts
@@ -50,7 +50,6 @@ test.describe('Client Validation', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
-			type: 'submit',
 			value: {
 				title: 'The Dark Knight',
 				description: 'When the menace known as the Joker wreaks havoc...',
@@ -127,7 +126,6 @@ test.describe('Client Validation', () => {
 
 		await clickSubmitButton(form);
 		expect(await getSubmission(form)).toEqual({
-			type: 'submit',
 			value: {
 				title: 'The Matrix',
 				description:
@@ -164,7 +162,6 @@ test.describe('Client Validation', () => {
 		await clickSubmitButton(playground);
 
 		expect(await getSubmission(playground)).toEqual({
-			type: 'submit',
 			value: {
 				email: 'me@edmund.dev',
 			},
@@ -234,7 +231,6 @@ test.describe('Client Validation', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
-			type: 'submit',
 			value: {
 				iban: 'DE89 3704 0044 0532 0130 00',
 				amount: {
@@ -306,7 +302,6 @@ test.describe('Client Validation', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
-			type: 'submit',
 			value: {
 				email: '',
 			},
@@ -321,7 +316,6 @@ test.describe('Client Validation', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
-			type: 'submit',
 			value: {
 				email: 'invalid email',
 			},
@@ -422,7 +416,6 @@ test.describe('Server Validation', () => {
 				status: 200,
 				contentType: 'application/json',
 				body: JSON.stringify({
-					type: 'submit',
 					value: {},
 					error: [['', 'Request forbidden']],
 				}),
@@ -656,7 +649,6 @@ test.describe('Field list', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
-			type: 'submit',
 			value: {
 				title: 'My schedule',
 				tasks: [
@@ -723,7 +715,6 @@ test.describe('Field list', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
-			type: 'submit',
 			value: {
 				title: 'Testing plan',
 				tasks: [

--- a/tests/react.spec.ts
+++ b/tests/react.spec.ts
@@ -50,6 +50,7 @@ test.describe('Client Validation', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
+			intent: 'submit',
 			value: {
 				title: 'The Dark Knight',
 				description: 'When the menace known as the Joker wreaks havoc...',
@@ -126,6 +127,7 @@ test.describe('Client Validation', () => {
 
 		await clickSubmitButton(form);
 		expect(await getSubmission(form)).toEqual({
+			intent: 'submit',
 			value: {
 				title: 'The Matrix',
 				description:
@@ -162,6 +164,7 @@ test.describe('Client Validation', () => {
 		await clickSubmitButton(playground);
 
 		expect(await getSubmission(playground)).toEqual({
+			intent: 'submit',
 			value: {
 				email: 'me@edmund.dev',
 			},
@@ -231,6 +234,7 @@ test.describe('Client Validation', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
+			intent: 'submit',
 			value: {
 				iban: 'DE89 3704 0044 0532 0130 00',
 				amount: {
@@ -302,6 +306,7 @@ test.describe('Client Validation', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
+			intent: 'submit',
 			value: {
 				email: '',
 			},
@@ -316,6 +321,7 @@ test.describe('Client Validation', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
+			intent: 'submit',
 			value: {
 				email: 'invalid email',
 			},
@@ -649,6 +655,7 @@ test.describe('Field list', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
+			intent: 'submit',
 			value: {
 				title: 'My schedule',
 				tasks: [
@@ -715,6 +722,7 @@ test.describe('Field list', () => {
 		await clickSubmitButton(form);
 
 		expect(await getSubmission(form)).toEqual({
+			intent: 'submit',
 			value: {
 				title: 'Testing plan',
 				tasks: [


### PR DESCRIPTION
> This PR includes breaking changes

This merges `submission.type` with `submission.intent` to align with the intent button approach that are common in Remix. More changes coming with the validation setup.  