### PR TITLE
feat(conform-dom,conform-react)!: introduce validation skipped and undefined messages

### DIFF
--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -205,6 +205,9 @@ export function getErrors(message: string | undefined): string[] {
 	return message.split(String.fromCharCode(31));
 }
 
+export const VALIDATION_UNDEFINED = '__undefined__';
+export const VALIDATION_SKIPPED = '__skipped__';
+
 export function reportSubmission(
 	form: HTMLFormElement,
 	submission: Submission,
@@ -253,7 +256,7 @@ export function reportSubmission(
 
 			if (
 				typeof message === 'undefined' ||
-				!([] as string[]).concat(message).includes('__SKIPPED__')
+				!([] as string[]).concat(message).includes(VALIDATION_SKIPPED)
 			) {
 				const invalidEvent = new Event('invalid', { cancelable: true });
 

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -181,13 +181,15 @@ export function getName(paths: Array<string | number>): string {
 }
 
 export function shouldValidate(intent: string, name: string): boolean {
-	switch (intent) {
-		case 'submit':
+	const [type] = intent.split('/', 1);
+
+	switch (type) {
 		case 'validate':
-		case `validate/${name}`:
-			return true;
-		default:
+			return intent === 'validate' || intent === `validate/${name}`;
+		case 'list':
 			return parseListCommand(intent)?.scope === name;
+		default:
+			return true;
 	}
 }
 
@@ -217,58 +219,63 @@ export function reportSubmission(
 		);
 	}
 
-	for (const name of Object.keys(submission.error)) {
-		// We can't use empty string as button name
-		// As `form.element.namedItem('')` will always returns null
-		const elementName = name ? name : '__form__';
-		let item = form.elements.namedItem(elementName);
+	setTimeout(() => {
+		for (const name of Object.keys(submission.error)) {
+			// We can't use empty string as button name
+			// As `form.element.namedItem('')` will always returns null
+			const elementName = name ? name : '__form__';
+			let item = form.elements.namedItem(elementName);
 
-		if (item instanceof RadioNodeList) {
-			for (const field of item) {
-				if ((field as FieldElement).type !== 'radio') {
-					throw new Error('Repeated field name is not supported');
+			if (item instanceof RadioNodeList) {
+				for (const field of item) {
+					if ((field as FieldElement).type !== 'radio') {
+						throw new Error('Repeated field name is not supported');
+					}
+				}
+			}
+
+			if (item === null) {
+				// Create placeholder button to keep the error without contributing to the form data
+				const button = document.createElement('button');
+
+				button.name = elementName;
+				button.hidden = true;
+				button.dataset.conformTouched = 'true';
+				item = button;
+
+				form.appendChild(button);
+			}
+		}
+
+		for (const element of form.elements) {
+			if (isFieldElement(element) && element.willValidate) {
+				const elementName = element.name !== '__form__' ? element.name : '';
+				const message = submission.error[elementName];
+				const elementShouldValidate = shouldValidate(
+					submission.intent,
+					elementName,
+				);
+
+				if (elementShouldValidate) {
+					element.dataset.conformTouched = 'true';
+				}
+
+				if (
+					typeof message === 'undefined' ||
+					!([] as string[]).concat(message).includes('__SKIPPED__')
+				) {
+					const invalidEvent = new Event('invalid', { cancelable: true });
+
+					element.setCustomValidity(getValidationMessage(message));
+					element.dispatchEvent(invalidEvent);
+				}
+
+				if (elementShouldValidate && !element.validity.valid) {
+					focus(element);
 				}
 			}
 		}
-
-		if (item === null) {
-			// Create placeholder button to keep the error without contributing to the form data
-			const button = document.createElement('button');
-
-			button.name = elementName;
-			button.hidden = true;
-			button.dataset.conformTouched = 'true';
-			item = button;
-
-			form.appendChild(button);
-		}
-	}
-
-	for (const element of form.elements) {
-		if (isFieldElement(element) && element.willValidate) {
-			const elementName = element.name !== '__form__' ? element.name : '';
-			const message = submission.error[elementName];
-			const elementShouldValidate = shouldValidate(
-				submission.intent,
-				elementName,
-			);
-
-			if (elementShouldValidate) {
-				element.dataset.conformTouched = 'true';
-			}
-
-			if (typeof message !== 'undefined' || elementShouldValidate) {
-				const invalidEvent = new Event('invalid', { cancelable: true });
-
-				element.setCustomValidity(getValidationMessage(message));
-				element.dispatchEvent(invalidEvent);
-			}
-
-			if (elementShouldValidate && !element.validity.valid) {
-				focus(element);
-			}
-		}
-	}
+	}, 0);
 }
 
 export function setValue<T>(
@@ -491,28 +498,6 @@ export function parse<Schema>(
 				};
 			},
 		};
-
-		// Cleanup
-		result.error = Object.fromEntries(
-			Object.entries(result.error).reduce<Array<[string, string | string[]]>>(
-				(entries, [name, message]) => {
-					if (shouldValidate(result.intent, name)) {
-						if (Array.isArray(message)) {
-							if (message.length > 0) {
-								entries.push([name, message]);
-							} else {
-								entries.push([name, '']);
-							}
-						} else {
-							entries.push([name, message]);
-						}
-					}
-
-					return entries;
-				},
-				[],
-			),
-		);
 
 		return result;
 	};

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -216,7 +216,7 @@ export function reportSubmission(
 		// We can't use empty string as button name
 		// As `form.element.namedItem('')` will always returns null
 		const elementName = name ? name : '__form__';
-		let item = form.elements.namedItem(elementName);
+		const item = form.elements.namedItem(elementName);
 
 		if (item instanceof RadioNodeList) {
 			for (const field of item) {
@@ -234,8 +234,6 @@ export function reportSubmission(
 			button.name = elementName;
 			button.hidden = true;
 			button.dataset.conformTouched = 'true';
-			button.dataset.conformManaged = 'true';
-			item = button;
 
 			form.appendChild(button);
 		}

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -1,4 +1,8 @@
-import type { FieldConfig } from '@conform-to/dom';
+import {
+	type FieldConfig,
+	VALIDATION_SKIPPED,
+	VALIDATION_UNDEFINED,
+} from '@conform-to/dom';
 import type { CSSProperties, HTMLInputTypeAttribute } from 'react';
 
 interface FieldProps {
@@ -179,3 +183,5 @@ export function textarea<Schema>(
 }
 
 export const intent = '__intent__';
+
+export { VALIDATION_UNDEFINED, VALIDATION_SKIPPED };

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -22,6 +22,7 @@ import {
 	getErrors,
 	getFormAttributes,
 	shouldValidate,
+	VALIDATION_UNDEFINED,
 } from '@conform-to/dom';
 import {
 	type FormEvent,
@@ -354,14 +355,18 @@ export function useForm<
 							Object.entries(submission.error).some(
 								([, message]) =>
 									message !== '' &&
-									!([] as string[]).concat(message).includes('__UNDEFINED__'),
+									!([] as string[])
+										.concat(message)
+										.includes(VALIDATION_UNDEFINED),
 							)) ||
 						(typeof config.onValidate !== 'undefined' &&
 							(submission.intent.startsWith('validate') ||
 								submission.intent.startsWith('list')) &&
 							Object.entries(submission.error).every(
 								([, message]) =>
-									!([] as string[]).concat(message).includes('__UNDEFINED__'),
+									!([] as string[])
+										.concat(message)
+										.includes(VALIDATION_UNDEFINED),
 							))
 					) {
 						const listCommand = parseListCommand(submission.intent);

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -8,7 +8,6 @@ export {
 	requestIntent,
 	requestSubmit,
 	parse,
-	shouldValidate,
 } from '@conform-to/dom';
 export * from './hooks';
 export * as conform from './helpers';

--- a/playground/app/routes/input-attributes.tsx
+++ b/playground/app/routes/input-attributes.tsx
@@ -1,6 +1,6 @@
-import { type Submission, conform, useForm } from '@conform-to/react';
-import { Form } from '@remix-run/react';
-import { useState } from 'react';
+import { conform, useForm, parse } from '@conform-to/react';
+import { json, type ActionArgs } from '@remix-run/node';
+import { Form, useActionData } from '@remix-run/react';
 import { Playground, Field } from '~/components';
 
 interface Schema {
@@ -11,10 +11,18 @@ interface Schema {
 	tags: string[];
 }
 
+export async function action({ request }: ActionArgs) {
+	const formData = await request.formData();
+	const submission = parse(formData, { resolve: () => ({ error: {} }) });
+
+	return json(submission);
+}
+
 export default function Example() {
-	const [state, setState] = useState<Submission>();
+	const state = useActionData<typeof action>();
 	const [form, { title, description, images, rating, tags }] = useForm<Schema>({
 		id: 'test',
+		state,
 		constraint: {
 			title: {
 				required: true,
@@ -41,10 +49,6 @@ export default function Example() {
 				required: true,
 				multiple: true,
 			},
-		},
-		onSubmit(event, { submission }) {
-			event.preventDefault();
-			setState(submission);
 		},
 	});
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -176,4 +176,4 @@ export function getPlayground(page: Page) {
 	};
 }
 
-export const expectNonEmptyString = expect.stringMatching(/\w+/);
+export const expectNonEmptyString = /\w+/;

--- a/tests/react.spec.ts
+++ b/tests/react.spec.ts
@@ -25,15 +25,14 @@ test.describe('Client Validation', () => {
 		const { title, description, genre, rating } = getMovieFieldset(form);
 
 		async function expectErrorMessagesEqualsToValidationMessages() {
-			const [actualMessages, ...expectedMessages] = await Promise.all([
-				getErrorMessages(form),
+			const expectedMessages = await Promise.all([
 				getValidationMessage(title),
 				getValidationMessage(description),
 				getValidationMessage(genre),
 				getValidationMessage(rating),
 			]);
 
-			expect(actualMessages).toEqual(expectedMessages);
+			await expect(form.locator('main p')).toHaveText(expectedMessages);
 		}
 
 		await clickSubmitButton(form);

--- a/tests/react.spec.ts
+++ b/tests/react.spec.ts
@@ -66,7 +66,7 @@ test.describe('Client Validation', () => {
 
 		await clickSubmitButton(form);
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'Title is required',
 			'',
 			'Genre is required',
@@ -74,7 +74,7 @@ test.describe('Client Validation', () => {
 		]);
 
 		await title.type('What?');
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'Please enter a valid title',
 			'',
 			'Genre is required',
@@ -83,7 +83,7 @@ test.describe('Client Validation', () => {
 
 		await title.fill('');
 		await title.type('The Matrix');
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'',
 			'',
 			'Genre is required',
@@ -91,7 +91,7 @@ test.describe('Client Validation', () => {
 		]);
 
 		await description.type('When a beautiful stranger...');
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'',
 			'Please provides more details',
 			'Genre is required',
@@ -102,7 +102,7 @@ test.describe('Client Validation', () => {
 		await description.type(
 			'When a beautiful stranger leads computer hacker Neo to...',
 		);
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'',
 			'',
 			'Genre is required',
@@ -110,10 +110,10 @@ test.describe('Client Validation', () => {
 		]);
 
 		await genre.selectOption({ label: 'Science Fiction' });
-		expect(await getErrorMessages(form)).toEqual(['', '', '', '']);
+		await expect(form.locator('main p')).toHaveText(['', '', '', '']);
 
 		await rating.type('3.9');
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'',
 			'',
 			'',
@@ -122,7 +122,7 @@ test.describe('Client Validation', () => {
 
 		await rating.fill('');
 		await rating.type('4.0');
-		expect(await getErrorMessages(form)).toEqual(['', '', '', '']);
+		await expect(form.locator('main p')).toHaveText(['', '', '', '']);
 
 		await clickSubmitButton(form);
 		expect(await getSubmission(form)).toEqual({
@@ -146,7 +146,7 @@ test.describe('Client Validation', () => {
 		await password.type('1234');
 		await clickSubmitButton(playground);
 
-		expect(await getErrorMessages(playground)).toEqual([
+		await expect(playground.locator('main p')).toHaveText([
 			expectNonEmptyString,
 			expectNonEmptyString,
 			expectNonEmptyString,
@@ -158,7 +158,7 @@ test.describe('Client Validation', () => {
 		await password.type('secretpassword');
 		await confirmPassword.type('secretpassword');
 
-		expect(await getErrorMessages(playground)).toEqual(['', '', '']);
+		await expect(playground.locator('main p')).toHaveText(['', '', '']);
 
 		await clickSubmitButton(playground);
 
@@ -178,7 +178,7 @@ test.describe('Client Validation', () => {
 
 		await clickSubmitButton(form);
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'IBAN is required',
 			'Please select a currency',
 			'Value is required',
@@ -188,7 +188,7 @@ test.describe('Client Validation', () => {
 
 		await fieldset.iban.type('DE89 3704 0044 0532 0130 00');
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'',
 			'Please select a currency',
 			'Value is required',
@@ -198,7 +198,7 @@ test.describe('Client Validation', () => {
 
 		await fieldset.currency.selectOption('EUR');
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'',
 			'',
 			'Value is required',
@@ -208,7 +208,7 @@ test.describe('Client Validation', () => {
 
 		await fieldset.value.type('1');
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'',
 			'',
 			'',
@@ -218,7 +218,7 @@ test.describe('Client Validation', () => {
 
 		await fieldset.timestamp.type(timestamp);
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'',
 			'',
 			'',
@@ -228,7 +228,7 @@ test.describe('Client Validation', () => {
 
 		await fieldset.verified.check();
 
-		expect(await getErrorMessages(form)).toEqual(['', '', '', '', '']);
+		await expect(form.locator('main p')).toHaveText(['', '', '', '', '']);
 
 		await clickSubmitButton(form);
 
@@ -262,24 +262,20 @@ test.describe('Client Validation', () => {
 		const currentValidationMessages = await getErrorMessages(form);
 
 		expect(currentValidationMessages).not.toEqual(initialValidationMessages);
-		expect(
-			await Promise.all([
-				isTouched(title),
-				isTouched(description),
-				isTouched(genre),
-				isTouched(rating),
-			]),
-		).not.toContain(false);
+		await expect(title).toHaveAttribute('data-conform-touched', 'true');
+		await expect(description).toHaveAttribute('data-conform-touched', 'true');
+		await expect(genre).toHaveAttribute('data-conform-touched', 'true');
+		await expect(rating).toHaveAttribute('data-conform-touched', 'true');
 
 		await title.type('Up');
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'',
 			...currentValidationMessages.slice(1),
 		]);
 
 		await clickResetButton(form);
 
-		expect(await getErrorMessages(form)).toEqual(['', '', '', '']);
+		await expect(form.locator('main p')).toHaveText(['', '', '', '']);
 		expect(
 			await Promise.all([
 				getValidationMessage(title),
@@ -355,27 +351,33 @@ test.describe('Server Validation', () => {
 
 		await clickSubmitButton(form);
 
-		await expect
-			.poll(() => getErrorMessages(form))
-			.toEqual(['', 'Email is required', 'Password is required']);
+		await expect(form.locator('main p')).toHaveText([
+			'',
+			'Email is required',
+			'Password is required',
+		]);
 
 		await email.type('me@edmund.dev');
 		await clickSubmitButton(form);
 
-		await expect
-			.poll(() => getErrorMessages(form))
-			.toEqual(['', '', 'Password is required']);
+		await expect(form.locator('main p')).toHaveText([
+			'',
+			'',
+			'Password is required',
+		]);
 
 		await password.type('SecretPassword');
 		await clickSubmitButton(form);
-		await expect
-			.poll(() => getErrorMessages(form))
-			.toEqual(['The provided email or password is not valid', '', '']);
+		await expect(form.locator('main p')).toHaveText([
+			'The provided email or password is not valid',
+			'',
+			'',
+		]);
 
 		await password.press('Control+a');
 		await password.type('$eCreTP@ssWord');
 		await clickSubmitButton(form);
-		await expect.poll(() => getErrorMessages(form)).toEqual(['', '', '']);
+		await expect(form.locator('main p')).toHaveText(['', '', '']);
 	});
 
 	test('Async validation', async ({ page }) => {
@@ -429,7 +431,7 @@ test.describe('Server Validation', () => {
 
 		await clickSubmitButton(form);
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'',
 			'Name is required',
 			'Email is required',
@@ -438,7 +440,7 @@ test.describe('Server Validation', () => {
 
 		await name.type('Edmund Hung');
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'',
 			'',
 			'Email is required',
@@ -447,7 +449,7 @@ test.describe('Server Validation', () => {
 
 		await email.type('hey@conform.g');
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'',
 			'',
 			'Email is invalid',
@@ -456,25 +458,34 @@ test.describe('Server Validation', () => {
 
 		await email.type('u');
 
-		await expect
-			.poll(() => getErrorMessages(form))
-			.toEqual(['', '', 'Email is already used', 'Title is required']);
+		await expect(form.locator('main p')).toHaveText([
+			'',
+			'',
+			'Email is already used',
+			'Title is required',
+		]);
 
 		await email.type('i');
 
-		await expect
-			.poll(() => getErrorMessages(form))
-			.toEqual(['', '', 'Email is already used', 'Title is required']);
+		await expect(form.locator('main p')).toHaveText([
+			'',
+			'',
+			'Email is already used',
+			'Title is required',
+		]);
 
 		await email.type('d');
 
-		await expect
-			.poll(() => getErrorMessages(form))
-			.toEqual(['', '', 'Email is already used', 'Title is required']);
+		await expect(form.locator('main p')).toHaveText([
+			'',
+			'',
+			'Email is already used',
+			'Title is required',
+		]);
 
 		await title.type('Software Developer');
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'',
 			'',
 			'Email is already used',
@@ -483,13 +494,11 @@ test.describe('Server Validation', () => {
 
 		await email.type('e');
 
-		await expect
-			.poll(() => getErrorMessages(form), { timeout: 10000 })
-			.toEqual(['', '', '', '']);
+		await expect(form.locator('main p')).toHaveText(['', '', '', '']);
 
 		await Promise.all([waitForDataResponse(page), clickSubmitButton(form)]);
 
-		expect(await getErrorMessages(form)).toEqual(['', '', '', '']);
+		await expect(form.locator('main p')).toHaveText(['', '', '', '']);
 	});
 
 	test('Autofocus invalid field', async ({ page }) => {
@@ -522,11 +531,11 @@ test.describe('Error Reporting', () => {
 		// To ensure it leaves the last field
 		await form.press('Tab');
 
-		expect(await getErrorMessages(form)).toEqual(['', '', '']);
+		await expect(form.locator('main p')).toHaveText(['', '', '']);
 
 		await clickSubmitButton(form);
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			expectNonEmptyString,
 			expectNonEmptyString,
 			expectNonEmptyString,
@@ -538,21 +547,21 @@ test.describe('Error Reporting', () => {
 		const { email, password, confirmPassword } = getSignupFieldset(form);
 
 		await email.type('Invalid email');
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			expectNonEmptyString,
 			'',
 			'',
 		]);
 
 		await password.type('1234');
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			expectNonEmptyString,
 			expectNonEmptyString,
 			'',
 		]);
 
 		await confirmPassword.type('5678');
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			expectNonEmptyString,
 			expectNonEmptyString,
 			expectNonEmptyString,
@@ -564,38 +573,38 @@ test.describe('Error Reporting', () => {
 		const { email, password, confirmPassword } = getSignupFieldset(form);
 
 		await email.type('Invalid email');
-		expect(await getErrorMessages(form)).toEqual(['', '', '']);
+		await expect(form.locator('main p')).toHaveText(['', '', '']);
 
 		await form.press('Tab');
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			expectNonEmptyString,
 			'',
 			'',
 		]);
 
 		await password.type('1234');
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			expectNonEmptyString,
 			'',
 			'',
 		]);
 
 		await form.press('Tab');
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			expectNonEmptyString,
 			expectNonEmptyString,
 			'',
 		]);
 
 		await confirmPassword.type('5678');
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			expectNonEmptyString,
 			expectNonEmptyString,
 			'',
 		]);
 
 		await form.press('Tab');
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			expectNonEmptyString,
 			expectNonEmptyString,
 			expectNonEmptyString,
@@ -610,7 +619,7 @@ test.describe('Field list', () => {
 
 		await clickSubmitButton(form);
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			expectNonEmptyString,
 			expectNonEmptyString,
 			'',
@@ -619,7 +628,7 @@ test.describe('Field list', () => {
 		await form.locator('button:text("Insert top")').click();
 		await clickSubmitButton(form);
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			expectNonEmptyString,
 			expectNonEmptyString,
 			'',
@@ -630,7 +639,7 @@ test.describe('Field list', () => {
 		await form.locator('button:text("Insert bottom")').click();
 		await clickSubmitButton(form);
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			expectNonEmptyString,
 			expectNonEmptyString,
 			'',
@@ -758,7 +767,7 @@ test.describe('No JS', () => {
 
 		await Promise.all([page.waitForNavigation(), clickSubmitButton(form)]);
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'',
 			'Email is required',
 			'Password is required',
@@ -767,7 +776,7 @@ test.describe('No JS', () => {
 		await email.type('me@edmund.dev');
 		await password.type('SecretPassword');
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'',
 			'Email is required',
 			'Password is required',
@@ -775,7 +784,7 @@ test.describe('No JS', () => {
 
 		await Promise.all([page.waitForNavigation(), clickSubmitButton(form)]);
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'The provided email or password is not valid',
 			'',
 			'',
@@ -784,7 +793,7 @@ test.describe('No JS', () => {
 		await password.type('$eCreTP@ssWord');
 		await Promise.all([page.waitForNavigation(), clickSubmitButton(form)]);
 
-		expect(await getErrorMessages(form)).toEqual(['', '', '']);
+		await expect(form.locator('main p')).toHaveText(['', '', '']);
 	});
 
 	test('List Command', async ({ page }) => {
@@ -854,7 +863,7 @@ test.describe('No JS', () => {
 
 		await Promise.all([page.waitForNavigation(), clickSubmitButton(form)]);
 
-		expect(await getErrorMessages(form)).toEqual([
+		await expect(form.locator('main p')).toHaveText([
 			'',
 			expectNonEmptyString,
 			'',


### PR DESCRIPTION
This PR removes the need of `shouldSubmissionPassthrough` as implemented on #95 and the `shouldValidate` config as proposed on #98 which tried to solve the questions: **What isn't validated and why**.

All the previous approaches are hard to maintain. It also introduce additional effort for user that don't need those functionalities. Now, the new approach make it totally opt-in. These questions are not required unless the form requires expensive validation or if it could only be run on the server.

Here is a quick example how to utilise the new special messages (`conform.VALIDATION_SKIPPED` and `conform.VALIDATION_UNDEFINED`) with zod:

```tsx
import { conform, useForm } from '@conform-to/react';
import { parse } from '@conform-to/zod';
import { z } from 'zod';

// Instead of sharing a schema, we prepare a schema creator
function createSchema(
    intent: string,
    // Note: the constraints parameter is optional
    constraints: {
        isEmailUnique?: (email: string) => Promise<boolean>;
    } = {},
) {
    return z.object({
        name: z
            .string()
            .min(1, 'Name is required'),
        email: z
            .string()
            .min(1, 'Email is required')
            .email('Email is invalid')
            // We use `.superRefine` instead of `.refine` for better control 
            .superRefine((value, ctx) => {
                if (intent !== 'validate/email' && intent !== 'submit') {
                    // Validate only when necessary
                    ctx.addIssue({
                        code: z.ZodIssueCode.custom,
                        message: conform.VALIDATION_SKIPPED,
                    });
                } else if (typeof constraints.isEmailUnique === 'undefined') {
                    // Validate only if the constraint is defined
                    ctx.addIssue({
                        code: z.ZodIssueCode.custom,
                        message: conform.VALIDATION_UNDEFINED,
                    });
                } else {
                    // Tell zod this is an async validation by returning the promise
                    return constraints.isEmailUnique(value).then((isUnique) => {
                        if (isUnique) {
                            return;
                        }

                        ctx.addIssue({
                            code: z.ZodIssueCode.custom,
                            message: 'Email is already used',
                        });
                    });
                }
            }),
        title: z
            .string().min(1, 'Title is required')
            .max(20, 'Title is too long'),
    });
}

export let action = async ({ request }: ActionArgs) => {
    const formData = await request.formData();
    const submission = await parse(formData, {
        schema: (intent) =>
            // create the zod schema with the intent and constraint
            createSchema(intent, {
                isEmailUnique(email) {
                    return new Promise((resolve) => {
                        setTimeout(() => {
                            // Only `hey@conform.guide` is unique
                            resolve(email === 'hey@conform.guide');
                        }, Math.random() * 500);
                    });
                },
            }),
        async: true,
    });

    return json(submission);
};

export default function EmployeeForm() {
    const config = useLoaderData();
    const state = useActionData();
    const [form, { name, email, title }] = useForm({
        ...config,
        state,
        onValidate({ formData }) {
            return parse(formData, {
                // Create the schema without any constraint defined
                schema: (intent) => createSchema(intent),
            });
        },
    });

    return (
        <Form method="post" {...form.props}>
            {/* ... */}
        </Form>
    );
}

```
