### PR TITLE
feat!: multiple errors support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ function parseLoginForm(formData: FormData) {
   const submission = parse(formData);
 
   if (!submission.payload.email) {
-    submission.error.push(['email', 'Email is required']);
+    submission.error.email = 'Email is required';
   } else if (!email.includes('@')) {
-    submission.error.push(['email', 'Email is invalid']);
+    submission.error.email = 'Email is invalid';
   }
 
   if (!password) {
-    submission.error.push(['password', 'Password is required']);
+    submission.error.password = 'Password is required';
   }
 
   return submission;

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -113,13 +113,13 @@ export async function action({ request }: ActionArgs) {
   // The value will now be available as `submission.payload`
   if (!submission.payload.email) {
     // Define the error as key-value pair instead
-    submission.error.push(['email', 'Email is required']);
+    submission.error.email = 'Email is required';
   } else if (!email.includes('@')) {
-    submission.error.push(['email', 'Email is invalid']);
+    submission.error.email = 'Email is invalid';
   }
 
   if (!password) {
-    submission.error.push(['password', 'Password is required']);
+    submission.error.password = 'Password is required';
   }
 
   // Just check if any error exists
@@ -201,13 +201,13 @@ function parseForm(formData: FormData) {
   const submission = parse(formData);
 
   if (!submission.payload.email) {
-    submission.error.push(['email', 'Email is required']);
+    submission.error.email = 'Email is required';
   } else if (!email.includes('@')) {
-    submission.error.push(['email', 'Email is invalid']);
+    submission.error.email = 'Email is invalid';
   }
 
   if (!password) {
-    submission.error.push(['password', 'Password is required']);
+    submission.error.password = 'Password is required';
   }
 
   return submission;

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -54,21 +54,21 @@ export async function action({ request }: ActionArgs) {
   const submission = parse<SignupForm>(formData);
 
   if (!submission.payload.email) {
-    submission.error.push(['email', 'Email is required']);
+    submission.error.email = 'Email is required';
   } else if (!submission.payload.email.includes('@')) {
-    submission.error.push(['email', 'Email is invalid']);
+    submission.error.email = 'Email is invalid';
   }
 
   if (!submission.payload.password) {
-    submission.error.push(['password', 'Password is required']);
+    submission.error.password = 'Password is required';
   }
 
   if (!submission.payload.confirmPassword) {
-    submission.error.push(['confirmPassword', 'Confirm password is required']);
+    submission.error.confirmPassword = 'Confirm password is required';
   } else if (
     submission.payload.confirmPassword !== submission.payload.password
   ) {
-    submission.error.push(['confirmPassword', 'Password does not match']);
+    submission.error.confirmPassword = 'Password does not match';
   }
 
   if (hasError(submission.error) || submission.intent !== 'submit') {

--- a/examples/async-validation/app/routes/index.tsx
+++ b/examples/async-validation/app/routes/index.tsx
@@ -79,7 +79,7 @@ export default function Signup() {
 			// Only the email field requires additional validation from the server
 			// We trust the client submission result otherwise
 			if (submission.intent === 'validate/username') {
-				return !hasError(submission.error, 'username');
+				return !submission.error.username;
 			}
 
 			return defaultShouldPassthrough;

--- a/examples/server-validation/app/routes/index.tsx
+++ b/examples/server-validation/app/routes/index.tsx
@@ -13,30 +13,34 @@ export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parse(formData, {
 		resolve({ email, password, confirmPassword }) {
-			const error: Array<[string, string]> = [];
+			const error: Record<string, string> = {};
 
 			if (!email) {
-				error.push(['email', 'Email is required']);
+				error.email = 'Email is required';
 			} else if (!email.includes('@')) {
-				error.push(['email', 'Email is invalid']);
+				error.email = 'Email is invalid';
 			}
 
 			if (!password) {
-				error.push(['password', 'Password is required']);
+				error.password = 'Password is required';
 			}
 
 			if (!confirmPassword) {
-				error.push(['confirmPassword', 'Confirm password is required']);
+				error.confirmPassword = 'Confirm password is required';
 			} else if (confirmPassword !== password) {
-				error.push(['confirmPassword', 'Password does not match']);
+				error.confirmPassword = 'Password does not match';
 			}
 
-			if (error.length > 0) {
+			if (error.email || error.password || error.confirmPassword) {
 				return { error };
 			}
 
 			return {
-				value: { email, password, confirmPassword },
+				value: {
+					email,
+					password,
+					confirmPassword,
+				},
 			};
 		},
 	});

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -40,28 +40,34 @@ export type FieldsetConstraint<Schema extends Record<string, any>> = {
 	[Key in keyof Schema]?: FieldConstraint<Schema[Key]>;
 };
 
+// type Join<K, P> = P extends string | number ?
+//     K extends string | number ?
+//     `${K}${"" extends P ? "" : "."}${P}`
+//     : never : never;
+
+// type DottedPaths<T> = T extends object ?
+//     { [K in keyof T]-?: K extends string | number ?
+//         `${K}` | Join<K, DottedPaths<T[K]>>
+//         : never
+//     }[keyof T] : ""
+
+// type Pathfix<T> = T extends `${infer Prefix}.${number}${infer Postfix}` ? `${Prefix}[${number}]${Pathfix<Postfix>}` : T;
+
+// type Path<Schema> = Pathfix<DottedPaths<Schema>> | '';
+
 export type Submission<Schema extends Record<string, any> | unknown = unknown> =
 	unknown extends Schema
 		? {
 				intent: string;
 				payload: Record<string, any>;
-				error: Array<[string, string]>;
-				toJSON(): {
-					intent: string;
-					payload: Record<string, any>;
-					error: Array<[string, string]>;
-				};
+				error: Record<string, string | string[]>;
 		  }
 		: {
 				intent: string;
 				payload: Record<string, any>;
 				value?: Schema;
-				error: Array<[string, string]>;
-				toJSON(): {
-					intent: string;
-					payload: Record<string, any>;
-					error: Array<[string, string]>;
-				};
+				error: Record<string, string | string[]>;
+				toJSON(): Submission;
 		  };
 
 export interface IntentButtonProps {
@@ -144,23 +150,10 @@ export function shouldValidate(intent: string, name: string): boolean {
 	}
 }
 
-export function hasError(
-	error: Array<[string, string]>,
-	name?: string,
-): boolean {
-	return (
-		typeof error.find(
-			([fieldName, message]) =>
-				(typeof name === 'undefined' || name === fieldName) && message !== '',
-		) !== 'undefined'
-	);
-}
-
 export function reportSubmission(
 	form: HTMLFormElement,
 	submission: Submission,
 ): void {
-	const messageByName: Map<string, string> = new Map();
 	const listCommand = parseListCommand(submission.intent);
 
 	if (listCommand) {
@@ -171,47 +164,45 @@ export function reportSubmission(
 		);
 	}
 
-	for (const [name, message] of submission.error) {
+	for (const name of Object.keys(submission.error)) {
 		if (listCommand !== null && name !== listCommand.scope) {
 			// Skip if not matching the scope
 			continue;
 		}
 
-		if (!messageByName.has(name)) {
-			// Only keep the first error message (for now)
-			messageByName.set(name, message);
+		// We can't use empty string as button name
+		// As `form.element.namedItem('')` will always returns null
+		const elementName = name ? name : '__form__';
+		let item = form.elements.namedItem(elementName);
 
-			// We can't use empty string as button name
-			// As `form.element.namedItem('')` will always returns null
-			const elementName = name ? name : '__form__';
-			let item = form.elements.namedItem(elementName);
-
-			if (item instanceof RadioNodeList) {
-				for (const field of item) {
-					if ((field as FieldElement).type !== 'radio') {
-						throw new Error('Repeated field name is not supported');
-					}
+		if (item instanceof RadioNodeList) {
+			for (const field of item) {
+				if ((field as FieldElement).type !== 'radio') {
+					throw new Error('Repeated field name is not supported');
 				}
 			}
+		}
 
-			if (item === null) {
-				// Create placeholder button to keep the error without contributing to the form data
-				const button = document.createElement('button');
+		if (item === null) {
+			// Create placeholder button to keep the error without contributing to the form data
+			const button = document.createElement('button');
 
-				button.name = elementName;
-				button.hidden = true;
-				button.dataset.conformTouched = 'true';
-				item = button;
+			button.name = elementName;
+			button.hidden = true;
+			button.dataset.conformTouched = 'true';
+			item = button;
 
-				form.appendChild(button);
-			}
+			form.appendChild(button);
 		}
 	}
 
 	for (const element of form.elements) {
 		if (isFieldElement(element) && element.willValidate) {
 			const elementName = element.name !== '__form__' ? element.name : '';
-			const message = messageByName.get(elementName);
+			const message =
+				listCommand !== null && elementName !== listCommand.scope
+					? undefined
+					: submission.error[elementName];
 			const elementShouldValidate = shouldValidate(
 				submission.intent,
 				elementName,
@@ -224,7 +215,9 @@ export function reportSubmission(
 			if (typeof message !== 'undefined' || elementShouldValidate) {
 				const invalidEvent = new Event('invalid', { cancelable: true });
 
-				element.setCustomValidity(message ?? '');
+				element.setCustomValidity(
+					([] as string[]).concat(message ?? []).join(String.fromCharCode(31)),
+				);
 				element.dispatchEvent(invalidEvent);
 			}
 
@@ -358,7 +351,7 @@ export function parse<Schema>(
 		resolve: (
 			payload: Record<string, any>,
 			intent: string,
-		) => { value: Schema } | { error: Array<[string, string]> };
+		) => { value: Schema } | { error: Record<string, string | string[]> };
 	},
 ): Submission<Schema>;
 export function parse<Schema>(
@@ -367,7 +360,9 @@ export function parse<Schema>(
 		resolve: (
 			payload: Record<string, any>,
 			intent: string,
-		) => Promise<{ value: Schema } | { error: Array<[string, string]> }>;
+		) => Promise<
+			{ value: Schema } | { error: Record<string, string | string[]> }
+		>;
 	},
 ): Promise<Submission<Schema>>;
 export function parse<Schema>(
@@ -377,8 +372,10 @@ export function parse<Schema>(
 			payload: Record<string, any>,
 			intent: string,
 		) =>
-			| ({ value: Schema } | { error: Array<[string, string]> })
-			| Promise<{ value: Schema } | { error: Array<[string, string]> }>;
+			| ({ value: Schema } | { error: Record<string, string | string[]> })
+			| Promise<
+					{ value: Schema } | { error: Record<string, string | string[]> }
+			  >;
 	},
 ): Submission<Schema> | Promise<Submission<Schema>>;
 export function parse<Schema>(
@@ -388,21 +385,16 @@ export function parse<Schema>(
 			payload: Record<string, any>,
 			intent: string,
 		) =>
-			| ({ value: Schema } | { error: Array<[string, string]> })
-			| Promise<{ value: Schema } | { error: Array<[string, string]> }>;
+			| ({ value: Schema } | { error: Record<string, string | string[]> })
+			| Promise<
+					{ value: Schema } | { error: Record<string, string | string[]> }
+			  >;
 	},
 ): Submission<Schema> | Promise<Submission<Schema>> {
 	const submission: Submission = {
 		intent: 'submit',
 		payload: {},
-		error: [],
-		toJSON() {
-			return {
-				intent: this.intent,
-				payload: this.payload,
-				error: this.error,
-			};
-		},
+		error: {},
 	};
 
 	for (let [name, value] of payload.entries()) {
@@ -442,14 +434,25 @@ export function parse<Schema>(
 	}
 
 	const result = options.resolve(submission.payload, submission.intent);
+	const mergeResolveResult = (
+		result: { error: Record<string, string | string[]> } | { value: Schema },
+	) => ({
+		...submission,
+		...result,
+		toJSON() {
+			return {
+				intent: this.intent,
+				payload: this.payload,
+				error: this.error,
+			};
+		},
+	});
 
 	if (result instanceof Promise) {
-		return result.then<Submission<Schema>>((resolved) =>
-			Object.assign(submission, resolved),
-		);
+		return result.then<Submission<Schema>>(mergeResolveResult);
 	}
 
-	return Object.assign(submission, result) as Submission<Schema>;
+	return mergeResolveResult(result);
 }
 
 export type ListCommand<Schema = unknown> =

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -10,7 +10,7 @@ export interface FieldConfig<Schema = unknown> extends FieldConstraint<Schema> {
 	id?: string;
 	name: string;
 	defaultValue?: FieldValue<Schema>;
-	initialError?: Array<[string, string]>;
+	initialError?: Record<string, string | string[]>;
 	form?: string;
 	errorId?: string;
 }
@@ -150,6 +150,14 @@ export function shouldValidate(intent: string, name: string): boolean {
 	}
 }
 
+export function getValidationMessage(errors?: string | string[]): string {
+	return ([] as string[]).concat(errors ?? []).join(String.fromCharCode(31));
+}
+
+export function getErrors(message: string | undefined): string[] {
+	return message?.split(String.fromCharCode(31)) ?? [];
+}
+
 export function reportSubmission(
 	form: HTMLFormElement,
 	submission: Submission,
@@ -207,9 +215,7 @@ export function reportSubmission(
 			if (typeof message !== 'undefined' || elementShouldValidate) {
 				const invalidEvent = new Event('invalid', { cancelable: true });
 
-				element.setCustomValidity(
-					([] as string[]).concat(message ?? []).join(String.fromCharCode(31)),
-				);
+				element.setCustomValidity(getValidationMessage(message));
 				element.dispatchEvent(invalidEvent);
 			}
 

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -155,7 +155,11 @@ export function getValidationMessage(errors?: string | string[]): string {
 }
 
 export function getErrors(message: string | undefined): string[] {
-	return message?.split(String.fromCharCode(31)) ?? [];
+	if (!message) {
+		return [];
+	}
+
+	return message.split(String.fromCharCode(31));
 }
 
 export function reportSubmission(

--- a/packages/conform-react/README.md
+++ b/packages/conform-react/README.md
@@ -572,27 +572,6 @@ export default function LoginForm() {
 
 ---
 
-### hasError
-
-This helper checks if there is any message defined in error array with the provided name.
-
-```ts
-import { hasError } from '@conform-to/react';
-
-/**
- * Assume the error looks like this:
- */
-const error = [['email', 'Email is required']];
-
-// This will log `true`
-console.log(hasError(error, 'email'));
-
-// This will log `false`
-console.log(hasError(error, 'password'));
-```
-
----
-
 ### parse
 
 It parses the formData based on the [naming convention](/docs/submission).

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -102,7 +102,7 @@ export function input<Schema>(
 		attributes['aria-hidden'] = true;
 	}
 
-	if (config.initialError && config.initialError.length > 0) {
+	if (config.initialError && Object.entries(config.initialError).length > 0) {
 		attributes.autoFocus = true;
 	}
 
@@ -141,7 +141,7 @@ export function select<Schema>(
 		attributes['aria-hidden'] = true;
 	}
 
-	if (config.initialError && config.initialError.length > 0) {
+	if (config.initialError && Object.entries(config.initialError).length > 0) {
 		attributes.autoFocus = true;
 	}
 
@@ -171,7 +171,7 @@ export function textarea<Schema>(
 		attributes['aria-hidden'] = true;
 	}
 
-	if (config.initialError && config.initialError.length > 0) {
+	if (config.initialError && Object.entries(config.initialError).length > 0) {
 		attributes.autoFocus = true;
 	}
 

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -320,7 +320,10 @@ export function useForm<
 					const formData = getFormData(form, submitter);
 					const onValidate =
 						config.onValidate ??
-						((context) => parse(context.formData) as ClientSubmission);
+						((context) =>
+							parse(context.formData, {
+								resolve: () => ({ error: [] }),
+							}) as ClientSubmission);
 					const submission = onValidate({ form, formData });
 					const defaultShouldPassthrough =
 						typeof config.onValidate !== 'function' ||

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -3,7 +3,6 @@ export {
 	type FieldsetConstraint,
 	type Submission,
 	getFormElements,
-	hasError,
 	list,
 	validate,
 	requestIntent,

--- a/packages/conform-yup/index.ts
+++ b/packages/conform-yup/index.ts
@@ -120,11 +120,18 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 			const resolveError = (error: unknown) => {
 				if (error instanceof yup.ValidationError) {
 					return {
-						error: error.inner.reduce<Array<[string, string]>>((result, e) => {
-							result.push([e.path ?? '', e.message]);
+						error: error.inner.reduce<Record<string, string | string[]>>(
+							(result, e) => {
+								const name = e.path ?? '';
 
-							return result;
-						}, []),
+								if (typeof result[name] === 'undefined') {
+									result[name] = e.message;
+								}
+
+								return result;
+							},
+							{},
+						),
 					};
 				}
 

--- a/packages/conform-yup/index.ts
+++ b/packages/conform-yup/index.ts
@@ -91,6 +91,7 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
+		acceptMultipleErrors?: (name: string) => boolean;
 		async?: false;
 	},
 ): Submission<yup.InferType<Schema>>;
@@ -98,6 +99,7 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
+		acceptMultipleErrors?: (name: string) => boolean;
 		async: true;
 	},
 ): Promise<Submission<yup.InferType<Schema>>>;
@@ -105,6 +107,7 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
+		acceptMultipleErrors?: (name: string) => boolean;
 		async?: boolean;
 	},
 ):
@@ -126,6 +129,11 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 
 								if (typeof result[name] === 'undefined') {
 									result[name] = e.message;
+								} else if (config.acceptMultipleErrors?.(name)) {
+									result[name] = ([] as string[]).concat(
+										result[name],
+										e.message,
+									);
 								}
 
 								return result;

--- a/packages/conform-yup/index.ts
+++ b/packages/conform-yup/index.ts
@@ -110,46 +110,43 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 ):
 	| Submission<yup.InferType<Schema>>
 	| Promise<Submission<yup.InferType<Schema>>> {
-	const submission = baseParse(payload);
-	const schema =
-		typeof config.schema === 'function'
-			? config.schema(submission.intent)
-			: config.schema;
-	const resolveData = (value: yup.InferType<Schema>) => ({
-		...submission,
-		value,
-	});
-	const resolveError = (error: unknown) => {
-		if (error instanceof yup.ValidationError) {
-			return {
-				...submission,
-				error: submission.error.concat(
-					error.inner.reduce<Array<[string, string]>>((result, e) => {
-						result.push([e.path ?? '', e.message]);
+	return baseParse<Submission<yup.InferType<Schema>>>(payload, {
+		resolve(payload, intent) {
+			const schema =
+				typeof config.schema === 'function'
+					? config.schema(intent)
+					: config.schema;
+			const resolveData = (value: yup.InferType<Schema>) => ({ value });
+			const resolveError = (error: unknown) => {
+				if (error instanceof yup.ValidationError) {
+					return {
+						error: error.inner.reduce<Array<[string, string]>>((result, e) => {
+							result.push([e.path ?? '', e.message]);
 
-						return result;
-					}, []),
-				),
+							return result;
+						}, []),
+					};
+				}
+
+				throw error;
 			};
-		}
 
-		throw error;
-	};
+			if (!config.async) {
+				try {
+					const data = schema.validateSync(payload, {
+						abortEarly: false,
+					});
 
-	if (!config.async) {
-		try {
-			const data = schema.validateSync(submission.payload, {
-				abortEarly: false,
-			});
+					return resolveData(data);
+				} catch (error) {
+					return resolveError(error);
+				}
+			}
 
-			return resolveData(data);
-		} catch (error) {
-			return resolveError(error);
-		}
-	}
-
-	return schema
-		.validate(submission.payload, { abortEarly: false })
-		.then(resolveData)
-		.catch(resolveError);
+			return schema
+				.validate(payload, { abortEarly: false })
+				.then(resolveData)
+				.catch(resolveError);
+		},
+	});
 }

--- a/packages/conform-yup/index.ts
+++ b/packages/conform-yup/index.ts
@@ -91,7 +91,15 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
-		acceptMultipleErrors?: (name: string) => boolean;
+		acceptMultipleErrors?: ({
+			name,
+			intent,
+			payload,
+		}: {
+			name: string;
+			intent: string;
+			payload: Record<string, any>;
+		}) => boolean;
 		async?: false;
 	},
 ): Submission<yup.InferType<Schema>>;
@@ -99,7 +107,15 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
-		acceptMultipleErrors?: (name: string) => boolean;
+		acceptMultipleErrors?: ({
+			name,
+			intent,
+			payload,
+		}: {
+			name: string;
+			intent: string;
+			payload: Record<string, any>;
+		}) => boolean;
 		async: true;
 	},
 ): Promise<Submission<yup.InferType<Schema>>>;
@@ -107,7 +123,15 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
-		acceptMultipleErrors?: (name: string) => boolean;
+		acceptMultipleErrors?: ({
+			name,
+			intent,
+			payload,
+		}: {
+			name: string;
+			intent: string;
+			payload: Record<string, any>;
+		}) => boolean;
 		async?: boolean;
 	},
 ):
@@ -129,7 +153,9 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 
 								if (typeof result[name] === 'undefined') {
 									result[name] = e.message;
-								} else if (config.acceptMultipleErrors?.(name)) {
+								} else if (
+									config.acceptMultipleErrors?.({ name, intent, payload })
+								) {
 									result[name] = ([] as string[]).concat(
 										result[name],
 										e.message,

--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -114,7 +114,15 @@ export function parse<Schema extends z.ZodTypeAny>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
-		acceptMultipleErrors?: (name: string) => boolean;
+		acceptMultipleErrors?: ({
+			name,
+			intent,
+			payload,
+		}: {
+			name: string;
+			intent: string;
+			payload: Record<string, any>;
+		}) => boolean;
 		async?: false;
 	},
 ): Submission<z.output<Schema>>;
@@ -122,7 +130,15 @@ export function parse<Schema extends z.ZodTypeAny>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
-		acceptMultipleErrors?: (name: string) => boolean;
+		acceptMultipleErrors?: ({
+			name,
+			intent,
+			payload,
+		}: {
+			name: string;
+			intent: string;
+			payload: Record<string, any>;
+		}) => boolean;
 		async: true;
 	},
 ): Promise<Submission<z.output<Schema>>>;
@@ -130,7 +146,15 @@ export function parse<Schema extends z.ZodTypeAny>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
-		acceptMultipleErrors?: (name: string) => boolean;
+		acceptMultipleErrors?: ({
+			name,
+			intent,
+			payload,
+		}: {
+			name: string;
+			intent: string;
+			payload: Record<string, any>;
+		}) => boolean;
 		async?: boolean;
 	},
 ): Submission<z.output<Schema>> | Promise<Submission<z.output<Schema>>> {
@@ -158,7 +182,9 @@ export function parse<Schema extends z.ZodTypeAny>(
 
 							if (typeof result[name] === 'undefined') {
 								result[name] = e.message;
-							} else if (config.acceptMultipleErrors?.(name)) {
+							} else if (
+								config.acceptMultipleErrors?.({ name, intent, payload })
+							) {
 								result[name] = ([] as string[]).concat(result[name], e.message);
 							}
 

--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -139,7 +139,9 @@ export function parse<Schema extends z.ZodTypeAny>(
 					: config.schema;
 			const resolveResult = (
 				result: z.SafeParseReturnType<z.input<Schema>, z.output<Schema>>,
-			): { value: z.output<Schema> } | { error: Array<[string, string]> } => {
+			):
+				| { value: z.output<Schema> }
+				| { error: Record<string, string | string[]> } => {
 				if (result.success) {
 					return {
 						value: result.data,
@@ -147,13 +149,17 @@ export function parse<Schema extends z.ZodTypeAny>(
 				}
 
 				return {
-					error: result.error.errors.reduce<Array<[string, string]>>(
+					error: result.error.errors.reduce<Record<string, string | string[]>>(
 						(result, e) => {
-							result.push([getName(e.path), e.message]);
+							const name = getName(e.path);
+
+							if (typeof result[name] === 'undefined') {
+								result[name] = e.message;
+							}
 
 							return result;
 						},
-						[],
+						{},
 					),
 				};
 			};

--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -114,6 +114,7 @@ export function parse<Schema extends z.ZodTypeAny>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
+		acceptMultipleErrors?: (name: string) => boolean;
 		async?: false;
 	},
 ): Submission<z.output<Schema>>;
@@ -121,6 +122,7 @@ export function parse<Schema extends z.ZodTypeAny>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
+		acceptMultipleErrors?: (name: string) => boolean;
 		async: true;
 	},
 ): Promise<Submission<z.output<Schema>>>;
@@ -128,6 +130,7 @@ export function parse<Schema extends z.ZodTypeAny>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: string) => Schema);
+		acceptMultipleErrors?: (name: string) => boolean;
 		async?: boolean;
 	},
 ): Submission<z.output<Schema>> | Promise<Submission<z.output<Schema>>> {
@@ -155,6 +158,8 @@ export function parse<Schema extends z.ZodTypeAny>(
 
 							if (typeof result[name] === 'undefined') {
 								result[name] = e.message;
+							} else if (config.acceptMultipleErrors?.(name)) {
+								result[name] = ([] as string[]).concat(result[name], e.message);
 							}
 
 							return result;

--- a/playground/app/components.tsx
+++ b/playground/app/components.tsx
@@ -82,12 +82,12 @@ export function Playground({
 interface FieldProps {
 	label: string;
 	inline?: boolean;
-	error?: string;
+	errors?: string[];
 	config?: FieldConfig<any>;
 	children: ReactNode;
 }
 
-export function Field({ label, inline, error, config, children }: FieldProps) {
+export function Field({ label, inline, errors, config, children }: FieldProps) {
 	return (
 		<div className="mb-4">
 			<div
@@ -105,9 +105,17 @@ export function Field({ label, inline, error, config, children }: FieldProps) {
 				</label>
 				{children}
 			</div>
-			<p id={config?.errorId} className="my-1 text-pink-600 text-sm">
-				{error}
-			</p>
+			<div id={config?.errorId} className="my-1 space-y-0.5">
+				{!errors || errors.length === 0 ? (
+					<p className="text-pink-600 text-sm" />
+				) : (
+					errors.map((message) => (
+						<p className="text-pink-600 text-sm" key={message}>
+							{message}
+						</p>
+					))
+				)}
+			</div>
 		</div>
 	);
 }

--- a/playground/app/routes/attributes.tsx
+++ b/playground/app/routes/attributes.tsx
@@ -12,7 +12,7 @@ interface Schema {
 }
 
 export default function Example() {
-	const [state, setState] = useState<Submission<Schema> | undefined>();
+	const [state, setState] = useState<Submission | undefined>();
 	const [form, { title, description, images, rating, tags }] = useForm<Schema>({
 		id: 'test',
 		constraint: {

--- a/playground/app/routes/employee.tsx
+++ b/playground/app/routes/employee.tsx
@@ -1,4 +1,4 @@
-import { conform, hasError, shouldValidate, useForm } from '@conform-to/react';
+import { conform, shouldValidate, useForm } from '@conform-to/react';
 import { parse } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
@@ -52,7 +52,7 @@ export default function EmployeeForm() {
 		state,
 		shouldSubmissionPassthrough({ submission, defaultShouldPassthrough }) {
 			if (submission.intent === 'validate/email') {
-				return !hasError(submission.error, 'email');
+				return !submission.error.email;
 			}
 
 			return defaultShouldPassthrough;

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -1,4 +1,4 @@
-import { type Submission, conform, useForm, parse } from '@conform-to/react';
+import { conform, useForm, parse } from '@conform-to/react';
 import { type ActionArgs, type LoaderArgs, json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { useId } from 'react';
@@ -10,20 +10,20 @@ interface Login {
 	password: string;
 }
 
-function parseLoginForm(formData: FormData): Submission {
+function parseLoginForm(formData: FormData) {
 	return parse(formData, {
 		resolve({ email, password }) {
-			const error: Array<[string, string]> = [];
+			const error: Record<string, string> = {};
 
 			if (!email) {
-				error.push(['email', 'Email is required']);
+				error.email = 'Email is required';
 			}
 
 			if (!password) {
-				error.push(['password', 'Password is required']);
+				error.password = 'Password is required';
 			}
 
-			if (error.length > 0) {
+			if (error.email || error.password) {
 				return { error };
 			}
 
@@ -46,11 +46,11 @@ export let action = async ({ request }: ActionArgs) => {
 	const submission = parseLoginForm(formData);
 
 	if (
-		submission.error.length === 0 &&
-		(submission.payload.email !== 'me@edmund.dev' ||
-			submission.payload.password !== '$eCreTP@ssWord')
+		submission.value &&
+		(submission.value.email !== 'me@edmund.dev' ||
+			submission.value.password !== '$eCreTP@ssWord')
 	) {
-		submission.error.push(['', 'The provided email or password is not valid']);
+		submission.error[''] = 'The provided email or password is not valid';
 	}
 
 	return json({

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -11,17 +11,30 @@ interface Login {
 }
 
 function parseLoginForm(formData: FormData): Submission {
-	const submission = parse(formData);
+	return parse(formData, {
+		resolve({ email, password }) {
+			const error: Array<[string, string]> = [];
 
-	if (!submission.payload.email) {
-		submission.error.push(['email', 'Email is required']);
-	}
+			if (!email) {
+				error.push(['email', 'Email is required']);
+			}
 
-	if (!submission.payload.password) {
-		submission.error.push(['password', 'Password is required']);
-	}
+			if (!password) {
+				error.push(['password', 'Password is required']);
+			}
 
-	return submission;
+			if (error.length > 0) {
+				return { error };
+			}
+
+			return {
+				value: {
+					email,
+					password,
+				},
+			};
+		},
+	});
 }
 
 export let loader = async ({ request }: LoaderArgs) => {

--- a/playground/app/routes/movie.tsx
+++ b/playground/app/routes/movie.tsx
@@ -19,27 +19,27 @@ export let action = async ({ request }: ActionArgs) => {
 	const formData = await request.formData();
 	const submission = parse(formData, {
 		resolve({ title, description, genre, rating }) {
-			const error: Array<[string, string]> = [];
+			const error: Record<string, string> = {};
 
 			if (!title) {
-				error.push(['title', 'Title is required']);
+				error.title = 'Title is required';
 			} else if (!title.match(/[0-9a-zA-Z ]{1,20}/)) {
-				error.push(['title', 'Please enter a valid title']);
+				error.title = 'Please enter a valid title';
 			}
 
 			if (description && description.length < 30) {
-				error.push(['description', 'Please provides more details']);
+				error.description = 'Please provides more details';
 			}
 
 			if (genre === '') {
-				error.push(['genre', 'Genre is required']);
+				error.genre = 'Genre is required';
 			}
 
 			if (rating && Number(rating) % 0.5 !== 0) {
-				error.push(['rating', 'The provided rating is invalid']);
+				error.rating = 'The provided rating is invalid';
 			}
 
-			if (error.length > 0) {
+			if (error.title || error.description || error.genre || error.rating) {
 				return { error };
 			}
 
@@ -93,42 +93,41 @@ export default function MovieForm() {
 			? ({ form, formData }) => {
 					const submission = parse(formData, {
 						resolve({ title, description, genre, rating }) {
-							const error: Array<[string, string]> = [];
+							const error: Record<string, string> = {};
 
 							for (const element of getFormElements(form)) {
 								switch (element.name) {
 									case 'title':
 										if (element.validity.valueMissing) {
-											error.push([element.name, 'Title is required']);
+											error[element.name] = 'Title is required';
 										} else if (element.validity.patternMismatch) {
-											error.push([element.name, 'Please enter a valid title']);
+											error[element.name] = 'Please enter a valid title';
 										}
 										break;
 									case 'description':
 										if (element.validity.tooShort) {
-											error.push([
-												element.name,
-												'Please provides more details',
-											]);
+											error[element.name] = 'Please provides more details';
 										}
 										break;
 									case 'genre':
 										if (element.validity.valueMissing) {
-											error.push([element.name, 'Genre is required']);
+											error[element.name] = 'Genre is required';
 										}
 										break;
 									case 'rating':
 										if (element.validity.stepMismatch) {
-											error.push([
-												element.name,
-												'The provided rating is invalid',
-											]);
+											error[element.name] = 'The provided rating is invalid';
 										}
 										break;
 								}
 							}
 
-							if (error.length > 0) {
+							if (
+								error.title ||
+								error.description ||
+								error.genre ||
+								error.rating
+							) {
 								return { error };
 							}
 

--- a/playground/app/routes/multiple-errors.tsx
+++ b/playground/app/routes/multiple-errors.tsx
@@ -1,52 +1,120 @@
 import { conform, parse, useForm } from '@conform-to/react';
+import { parse as parseWithZod } from '@conform-to/zod';
+import { parse as parseWithYup } from '@conform-to/yup';
 import { type LoaderArgs, type ActionArgs, json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { Playground, Field } from '~/components';
+import { z } from 'zod';
+import * as yup from 'yup';
 
 interface Schema {
 	username: string;
 }
 
-function parseForm(formData: FormData) {
-	return parse(formData, {
-		resolve({ username }) {
-			const errors: string[] = [];
-
-			if (typeof username !== 'string' || username === '') {
-				errors.push('Username is required');
-			} else {
-				if (username.length < 5) {
-					errors.push('Min. 5 characters');
-				}
-
-				if (username.toUpperCase() === username) {
-					errors.push('At least 1 lowercase character');
-				}
-
-				if (username.toLowerCase() === username) {
-					errors.push('At least 1 uppercase character');
-				}
-
-				if (!username.match(/[0-9]/)) {
-					errors.push('At least 1 number');
-				}
-			}
-
-			if (errors.length > 0) {
-				return {
-					error: {
-						username: errors,
-					},
-				};
-			}
-
-			return {
-				value: {
-					username,
+function parseForm(formData: FormData, validator: string | null) {
+	switch (validator) {
+		case 'yup': {
+			return parseWithYup(formData, {
+				schema: yup.object({
+					username: yup
+						.string()
+						.required('Username is required')
+						.test(
+							'test-minlength',
+							'Min. 5 characters',
+							(username) => !username || username.length > 5,
+						)
+						.test(
+							'test-lowercase',
+							'At least 1 lowercase character',
+							(username) => !username || username.toUpperCase() !== username,
+						)
+						.test(
+							'test-uppercase',
+							'At least 1 uppercase character',
+							(username) => !username || username.toLowerCase() !== username,
+						)
+						.test(
+							'test-number',
+							'At least 1 number',
+							(username) => !username || username.match(/[0-9]/) !== null,
+						),
+				}),
+				acceptMultipleErrors(name) {
+					return name === 'username';
 				},
-			};
-		},
-	});
+			});
+		}
+		case 'zod': {
+			return parseWithZod(formData, {
+				schema: z.object({
+					username: z
+						.string()
+						.min(1, 'Username is required')
+						.refine(
+							(username) => !username || username.length > 5,
+							'Min. 5 characters',
+						)
+						.refine(
+							(username) => !username || username.toUpperCase() !== username,
+							'At least 1 lowercase character',
+						)
+						.refine(
+							(username) => !username || username.toLowerCase() !== username,
+							'At least 1 uppercase character',
+						)
+						.refine(
+							(username) => !username || username.match(/[0-9]/),
+							'At least 1 number',
+						),
+				}),
+				acceptMultipleErrors(name) {
+					return name === 'username';
+				},
+			});
+		}
+		default: {
+			return parse(formData, {
+				resolve({ username }) {
+					const errors: string[] = [];
+
+					if (typeof username !== 'string' || username === '') {
+						errors.push('Username is required');
+					} else {
+						if (username.length < 5) {
+							errors.push('Min. 5 characters');
+						}
+
+						if (username.toUpperCase() === username) {
+							errors.push('At least 1 lowercase character');
+						}
+
+						if (username.toLowerCase() === username) {
+							errors.push('At least 1 uppercase character');
+						}
+
+						if (!username.match(/[0-9]/)) {
+							errors.push('At least 1 number');
+						}
+					}
+
+					if (errors.length > 0) {
+						return {
+							error: {
+								username: errors,
+							},
+						};
+					}
+
+					return {
+						value: {
+							username,
+						},
+					};
+				},
+			});
+		}
+	}
 }
 
 export async function loader({ request }: LoaderArgs) {
@@ -54,23 +122,25 @@ export async function loader({ request }: LoaderArgs) {
 
 	return {
 		noClientValidate: url.searchParams.get('noClientValidate') === 'yes',
+		validator: url.searchParams.get('validator'),
 	};
 }
 
 export async function action({ request }: ActionArgs) {
+	const url = new URL(request.url);
 	const formData = await request.formData();
-	const submission = parseForm(formData);
+	const submission = parseForm(formData, url.searchParams.get('validator'));
 
 	return json(submission);
 }
 
 export default function Example() {
-	const { noClientValidate } = useLoaderData<typeof loader>();
+	const { validator, noClientValidate } = useLoaderData<typeof loader>();
 	const state = useActionData<typeof action>();
 	const [form, { username }] = useForm<Schema>({
 		state,
 		onValidate: !noClientValidate
-			? ({ formData }) => parseForm(formData)
+			? ({ formData }) => parseForm(formData, validator)
 			: undefined,
 	});
 

--- a/playground/app/routes/multiple-errors.tsx
+++ b/playground/app/routes/multiple-errors.tsx
@@ -1,0 +1,86 @@
+import { conform, parse, useForm } from '@conform-to/react';
+import { type LoaderArgs, type ActionArgs, json } from '@remix-run/node';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { Playground, Field } from '~/components';
+
+interface Schema {
+	username: string;
+}
+
+function parseForm(formData: FormData) {
+	return parse(formData, {
+		resolve({ username }) {
+			const errors: string[] = [];
+
+			if (typeof username !== 'string' || username === '') {
+				errors.push('Username is required');
+			} else {
+				if (username.length < 5) {
+					errors.push('Min. 5 characters');
+				}
+
+				if (username.toUpperCase() === username) {
+					errors.push('At least 1 lowercase character');
+				}
+
+				if (username.toLowerCase() === username) {
+					errors.push('At least 1 uppercase character');
+				}
+
+				if (!username.match(/[0-9]/)) {
+					errors.push('At least 1 number');
+				}
+			}
+
+			if (errors.length > 0) {
+				return {
+					error: {
+						username: errors,
+					},
+				};
+			}
+
+			return {
+				value: {
+					username,
+				},
+			};
+		},
+	});
+}
+
+export async function loader({ request }: LoaderArgs) {
+	const url = new URL(request.url);
+
+	return {
+		noClientValidate: url.searchParams.get('noClientValidate') === 'yes',
+	};
+}
+
+export async function action({ request }: ActionArgs) {
+	const formData = await request.formData();
+	const submission = parseForm(formData);
+
+	return json(submission);
+}
+
+export default function Example() {
+	const { noClientValidate } = useLoaderData<typeof loader>();
+	const state = useActionData<typeof action>();
+	const [form, { username }] = useForm<Schema>({
+		state,
+		onValidate: !noClientValidate
+			? ({ formData }) => parseForm(formData)
+			: undefined,
+	});
+
+	return (
+		<Form method="post" {...form.props}>
+			<Playground title="Mutliple Errors" state={state}>
+				<Field label="Username" {...username}>
+					<input {...conform.input(username.config, { type: 'text' })} />
+				</Field>
+			</Playground>
+		</Form>
+	);
+}

--- a/playground/app/routes/multiple-errors.tsx
+++ b/playground/app/routes/multiple-errors.tsx
@@ -40,7 +40,7 @@ function parseForm(formData: FormData, validator: string | null) {
 							(username) => !username || username.match(/[0-9]/) !== null,
 						),
 				}),
-				acceptMultipleErrors(name) {
+				acceptMultipleErrors({ name }) {
 					return name === 'username';
 				},
 			});
@@ -68,7 +68,7 @@ function parseForm(formData: FormData, validator: string | null) {
 							'At least 1 number',
 						),
 				}),
-				acceptMultipleErrors(name) {
+				acceptMultipleErrors({ name }) {
 					return name === 'username';
 				},
 			});

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -83,7 +83,7 @@ export default function PaymentForm() {
 					<Field label="Timestamp" {...timestamp}>
 						<input {...conform.input(timestamp.config, { type: 'text' })} />
 					</Field>
-					<Field label="Verified" error={verified.error} inline>
+					<Field label="Verified" {...verified} inline>
 						<input
 							{...conform.input(verified.config, {
 								type: 'checkbox',

--- a/playground/app/routes/radio-buttons.tsx
+++ b/playground/app/routes/radio-buttons.tsx
@@ -8,13 +8,25 @@ interface Schema {
 }
 
 function parseForm(formData: FormData) {
-	const submission = parse(formData);
+	return parse(formData, {
+		resolve({ answer }) {
+			const error: Array<[string, string]> = [];
 
-	if (!submission.payload.answer) {
-		submission.error.push(['answer', 'Required']);
-	}
+			if (!answer) {
+				error.push(['answer', 'Required']);
+			}
 
-	return submission;
+			if (error.length > 0) {
+				return { error };
+			}
+
+			return {
+				value: {
+					answer,
+				},
+			};
+		},
+	});
 }
 
 export async function loader({ request }: LoaderArgs) {

--- a/playground/app/routes/radio-buttons.tsx
+++ b/playground/app/routes/radio-buttons.tsx
@@ -10,13 +10,13 @@ interface Schema {
 function parseForm(formData: FormData) {
 	return parse(formData, {
 		resolve({ answer }) {
-			const error: Array<[string, string]> = [];
+			const error: Record<string, string> = {};
 
 			if (!answer) {
-				error.push(['answer', 'Required']);
+				error.answer = 'Required';
 			}
 
-			if (error.length > 0) {
+			if (error.answer) {
 				return { error };
 			}
 

--- a/playground/app/routes/signup.tsx
+++ b/playground/app/routes/signup.tsx
@@ -13,30 +13,30 @@ interface Signup {
 function parseSignupForm(formData: FormData) {
 	return parse(formData, {
 		resolve({ email, password, confirmPassword }) {
-			const error: Array<[string, string]> = [];
+			const error: Record<string, string> = {};
 
 			if (!email) {
-				error.push(['email', 'Email is required']);
+				error.email = 'Email is required';
 			} else if (
 				typeof email !== 'string' ||
 				!email.match(/^[^()@\s]+@[\w\d.]+$/)
 			) {
-				error.push(['email', 'Email is invalid']);
+				error.email = 'Email is invalid';
 			}
 
 			if (!password) {
-				error.push(['password', 'Password is required']);
+				error.password = 'Password is required';
 			} else if (typeof password === 'string' && password.length < 8) {
-				error.push(['password', 'Password is too short']);
+				error.password = 'Password is too short';
 			}
 
 			if (!confirmPassword) {
-				error.push(['confirmPassword', 'Confirm password is required']);
+				error.confirmPassword = 'Confirm password is required';
 			} else if (confirmPassword !== password) {
-				error.push(['confirmPassword', 'The password provided does not match']);
+				error.confirmPassword = 'The password provided does not match';
 			}
 
-			if (error.length > 0) {
+			if (error.email || error.password || error.confirmPassword) {
 				return { error };
 			}
 

--- a/playground/app/routes/signup.tsx
+++ b/playground/app/routes/signup.tsx
@@ -11,34 +11,44 @@ interface Signup {
 }
 
 function parseSignupForm(formData: FormData) {
-	const submission = parse(formData);
-	const { email, password, confirmPassword } = submission.payload;
+	return parse(formData, {
+		resolve({ email, password, confirmPassword }) {
+			const error: Array<[string, string]> = [];
 
-	if (!email) {
-		submission.error.push(['email', 'Email is required']);
-	} else if (
-		typeof email !== 'string' ||
-		!email.match(/^[^()@\s]+@[\w\d.]+$/)
-	) {
-		submission.error.push(['email', 'Email is invalid']);
-	}
+			if (!email) {
+				error.push(['email', 'Email is required']);
+			} else if (
+				typeof email !== 'string' ||
+				!email.match(/^[^()@\s]+@[\w\d.]+$/)
+			) {
+				error.push(['email', 'Email is invalid']);
+			}
 
-	if (!password) {
-		submission.error.push(['password', 'Password is required']);
-	} else if (typeof password === 'string' && password.length < 8) {
-		submission.error.push(['password', 'Password is too short']);
-	}
+			if (!password) {
+				error.push(['password', 'Password is required']);
+			} else if (typeof password === 'string' && password.length < 8) {
+				error.push(['password', 'Password is too short']);
+			}
 
-	if (!confirmPassword) {
-		submission.error.push(['confirmPassword', 'Confirm password is required']);
-	} else if (confirmPassword !== password) {
-		submission.error.push([
-			'confirmPassword',
-			'The password provided does not match',
-		]);
-	}
+			if (!confirmPassword) {
+				error.push(['confirmPassword', 'Confirm password is required']);
+			} else if (confirmPassword !== password) {
+				error.push(['confirmPassword', 'The password provided does not match']);
+			}
 
-	return submission;
+			if (error.length > 0) {
+				return { error };
+			}
+
+			return {
+				value: {
+					email,
+					password,
+					confirmPassword,
+				},
+			};
+		},
+	});
 }
 
 export let loader = async ({ request }: LoaderArgs) => {

--- a/tests/conform-dom.spec.ts
+++ b/tests/conform-dom.spec.ts
@@ -25,6 +25,7 @@ test.describe('conform-dom', () => {
 						['title', 'The cat'],
 						['description', 'Once upon a time...'],
 					]),
+					{ resolve: () => ({ error: {} }) },
 				),
 			).toEqual({
 				intent: 'submit',
@@ -32,7 +33,7 @@ test.describe('conform-dom', () => {
 					title: 'The cat',
 					description: 'Once upon a time...',
 				},
-				error: [],
+				error: {},
 				toJSON: expect.any(Function),
 			});
 			expect(
@@ -43,6 +44,7 @@ test.describe('conform-dom', () => {
 						['amount.value', '99.9'],
 						['reference', ''],
 					]),
+					{ resolve: () => ({ error: {} }) },
 				),
 			).toEqual({
 				intent: 'submit',
@@ -54,7 +56,7 @@ test.describe('conform-dom', () => {
 					},
 					reference: '',
 				},
-				error: [],
+				error: {},
 				toJSON: expect.any(Function),
 			});
 			expect(
@@ -65,6 +67,7 @@ test.describe('conform-dom', () => {
 						['tasks[0].completed', 'Yes'],
 						['tasks[1].content', 'Test integration'],
 					]),
+					{ resolve: () => ({ error: {} }) },
 				),
 			).toEqual({
 				intent: 'submit',
@@ -75,7 +78,7 @@ test.describe('conform-dom', () => {
 						{ content: 'Test integration' },
 					],
 				},
-				error: [],
+				error: {},
 				toJSON: expect.any(Function),
 			});
 		});
@@ -87,6 +90,7 @@ test.describe('conform-dom', () => {
 						['title', 'The cat'],
 						['description', 'Once upon a time...'],
 					]),
+					{ resolve: () => ({ error: {} }) },
 				),
 			).toEqual({
 				intent: 'submit',
@@ -94,7 +98,7 @@ test.describe('conform-dom', () => {
 					title: 'The cat',
 					description: 'Once upon a time...',
 				},
-				error: [],
+				error: {},
 				toJSON: expect.any(Function),
 			});
 		});
@@ -106,13 +110,14 @@ test.describe('conform-dom', () => {
 						['title', 'Test command'],
 						['__intent__', 'command value'],
 					]),
+					{ resolve: () => ({ error: {} }) },
 				),
 			).toEqual({
 				intent: 'command value',
 				payload: {
 					title: 'Test command',
 				},
-				error: [],
+				error: {},
 				toJSON: expect.any(Function),
 			});
 			expect(
@@ -121,13 +126,14 @@ test.describe('conform-dom', () => {
 						['title', ''],
 						['__intent__', 'list/helloworld'],
 					]),
+					{ resolve: () => ({ error: {} }) },
 				),
 			).toEqual({
 				intent: 'list/helloworld',
 				payload: {
 					title: '',
 				},
-				error: [],
+				error: {},
 				toJSON: expect.any(Function),
 			});
 		});
@@ -141,14 +147,16 @@ test.describe('conform-dom', () => {
 				payload: {
 					tasks: [{ content: 'Test some stuffs', completed: 'Yes' }],
 				},
-				error: [],
+				error: {},
 				toJSON: expect.any(Function),
 			};
 
 			const command1 = list.prepend('tasks');
 
 			expect(
-				parse(createFormData([...entries, [command1.name, command1.value]])),
+				parse(createFormData([...entries, [command1.name, command1.value]]), {
+					resolve: () => ({ error: {} }),
+				}),
 			).toEqual({
 				...result,
 				intent: command1.value,
@@ -162,7 +170,9 @@ test.describe('conform-dom', () => {
 			});
 
 			expect(
-				parse(createFormData([...entries, [command2.name, command2.value]])),
+				parse(createFormData([...entries, [command2.name, command2.value]]), {
+					resolve: () => ({ error: {} }),
+				}),
 			).toEqual({
 				...result,
 				intent: command2.value,
@@ -174,7 +184,9 @@ test.describe('conform-dom', () => {
 			const command3 = list.append('tasks');
 
 			expect(
-				parse(createFormData([...entries, [command3.name, command3.value]])),
+				parse(createFormData([...entries, [command3.name, command3.value]]), {
+					resolve: () => ({ error: {} }),
+				}),
 			).toEqual({
 				...result,
 				intent: command3.value,
@@ -188,7 +200,9 @@ test.describe('conform-dom', () => {
 			});
 
 			expect(
-				parse(createFormData([...entries, [command4.name, command4.value]])),
+				parse(createFormData([...entries, [command4.name, command4.value]]), {
+					resolve: () => ({ error: {} }),
+				}),
 			).toEqual({
 				...result,
 				intent: command4.value,
@@ -203,7 +217,9 @@ test.describe('conform-dom', () => {
 			});
 
 			expect(
-				parse(createFormData([...entries, [command5.name, command5.value]])),
+				parse(createFormData([...entries, [command5.name, command5.value]]), {
+					resolve: () => ({ error: {} }),
+				}),
 			).toEqual({
 				...result,
 				intent: command5.value,
@@ -215,7 +231,9 @@ test.describe('conform-dom', () => {
 			const command6 = list.remove('tasks', { index: 0 });
 
 			expect(
-				parse(createFormData([...entries, [command6.name, command6.value]])),
+				parse(createFormData([...entries, [command6.name, command6.value]]), {
+					resolve: () => ({ error: {} }),
+				}),
 			).toEqual({
 				...result,
 				intent: command6.value,
@@ -233,6 +251,7 @@ test.describe('conform-dom', () => {
 						['tasks[1].content', 'Test more stuffs'],
 						[command7.name, command7.value],
 					]),
+					{ resolve: () => ({ error: {} }) },
 				),
 			).toEqual({
 				...result,

--- a/tests/conform-yup.spec.ts
+++ b/tests/conform-yup.spec.ts
@@ -52,7 +52,7 @@ test.describe('conform-yup', () => {
 		})
 		.test('root', 'error', () => false);
 
-	const value = {
+	const payload = {
 		text: '',
 		tag: '',
 		number: '99',
@@ -101,19 +101,47 @@ test.describe('conform-yup', () => {
 
 	test('parse', () => {
 		const formData = createFormData([
-			['text', value.text],
-			['tag', value.tag],
-			['number', value.number],
-			['timestamp', value.timestamp],
-			['options[0]', value.options[0]],
-			['options[1]', value.options[1]],
-			['nested.key', value.nested.key],
-			['list[0].key', value.list[0].key],
+			['text', payload.text],
+			['tag', payload.tag],
+			['number', payload.number],
+			['timestamp', payload.timestamp],
+			['options[0]', payload.options[0]],
+			['options[1]', payload.options[1]],
+			['nested.key', payload.nested.key],
+			['list[0].key', payload.list[0].key],
 		]);
-		const submission = parse(formData, { schema });
 
-		expect(submission.payload).toEqual(value);
-		expect(submission.error).toEqual(error);
-		expect(submission.value).not.toBeDefined();
+		expect(parse(formData, { schema })).toEqual({
+			intent: 'submit',
+			payload,
+			error,
+			toJSON: expect.any(Function),
+		});
+		expect(
+			parse(formData, { schema, acceptMultipleErrors: () => true }),
+		).toEqual({
+			intent: 'submit',
+			payload,
+			error: {
+				...error,
+				text: ['min', 'regex'],
+				tag: ['required', 'invalid'],
+			},
+			toJSON: expect.any(Function),
+		});
+		expect(
+			parse(formData, {
+				schema,
+				acceptMultipleErrors: ({ name }) => name === 'tag',
+			}),
+		).toEqual({
+			intent: 'submit',
+			payload,
+			error: {
+				...error,
+				tag: ['required', 'invalid'],
+			},
+			toJSON: expect.any(Function),
+		});
 	});
 });

--- a/tests/conform-yup.spec.ts
+++ b/tests/conform-yup.spec.ts
@@ -61,22 +61,20 @@ test.describe('conform-yup', () => {
 		nested: { key: '' },
 		list: [{ key: '' }],
 	};
-	const error = [
-		['text', 'min'],
-		['text', 'regex'],
-		['tag', 'required'],
-		['tag', 'invalid'],
-		['number', 'max'],
-		['timestamp', 'min'],
-		['options[1]', 'invalid'],
-		['options', 'min'],
-		['nested.key', 'required'],
-		['nested', 'error'],
-		['list[0].key', 'required'],
-		['list[0]', 'error'],
-		['list', 'max'],
-		['', 'error'],
-	];
+	const error = {
+		text: 'min',
+		tag: 'required',
+		number: 'max',
+		timestamp: 'min',
+		'options[1]': 'invalid',
+		options: 'min',
+		'nested.key': 'required',
+		nested: 'error',
+		'list[0].key': 'required',
+		'list[0]': 'error',
+		list: 'max',
+		'': 'error',
+	};
 
 	test('getFieldsetConstraint', () => {
 		expect(getFieldsetConstraint(schema)).toEqual({

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -75,22 +75,20 @@ test.describe('conform-zod', () => {
 		nested: { key: '' },
 		list: [{ key: '' }],
 	};
-	const error = [
-		['text', 'min'],
-		['text', 'regex'],
-		['text', 'refine'],
-		['number', 'step'],
-		['timestamp', 'min'],
-		['options', 'min'],
-		['options[0]', 'refine'],
-		['options[1]', 'refine'],
-		['nested.key', 'refine'],
-		['nested', 'refine'],
-		['list', 'max'],
-		['list[0].key', 'refine'],
-		['list[0]', 'refine'],
-		['', 'refine'],
-	];
+	const error = {
+		text: 'min',
+		number: 'step',
+		timestamp: 'min',
+		options: 'min',
+		'options[0]': 'refine',
+		'options[1]': 'refine',
+		'nested.key': 'refine',
+		nested: 'refine',
+		list: 'max',
+		'list[0].key': 'refine',
+		'list[0]': 'refine',
+		'': 'refine',
+	};
 
 	test('getFieldsetConstraint', () => {
 		expect(getFieldsetConstraint(schema)).toEqual({

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -66,7 +66,7 @@ test.describe('conform-zod', () => {
 		})
 		.refine(() => false, 'refine');
 
-	const value = {
+	const payload = {
 		text: '',
 		number: '3',
 		timestamp: new Date(0).toISOString(),
@@ -124,21 +124,42 @@ test.describe('conform-zod', () => {
 		});
 	});
 
-	test('validate', () => {
+	test('parse', () => {
 		const formData = createFormData([
-			['text', value.text],
-			['number', value.number],
-			['timestamp', value.timestamp],
-			['flag', value.flag],
-			['options[0]', value.options[0]],
-			['options[1]', value.options[1]],
-			['nested.key', value.nested.key],
-			['list[0].key', value.list[0].key],
+			['text', payload.text],
+			['number', payload.number],
+			['timestamp', payload.timestamp],
+			['flag', payload.flag],
+			['options[0]', payload.options[0]],
+			['options[1]', payload.options[1]],
+			['nested.key', payload.nested.key],
+			['list[0].key', payload.list[0].key],
 		]);
-		const submission = parse(formData, { schema });
 
-		expect(submission.payload).toEqual(value);
-		expect(submission.error).toEqual(error);
-		expect(submission.value).not.toBeDefined();
+		expect(parse(formData, { schema })).toEqual({
+			intent: 'submit',
+			payload,
+			error,
+			toJSON: expect.any(Function),
+		});
+		expect(
+			parse(formData, { schema, acceptMultipleErrors: () => false }),
+		).toEqual({
+			intent: 'submit',
+			payload,
+			error,
+			toJSON: expect.any(Function),
+		});
+		expect(
+			parse(formData, { schema, acceptMultipleErrors: () => true }),
+		).toEqual({
+			intent: 'submit',
+			payload,
+			error: {
+				...error,
+				text: ['min', 'regex', 'refine'],
+			},
+			toJSON: expect.any(Function),
+		});
 	});
 });

--- a/tests/integrations/file-upload.spec.ts
+++ b/tests/integrations/file-upload.spec.ts
@@ -92,7 +92,7 @@ async function runValidationScenario(page: Page) {
 				_lastModified: expect.anything(),
 			},
 		},
-		error: [],
+		error: {},
 	});
 }
 

--- a/tests/integrations/multiple-errors.spec.ts
+++ b/tests/integrations/multiple-errors.spec.ts
@@ -1,0 +1,109 @@
+import { type Page, type Locator, test, expect } from '@playwright/test';
+import { getPlayground } from '../helpers';
+
+function getUsernameInput(container: Locator) {
+	return container.locator('[name="username"]');
+}
+
+async function runValidationScenario(page: Page) {
+	const playground = getPlayground(page);
+	const username = getUsernameInput(playground.container);
+
+	await playground.submit.click();
+
+	await expect(playground.error).toHaveText(['Username is required']);
+
+	await username.type('@');
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'Min. 5 characters',
+		'At least 1 lowercase character',
+		'At least 1 uppercase character',
+		'At least 1 number',
+	]);
+
+	await username.press('Control+a');
+	await username.press('ArrowRight');
+	await username.type('C');
+
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'Min. 5 characters',
+		'At least 1 lowercase character',
+		'At least 1 number',
+	]);
+
+	await username.press('Control+a');
+	await username.press('ArrowRight');
+	await username.type('on');
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'Min. 5 characters',
+		'At least 1 number',
+	]);
+
+	await username.press('Control+a');
+	await username.press('ArrowRight');
+	await username.type('form');
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['At least 1 number']);
+
+	await username.press('Control+a');
+	await username.press('ArrowRight');
+	await username.type('2023');
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['']);
+	await expect(playground.submission).toHaveText(
+		JSON.stringify(
+			{
+				intent: 'submit',
+				payload: {
+					username: '@Conform2023',
+				},
+				error: {},
+			},
+			null,
+			2,
+		),
+	);
+}
+
+test.describe('With JS', () => {
+	test('Client Validation', async ({ page }) => {
+		await page.goto('/multiple-errors');
+		await runValidationScenario(page);
+	});
+
+	test('Server Validation', async ({ page }) => {
+		await page.goto('/multiple-errors?noClientValidate=yes');
+		await runValidationScenario(page);
+	});
+
+	test('Form reset', async ({ page }) => {
+		await page.goto('/multiple-errors');
+
+		const playground = getPlayground(page);
+		const username = getUsernameInput(playground.container);
+
+		await username.type('?');
+		await playground.submit.click();
+		await expect(playground.error).toHaveText([
+			'Min. 5 characters',
+			'At least 1 lowercase character',
+			'At least 1 uppercase character',
+			'At least 1 number',
+		]);
+
+		await playground.reset.click();
+		await expect(playground.error).toHaveText(['']);
+	});
+});
+
+test.describe('No JS', () => {
+	test.use({ javaScriptEnabled: false });
+
+	test('Validation', async ({ page }) => {
+		await page.goto('/multiple-errors');
+		await runValidationScenario(page);
+	});
+});

--- a/tests/integrations/multiple-errors.spec.ts
+++ b/tests/integrations/multiple-errors.spec.ts
@@ -68,7 +68,7 @@ async function runValidationScenario(page: Page) {
 	);
 }
 
-test.describe('With JS', () => {
+test.describe('Custom Validation', () => {
 	test('Client Validation', async ({ page }) => {
 		await page.goto('/multiple-errors');
 		await runValidationScenario(page);
@@ -78,32 +78,66 @@ test.describe('With JS', () => {
 		await page.goto('/multiple-errors?noClientValidate=yes');
 		await runValidationScenario(page);
 	});
+});
 
-	test('Form reset', async ({ page }) => {
-		await page.goto('/multiple-errors');
-
-		const playground = getPlayground(page);
-		const username = getUsernameInput(playground.container);
-
-		await username.type('?');
-		await playground.submit.click();
-		await expect(playground.error).toHaveText([
-			'Min. 5 characters',
-			'At least 1 lowercase character',
-			'At least 1 uppercase character',
-			'At least 1 number',
-		]);
-
-		await playground.reset.click();
-		await expect(playground.error).toHaveText(['']);
+test.describe('Zod', () => {
+	test('Client Validation', async ({ page }) => {
+		await page.goto('/multiple-errors?validator=zod');
+		await runValidationScenario(page);
 	});
+
+	test('Server Validation', async ({ page }) => {
+		await page.goto('/multiple-errors?validator=zod&noClientValidate=yes');
+		await runValidationScenario(page);
+	});
+});
+
+test.describe('Yup', () => {
+	test('Client Validation', async ({ page }) => {
+		await page.goto('/multiple-errors?validator=yup');
+		await runValidationScenario(page);
+	});
+
+	test('Server Validation', async ({ page }) => {
+		await page.goto('/multiple-errors?validator=yup&noClientValidate=yes');
+		await runValidationScenario(page);
+	});
+});
+
+test('Form reset', async ({ page }) => {
+	await page.goto('/multiple-errors');
+
+	const playground = getPlayground(page);
+	const username = getUsernameInput(playground.container);
+
+	await username.type('?');
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'Min. 5 characters',
+		'At least 1 lowercase character',
+		'At least 1 uppercase character',
+		'At least 1 number',
+	]);
+
+	await playground.reset.click();
+	await expect(playground.error).toHaveText(['']);
 });
 
 test.describe('No JS', () => {
 	test.use({ javaScriptEnabled: false });
 
-	test('Validation', async ({ page }) => {
+	test('Custom Validation', async ({ page }) => {
 		await page.goto('/multiple-errors');
+		await runValidationScenario(page);
+	});
+
+	test('Zod', async ({ page }) => {
+		await page.goto('/multiple-errors?validator=zod');
+		await runValidationScenario(page);
+	});
+
+	test('Yup', async ({ page }) => {
+		await page.goto('/multiple-errors?validator=yup');
 		await runValidationScenario(page);
 	});
 });

--- a/tests/integrations/radio-buttons.spec.ts
+++ b/tests/integrations/radio-buttons.spec.ts
@@ -19,7 +19,7 @@ async function runValidationScenario(page: Page) {
 				payload: {
 					answer: 'b',
 				},
-				error: [],
+				error: {},
 			},
 			null,
 			2,

--- a/tests/integrations/simple-list.spec.ts
+++ b/tests/integrations/simple-list.spec.ts
@@ -123,7 +123,7 @@ async function runValidationScenario(page: Page) {
 				payload: {
 					items: ['Top item', 'First item'],
 				},
-				error: [],
+				error: {},
 			},
 			null,
 			2,

--- a/tests/integrations/validate.spec.ts
+++ b/tests/integrations/validate.spec.ts
@@ -42,7 +42,7 @@ async function runValidationScenario(page: Page) {
 					name: 'Conform',
 					message: 'A form validation library',
 				},
-				error: [],
+				error: {},
 			},
 			null,
 			2,

--- a/tests/react.spec.ts
+++ b/tests/react.spec.ts
@@ -57,7 +57,7 @@ test.describe('Client Validation', () => {
 				genre: 'action',
 				rating: '4.5',
 			},
-			error: [],
+			error: {},
 		});
 	});
 
@@ -135,7 +135,7 @@ test.describe('Client Validation', () => {
 				genre: 'sci-fi',
 				rating: '4.0',
 			},
-			error: [],
+			error: {},
 		});
 	});
 
@@ -168,7 +168,7 @@ test.describe('Client Validation', () => {
 			payload: {
 				email: 'me@edmund.dev',
 			},
-			error: [],
+			error: {},
 		});
 	});
 
@@ -244,7 +244,7 @@ test.describe('Client Validation', () => {
 				timestamp,
 				verified: 'Yes',
 			},
-			error: [],
+			error: {},
 		});
 	});
 
@@ -310,10 +310,10 @@ test.describe('Client Validation', () => {
 			payload: {
 				email: '',
 			},
-			error: [
-				['email', 'Email is required'],
-				['password', 'Password is required'],
-			],
+			error: {
+				email: 'Email is required',
+				password: 'Password is required',
+			},
 		});
 
 		await email.type('invalid email');
@@ -325,7 +325,9 @@ test.describe('Client Validation', () => {
 			payload: {
 				email: 'invalid email',
 			},
-			error: [['password', 'Password is required']],
+			error: {
+				password: 'Password is required',
+			},
 		});
 	});
 
@@ -662,7 +664,7 @@ test.describe('Field list', () => {
 					{ content: 'Ad hoc task' },
 				],
 			},
-			error: [],
+			error: {},
 		});
 	});
 
@@ -728,7 +730,7 @@ test.describe('Field list', () => {
 					{ content: 'Write tests for nested list', completed: 'on' },
 				],
 			},
-			error: [],
+			error: {},
 		});
 	});
 


### PR DESCRIPTION
> This PR includes breaking change

I still have a few more changes planned for the `parse` function. This PR introduces a new `resolve` option with a new error structure to support multiple errors:

Here is how you will validate a simple signup form with custom validation:
```tsx
import { parse } from '@conform-to/react';

export async function action({ request }: ActionArgs) {
    const formData = await request.formData();
    const submission = parse(formData, {
        resolve({ email, password, confirmPassword }) {
            // Instead of an array, error is now a simple dictionary
            // The key should be the path while the value would be the corresponding message
            const error: Record<string, string | string[]> = {};

            if (!email) {
                error.email = 'Email is required';
            } else if (!email.includes('@')) {
                error.email = 'Email is invalid';
            }

            if (!password) {
                error.password = 'Password is required';
            }

            if (!confirmPassword) {
                error.confirmPassword = 'Confirm password is required';
            } else if (confirmPassword !== password) {
                error.confirmPassword = 'Password does not match';
            }

            // You can either return an error or a value
            if (error.email || error.password || error.confirmPassword) {
                return { error };
            }

            // You should return the value only if no error 
            return {
                value: {
                    email,
                    password,
                    confirmPassword,
                },
            };
        },
    });

    // You can confirm if there is any error by checking if `submission.value` exists  
    if (!submission.value || submission.intent !== 'submit') {
        return json(submission);
    }

    // ...
}
```

To support multiple error, just assign an array to the error instead of a string:
```tsx
export async function action({ request }: ActionArgs) {
    const formData = await request.formData();
    const submission = parse(formData, {
        resolve({ email, password, confirmPassword }) {
            const error: Record<string, string | string[]> = {};

            // ...

            if (!password) {
                error.password = 'Password is required';
            } else {
                const passwordErrors: string[] = [];
 
                if (password.length < 10) {
                    passwordErrors.push('The password should have minimum 10 characters');
                }

                if (password.toLowerCase() === password) {
                    passwordErrors.push('The password should have at least 1 uppercase character');
                }

                if (password.toUpperCase() === password) {
                    passwordErrors.push('The password should have at least 1 lowercase character');
                }

                // Assign an array of errors instead
                error.password = passwordErrors;
            }

            // ...
        },
    });

    // ...
}
```

You can achieve the same functionality with zod/yup by specifing the `acceptMultipleErrors()` config:
```tsx
import { parse } from '@conform-to/zod';
import { z } from 'zod';

export async function action({ request }: ActionArgs) {
    const formData = await request.formData();
    const submission = parse(formData, {
        schema: z.object({
            // ...
            password: z
                .string()
                .min(10, 'The password should have minimum 10 characters')
                .refine(password => password.toLowerCase() === password, 'The password should have at least 1 uppercase character')
                .refine(password => password.toUpperCase() === password, 'The password should have at least 1 lowercase character')
        }),

        // Default to false if not specified
        acceptMultipleErrors(name) {
            return name === 'password';
        }
    });

    // ...
}
```

You can then access all the errors through `.errors` instead of `.error`. You can always access both `.error` and `.errors` regardless if you have sent multiple errors back. It will just be the first error / an array of 1 item instead: 
```tsx
import { conform, useForm } from '@conform-to/react';

export default function Example() {
    const state = useActionData();
    const [form, { password }] = useForm({
        state,
    });

    return (
        <Form {...form.props}>
            { /* ... */ }
            <div>
                <label>Password</label>
                <input {...conform.input(password.config, { type: 'password' })} />
                <ul>
                    {password.errors?.map((error, i) => (
                        <li key={i}>{error}</li>
                    ))}
                </ul>
            </div>
            { /* ... */ }
        </Form>

    )
}
```