### PR TITLE
feat(conform-react,conform-zod,conform-yup)!: improved parse helper

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,19 +3,16 @@ on:
   push:
     branches:
     - main
-    - dev
   pull_request:
     branches:
     - main
-    - dev
+    - next
 jobs:
 
   e2e:
     name: 🔍 E2E Testing
     runs-on: ubuntu-latest
     steps:
-    - name: 🛑 Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
     - name: ⬇️ Checkout repo
       uses: actions/checkout@v3
     - name: ⎔ Setup node

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A progressive enhancement first form validation library for [Remix](https://remi
 Here is a real world example built with [Remix](https://remix.run).
 
 ```tsx
-import { useForm, parse } from '@conform-to/react';
+import { useForm, parse, report } from '@conform-to/react';
 import { Form } from '@remix-run/react';
 import { json, redirect } from '@remix-run/node';
 import { useId } from 'react';
@@ -59,7 +59,7 @@ export async function action({ request }: ActionArgs) {
     submission.error.push(['', error.message]);
   }
 
-  return json(submission);
+  return json(report(submission));
 }
 
 export default function LoginForm() {

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import { json, redirect } from '@remix-run/node';
 import { useId } from 'react';
 import { authenticate } from '~/auth';
 
-function validate(formData: FormData) {
+function parseLoginForm(formData: FormData) {
   const submission = parse(formData);
 
   if (!submission.value.email) {
@@ -41,7 +41,7 @@ function validate(formData: FormData) {
 
 export async function action({ request }: ActionArgs) {
   const formData = await request.formData();
-  const submission = validate(formData);
+  const submission = parseLoginForm(formData);
 
   try {
     if (submission.error.length === 0 && submission.intent === 'submit') {
@@ -69,7 +69,7 @@ export default function LoginForm() {
     id,
     state,
     onValidate({ formData }) {
-      return validate(formData);
+      return parseLoginForm(formData);
     },
   });
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A progressive enhancement first form validation library for [Remix](https://remi
 Here is a real world example built with [Remix](https://remix.run).
 
 ```tsx
-import { useForm, parse, report } from '@conform-to/react';
+import { useForm, parse } from '@conform-to/react';
 import { Form } from '@remix-run/react';
 import { json, redirect } from '@remix-run/node';
 import { useId } from 'react';
@@ -26,7 +26,7 @@ import { authenticate } from '~/auth';
 function parseLoginForm(formData: FormData) {
   const submission = parse(formData);
 
-  if (!submission.value.email) {
+  if (!submission.payload.email) {
     submission.error.push(['email', 'Email is required']);
   } else if (!email.includes('@')) {
     submission.error.push(['email', 'Email is invalid']);
@@ -45,7 +45,7 @@ export async function action({ request }: ActionArgs) {
 
   try {
     if (submission.error.length === 0 && submission.intent === 'submit') {
-      const user = await authenticate(submission.value);
+      const user = await authenticate(submission.payload);
 
       if (!user) {
         throw new Error(
@@ -59,7 +59,7 @@ export async function action({ request }: ActionArgs) {
     submission.error.push(['', error.message]);
   }
 
-  return json(report(submission));
+  return json(submission);
 }
 
 export default function LoginForm() {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,7 @@ Conform has support for nested object and array by introducing a naming conventi
 
 **Conform** uses `object.property` and `array[index]` to structure data. These notations could be combined for nest list as well. e.g. `tasks[0].content`.
 
-You can [parse](/packages/conform-react/README.md#parse) the form data and access its value in the defined structure through `submission.value`. If some entries in the form data violate the naming convention, a form error will be set as well.
+You can [parse](/packages/conform-react/README.md#parse) the form data and access its payload in the defined structure through `submission.payload`. If some entries in the form data violate the naming convention, a form error will be set as well.
 
 ```ts
 import { parse } from '@conform-to/react';
@@ -25,7 +25,7 @@ import { parse } from '@conform-to/react';
 const formData = new FormData();
 const submission = parse(formData);
 
-console.log(submission.value); // e.g. { tasks: [{ content: '' }] }
+console.log(submission.payload); // e.g. { tasks: [{ content: '' }] }
 console.log(submission.error); // e.g. []
 ```
 

--- a/docs/file-upload.md
+++ b/docs/file-upload.md
@@ -19,7 +19,7 @@ When the browser constructs a form data set with an empty file input, a default 
 
 ```tsx
 import { useForm } from '@conform-to/react';
-import { validate } from '@conform-to/zod';
+import { parse } from '@conform-to/zod';
 import { z } from 'zod';
 
 const schema = z.object({
@@ -30,8 +30,8 @@ const schema = z.object({
 
 function Example() {
   const [form, { file }] = useForm({
-    validate({ formData }) {
-      return validate(formData, schema);
+    onValidate({ formData }) {
+      return parse(formData, { schema });
     },
   });
 
@@ -79,7 +79,7 @@ There are some caveats when validating a multiple file input:
 
 ```tsx
 import { useForm } from '@conform-to/react';
-import { validate } from '@conform-to/zod';
+import { parse } from '@conform-to/zod';
 import { z } from 'zod';
 
 const schema = z.object({
@@ -104,8 +104,8 @@ const schema = z.object({
 
 function Example() {
   const [form, { files }] = useForm({
-    validate({ formData }) {
-      return validate(formData, schema);
+    onValidate({ formData }) {
+      return parse(formData, { schema });
     },
   });
 

--- a/docs/intent-button.md
+++ b/docs/intent-button.md
@@ -27,7 +27,7 @@ function Product() {
 
       // This will log `{ productId: 'rf23g43', intent: 'add-to-cart' }`
       // or `{ productId: 'rf23g43', intent: 'buy-now' }`
-      console.log(submission.value);
+      console.log(submission.payload);
     },
   });
 
@@ -59,7 +59,7 @@ function Product() {
       console.log(submission.intent);
 
       // This will log `{ productId: 'rf23g43' }`
-      console.log(submission.value);
+      console.log(submission.payload);
     },
   });
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -198,7 +198,7 @@ import { Form, useActionData } from '@remix-run/react';
 import { authenticate } from '~/auth';
 
 // Refactor the validation logic to a standalone function
-function validate(formData: FormData) {
+function parseForm(formData: FormData) {
   const submission = parse(formData);
 
   if (!submission.value.email) {
@@ -218,7 +218,7 @@ export async function action({ request }: ActionArgs) {
   const formData = await request.formData();
 
   // Parse and validate the formData
-  const submission = validate(formData);
+  const submission = parseForm(formData);
 
   if (submission.error.length === 0) {
     await authenticate(email, password);
@@ -246,7 +246,7 @@ export default function LoginForm() {
     state: result,
     onValidate({ formData }) {
       // Run the same validation logic on client side
-      return validate(formData);
+      return parseForm(formData);
     },
   });
 
@@ -275,7 +275,7 @@ interface Schema {
   password: string;
 }
 
-function validate(formData: FormData) {
+function parseForm(formData: FormData) {
   // as shown before
 }
 
@@ -291,7 +291,7 @@ export default function LoginForm() {
     initialReport: 'onBlur',
     state: result,
     onValidate({ formData }) {
-      return validate(formData);
+      return parseForm(formData);
     },
   });
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -110,8 +110,8 @@ export async function action({ request }: ActionArgs) {
   // Replace `Object.fromEntries()` with parse()
   const submission = parse(formData);
 
-  // The value will now be available as `submission.value`
-  if (!submission.value.email) {
+  // The value will now be available as `submission.payload`
+  if (!submission.payload.email) {
     // Define the error as key-value pair instead
     submission.error.push(['email', 'Email is required']);
   } else if (!email.includes('@')) {
@@ -133,8 +133,8 @@ export async function action({ request }: ActionArgs) {
   return json(
     {
       ...submission,
-      value: {
-        email: submission.value.email,
+      payload: {
+        email: submission.payload.email,
       },
     },
     {
@@ -201,7 +201,7 @@ import { authenticate } from '~/auth';
 function parseForm(formData: FormData) {
   const submission = parse(formData);
 
-  if (!submission.value.email) {
+  if (!submission.payload.email) {
     submission.error.push(['email', 'Email is required']);
   } else if (!email.includes('@')) {
     submission.error.push(['email', 'Email is invalid']);
@@ -229,8 +229,8 @@ export async function action({ request }: ActionArgs) {
   return json(
     {
       ...submission,
-      value: {
-        email: submission.value.email,
+      payload: {
+        email: submission.payload.email,
       },
     },
     {

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -41,7 +41,7 @@ Conform unifies validation and submission as one single flow by utilizing the fo
 **Conform** enables you to validate a form **fully server side**.
 
 ```tsx
-import { parse, useForm } from '@conform-to/react';
+import { parse, report, useForm } from '@conform-to/react';
 
 interface SignupForm {
   email: string;
@@ -70,7 +70,7 @@ export async function action({ request }: ActionArgs) {
   }
 
   if (hasError(submission.error) || submission.intent !== 'submit') {
-    return json(submission);
+    return json(report(submission));
   }
 
   try {
@@ -132,7 +132,7 @@ export async function action({ request }: ActionArgs) {
   const submission = parse(formData, { schema });
 
   if (!submission.data || submission.intent !== 'submit') {
-    return json(submission);
+    return json(report(submission));
   }
 
   return await signup(data);
@@ -269,7 +269,7 @@ export async function action({ request }: ActionArgs) {
   });
 
   if (!submission.data || submission.intent !== 'submit') {
-    return json(submission);
+    return json(report(submission));
   }
 
   return await signup(data);

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -113,7 +113,7 @@ export default function Signup() {
 Writing validation logic manually could be cumbersome. You can also use a schema validation library like [yup](https://github.com/jquense/yup) or [zod](https://github.com/colinhacks/zod):
 
 ```tsx
-import { formatError } from '@conform-to/zod';
+import { parse } from '@conform-to/zod';
 import { z } from 'zod';
 
 const schema = z
@@ -129,19 +129,13 @@ const schema = z
 
 export async function action({ request }: ActionArgs) {
   const formData = await request.formData();
-  const submission = parse(formData);
+  const submission = parse(formData, { schema });
 
-  try {
-    const data = schema.parse(submission.value);
-
-    if (submission.intent === 'submit') {
-      return await signup(data);
-    }
-  } catch (error) {
-    submission.error.push(...formatError(error));
+  if (!submission.data || submission.intent !== 'submit') {
+    return json(submission);
   }
 
-  return json(submission);
+  return await signup(data);
 }
 ```
 
@@ -151,7 +145,7 @@ Server validation works well generally. However, network latency would be a conc
 
 ```tsx
 import { useForm } from '@conform-to/react';
-import { validate } from '@conform-to/zod';
+import { parse } from '@conform-to/zod';
 
 const schema = z
   .object({
@@ -190,7 +184,7 @@ export default function Signup() {
        * and return the submission state with the validation
        * error
        */
-      return validate(formData, schema);
+      return parse(formData, { schema });
     },
   });
 
@@ -249,18 +243,17 @@ export default function Signup() {
 Some validation rules could be expensive especially when they require querying from database or 3rd party services. This can be minimized by checking the submission type and intent, or using the `shouldValidate()` helper.
 
 ```tsx
-import { parse, shouldValidate } from '@conform-to/react';
+import { shouldValidate } from '@conform-to/react';
+import { parse } from '@conform-to/zod';
 
 export async function action({ request }: ActionArgs) {
   const formData = await request.formData();
-  const submission = parse(formData);
-
-  try {
-    const data = await schema
-      .refine(
+  const submission = parse(formData, {
+    schema: (intent) =>
+      schema.refine(
         async ({ username }) => {
           // Continue checking only if necessary
-          if (!shouldValidate(submission.intent, 'username')) {
+          if (!shouldValidate(intent, 'username')) {
             return true;
           }
 
@@ -271,16 +264,14 @@ export async function action({ request }: ActionArgs) {
           message: 'Username is already used',
           path: ['username'],
         },
-      )
-      .parseAsync(submission.value);
+      ),
+    async: true,
+  });
 
-    if (submission.intent === 'submit') {
-      return await signup(data);
-    }
-  } catch (error) {
-    submission.error.push(...formatError(error));
+  if (!submission.data || submission.intent !== 'submit') {
+    return json(submission);
   }
 
-  return json(submission);
+  return await signup(data);
 }
 ```

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -41,7 +41,7 @@ Conform unifies validation and submission as one single flow by utilizing the fo
 **Conform** enables you to validate a form **fully server side**.
 
 ```tsx
-import { parse, report, useForm } from '@conform-to/react';
+import { parse, useForm } from '@conform-to/react';
 
 interface SignupForm {
   email: string;
@@ -53,28 +53,30 @@ export async function action({ request }: ActionArgs) {
   const formData = await request.formData();
   const submission = parse<SignupForm>(formData);
 
-  if (!submission.value.email) {
+  if (!submission.payload.email) {
     submission.error.push(['email', 'Email is required']);
-  } else if (!submission.value.email.includes('@')) {
+  } else if (!submission.payload.email.includes('@')) {
     submission.error.push(['email', 'Email is invalid']);
   }
 
-  if (!submission.value.password) {
+  if (!submission.payload.password) {
     submission.error.push(['password', 'Password is required']);
   }
 
-  if (!submission.value.confirmPassword) {
+  if (!submission.payload.confirmPassword) {
     submission.error.push(['confirmPassword', 'Confirm password is required']);
-  } else if (submission.value.confirmPassword !== submission.value.password) {
+  } else if (
+    submission.payload.confirmPassword !== submission.payload.password
+  ) {
     submission.error.push(['confirmPassword', 'Password does not match']);
   }
 
   if (hasError(submission.error) || submission.intent !== 'submit') {
-    return json(report(submission));
+    return json(submission);
   }
 
   try {
-    return await signup(submission.value);
+    return await signup(submission.payload);
   } catch (error) {
     return json({
       ...submission,
@@ -131,8 +133,8 @@ export async function action({ request }: ActionArgs) {
   const formData = await request.formData();
   const submission = parse(formData, { schema });
 
-  if (!submission.data || submission.intent !== 'submit') {
-    return json(report(submission));
+  if (!submission.value || submission.intent !== 'submit') {
+    return json(submission);
   }
 
   return await signup(data);
@@ -268,10 +270,10 @@ export async function action({ request }: ActionArgs) {
     async: true,
   });
 
-  if (!submission.data || submission.intent !== 'submit') {
-    return json(report(submission));
+  if (!submission.value || submission.intent !== 'submit') {
+    return json(submission);
   }
 
-  return await signup(data);
+  return await signup(submission.value);
 }
 ```

--- a/examples/async-validation/app/routes/index.tsx
+++ b/examples/async-validation/app/routes/index.tsx
@@ -55,16 +55,16 @@ export async function action({ request }: ActionArgs) {
 		async: true,
 	});
 
-	if (!submission.data || submission.intent !== 'submit') {
+	if (!submission.value || submission.intent !== 'submit') {
 		return json({
 			...submission,
-			value: {
-				email: submission.value.email,
+			payload: {
+				email: submission.payload.email,
 			},
 		});
 	}
 
-	return await signup(submission.data);
+	return await signup(submission.value);
 }
 
 export default function Signup() {

--- a/examples/nested-list/app/routes/index.tsx
+++ b/examples/nested-list/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import type { FieldsetConfig } from '@conform-to/react';
+import { FieldsetConfig, report } from '@conform-to/react';
 import {
 	useForm,
 	useFieldset,
@@ -32,7 +32,7 @@ export let action = async ({ request }: ActionArgs) => {
 	});
 
 	if (!submission.data || submission.intent !== 'submit') {
-		return json(submission);
+		return json(report(submission));
 	}
 
 	throw new Error('Not implemented');

--- a/examples/nested-list/app/routes/index.tsx
+++ b/examples/nested-list/app/routes/index.tsx
@@ -4,10 +4,9 @@ import {
 	useFieldset,
 	useFieldList,
 	conform,
-	parse,
 	list,
 } from '@conform-to/react';
-import { formatError, validate } from '@conform-to/zod';
+import { parse } from '@conform-to/zod';
 import type { ActionArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import { Form, useActionData } from '@remix-run/react';
@@ -28,19 +27,15 @@ type Schema = z.infer<typeof todosSchema>;
 
 export let action = async ({ request }: ActionArgs) => {
 	const formData = await request.formData();
-	const submission = parse<Schema>(formData);
+	const submission = parse(formData, {
+		schema: todosSchema,
+	});
 
-	try {
-		todosSchema.parse(submission.value);
-
-		if (submission.intent === 'submit') {
-			throw new Error('Not implemented');
-		}
-	} catch (error) {
-		submission.error.push(...formatError(error));
+	if (!submission.data || submission.intent !== 'submit') {
+		return json(submission);
 	}
 
-	return json(submission);
+	throw new Error('Not implemented');
 };
 
 export default function TodoForm() {
@@ -49,7 +44,7 @@ export default function TodoForm() {
 		initialReport: 'onBlur',
 		state,
 		onValidate({ formData }) {
-			return validate(formData, todosSchema);
+			return parse(formData, { schema: todosSchema });
 		},
 	});
 	const taskList = useFieldList(form.ref, tasks.config);

--- a/examples/nested-list/app/routes/index.tsx
+++ b/examples/nested-list/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import { FieldsetConfig, report } from '@conform-to/react';
+import type { FieldsetConfig } from '@conform-to/react';
 import {
 	useForm,
 	useFieldset,
@@ -31,8 +31,8 @@ export let action = async ({ request }: ActionArgs) => {
 		schema: todosSchema,
 	});
 
-	if (!submission.data || submission.intent !== 'submit') {
-		return json(report(submission));
+	if (!submission.value || submission.intent !== 'submit') {
+		return json(submission);
 	}
 
 	throw new Error('Not implemented');

--- a/examples/server-validation/app/routes/index.tsx
+++ b/examples/server-validation/app/routes/index.tsx
@@ -11,21 +11,23 @@ interface SignupForm {
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = parse<SignupForm>(formData);
+	const submission = parse(formData);
 
-	if (!submission.value.email) {
+	if (!submission.payload.email) {
 		submission.error.push(['email', 'Email is required']);
-	} else if (!submission.value.email.includes('@')) {
+	} else if (!submission.payload.email.includes('@')) {
 		submission.error.push(['email', 'Email is invalid']);
 	}
 
-	if (!submission.value.password) {
+	if (!submission.payload.password) {
 		submission.error.push(['password', 'Password is required']);
 	}
 
-	if (!submission.value.confirmPassword) {
+	if (!submission.payload.confirmPassword) {
 		submission.error.push(['confirmPassword', 'Confirm password is required']);
-	} else if (submission.value.confirmPassword !== submission.value.password) {
+	} else if (
+		submission.payload.confirmPassword !== submission.payload.password
+	) {
 		submission.error.push(['confirmPassword', 'Password does not match']);
 	}
 
@@ -49,9 +51,9 @@ export async function action({ request }: ActionArgs) {
 	// Always sends the submission state back to client until the user is signed up
 	return json({
 		...submission,
-		value: {
+		payload: {
 			// Never send the password back to client
-			email: submission.value.email,
+			email: submission.payload.email,
 		},
 	});
 }

--- a/examples/yup/app/routes/index.tsx
+++ b/examples/yup/app/routes/index.tsx
@@ -39,7 +39,7 @@ export async function action({ request }: ActionArgs) {
 export default function SignupForm() {
 	const state = useActionData<typeof action>();
 	const [form, { email, password, 'confirm-password': confirmPassword }] =
-		useForm<yup.InferType<typeof schema>>({
+		useForm({
 			state,
 			initialReport: 'onBlur',
 			onValidate({ formData }) {

--- a/examples/yup/app/routes/index.tsx
+++ b/examples/yup/app/routes/index.tsx
@@ -1,5 +1,5 @@
-import { conform, parse, useForm } from '@conform-to/react';
-import { formatError, validate } from '@conform-to/yup';
+import { conform, useForm } from '@conform-to/react';
+import { parse } from '@conform-to/yup';
 import type { ActionArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import { Form, useActionData } from '@remix-run/react';
@@ -22,27 +22,18 @@ const schema = yup.object({
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = parse(formData);
+	const submission = parse(formData, { schema });
 
-	try {
-		const data = schema.validateSync(submission.value, {
-			abortEarly: false,
+	if (!submission.data || submission.intent !== 'submit') {
+		return json({
+			...submission,
+			value: {
+				email: submission.value.email,
+			},
 		});
-
-		if (submission.intent === 'submit') {
-			console.log(data);
-			throw new Error('Not implemented');
-		}
-	} catch (error) {
-		submission.error.push(...formatError(error));
 	}
 
-	return json({
-		...submission,
-		value: {
-			email: submission.value.email,
-		},
-	});
+	throw new Error('Not implemented');
 }
 
 export default function SignupForm() {
@@ -52,7 +43,7 @@ export default function SignupForm() {
 			state,
 			initialReport: 'onBlur',
 			onValidate({ formData }) {
-				return validate(formData, schema);
+				return parse(formData, { schema });
 			},
 		});
 

--- a/examples/yup/app/routes/index.tsx
+++ b/examples/yup/app/routes/index.tsx
@@ -24,11 +24,11 @@ export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parse(formData, { schema });
 
-	if (!submission.data || submission.intent !== 'submit') {
+	if (!submission.value || submission.intent !== 'submit') {
 		return json({
 			...submission,
-			value: {
-				email: submission.value.email,
+			payload: {
+				email: submission.payload.email,
 			},
 		});
 	}

--- a/examples/zod/app/routes/index.tsx
+++ b/examples/zod/app/routes/index.tsx
@@ -41,11 +41,14 @@ export async function action({ request }: ActionArgs) {
 export default function SignupForm() {
 	const state = useActionData<typeof action>();
 	const [form, { email, password, 'confirm-password': confirmPassword }] =
-		useForm<z.infer<typeof schema>>({
+		useForm({
 			state,
 			initialReport: 'onBlur',
 			onValidate({ formData }) {
 				return parse(formData, { schema });
+			},
+			onSubmit(event, { submission }) {
+				console.log(submission.data);
 			},
 		});
 

--- a/examples/zod/app/routes/index.tsx
+++ b/examples/zod/app/routes/index.tsx
@@ -26,11 +26,11 @@ export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parse(formData, { schema });
 
-	if (!submission.data || submission.intent !== 'submit') {
+	if (!submission.value || submission.intent !== 'submit') {
 		return json({
 			...submission,
-			value: {
-				email: submission.value.email,
+			payload: {
+				email: submission.payload.email,
 			},
 		});
 	}
@@ -48,7 +48,7 @@ export default function SignupForm() {
 				return parse(formData, { schema });
 			},
 			onSubmit(event, { submission }) {
-				console.log(submission.data);
+				console.log(submission.value);
 			},
 		});
 

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -513,3 +513,11 @@ export const list = new Proxy({} as ListCommandButtonBuilder, {
 		}
 	},
 });
+
+export function report<Payload>(
+	submission: Submission<Payload, any>,
+): Submission<Payload> {
+	const { intent, value, error } = submission;
+
+	return { intent, value, error };
+}

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -44,12 +44,12 @@ export type Submission<Schema extends Record<string, any> | unknown = unknown> =
 	unknown extends Schema
 		? {
 				intent: string;
-				payload: FieldValue<Record<string, any>>;
+				payload: Record<string, any>;
 				error: Array<[string, string]>;
 		  }
 		: {
 				intent: string;
-				payload: FieldValue<Record<string, any>>;
+				payload: Record<string, any>;
 				value?: Schema;
 				error: Array<[string, string]>;
 		  };

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -40,10 +40,11 @@ export type FieldsetConstraint<Schema extends Record<string, any>> = {
 	[Key in keyof Schema]?: FieldConstraint<Schema[Key]>;
 };
 
-export type Submission<Schema = unknown> = {
+export type Submission<Payload = unknown, Schema = never> = {
 	intent: string;
-	value: FieldValue<Schema>;
+	value: FieldValue<Payload>;
 	error: Array<[string, string]>;
+	data?: Schema;
 };
 
 export interface IntentButtonProps {
@@ -136,9 +137,9 @@ export function hasError(
 	);
 }
 
-export function reportSubmission(
+export function reportSubmission<Payload, Schema>(
 	form: HTMLFormElement,
-	submission: Submission,
+	submission: Submission<Payload, Schema>,
 ): void {
 	const messageByName: Map<string, string> = new Map();
 	const listCommand = parseListCommand(submission.intent);

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -32,7 +32,10 @@ import {
 } from 'react';
 import { input } from './helpers';
 
-export interface FormConfig<Schema extends Record<string, any>> {
+export interface FormConfig<
+	Schema extends Record<string, any>,
+	SubmissionResult extends Submission | Submission<Schema> = Submission,
+> {
 	/**
 	 * If the form id is provided, Id for label,
 	 * input and error elements will be derived.
@@ -90,7 +93,7 @@ export interface FormConfig<Schema extends Record<string, any>> {
 	}: {
 		form: HTMLFormElement;
 		formData: FormData;
-	}) => Submission<Schema>;
+	}) => SubmissionResult;
 
 	/**
 	 * The submit event handler of the form. It will be called
@@ -100,7 +103,7 @@ export interface FormConfig<Schema extends Record<string, any>> {
 		event: FormEvent<HTMLFormElement>,
 		context: {
 			formData: FormData;
-			submission: Submission<Schema>;
+			submission: SubmissionResult;
 		},
 	) => void;
 }
@@ -129,8 +132,11 @@ interface Form<Schema extends Record<string, any>> {
  *
  * @see https://conform.guide/api/react#useform
  */
-export function useForm<Schema extends Record<string, any>>(
-	config: FormConfig<Schema> = {},
+export function useForm<
+	Schema extends Record<string, any>,
+	SubmissionResult extends Submission | Submission<Schema> = Submission,
+>(
+	config: FormConfig<Schema, SubmissionResult> = {},
 ): [Form<Schema>, Fieldset<Schema>] {
 	const configRef = useRef(config);
 	const ref = useRef<HTMLFormElement>(null);
@@ -328,7 +334,7 @@ export function useForm<Schema extends Record<string, any>>(
 								}
 							}
 
-							return submission as Submission<Schema>;
+							return submission as SubmissionResult;
 						});
 					const submission = onValidate({ form, formData });
 

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -8,6 +8,7 @@ export {
 	validate,
 	requestIntent,
 	requestSubmit,
+	report,
 	parse,
 	shouldValidate,
 } from '@conform-to/dom';

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -8,7 +8,6 @@ export {
 	validate,
 	requestIntent,
 	requestSubmit,
-	report,
 	parse,
 	shouldValidate,
 } from '@conform-to/dom';

--- a/packages/conform-yup/README.md
+++ b/packages/conform-yup/README.md
@@ -39,7 +39,7 @@ function Example() {
 
 ### parse
 
-It parses the formData and returns a submission result with the validation error. If no error is found, the parsed data will also be populated as `submission.data`.
+It parses the formData and returns a submission result with the validation error. If no error is found, the parsed data will also be populated as `submission.value`.
 
 ```tsx
 import { useForm } from '@conform-to/react';
@@ -83,7 +83,7 @@ export let action = async ({ request }) => {
     async: true,
   });
 
-  if (!submission.data || submission.intent !== 'submit') {
+  if (!submission.value || submission.intent !== 'submit') {
     return submission;
   }
 

--- a/packages/conform-yup/README.md
+++ b/packages/conform-yup/README.md
@@ -6,91 +6,10 @@
 
 ## API Reference
 
-- [formatError](#formatError)
 - [getFieldsetConstraint](#getfieldsetconstraint)
-- [validate](#validate)
+- [parse](#parse)
 
 <!-- /aside -->
-
-### formatError
-
-This formats Yup **ValidationError** to conform's error structure (i.e. A set of key/value pairs).
-
-If an error is received instead of the Yup **ValidationError**, it will be treated as a form level error with message set to **error.messages**.
-
-```tsx
-import { useForm, parse } from '@conform-to/react';
-import { formatError } from '@conform-to/yup';
-import * as yup from 'yup';
-
-const schema = yup.object({
-  email: yup.string().required(),
-  password: yup.string().required(),
-});
-
-function ExampleForm() {
-  const [form] = useForm<yup.InferType<typeof schema>>({
-    onValidate({ formData }) {
-      const submission = parse(formData);
-
-      try {
-        // Only sync validation is allowed on the client side
-        schema.validateSync(submission.value, {
-          abortEarly: false,
-        });
-      } catch (error) {
-        submission.error.push(...formatError(error));
-      }
-
-      return submission;
-    },
-  });
-
-  // ...
-}
-```
-
-Or when validating the formData on server side (e.g. Remix):
-
-```tsx
-import { useForm, parse } from '@conform-to/react';
-import { formatError } from '@conform-to/yup';
-import * as yup from 'yup';
-
-const schema = yup.object({
-  // Define the schema with yup
-});
-
-export let action = async ({ request }) => {
-  const formData = await request.formData();
-  const submission = parse(formData);
-
-  try {
-    // You can extends the schema with async validation as well
-    const data = await schema.validate(submission.value, {
-      abortEarly: false,
-    });
-
-    if (submission.intent === 'submit') {
-      return await handleFormData(data);
-    }
-  } catch (error) {
-    submission.error.push(...formatError(error));
-  }
-
-  return submission;
-};
-
-export default function ExampleRoute() {
-  const state = useActionData();
-  const [form] = useForm({
-    mode: 'server-validation',
-    state,
-  });
-
-  // ...
-}
-```
 
 ### getFieldsetConstraint
 
@@ -118,13 +37,13 @@ function Example() {
 }
 ```
 
-### validate
+### parse
 
-It parses the formData and returns a [submission](/docs/submission.md) object with the validation error, which removes the boilerplate code shown on the [formatError](#formaterror) example.
+It parses the formData and returns a submission result with the validation error. If no error is found, the parsed data will also be populated as `submission.data`.
 
 ```tsx
 import { useForm } from '@conform-to/react';
-import { validate } from '@conform-to/yup';
+import { parse } from '@conform-to/yup';
 import * as yup from 'yup';
 
 const schema = yup.object({
@@ -135,10 +54,39 @@ const schema = yup.object({
 function ExampleForm() {
   const [form] = useForm({
     onValidate({ formData }) {
-      return validate(formData, schema);
+      return parse(formData, { schema });
     },
   });
 
   // ...
 }
+```
+
+Or when parsing the formData on server side (e.g. Remix):
+
+```tsx
+import { useForm } from '@conform-to/react';
+import { parse } from '@conform-to/yup';
+import * as yup from 'yup';
+
+const schema = yup.object({
+  // Define the schema with yup
+});
+
+export let action = async ({ request }) => {
+  const formData = await request.formData();
+  const submission = parse(formData, {
+    // If you need extra validation on server side
+    schema: schema.test(/* ... */),
+
+    // If the schema definition includes async validation
+    async: true,
+  });
+
+  if (!submission.data || submission.intent !== 'submit') {
+    return submission;
+  }
+
+  // ...
+};
 ```

--- a/packages/conform-yup/index.ts
+++ b/packages/conform-yup/index.ts
@@ -1,8 +1,8 @@
 import {
 	type FieldConstraint,
 	type FieldsetConstraint,
-	type Submission,
-	parse,
+	type Submission as ConformSubmission,
+	parse as baseParse,
 } from '@conform-to/dom';
 import * as yup from 'yup';
 
@@ -87,35 +87,73 @@ export function getFieldsetConstraint<Source extends yup.AnyObjectSchema>(
 	) as FieldsetConstraint<yup.InferType<Source>>;
 }
 
-export function formatError(
-	error: unknown,
-	fallbackMessage = 'Oops! Something went wrong.',
-): Array<[string, string]> {
-	if (error instanceof yup.ValidationError) {
-		return error.inner.reduce<Array<[string, string]>>((result, e) => {
-			result.push([e.path ?? '', e.message]);
-
-			return result;
-		}, []);
-	}
-
-	return [['', error instanceof Error ? error.message : fallbackMessage]];
+interface Submission<Output, Input = Output> extends ConformSubmission<Input> {
+	data?: Output;
 }
 
-export function validate<Schema extends yup.AnyObjectSchema>(
-	formData: FormData,
-	schema: Schema,
-	options: { fallbackMessage?: string } = {},
-): Submission<yup.InferType<Schema>> {
-	const submission = parse<yup.InferType<Schema>>(formData);
+export function parse<Schema extends yup.AnyObjectSchema>(
+	payload: FormData | URLSearchParams,
+	config: {
+		schema: Schema | ((intent: string) => Schema);
+		async?: false;
+	},
+): Submission<yup.InferType<Schema>>;
+export function parse<Schema extends yup.AnyObjectSchema>(
+	payload: FormData | URLSearchParams,
+	config: {
+		schema: Schema | ((intent: string) => Schema);
+		async: true;
+	},
+): Promise<Submission<yup.InferType<Schema>>>;
+export function parse<Schema extends yup.AnyObjectSchema>(
+	payload: FormData | URLSearchParams,
+	config: {
+		schema: Schema | ((intent: string) => Schema);
+		async?: boolean;
+	},
+):
+	| Submission<yup.InferType<Schema>>
+	| Promise<Submission<yup.InferType<Schema>>> {
+	const submission = baseParse<yup.InferType<Schema>>(payload);
+	const schema =
+		typeof config.schema === 'function'
+			? config.schema(submission.intent)
+			: config.schema;
+	const resolveData = (data: yup.InferType<Schema>) => ({
+		...submission,
+		data,
+	});
+	const resolveError = (error: unknown) => {
+		if (error instanceof yup.ValidationError) {
+			return {
+				...submission,
+				error: submission.error.concat(
+					error.inner.reduce<Array<[string, string]>>((result, e) => {
+						result.push([e.path ?? '', e.message]);
 
-	try {
-		schema.validateSync(submission.value, {
-			abortEarly: false,
-		});
-	} catch (error) {
-		submission.error.push(...formatError(error, options.fallbackMessage));
+						return result;
+					}, []),
+				),
+			};
+		}
+
+		throw error;
+	};
+
+	if (!config.async) {
+		try {
+			const data = schema.validateSync(submission.value, {
+				abortEarly: false,
+			});
+
+			return resolveData(data);
+		} catch (error) {
+			return resolveError(error);
+		}
 	}
 
-	return submission;
+	return schema
+		.validate(submission.value, { abortEarly: false })
+		.then(resolveData)
+		.catch(resolveError);
 }

--- a/packages/conform-yup/index.ts
+++ b/packages/conform-yup/index.ts
@@ -1,7 +1,7 @@
 import {
 	type FieldConstraint,
 	type FieldsetConstraint,
-	type Submission as ConformSubmission,
+	type Submission,
 	parse as baseParse,
 } from '@conform-to/dom';
 import * as yup from 'yup';
@@ -87,24 +87,20 @@ export function getFieldsetConstraint<Source extends yup.AnyObjectSchema>(
 	) as FieldsetConstraint<yup.InferType<Source>>;
 }
 
-interface Submission<Output, Input = Output> extends ConformSubmission<Input> {
-	data?: Output;
-}
-
 export function parse<Schema extends yup.AnyObjectSchema>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
 		async?: false;
 	},
-): Submission<yup.InferType<Schema>>;
+): Submission<yup.InferType<Schema>, yup.InferType<Schema>>;
 export function parse<Schema extends yup.AnyObjectSchema>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
 		async: true;
 	},
-): Promise<Submission<yup.InferType<Schema>>>;
+): Promise<Submission<yup.InferType<Schema>, yup.InferType<Schema>>>;
 export function parse<Schema extends yup.AnyObjectSchema>(
 	payload: FormData | URLSearchParams,
 	config: {
@@ -112,8 +108,8 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 		async?: boolean;
 	},
 ):
-	| Submission<yup.InferType<Schema>>
-	| Promise<Submission<yup.InferType<Schema>>> {
+	| Submission<yup.InferType<Schema>, yup.InferType<Schema>>
+	| Promise<Submission<yup.InferType<Schema>, yup.InferType<Schema>>> {
 	const submission = baseParse<yup.InferType<Schema>>(payload);
 	const schema =
 		typeof config.schema === 'function'

--- a/packages/conform-yup/index.ts
+++ b/packages/conform-yup/index.ts
@@ -93,14 +93,14 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 		schema: Schema | ((intent: string) => Schema);
 		async?: false;
 	},
-): Submission<yup.InferType<Schema>, yup.InferType<Schema>>;
+): Submission<yup.InferType<Schema>>;
 export function parse<Schema extends yup.AnyObjectSchema>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
 		async: true;
 	},
-): Promise<Submission<yup.InferType<Schema>, yup.InferType<Schema>>>;
+): Promise<Submission<yup.InferType<Schema>>>;
 export function parse<Schema extends yup.AnyObjectSchema>(
 	payload: FormData | URLSearchParams,
 	config: {
@@ -108,16 +108,16 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 		async?: boolean;
 	},
 ):
-	| Submission<yup.InferType<Schema>, yup.InferType<Schema>>
-	| Promise<Submission<yup.InferType<Schema>, yup.InferType<Schema>>> {
-	const submission = baseParse<yup.InferType<Schema>>(payload);
+	| Submission<yup.InferType<Schema>>
+	| Promise<Submission<yup.InferType<Schema>>> {
+	const submission = baseParse(payload);
 	const schema =
 		typeof config.schema === 'function'
 			? config.schema(submission.intent)
 			: config.schema;
-	const resolveData = (data: yup.InferType<Schema>) => ({
+	const resolveData = (value: yup.InferType<Schema>) => ({
 		...submission,
-		data,
+		value,
 	});
 	const resolveError = (error: unknown) => {
 		if (error instanceof yup.ValidationError) {
@@ -138,7 +138,7 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 
 	if (!config.async) {
 		try {
-			const data = schema.validateSync(submission.value, {
+			const data = schema.validateSync(submission.payload, {
 				abortEarly: false,
 			});
 
@@ -149,7 +149,7 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 	}
 
 	return schema
-		.validate(submission.value, { abortEarly: false })
+		.validate(submission.payload, { abortEarly: false })
 		.then(resolveData)
 		.catch(resolveError);
 }

--- a/packages/conform-zod/README.md
+++ b/packages/conform-zod/README.md
@@ -39,7 +39,7 @@ function Example() {
 
 ### parse
 
-It parses the formData and returns a submission result with the validation error. If no error is found, the parsed data will also be populated as `submission.data`.
+It parses the formData and returns a submission result with the validation error. If no error is found, the parsed data will also be populated as `submission.value`.
 
 ```tsx
 import { useForm } from '@conform-to/react';
@@ -83,7 +83,7 @@ export let action = async ({ request }) => {
     async: true,
   });
 
-  if (!submission.data || submission.intent !== 'submit') {
+  if (!submission.value || submission.intent !== 'submit') {
     return submission;
   }
 

--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -1,7 +1,7 @@
 import {
 	type FieldConstraint,
 	type FieldsetConstraint,
-	type Submission as ConformSubmission,
+	type Submission,
 	getName,
 	parse as baseParse,
 } from '@conform-to/dom';
@@ -108,10 +108,6 @@ export function getFieldsetConstraint<Source extends z.ZodTypeAny>(
 	}
 
 	return result;
-}
-
-interface Submission<Output, Input = Output> extends ConformSubmission<Input> {
-	data?: Output;
 }
 
 export function parse<Schema extends z.ZodTypeAny>(

--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -116,24 +116,22 @@ export function parse<Schema extends z.ZodTypeAny>(
 		schema: Schema | ((intent: string) => Schema);
 		async?: false;
 	},
-): Submission<z.output<Schema>, z.input<Schema>>;
+): Submission<z.output<Schema>>;
 export function parse<Schema extends z.ZodTypeAny>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
 		async: true;
 	},
-): Promise<Submission<z.output<Schema>, z.input<Schema>>>;
+): Promise<Submission<z.output<Schema>>>;
 export function parse<Schema extends z.ZodTypeAny>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
 		async?: boolean;
 	},
-):
-	| Submission<z.output<Schema>, z.input<Schema>>
-	| Promise<Submission<z.output<Schema>, z.input<Schema>>> {
-	const submission = baseParse<z.input<Schema>>(payload);
+): Submission<z.output<Schema>> | Promise<Submission<z.output<Schema>>> {
+	const submission = baseParse(payload);
 	const schema =
 		typeof config.schema === 'function'
 			? config.schema(submission.intent)
@@ -144,7 +142,7 @@ export function parse<Schema extends z.ZodTypeAny>(
 		if (result.success) {
 			return {
 				...submission,
-				data: result.data,
+				value: result.data,
 			};
 		} else {
 			return {
@@ -161,8 +159,8 @@ export function parse<Schema extends z.ZodTypeAny>(
 	};
 
 	return config.async
-		? schema.safeParseAsync(submission.value).then(resolve)
-		: resolve(schema.safeParse(submission.value));
+		? schema.safeParseAsync(submission.payload).then(resolve)
+		: resolve(schema.safeParse(submission.payload));
 }
 
 export function ifNonEmptyString(

--- a/playground/app/components.tsx
+++ b/playground/app/components.tsx
@@ -6,7 +6,7 @@ interface PlaygroundProps {
 	title: string;
 	description?: string;
 	form?: string;
-	state?: Submission<Record<string, unknown>>;
+	state?: Submission;
 	children: ReactNode;
 }
 

--- a/playground/app/routes/employee.tsx
+++ b/playground/app/routes/employee.tsx
@@ -1,10 +1,4 @@
-import {
-	conform,
-	hasError,
-	shouldValidate,
-	report,
-	useForm,
-} from '@conform-to/react';
+import { conform, hasError, shouldValidate, useForm } from '@conform-to/react';
 import { parse } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
@@ -47,7 +41,7 @@ export let action = async ({ request }: ActionArgs) => {
 		async: true,
 	});
 
-	return json(report(submission));
+	return json(submission);
 };
 
 export default function EmployeeForm() {

--- a/playground/app/routes/employee.tsx
+++ b/playground/app/routes/employee.tsx
@@ -13,8 +13,6 @@ const schema = z.object({
 	title: z.string().min(1, 'Title is required').max(20, 'Title is too long'),
 });
 
-type Schema = z.infer<typeof schema>;
-
 export let loader = async ({ request }: LoaderArgs) => {
 	return parseConfig(request);
 };
@@ -49,7 +47,7 @@ export let action = async ({ request }: ActionArgs) => {
 export default function EmployeeForm() {
 	const config = useLoaderData();
 	const state = useActionData();
-	const [form, { name, email, title }] = useForm<Schema>({
+	const [form, { name, email, title }] = useForm({
 		...config,
 		state,
 		onValidate({ formData }) {

--- a/playground/app/routes/employee.tsx
+++ b/playground/app/routes/employee.tsx
@@ -1,4 +1,10 @@
-import { conform, hasError, shouldValidate, useForm } from '@conform-to/react';
+import {
+	conform,
+	hasError,
+	shouldValidate,
+	report,
+	useForm,
+} from '@conform-to/react';
 import { parse } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
@@ -41,7 +47,7 @@ export let action = async ({ request }: ActionArgs) => {
 		async: true,
 	});
 
-	return json(submission);
+	return json(report(submission));
 };
 
 export default function EmployeeForm() {

--- a/playground/app/routes/file-upload.tsx
+++ b/playground/app/routes/file-upload.tsx
@@ -1,4 +1,4 @@
-import { conform, report, useForm } from '@conform-to/react';
+import { conform, useForm } from '@conform-to/react';
 import { parse } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
@@ -47,7 +47,7 @@ export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parse(formData, { schema });
 
-	return json(report(submission));
+	return json(submission);
 }
 
 export default function FileUpload() {

--- a/playground/app/routes/file-upload.tsx
+++ b/playground/app/routes/file-upload.tsx
@@ -1,4 +1,4 @@
-import { conform, useForm } from '@conform-to/react';
+import { conform, report, useForm } from '@conform-to/react';
 import { parse } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
@@ -35,8 +35,6 @@ const schema = z.object({
 		),
 });
 
-type Schema = z.infer<typeof schema>;
-
 export async function loader({ request }: LoaderArgs) {
 	const url = new URL(request.url);
 
@@ -49,13 +47,13 @@ export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parse(formData, { schema });
 
-	return json(submission);
+	return json(report(submission));
 }
 
 export default function FileUpload() {
 	const { noClientValidate } = useLoaderData<typeof loader>();
 	const state = useActionData();
-	const [form, { file, files }] = useForm<Schema>({
+	const [form, { file, files }] = useForm({
 		state,
 		onValidate: !noClientValidate
 			? ({ formData }) => parse(formData, { schema })

--- a/playground/app/routes/file-upload.tsx
+++ b/playground/app/routes/file-upload.tsx
@@ -1,5 +1,5 @@
-import { conform, parse, useForm } from '@conform-to/react';
-import { formatError, validate } from '@conform-to/zod';
+import { conform, useForm } from '@conform-to/react';
+import { parse } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
@@ -47,13 +47,7 @@ export async function loader({ request }: LoaderArgs) {
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = parse(formData);
-
-	try {
-		schema.parse(submission.value);
-	} catch (error) {
-		submission.error.push(...formatError(error));
-	}
+	const submission = parse(formData, { schema });
 
 	return json(submission);
 }
@@ -64,7 +58,7 @@ export default function FileUpload() {
 	const [form, { file, files }] = useForm<Schema>({
 		state,
 		onValidate: !noClientValidate
-			? ({ formData }) => validate(formData, schema)
+			? ({ formData }) => parse(formData, { schema })
 			: undefined,
 	});
 

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -10,7 +10,7 @@ interface Login {
 	password: string;
 }
 
-function validate(formData: FormData): Submission<Login> {
+function parseLoginForm(formData: FormData): Submission<Login> {
 	const submission = parse<Login>(formData);
 
 	if (!submission.value.email) {
@@ -30,7 +30,7 @@ export let loader = async ({ request }: LoaderArgs) => {
 
 export let action = async ({ request }: ActionArgs) => {
 	const formData = await request.formData();
-	const submission = validate(formData);
+	const submission = parseLoginForm(formData);
 
 	if (
 		submission.error.length === 0 &&
@@ -58,7 +58,7 @@ export default function LoginForm() {
 		id: formId,
 		state,
 		onValidate: config.validate
-			? ({ formData }) => validate(formData)
+			? ({ formData }) => parseLoginForm(formData)
 			: undefined,
 		onSubmit:
 			config.mode === 'server-validation'

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -1,5 +1,11 @@
-import { type Submission, conform, useForm, parse } from '@conform-to/react';
-import type { ActionArgs, LoaderArgs } from '@remix-run/node';
+import {
+	type Submission,
+	conform,
+	useForm,
+	parse,
+	report,
+} from '@conform-to/react';
+import { ActionArgs, LoaderArgs, json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { useId } from 'react';
 import { Playground, Field, Alert } from '~/components';
@@ -40,13 +46,15 @@ export let action = async ({ request }: ActionArgs) => {
 		submission.error.push(['', 'The provided email or password is not valid']);
 	}
 
-	return {
-		...submission,
-		value: {
-			email: submission.value.email,
-			// Never send the password back to the client
-		},
-	};
+	return json(
+		report({
+			...submission,
+			value: {
+				email: submission.value.email,
+				// Never send the password back to the client
+			},
+		}),
+	);
 };
 
 export default function LoginForm() {

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -5,7 +5,7 @@ import {
 	parse,
 	report,
 } from '@conform-to/react';
-import { ActionArgs, LoaderArgs, json } from '@remix-run/node';
+import { type ActionArgs, type LoaderArgs, json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { useId } from 'react';
 import { Playground, Field, Alert } from '~/components';
@@ -16,14 +16,14 @@ interface Login {
 	password: string;
 }
 
-function parseLoginForm(formData: FormData): Submission<Login> {
-	const submission = parse<Login>(formData);
+function parseLoginForm(formData: FormData): Submission {
+	const submission = parse(formData);
 
-	if (!submission.value.email) {
+	if (!submission.payload.email) {
 		submission.error.push(['email', 'Email is required']);
 	}
 
-	if (!submission.value.password) {
+	if (!submission.payload.password) {
 		submission.error.push(['password', 'Password is required']);
 	}
 
@@ -40,21 +40,19 @@ export let action = async ({ request }: ActionArgs) => {
 
 	if (
 		submission.error.length === 0 &&
-		(submission.value.email !== 'me@edmund.dev' ||
-			submission.value.password !== '$eCreTP@ssWord')
+		(submission.payload.email !== 'me@edmund.dev' ||
+			submission.payload.password !== '$eCreTP@ssWord')
 	) {
 		submission.error.push(['', 'The provided email or password is not valid']);
 	}
 
-	return json(
-		report({
-			...submission,
-			value: {
-				email: submission.value.email,
-				// Never send the password back to the client
-			},
-		}),
-	);
+	return json({
+		...submission,
+		payload: {
+			email: submission.payload.email,
+			// Never send the password back to the client
+		},
+	});
 };
 
 export default function LoginForm() {

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -1,10 +1,4 @@
-import {
-	type Submission,
-	conform,
-	useForm,
-	parse,
-	report,
-} from '@conform-to/react';
+import { type Submission, conform, useForm, parse } from '@conform-to/react';
 import { type ActionArgs, type LoaderArgs, json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { useId } from 'react';

--- a/playground/app/routes/movie.tsx
+++ b/playground/app/routes/movie.tsx
@@ -1,11 +1,5 @@
-import {
-	conform,
-	getFormElements,
-	parse,
-	report,
-	useForm,
-} from '@conform-to/react';
-import { ActionArgs, LoaderArgs, json } from '@remix-run/node';
+import { conform, getFormElements, parse, useForm } from '@conform-to/react';
+import { type ActionArgs, type LoaderArgs, json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { Playground, Field } from '~/components';
 import { parseConfig } from '~/config';
@@ -23,30 +17,33 @@ export let loader = async ({ request }: LoaderArgs) => {
 
 export let action = async ({ request }: ActionArgs) => {
 	const formData = await request.formData();
-	const submission = parse<Movie>(formData);
+	const submission = parse(formData);
 
-	if (!submission.value.title) {
+	if (!submission.payload.title) {
 		submission.error.push(['title', 'Title is required']);
-	} else if (!submission.value.title.match(/[0-9a-zA-Z ]{1,20}/)) {
+	} else if (!submission.payload.title.match(/[0-9a-zA-Z ]{1,20}/)) {
 		submission.error.push(['title', 'Please enter a valid title']);
 	}
 
 	if (
-		submission.value.description &&
-		submission.value.description.length < 30
+		submission.payload.description &&
+		submission.payload.description.length < 30
 	) {
 		submission.error.push(['description', 'Please provides more details']);
 	}
 
-	if (submission.value.genre === '') {
+	if (submission.payload.genre === '') {
 		submission.error.push(['genre', 'Genre is required']);
 	}
 
-	if (submission.value.rating && Number(submission.value.rating) % 0.5 !== 0) {
+	if (
+		submission.payload.rating &&
+		Number(submission.payload.rating) % 0.5 !== 0
+	) {
 		submission.error.push(['rating', 'The provided rating is invalid']);
 	}
 
-	return json(report(submission));
+	return json(submission);
 };
 
 export default function MovieForm() {

--- a/playground/app/routes/movie.tsx
+++ b/playground/app/routes/movie.tsx
@@ -1,5 +1,11 @@
-import { conform, getFormElements, parse, useForm } from '@conform-to/react';
-import type { ActionArgs, LoaderArgs } from '@remix-run/node';
+import {
+	conform,
+	getFormElements,
+	parse,
+	report,
+	useForm,
+} from '@conform-to/react';
+import { ActionArgs, LoaderArgs, json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { Playground, Field } from '~/components';
 import { parseConfig } from '~/config';
@@ -40,7 +46,7 @@ export let action = async ({ request }: ActionArgs) => {
 		submission.error.push(['rating', 'The provided rating is invalid']);
 	}
 
-	return submission;
+	return json(report(submission));
 };
 
 export default function MovieForm() {

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -2,7 +2,7 @@ import { conform, useFieldset, useForm } from '@conform-to/react';
 import {
 	getFieldsetConstraint,
 	ifNonEmptyString,
-	validate,
+	parse,
 } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
@@ -41,7 +41,7 @@ export let loader = async ({ request }: LoaderArgs) => {
 
 export let action = async ({ request }: ActionArgs) => {
 	const formData = await request.formData();
-	const submission = validate(formData, schema);
+	const submission = parse(formData, { schema });
 
 	return submission;
 };
@@ -54,7 +54,7 @@ export default function PaymentForm() {
 		state,
 		constraint: getFieldsetConstraint(schema),
 		onValidate: config.validate
-			? ({ formData }) => validate(formData, schema)
+			? ({ formData }) => parse(formData, { schema })
 			: undefined,
 		onSubmit:
 			config.mode === 'server-validation'

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -1,10 +1,10 @@
-import { conform, report, useFieldset, useForm } from '@conform-to/react';
+import { conform, useFieldset, useForm } from '@conform-to/react';
 import {
 	getFieldsetConstraint,
 	ifNonEmptyString,
 	parse,
 } from '@conform-to/zod';
-import { ActionArgs, LoaderArgs, json } from '@remix-run/node';
+import { type ActionArgs, type LoaderArgs, json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { z } from 'zod';
 import { Playground, Field } from '~/components';
@@ -43,7 +43,7 @@ export let action = async ({ request }: ActionArgs) => {
 	const formData = await request.formData();
 	const submission = parse(formData, { schema });
 
-	return json(report(submission));
+	return json(submission);
 };
 
 export default function PaymentForm() {

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -1,10 +1,10 @@
-import { conform, useFieldset, useForm } from '@conform-to/react';
+import { conform, report, useFieldset, useForm } from '@conform-to/react';
 import {
 	getFieldsetConstraint,
 	ifNonEmptyString,
 	parse,
 } from '@conform-to/zod';
-import type { ActionArgs, LoaderArgs } from '@remix-run/node';
+import { ActionArgs, LoaderArgs, json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { z } from 'zod';
 import { Playground, Field } from '~/components';
@@ -43,7 +43,7 @@ export let action = async ({ request }: ActionArgs) => {
 	const formData = await request.formData();
 	const submission = parse(formData, { schema });
 
-	return submission;
+	return json(report(submission));
 };
 
 export default function PaymentForm() {

--- a/playground/app/routes/radio-buttons.tsx
+++ b/playground/app/routes/radio-buttons.tsx
@@ -1,4 +1,4 @@
-import { conform, parse, useForm } from '@conform-to/react';
+import { conform, parse, report, useForm } from '@conform-to/react';
 import { type LoaderArgs, type ActionArgs, json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { Playground, Field } from '~/components';
@@ -29,7 +29,7 @@ export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parseForm(formData);
 
-	return json(submission);
+	return json(report(submission));
 }
 
 export default function Example() {

--- a/playground/app/routes/radio-buttons.tsx
+++ b/playground/app/routes/radio-buttons.tsx
@@ -7,7 +7,7 @@ interface Schema {
 	answer: string;
 }
 
-function validate(formData: FormData) {
+function parseForm(formData: FormData) {
 	const submission = parse(formData);
 
 	if (!submission.value.answer) {
@@ -27,7 +27,7 @@ export async function loader({ request }: LoaderArgs) {
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = validate(formData);
+	const submission = parseForm(formData);
 
 	return json(submission);
 }
@@ -38,7 +38,7 @@ export default function Example() {
 	const [form, { answer }] = useForm<Schema>({
 		state,
 		onValidate: !noClientValidate
-			? ({ formData }) => validate(formData)
+			? ({ formData }) => parseForm(formData)
 			: undefined,
 	});
 

--- a/playground/app/routes/radio-buttons.tsx
+++ b/playground/app/routes/radio-buttons.tsx
@@ -1,4 +1,4 @@
-import { conform, parse, report, useForm } from '@conform-to/react';
+import { conform, parse, useForm } from '@conform-to/react';
 import { type LoaderArgs, type ActionArgs, json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { Playground, Field } from '~/components';
@@ -10,7 +10,7 @@ interface Schema {
 function parseForm(formData: FormData) {
 	const submission = parse(formData);
 
-	if (!submission.value.answer) {
+	if (!submission.payload.answer) {
 		submission.error.push(['answer', 'Required']);
 	}
 
@@ -29,7 +29,7 @@ export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parseForm(formData);
 
-	return json(report(submission));
+	return json(submission);
 }
 
 export default function Example() {

--- a/playground/app/routes/signup.tsx
+++ b/playground/app/routes/signup.tsx
@@ -11,7 +11,7 @@ interface Signup {
 	confirmPassword: string;
 }
 
-function validate(formData: FormData): Submission<Signup> {
+function parseSignupForm(formData: FormData): Submission<Signup> {
 	const submission = parse<Signup>(formData);
 	const { email, password, confirmPassword } = submission.value;
 
@@ -45,7 +45,7 @@ export let loader = async ({ request }: LoaderArgs) => {
 
 export let action = async ({ request }: ActionArgs) => {
 	const formData = await request.formData();
-	const submission = validate(formData);
+	const submission = parseSignupForm(formData);
 
 	return {
 		...submission,
@@ -64,7 +64,7 @@ export default function SignupForm() {
 		id: 'signup',
 		state,
 		onValidate: config.validate
-			? ({ formData }) => validate(formData)
+			? ({ formData }) => parseSignupForm(formData)
 			: undefined,
 		onSubmit:
 			config.mode === 'server-validation'

--- a/playground/app/routes/signup.tsx
+++ b/playground/app/routes/signup.tsx
@@ -1,6 +1,6 @@
-import type { Submission } from '@conform-to/react';
+import { Submission, report } from '@conform-to/react';
 import { conform, parse, useForm } from '@conform-to/react';
-import type { ActionArgs, LoaderArgs } from '@remix-run/node';
+import { ActionArgs, LoaderArgs, json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { Playground, Field } from '~/components';
 import { parseConfig } from '~/config';
@@ -47,13 +47,15 @@ export let action = async ({ request }: ActionArgs) => {
 	const formData = await request.formData();
 	const submission = parseSignupForm(formData);
 
-	return {
-		...submission,
-		value: {
-			email: submission.value.email,
-			// Never send the password back to the client
-		},
-	};
+	return json(
+		report({
+			...submission,
+			value: {
+				email: submission.value.email,
+				// Never send the password back to the client
+			},
+		}),
+	);
 };
 
 export default function SignupForm() {

--- a/playground/app/routes/simple-list.tsx
+++ b/playground/app/routes/simple-list.tsx
@@ -1,4 +1,10 @@
-import { conform, useFieldList, useForm, list } from '@conform-to/react';
+import {
+	conform,
+	useFieldList,
+	useForm,
+	list,
+	report,
+} from '@conform-to/react';
 import { parse } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
@@ -27,8 +33,8 @@ export async function loader({ request }: LoaderArgs) {
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parse(formData, { schema });
-
-	return json(submission);
+	console.log('reporting', report(submission));
+	return json(report(submission));
 }
 
 export default function SimpleList() {
@@ -42,7 +48,7 @@ export default function SimpleList() {
 			: undefined,
 	});
 	const itemsList = useFieldList(form.ref, items.config);
-
+	console.log('state', state);
 	return (
 		<Form method="post" {...form.props}>
 			<Playground title="Simple list" state={state}>

--- a/playground/app/routes/simple-list.tsx
+++ b/playground/app/routes/simple-list.tsx
@@ -1,5 +1,5 @@
-import { conform, parse, useFieldList, useForm, list } from '@conform-to/react';
-import { formatError, validate } from '@conform-to/zod';
+import { conform, useFieldList, useForm, list } from '@conform-to/react';
+import { parse } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
@@ -26,13 +26,7 @@ export async function loader({ request }: LoaderArgs) {
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = parse(formData);
-
-	try {
-		schema.parse(submission.value);
-	} catch (error) {
-		submission.error.push(...formatError(error));
-	}
+	const submission = parse(formData, { schema });
 
 	return json(submission);
 }
@@ -44,7 +38,7 @@ export default function SimpleList() {
 		mode: noClientValidate ? 'server-validation' : 'client-only',
 		state,
 		onValidate: !noClientValidate
-			? ({ formData }) => validate(formData, schema)
+			? ({ formData }) => parse(formData, { schema })
 			: undefined,
 	});
 	const itemsList = useFieldList(form.ref, items.config);

--- a/playground/app/routes/simple-list.tsx
+++ b/playground/app/routes/simple-list.tsx
@@ -1,10 +1,4 @@
-import {
-	conform,
-	useFieldList,
-	useForm,
-	list,
-	report,
-} from '@conform-to/react';
+import { conform, useFieldList, useForm, list } from '@conform-to/react';
 import { parse } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
@@ -33,8 +27,8 @@ export async function loader({ request }: LoaderArgs) {
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parse(formData, { schema });
-	console.log('reporting', report(submission));
-	return json(report(submission));
+
+	return json(submission);
 }
 
 export default function SimpleList() {
@@ -48,7 +42,7 @@ export default function SimpleList() {
 			: undefined,
 	});
 	const itemsList = useFieldList(form.ref, items.config);
-	console.log('state', state);
+
 	return (
 		<Form method="post" {...form.props}>
 			<Playground title="Simple list" state={state}>

--- a/playground/app/routes/simple-list.tsx
+++ b/playground/app/routes/simple-list.tsx
@@ -34,7 +34,7 @@ export async function action({ request }: ActionArgs) {
 export default function SimpleList() {
 	const { noClientValidate } = useLoaderData<typeof loader>();
 	const state = useActionData();
-	const [form, { items }] = useForm<z.infer<typeof schema>>({
+	const [form, { items }] = useForm({
 		mode: noClientValidate ? 'server-validation' : 'client-only',
 		state,
 		onValidate: !noClientValidate

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -20,7 +20,7 @@ const schema = z.object({
 		z.object({
 			content: z.string().min(1, 'Content is required'),
 			completed: z.preprocess(
-				(value) => value === 'yes',
+				(value) => value === 'on',
 				z.boolean().optional(),
 			),
 		}),

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -1,5 +1,5 @@
-import { FieldsetConfig, report } from '@conform-to/react';
 import {
+	type FieldsetConfig,
 	conform,
 	useFieldList,
 	useFieldset,
@@ -36,7 +36,7 @@ export let action = async ({ request }: ActionArgs) => {
 	const formData = await request.formData();
 	const submission = parse(formData, { schema });
 
-	return json(report(submission));
+	return json(submission);
 };
 
 export default function TodosForm() {

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -1,13 +1,12 @@
-import type { FieldsetConfig, Submission } from '@conform-to/react';
+import type { FieldsetConfig } from '@conform-to/react';
 import {
 	conform,
 	useFieldList,
 	useFieldset,
 	useForm,
-	parse,
 	list,
 } from '@conform-to/react';
-import { formatError, getFieldsetConstraint } from '@conform-to/zod';
+import { parse, getFieldsetConstraint } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { useRef } from 'react';
@@ -28,27 +27,13 @@ const schema = z.object({
 	),
 });
 
-type Schema = z.infer<typeof schema>;
-
-function validate(formData: FormData): Submission<Schema> {
-	const submission = parse<Schema>(formData);
-
-	try {
-		schema.parse(submission.value);
-	} catch (error) {
-		submission.error.push(...formatError(error));
-	}
-
-	return submission;
-}
-
 export let loader = async ({ request }: LoaderArgs) => {
 	return parseConfig(request);
 };
 
 export let action = async ({ request }: ActionArgs) => {
 	const formData = await request.formData();
-	const submission = validate(formData);
+	const submission = parse(formData, { schema });
 
 	return submission;
 };
@@ -60,7 +45,7 @@ export default function TodosForm() {
 		...config,
 		state,
 		onValidate: config.validate
-			? ({ formData }) => validate(formData)
+			? ({ formData }) => parse(formData, { schema })
 			: undefined,
 		onSubmit:
 			config.mode === 'server-validation'

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -41,7 +41,7 @@ export let action = async ({ request }: ActionArgs) => {
 export default function TodosForm() {
 	const config = useLoaderData();
 	const state = useActionData();
-	const [form] = useForm<z.infer<typeof schema>>({
+	const [form] = useForm({
 		...config,
 		state,
 		onValidate: config.validate

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -1,4 +1,4 @@
-import type { FieldsetConfig } from '@conform-to/react';
+import { FieldsetConfig, report } from '@conform-to/react';
 import {
 	conform,
 	useFieldList,
@@ -8,6 +8,7 @@ import {
 } from '@conform-to/react';
 import { parse, getFieldsetConstraint } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
+import { json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { useRef } from 'react';
 import { z } from 'zod';
@@ -35,7 +36,7 @@ export let action = async ({ request }: ActionArgs) => {
 	const formData = await request.formData();
 	const submission = parse(formData, { schema });
 
-	return submission;
+	return json(report(submission));
 };
 
 export default function TodosForm() {

--- a/playground/app/routes/validate.tsx
+++ b/playground/app/routes/validate.tsx
@@ -1,4 +1,4 @@
-import { conform, useForm, validate } from '@conform-to/react';
+import { conform, report, useForm, validate } from '@conform-to/react';
 import { parse } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
@@ -23,7 +23,7 @@ export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parse(formData, { schema });
 
-	return json(submission);
+	return json(report(submission));
 }
 
 export default function Validate() {

--- a/playground/app/routes/validate.tsx
+++ b/playground/app/routes/validate.tsx
@@ -1,5 +1,5 @@
-import { conform, parse, useForm, validate } from '@conform-to/react';
-import { formatError, validate as validateSchema } from '@conform-to/zod';
+import { conform, useForm, validate } from '@conform-to/react';
+import { parse } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
@@ -21,13 +21,7 @@ export async function loader({ request }: LoaderArgs) {
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = parse(formData);
-
-	try {
-		schema.parse(submission.value);
-	} catch (error) {
-		submission.error.push(...formatError(error));
-	}
+	const submission = parse(formData, { schema });
 
 	return json(submission);
 }
@@ -39,7 +33,7 @@ export default function Validate() {
 		mode: noClientValidate ? 'server-validation' : 'client-only',
 		state,
 		onValidate: !noClientValidate
-			? ({ formData }) => validateSchema(formData, schema)
+			? ({ formData }) => parse(formData, { schema })
 			: undefined,
 	});
 

--- a/playground/app/routes/validate.tsx
+++ b/playground/app/routes/validate.tsx
@@ -29,7 +29,7 @@ export async function action({ request }: ActionArgs) {
 export default function Validate() {
 	const { noClientValidate } = useLoaderData<typeof loader>();
 	const state = useActionData();
-	const [form, { name, message }] = useForm<z.infer<typeof schema>>({
+	const [form, { name, message }] = useForm({
 		mode: noClientValidate ? 'server-validation' : 'client-only',
 		state,
 		onValidate: !noClientValidate

--- a/playground/app/routes/validate.tsx
+++ b/playground/app/routes/validate.tsx
@@ -1,4 +1,4 @@
-import { conform, report, useForm, validate } from '@conform-to/react';
+import { conform, useForm, validate } from '@conform-to/react';
 import { parse } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
@@ -23,7 +23,7 @@ export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parse(formData, { schema });
 
-	return json(report(submission));
+	return json(submission);
 }
 
 export default function Validate() {

--- a/tests/conform-dom.spec.ts
+++ b/tests/conform-dom.spec.ts
@@ -33,6 +33,7 @@ test.describe('conform-dom', () => {
 					description: 'Once upon a time...',
 				},
 				error: [],
+				toJSON: expect.any(Function),
 			});
 			expect(
 				parse(
@@ -54,6 +55,7 @@ test.describe('conform-dom', () => {
 					reference: '',
 				},
 				error: [],
+				toJSON: expect.any(Function),
 			});
 			expect(
 				parse(
@@ -74,6 +76,7 @@ test.describe('conform-dom', () => {
 					],
 				},
 				error: [],
+				toJSON: expect.any(Function),
 			});
 		});
 
@@ -92,6 +95,7 @@ test.describe('conform-dom', () => {
 					description: 'Once upon a time...',
 				},
 				error: [],
+				toJSON: expect.any(Function),
 			});
 		});
 
@@ -109,6 +113,7 @@ test.describe('conform-dom', () => {
 					title: 'Test command',
 				},
 				error: [],
+				toJSON: expect.any(Function),
 			});
 			expect(
 				parse(
@@ -123,6 +128,7 @@ test.describe('conform-dom', () => {
 					title: '',
 				},
 				error: [],
+				toJSON: expect.any(Function),
 			});
 		});
 
@@ -136,6 +142,7 @@ test.describe('conform-dom', () => {
 					tasks: [{ content: 'Test some stuffs', completed: 'Yes' }],
 				},
 				error: [],
+				toJSON: expect.any(Function),
 			};
 
 			const command1 = list.prepend('tasks');

--- a/tests/conform-dom.spec.ts
+++ b/tests/conform-dom.spec.ts
@@ -28,7 +28,7 @@ test.describe('conform-dom', () => {
 				),
 			).toEqual({
 				intent: 'submit',
-				value: {
+				payload: {
 					title: 'The cat',
 					description: 'Once upon a time...',
 				},
@@ -45,7 +45,7 @@ test.describe('conform-dom', () => {
 				),
 			).toEqual({
 				intent: 'submit',
-				value: {
+				payload: {
 					account: 'AB00 1111 2222 3333 4444',
 					amount: {
 						currency: 'EUR',
@@ -66,7 +66,7 @@ test.describe('conform-dom', () => {
 				),
 			).toEqual({
 				intent: 'submit',
-				value: {
+				payload: {
 					title: '',
 					tasks: [
 						{ content: 'Test some stuffs', completed: 'Yes' },
@@ -87,7 +87,7 @@ test.describe('conform-dom', () => {
 				),
 			).toEqual({
 				intent: 'submit',
-				value: {
+				payload: {
 					title: 'The cat',
 					description: 'Once upon a time...',
 				},
@@ -105,7 +105,7 @@ test.describe('conform-dom', () => {
 				),
 			).toEqual({
 				intent: 'command value',
-				value: {
+				payload: {
 					title: 'Test command',
 				},
 				error: [],
@@ -119,7 +119,7 @@ test.describe('conform-dom', () => {
 				),
 			).toEqual({
 				intent: 'list/helloworld',
-				value: {
+				payload: {
 					title: '',
 				},
 				error: [],
@@ -132,7 +132,7 @@ test.describe('conform-dom', () => {
 				['tasks[0].completed', 'Yes'],
 			];
 			const result = {
-				value: {
+				payload: {
 					tasks: [{ content: 'Test some stuffs', completed: 'Yes' }],
 				},
 				error: [],
@@ -145,8 +145,8 @@ test.describe('conform-dom', () => {
 			).toEqual({
 				...result,
 				intent: command1.value,
-				value: {
-					tasks: [undefined, ...result.value.tasks],
+				payload: {
+					tasks: [undefined, ...result.payload.tasks],
 				},
 			});
 
@@ -159,8 +159,8 @@ test.describe('conform-dom', () => {
 			).toEqual({
 				...result,
 				intent: command2.value,
-				value: {
-					tasks: [{ content: 'Something' }, ...result.value.tasks],
+				payload: {
+					tasks: [{ content: 'Something' }, ...result.payload.tasks],
 				},
 			});
 
@@ -171,8 +171,8 @@ test.describe('conform-dom', () => {
 			).toEqual({
 				...result,
 				intent: command3.value,
-				value: {
-					tasks: [...result.value.tasks, undefined],
+				payload: {
+					tasks: [...result.payload.tasks, undefined],
 				},
 			});
 
@@ -185,8 +185,8 @@ test.describe('conform-dom', () => {
 			).toEqual({
 				...result,
 				intent: command4.value,
-				value: {
-					tasks: [...result.value.tasks, { content: 'Something' }],
+				payload: {
+					tasks: [...result.payload.tasks, { content: 'Something' }],
 				},
 			});
 
@@ -200,7 +200,7 @@ test.describe('conform-dom', () => {
 			).toEqual({
 				...result,
 				intent: command5.value,
-				value: {
+				payload: {
 					tasks: [{ content: 'Something' }],
 				},
 			});
@@ -212,7 +212,7 @@ test.describe('conform-dom', () => {
 			).toEqual({
 				...result,
 				intent: command6.value,
-				value: {
+				payload: {
 					tasks: [],
 				},
 			});
@@ -230,8 +230,8 @@ test.describe('conform-dom', () => {
 			).toEqual({
 				...result,
 				intent: command7.value,
-				value: {
-					tasks: [{ content: 'Test more stuffs' }, ...result.value.tasks],
+				payload: {
+					tasks: [{ content: 'Test more stuffs' }, ...result.payload.tasks],
 				},
 			});
 		});

--- a/tests/conform-yup.spec.ts
+++ b/tests/conform-yup.spec.ts
@@ -114,8 +114,8 @@ test.describe('conform-yup', () => {
 		]);
 		const submission = parse(formData, { schema });
 
-		expect(submission.value).toEqual(value);
+		expect(submission.payload).toEqual(value);
 		expect(submission.error).toEqual(error);
-		expect(submission.data).not.toBeDefined();
+		expect(submission.value).not.toBeDefined();
 	});
 });

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -139,8 +139,8 @@ test.describe('conform-zod', () => {
 		]);
 		const submission = parse(formData, { schema });
 
-		expect(submission.value).toEqual(value);
+		expect(submission.payload).toEqual(value);
 		expect(submission.error).toEqual(error);
-		expect(submission.data).not.toBeDefined();
+		expect(submission.value).not.toBeDefined();
 	});
 });

--- a/tests/integrations/file-upload.spec.ts
+++ b/tests/integrations/file-upload.spec.ts
@@ -81,7 +81,8 @@ async function runValidationScenario(page: Page) {
 	await expect(playground.error).toHaveText(['', '', '']);
 
 	expect(JSON.parse(await playground.submission.innerText())).toMatchObject({
-		value: {
+		intent: 'submit',
+		payload: {
 			file: {
 				_name: 'test.json',
 				_lastModified: expect.anything(),

--- a/tests/integrations/radio-buttons.spec.ts
+++ b/tests/integrations/radio-buttons.spec.ts
@@ -16,7 +16,7 @@ async function runValidationScenario(page: Page) {
 		JSON.stringify(
 			{
 				intent: 'submit',
-				value: {
+				payload: {
 					answer: 'b',
 				},
 				error: [],

--- a/tests/integrations/simple-list.spec.ts
+++ b/tests/integrations/simple-list.spec.ts
@@ -124,9 +124,6 @@ async function runValidationScenario(page: Page) {
 					items: ['Top item', 'First item'],
 				},
 				error: [],
-				data: {
-					items: ['Top item', 'First item'],
-				},
 			},
 			null,
 			2,

--- a/tests/integrations/simple-list.spec.ts
+++ b/tests/integrations/simple-list.spec.ts
@@ -124,6 +124,9 @@ async function runValidationScenario(page: Page) {
 					items: ['Top item', 'First item'],
 				},
 				error: [],
+				data: {
+					items: ['Top item', 'First item'],
+				},
 			},
 			null,
 			2,

--- a/tests/integrations/simple-list.spec.ts
+++ b/tests/integrations/simple-list.spec.ts
@@ -120,7 +120,7 @@ async function runValidationScenario(page: Page) {
 		JSON.stringify(
 			{
 				intent: 'submit',
-				value: {
+				payload: {
 					items: ['Top item', 'First item'],
 				},
 				error: [],

--- a/tests/integrations/validate.spec.ts
+++ b/tests/integrations/validate.spec.ts
@@ -38,7 +38,7 @@ async function runValidationScenario(page: Page) {
 		JSON.stringify(
 			{
 				intent: 'submit',
-				value: {
+				payload: {
 					name: 'Conform',
 					message: 'A form validation library',
 				},

--- a/tests/integrations/validate.spec.ts
+++ b/tests/integrations/validate.spec.ts
@@ -43,6 +43,10 @@ async function runValidationScenario(page: Page) {
 					message: 'A form validation library',
 				},
 				error: [],
+				data: {
+					name: 'Conform',
+					message: 'A form validation library',
+				},
 			},
 			null,
 			2,

--- a/tests/integrations/validate.spec.ts
+++ b/tests/integrations/validate.spec.ts
@@ -43,10 +43,6 @@ async function runValidationScenario(page: Page) {
 					message: 'A form validation library',
 				},
 				error: [],
-				data: {
-					name: 'Conform',
-					message: 'A form validation library',
-				},
 			},
 			null,
 			2,

--- a/tests/react.spec.ts
+++ b/tests/react.spec.ts
@@ -244,6 +244,15 @@ test.describe('Client Validation', () => {
 				timestamp,
 				verified: 'Yes',
 			},
+			data: {
+				iban: 'DE89 3704 0044 0532 0130 00',
+				amount: {
+					currency: 'EUR',
+					value: 1,
+				},
+				timestamp,
+				verified: true,
+			},
 			error: [],
 		});
 	});

--- a/tests/react.spec.ts
+++ b/tests/react.spec.ts
@@ -51,7 +51,7 @@ test.describe('Client Validation', () => {
 
 		expect(await getSubmission(form)).toEqual({
 			intent: 'submit',
-			value: {
+			payload: {
 				title: 'The Dark Knight',
 				description: 'When the menace known as the Joker wreaks havoc...',
 				genre: 'action',
@@ -128,7 +128,7 @@ test.describe('Client Validation', () => {
 		await clickSubmitButton(form);
 		expect(await getSubmission(form)).toEqual({
 			intent: 'submit',
-			value: {
+			payload: {
 				title: 'The Matrix',
 				description:
 					'When a beautiful stranger leads computer hacker Neo to...',
@@ -165,7 +165,7 @@ test.describe('Client Validation', () => {
 
 		expect(await getSubmission(playground)).toEqual({
 			intent: 'submit',
-			value: {
+			payload: {
 				email: 'me@edmund.dev',
 			},
 			error: [],
@@ -235,7 +235,7 @@ test.describe('Client Validation', () => {
 
 		expect(await getSubmission(form)).toEqual({
 			intent: 'submit',
-			value: {
+			payload: {
 				iban: 'DE89 3704 0044 0532 0130 00',
 				amount: {
 					currency: 'EUR',
@@ -307,7 +307,7 @@ test.describe('Client Validation', () => {
 
 		expect(await getSubmission(form)).toEqual({
 			intent: 'submit',
-			value: {
+			payload: {
 				email: '',
 			},
 			error: [
@@ -322,7 +322,7 @@ test.describe('Client Validation', () => {
 
 		expect(await getSubmission(form)).toEqual({
 			intent: 'submit',
-			value: {
+			payload: {
 				email: 'invalid email',
 			},
 			error: [['password', 'Password is required']],
@@ -422,7 +422,7 @@ test.describe('Server Validation', () => {
 				status: 200,
 				contentType: 'application/json',
 				body: JSON.stringify({
-					value: {},
+					payload: {},
 					error: [['', 'Request forbidden']],
 				}),
 			});
@@ -656,7 +656,7 @@ test.describe('Field list', () => {
 
 		expect(await getSubmission(form)).toEqual({
 			intent: 'submit',
-			value: {
+			payload: {
 				title: 'My schedule',
 				tasks: [
 					{ content: 'Urgent task' },
@@ -723,7 +723,7 @@ test.describe('Field list', () => {
 
 		expect(await getSubmission(form)).toEqual({
 			intent: 'submit',
-			value: {
+			payload: {
 				title: 'Testing plan',
 				tasks: [
 					{ content: 'Write even more tests' },

--- a/tests/react.spec.ts
+++ b/tests/react.spec.ts
@@ -244,15 +244,6 @@ test.describe('Client Validation', () => {
 				timestamp,
 				verified: 'Yes',
 			},
-			data: {
-				iban: 'DE89 3704 0044 0532 0130 00',
-				amount: {
-					currency: 'EUR',
-					value: 1,
-				},
-				timestamp,
-				verified: true,
-			},
 			error: [],
 		});
 	});
@@ -674,14 +665,6 @@ test.describe('Field list', () => {
 				],
 			},
 			error: [],
-			data: {
-				title: 'My schedule',
-				tasks: [
-					{ content: 'Urgent task', completed: false },
-					{ content: 'Daily task', completed: false },
-					{ content: 'Ad hoc task', completed: false },
-				],
-			},
 		});
 	});
 
@@ -748,13 +731,6 @@ test.describe('Field list', () => {
 				],
 			},
 			error: [],
-			data: {
-				title: 'Testing plan',
-				tasks: [
-					{ content: 'Write even more tests', completed: false },
-					{ content: 'Write tests for nested list', completed: true },
-				],
-			},
 		});
 	});
 

--- a/tests/react.spec.ts
+++ b/tests/react.spec.ts
@@ -674,6 +674,14 @@ test.describe('Field list', () => {
 				],
 			},
 			error: [],
+			data: {
+				title: 'My schedule',
+				tasks: [
+					{ content: 'Urgent task', completed: false },
+					{ content: 'Daily task', completed: false },
+					{ content: 'Ad hoc task', completed: false },
+				],
+			},
 		});
 	});
 
@@ -740,6 +748,13 @@ test.describe('Field list', () => {
 				],
 			},
 			error: [],
+			data: {
+				title: 'Testing plan',
+				tasks: [
+					{ content: 'Write even more tests', completed: false },
+					{ content: 'Write tests for nested list', completed: true },
+				],
+			},
 		});
 	});
 


### PR DESCRIPTION
> This PR includes breaking changes

This replaces the current `validate` and `formatError` helper with a `parse` helper that wrap both the base `parse` function from `@conform-to/react` with validation error set by validating it with the schema.

```tsx
import { parse } from '@conform-to/zod';

export async function action({ request }: ActionArgs) {
    const formData = await request.formData();
    const submission = parse(formData, { schema });

    if (!submission.value || submission.intent !== 'submit') {
        return json(submission);
    }

    // ...
}

export default function SignupForm() {
    const [form, fieldset] = useForm({
        onValidate({ formData }) {
            return parse(formData, { schema });
        },
        // ...
    });

    // ...
}
```