### PR TITLE
feat: shouldValidate config

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -224,20 +224,19 @@ export default function Signup() {
 
 ### Validate on-demand
 
-Some validation rules could be expensive especially when they require querying from database or 3rd party services. This can be minimized by checking the submission type and intent, or using the `shouldValidate()` helper.
+Some validation rules could be expensive especially when they require querying from database or 3rd party services. This can be minimized with the `shouldValidate()` helper.
 
 ```tsx
-import { shouldValidate } from '@conform-to/react';
 import { parse } from '@conform-to/zod';
 
 export async function action({ request }: ActionArgs) {
   const formData = await request.formData();
   const submission = parse(formData, {
-    schema: (intent) =>
+    schema: ({ shouldValidate }) =>
       schema.refine(
         async ({ username }) => {
           // Continue checking only if necessary
-          if (!shouldValidate(intent, 'username')) {
+          if (!shouldValidate('username')) {
             return true;
           }
 

--- a/examples/async-validation/app/routes/index.tsx
+++ b/examples/async-validation/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import { conform, useForm, hasError, shouldValidate } from '@conform-to/react';
+import { conform, useForm } from '@conform-to/react';
 import { parse } from '@conform-to/zod';
 import type { ActionArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
@@ -38,10 +38,10 @@ async function signup(data: z.infer<typeof schema>): Promise<Response> {
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = await parse(formData, {
-		schema: (intent) =>
+		schema: ({ shouldValidate }) =>
 			schema.refine(
 				async ({ username }) => {
-					if (!shouldValidate(intent, 'username')) {
+					if (!shouldValidate('username')) {
 						return true;
 					}
 

--- a/packages/conform-react/README.md
+++ b/packages/conform-react/README.md
@@ -15,9 +15,7 @@
 - [validate](#validate)
 - [requestIntent](#requestintent)
 - [getFormElements](#getformelements)
-- [hasError](#haserror)
 - [parse](#parse)
-- [shouldValidate](#shouldvalidate)
 
 <!-- /aside -->
 
@@ -539,27 +537,4 @@ const formData = new FormData();
 const submission = parse(formData);
 
 console.log(submission);
-```
-
----
-
-### shouldValidate
-
-This helper checks if the scope of validation includes a specific field by checking the submission:
-
-```tsx
-import { shouldValidate } from '@conform-to/react';
-
-/**
- * The submission intent give us hint on what should be valdiated.
- * If the intent is 'validate/:field', only the field with name matching must be validated.
- * If the intent is undefined, everything should be validated (Default submission)
- */
-const intent = 'validate/email';
-
-// This will log 'true'
-console.log(shouldValidate(intent, 'email'));
-
-// This will log 'false'
-console.log(shouldValidate(intent, 'password'));
 ```

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -126,6 +126,7 @@ interface Form<Schema extends Record<string, any>> {
 	id?: string;
 	ref: RefObject<HTMLFormElement>;
 	error: string;
+	errors: string[];
 	props: FormProps;
 	config: FieldsetConfig<Schema>;
 }
@@ -144,14 +145,14 @@ export function useForm<
 ): [Form<Schema>, Fieldset<Schema>] {
 	const configRef = useRef(config);
 	const ref = useRef<HTMLFormElement>(null);
-	const [error, setError] = useState<string>(() => {
+	const [errors, setErrors] = useState<string[]>(() => {
 		if (!config.state) {
-			return '';
+			return [];
 		}
 
 		const message = config.state.error[''];
 
-		return getValidationMessage(message);
+		return getErrors(getValidationMessage(message));
 	});
 	const [uncontrolledState, setUncontrolledState] = useState<
 		FieldsetConfig<Schema>
@@ -250,7 +251,15 @@ export function useForm<
 			event.preventDefault();
 
 			if (field.dataset.conformTouched) {
-				setError(field.validationMessage);
+				setErrors((error) => {
+					const message = getValidationMessage(error);
+
+					if (message === field.validationMessage) {
+						return error;
+					}
+
+					return getErrors(field.validationMessage);
+				});
 			}
 		};
 		const handleReset = (event: Event) => {
@@ -270,7 +279,7 @@ export function useForm<
 				}
 			}
 
-			setError('');
+			setErrors([]);
 			setUncontrolledState({
 				defaultValue: formConfig.defaultValue,
 			});
@@ -299,7 +308,8 @@ export function useForm<
 	const form: Form<Schema> = {
 		id: config.id,
 		ref,
-		error,
+		error: errors[0] ?? '',
+		errors,
 		props: {
 			ref,
 			id: config.id,

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -8,7 +8,6 @@ export {
 	requestIntent,
 	requestSubmit,
 	parse,
-	shouldValidate,
 } from '@conform-to/dom';
 export * from './hooks';
 export * as conform from './helpers';

--- a/packages/conform-yup/index.ts
+++ b/packages/conform-yup/index.ts
@@ -90,7 +90,13 @@ export function getFieldsetConstraint<Source extends yup.AnyObjectSchema>(
 export function parse<Schema extends yup.AnyObjectSchema>(
 	payload: FormData | URLSearchParams,
 	config: {
-		schema: Schema | ((intent: string) => Schema);
+		schema:
+			| Schema
+			| (({
+					shouldValidate,
+			  }: {
+					shouldValidate: (name: string) => boolean;
+			  }) => Schema);
 		acceptMultipleErrors?: ({
 			name,
 			intent,
@@ -100,13 +106,28 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 			intent: string;
 			payload: Record<string, any>;
 		}) => boolean;
+		shouldBeValidated?: ({
+			intent,
+			payload,
+			defaultValidated,
+		}: {
+			intent: string;
+			payload: Record<string, any>;
+			defaultValidated: string[] | undefined;
+		}) => string[] | undefined;
 		async?: false;
 	},
 ): Submission<yup.InferType<Schema>>;
 export function parse<Schema extends yup.AnyObjectSchema>(
 	payload: FormData | URLSearchParams,
 	config: {
-		schema: Schema | ((intent: string) => Schema);
+		schema:
+			| Schema
+			| (({
+					shouldValidate,
+			  }: {
+					shouldValidate: (name: string) => boolean;
+			  }) => Schema);
 		acceptMultipleErrors?: ({
 			name,
 			intent,
@@ -116,13 +137,28 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 			intent: string;
 			payload: Record<string, any>;
 		}) => boolean;
+		shouldBeValidated?: ({
+			intent,
+			payload,
+			defaultValidated,
+		}: {
+			intent: string;
+			payload: Record<string, any>;
+			defaultValidated: string[] | undefined;
+		}) => string[] | undefined;
 		async: true;
 	},
 ): Promise<Submission<yup.InferType<Schema>>>;
 export function parse<Schema extends yup.AnyObjectSchema>(
 	payload: FormData | URLSearchParams,
 	config: {
-		schema: Schema | ((intent: string) => Schema);
+		schema:
+			| Schema
+			| (({
+					shouldValidate,
+			  }: {
+					shouldValidate: (name: string) => boolean;
+			  }) => Schema);
 		acceptMultipleErrors?: ({
 			name,
 			intent,
@@ -132,16 +168,25 @@ export function parse<Schema extends yup.AnyObjectSchema>(
 			intent: string;
 			payload: Record<string, any>;
 		}) => boolean;
+		shouldBeValidated?: ({
+			intent,
+			payload,
+			defaultValidated,
+		}: {
+			intent: string;
+			payload: Record<string, any>;
+			defaultValidated: string[] | undefined;
+		}) => string[] | undefined;
 		async?: boolean;
 	},
 ):
 	| Submission<yup.InferType<Schema>>
 	| Promise<Submission<yup.InferType<Schema>>> {
 	return baseParse<Submission<yup.InferType<Schema>>>(payload, {
-		resolve(payload, intent) {
+		resolve(payload, { intent, shouldValidate }) {
 			const schema =
 				typeof config.schema === 'function'
-					? config.schema(intent)
+					? config.schema({ shouldValidate })
 					: config.schema;
 			const resolveData = (value: yup.InferType<Schema>) => ({ value });
 			const resolveError = (error: unknown) => {

--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -113,7 +113,13 @@ export function getFieldsetConstraint<Source extends z.ZodTypeAny>(
 export function parse<Schema extends z.ZodTypeAny>(
 	payload: FormData | URLSearchParams,
 	config: {
-		schema: Schema | ((intent: string) => Schema);
+		schema:
+			| Schema
+			| (({
+					shouldValidate,
+			  }: {
+					shouldValidate: (name: string) => boolean;
+			  }) => Schema);
 		acceptMultipleErrors?: ({
 			name,
 			intent,
@@ -123,13 +129,28 @@ export function parse<Schema extends z.ZodTypeAny>(
 			intent: string;
 			payload: Record<string, any>;
 		}) => boolean;
+		shouldBeValidated?: ({
+			intent,
+			payload,
+			defaultValidated,
+		}: {
+			intent: string;
+			payload: Record<string, any>;
+			defaultValidated: string[] | undefined;
+		}) => string[] | undefined;
 		async?: false;
 	},
 ): Submission<z.output<Schema>>;
 export function parse<Schema extends z.ZodTypeAny>(
 	payload: FormData | URLSearchParams,
 	config: {
-		schema: Schema | ((intent: string) => Schema);
+		schema:
+			| Schema
+			| (({
+					shouldValidate,
+			  }: {
+					shouldValidate: (name: string) => boolean;
+			  }) => Schema);
 		acceptMultipleErrors?: ({
 			name,
 			intent,
@@ -139,13 +160,28 @@ export function parse<Schema extends z.ZodTypeAny>(
 			intent: string;
 			payload: Record<string, any>;
 		}) => boolean;
+		shouldBeValidated?: ({
+			intent,
+			payload,
+			defaultValidated,
+		}: {
+			intent: string;
+			payload: Record<string, any>;
+			defaultValidated: string[] | undefined;
+		}) => string[] | undefined;
 		async: true;
 	},
 ): Promise<Submission<z.output<Schema>>>;
 export function parse<Schema extends z.ZodTypeAny>(
 	payload: FormData | URLSearchParams,
 	config: {
-		schema: Schema | ((intent: string) => Schema);
+		schema:
+			| Schema
+			| (({
+					shouldValidate,
+			  }: {
+					shouldValidate: (name: string) => boolean;
+			  }) => Schema);
 		acceptMultipleErrors?: ({
 			name,
 			intent,
@@ -155,14 +191,23 @@ export function parse<Schema extends z.ZodTypeAny>(
 			intent: string;
 			payload: Record<string, any>;
 		}) => boolean;
+		shouldBeValidated?: ({
+			intent,
+			payload,
+			defaultValidated,
+		}: {
+			intent: string;
+			payload: Record<string, any>;
+			defaultValidated: string[] | undefined;
+		}) => string[] | undefined;
 		async?: boolean;
 	},
 ): Submission<z.output<Schema>> | Promise<Submission<z.output<Schema>>> {
 	return baseParse<z.output<Schema>>(payload, {
-		resolve(payload, intent) {
+		resolve(payload, { intent, shouldValidate }) {
 			const schema =
 				typeof config.schema === 'function'
-					? config.schema(intent)
+					? config.schema({ shouldValidate })
 					: config.schema;
 			const resolveResult = (
 				result: z.SafeParseReturnType<z.input<Schema>, z.output<Schema>>,
@@ -199,6 +244,7 @@ export function parse<Schema extends z.ZodTypeAny>(
 				? schema.safeParseAsync(payload).then(resolveResult)
 				: resolveResult(schema.safeParse(payload));
 		},
+		shouldBeValidated: config.shouldBeValidated,
 	});
 }
 

--- a/playground/app/routes/employee.tsx
+++ b/playground/app/routes/employee.tsx
@@ -1,4 +1,4 @@
-import { conform, shouldValidate, useForm } from '@conform-to/react';
+import { conform, useForm } from '@conform-to/react';
 import { parse } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
@@ -20,10 +20,10 @@ export let loader = async ({ request }: LoaderArgs) => {
 export let action = async ({ request }: ActionArgs) => {
 	const formData = await request.formData();
 	const submission = await parse(formData, {
-		schema: (intent) =>
+		schema: ({ shouldValidate }) =>
 			schema.refine(
 				async (employee) => {
-					if (!shouldValidate(intent, 'email')) {
+					if (!shouldValidate('email')) {
 						return true;
 					}
 


### PR DESCRIPTION
This is a hard one. I have been going back and forth on how to handle this properly for a while.

## Background
When you are validating a form, especially with a schema validation library like Zod, you are always validating the whole form at once. However, this get a bit tricky with server validation which includes async validation.

In order to minimize the time taken for validation, conform allows you to optimize it by checking the submission intent with the `shouldValidate` helper to identify if validation for a particular field is actually needed. But this also introduced another problem: Conform cannot reset the error of a particular field if no error is returned unless it **should be validated** (i.e. `shouldValidate` returns true).

The `shouldValidate` helper works with a simple assumption: only the field triggered the validation should be validated. This works fine for most of the form, except when a dependent field is needed in which more than the field triggered needs to be validated as well. 

## Solutions

There are two solutions I thought of:

### 1. Customize it with the `useForm` hook

This ideas requires providing two new custom functions:
- `shouldClientValidate(intent: string, name: string): boolean`
- `shouldServerValdiate(intent: string, name: string): boolean`

These functions works like `shouldValidate` by default and could be customize to handle dependent fields if needed.

Pros: Both custom functions are easy to learn and use.
Cons: You either have to duplicate the `shouldServerValdiate` logic on the server or share it for on-demand validation setup. 

### 2. Includes field names that should be validated as part of the submission

By including the field names, Conform can easily identify which errors could be trusted. This will be set during the `parse` step.

```tsx
export async function action({ request }) {
    const formData = await request.formData();
    const submission = parse(formData, {
        schema: ({ shouldValidate }) => z
            .object({
                // ...
            })
            .refine(value => {
                // You can do on demand validation with
                // the result of `shouldBeValidated`
                if (shouldValidate('password')) {
                    // ...
                }

                // ...
            }),
        shouldBeValidated({ intent, defaultValidated }) {
            if (intent === 'validate/password') {
                // Both fields should be validated together 
                return ['password', 'confirm-password'];
            }
    
            return defaultValidated;
        },
    });

    // This will log ['password', 'confirm-password'] when validating the password field
    console.log(submission.validated);

    // ...
}
```

Pros: By knowing which fields should be validated, we can minimize the data sent back to client by removing error that are not supposed to be validated.
Cons: The custom function is much harder to learn. It is also complicated to find out all the field names especially when dealing with list field, which might need to loop through the parsed result to see how many items in a list. 

## Status

This PR implemented solution 2. But I start wonder if solution 1 is better.