### PR TITLE
feat(conform-dom): focus first non button invalid field

### DIFF
--- a/docs/intent-button.md
+++ b/docs/intent-button.md
@@ -45,7 +45,7 @@ function Product() {
 }
 ```
 
-In **Conform**, if the name of a button is configured with `conform.intent`, its value will be treated as the intent of the submission instead. Otherwise, the intent would be `submit` by default.
+In **Conform**, if the name of a button is configured with `conform.INTENT`, its value will be treated as the intent of the submission instead. Otherwise, the intent would be `submit` by default.
 
 ```tsx
 import { useForm, conform } from '@conform-to/react';
@@ -66,10 +66,10 @@ function Product() {
   return (
     <form {...form.props}>
       <input type="hidden" name="productId" value="rf23g43" />
-      <button type="submit" name={conform.intent} value="add-to-cart">
+      <button type="submit" name={conform.INTENT} value="add-to-cart">
         Add to Cart
       </button>
-      <button type="submit" name={conform.intent} value="buy-now">
+      <button type="submit" name={conform.INTENT} value="buy-now">
         Buy now
       </button>
     </form>

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -40,21 +40,6 @@ export type FieldsetConstraint<Schema extends Record<string, any>> = {
 	[Key in keyof Schema]?: FieldConstraint<Schema[Key]>;
 };
 
-// type Join<K, P> = P extends string | number ?
-//     K extends string | number ?
-//     `${K}${"" extends P ? "" : "."}${P}`
-//     : never : never;
-
-// type DottedPaths<T> = T extends object ?
-//     { [K in keyof T]-?: K extends string | number ?
-//         `${K}` | Join<K, DottedPaths<T[K]>>
-//         : never
-//     }[keyof T] : ""
-
-// type Pathfix<T> = T extends `${infer Prefix}.${number}${infer Postfix}` ? `${Prefix}[${number}]${Pathfix<Postfix>}` : T;
-
-// type Path<Schema> = Pathfix<DottedPaths<Schema>> | '';
-
 export type Submission<Schema extends Record<string, any> | unknown = unknown> =
 	unknown extends Schema
 		? {

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -189,6 +189,27 @@ export function shouldValidate(intent: string, name: string): boolean {
 	}
 }
 
+export function isSubmitting(intent: string) {
+	const [type, ...rest] = intent.split('/');
+
+	switch (type) {
+		case 'validate':
+			return rest.length > 1;
+		case 'list':
+			return parseListCommand(intent) === null;
+		default:
+			return true;
+	}
+}
+
+export function isFocusedOnButton(form: HTMLFormElement) {
+	return (
+		isFieldElement(document.activeElement) &&
+		document.activeElement.tagName === 'BUTTON' &&
+		document.activeElement.form === form
+	);
+}
+
 export function getValidationMessage(errors?: string | string[]): string {
 	return ([] as string[]).concat(errors ?? []).join(String.fromCharCode(31));
 }
@@ -267,6 +288,7 @@ export function reportSubmission(
 
 			if (
 				!focusedFirstInvalidField &&
+				(isSubmitting(submission.intent) || isFocusedOnButton(form)) &&
 				elementShouldValidate &&
 				element.tagName !== 'BUTTON' &&
 				!element.validity.valid

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -203,8 +203,8 @@ export function getErrors(message: string | undefined): string[] {
 
 export const FORM_ERROR_ELEMENT_NAME = '__form__';
 export const INTENT_BUTTON_NAME = '__intent__';
-export const VALIDATION_UNDEFINED_MESSAGE = '__undefined__';
-export const VALIDATION_SKIPPED_MESSAGE = '__skipped__';
+export const VALIDATION_UNDEFINED = '__undefined__';
+export const VALIDATION_SKIPPED = '__skipped__';
 
 export function reportSubmission(
 	form: HTMLFormElement,
@@ -261,7 +261,7 @@ export function reportSubmission(
 
 			if (
 				typeof message === 'undefined' ||
-				!([] as string[]).concat(message).includes(VALIDATION_SKIPPED_MESSAGE)
+				!([] as string[]).concat(message).includes(VALIDATION_SKIPPED)
 			) {
 				const invalidEvent = new Event('invalid', { cancelable: true });
 

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -240,6 +240,8 @@ export function reportSubmission(
 		}
 	}
 
+	let focusedFirstInvalidField = false;
+
 	for (const element of form.elements) {
 		if (isFieldElement(element) && element.willValidate) {
 			const elementName = element.name !== '__form__' ? element.name : '';
@@ -263,8 +265,14 @@ export function reportSubmission(
 				element.dispatchEvent(invalidEvent);
 			}
 
-			if (elementShouldValidate && !element.validity.valid) {
-				focus(element);
+			if (
+				!focusedFirstInvalidField &&
+				elementShouldValidate &&
+				element.tagName !== 'BUTTON' &&
+				!element.validity.valid
+			) {
+				element.focus();
+				focusedFirstInvalidField = true;
 			}
 		}
 	}
@@ -353,20 +361,6 @@ export function getFormElement(
 	}
 
 	return form;
-}
-
-export function focus(field: FieldElement): void {
-	const currentFocus = document.activeElement;
-
-	if (
-		!isFieldElement(currentFocus) ||
-		currentFocus.tagName !== 'BUTTON' ||
-		currentFocus.form !== field.form
-	) {
-		return;
-	}
-
-	field.focus();
 }
 
 export function parse(payload: FormData | URLSearchParams): Submission;

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -56,7 +56,7 @@ export type Submission<Schema extends Record<string, any> | unknown = unknown> =
 		  };
 
 export interface IntentButtonProps {
-	name: typeof INTENT_BUTTON_NAME;
+	name: typeof INTENT;
 	value: string;
 	formNoValidate?: boolean;
 }
@@ -184,7 +184,7 @@ export function isFocusedOnIntentButton(
 		isFieldElement(element) &&
 		element.tagName === 'BUTTON' &&
 		element.form === form &&
-		element.name === INTENT_BUTTON_NAME &&
+		element.name === INTENT &&
 		element.value === intent
 	);
 }
@@ -201,8 +201,8 @@ export function getErrors(message: string | undefined): string[] {
 	return message.split(String.fromCharCode(31));
 }
 
-export const FORM_ERROR_ELEMENT_NAME = '__form__';
-export const INTENT_BUTTON_NAME = '__intent__';
+const FORM_ERROR_ELEMENT_NAME = '__form__';
+export const INTENT = '__intent__';
 export const VALIDATION_UNDEFINED = '__undefined__';
 export const VALIDATION_SKIPPED = '__skipped__';
 
@@ -323,7 +323,7 @@ export function requestIntent(
 
 	const button = document.createElement('button');
 
-	button.name = INTENT_BUTTON_NAME;
+	button.name = INTENT;
 	button.value = buttonProps.value;
 	button.hidden = true;
 
@@ -343,7 +343,7 @@ export function requestIntent(
  */
 export function validate(field?: string): IntentButtonProps {
 	return {
-		name: INTENT_BUTTON_NAME,
+		name: INTENT,
 		value: field ? `validate/${field}` : 'validate',
 		formNoValidate: true,
 	};
@@ -422,7 +422,7 @@ export function parse<Schema>(
 	};
 
 	for (let [name, value] of payload.entries()) {
-		if (name === INTENT_BUTTON_NAME) {
+		if (name === INTENT) {
 			if (typeof value !== 'string' || submission.intent !== 'submit') {
 				throw new Error('The intent could only be set on a button');
 			}
@@ -594,7 +594,7 @@ export const list = new Proxy({} as ListCommandButtonBuilder, {
 			case 'reorder':
 				return (scope: string, payload = {}): IntentButtonProps => {
 					return {
-						name: INTENT_BUTTON_NAME,
+						name: INTENT,
 						value: `list/${type}/${scope}/${JSON.stringify(payload)}`,
 						formNoValidate: true,
 					};
@@ -672,7 +672,7 @@ export function validateConstraint(options: {
 			for (const element of options.form.elements) {
 				if (isFieldElement(element)) {
 					const name =
-						element.name === FORM_ERROR_ELEMENT_NAME ? '' : element.name;
+						element.name !== FORM_ERROR_ELEMENT_NAME ? element.name : '';
 					const constraint = Object.entries(element.dataset).reduce<
 						Record<string, boolean>
 					>((result, [name, attributeValue = '']) => {

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -1,7 +1,7 @@
 import {
 	type FieldConfig,
-	VALIDATION_UNDEFINED_MESSAGE,
-	VALIDATION_SKIPPED_MESSAGE,
+	VALIDATION_UNDEFINED,
+	VALIDATION_SKIPPED,
 	INTENT_BUTTON_NAME,
 } from '@conform-to/dom';
 import type { CSSProperties, HTMLInputTypeAttribute } from 'react';
@@ -184,5 +184,5 @@ export function textarea<Schema>(
 }
 
 export const intent = INTENT_BUTTON_NAME;
-export const VALIDATION_UNDEFINED = VALIDATION_UNDEFINED_MESSAGE;
-export const VALIDATION_SKIPPED = VALIDATION_SKIPPED_MESSAGE;
+
+export { VALIDATION_UNDEFINED, VALIDATION_SKIPPED };

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -1,7 +1,8 @@
 import {
 	type FieldConfig,
-	VALIDATION_SKIPPED,
-	VALIDATION_UNDEFINED,
+	VALIDATION_UNDEFINED_MESSAGE,
+	VALIDATION_SKIPPED_MESSAGE,
+	INTENT_BUTTON_NAME,
 } from '@conform-to/dom';
 import type { CSSProperties, HTMLInputTypeAttribute } from 'react';
 
@@ -182,6 +183,6 @@ export function textarea<Schema>(
 	return attributes;
 }
 
-export const intent = '__intent__';
-
-export { VALIDATION_UNDEFINED, VALIDATION_SKIPPED };
+export const intent = INTENT_BUTTON_NAME;
+export const VALIDATION_UNDEFINED = VALIDATION_UNDEFINED_MESSAGE;
+export const VALIDATION_SKIPPED = VALIDATION_SKIPPED_MESSAGE;

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -2,7 +2,7 @@ import {
 	type FieldConfig,
 	VALIDATION_UNDEFINED,
 	VALIDATION_SKIPPED,
-	INTENT_BUTTON_NAME,
+	INTENT,
 } from '@conform-to/dom';
 import type { CSSProperties, HTMLInputTypeAttribute } from 'react';
 
@@ -183,6 +183,4 @@ export function textarea<Schema>(
 	return attributes;
 }
 
-export const intent = INTENT_BUTTON_NAME;
-
-export { VALIDATION_UNDEFINED, VALIDATION_SKIPPED };
+export { INTENT, VALIDATION_UNDEFINED, VALIDATION_SKIPPED };

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -21,8 +21,8 @@ import {
 	getValidationMessage,
 	getErrors,
 	getFormAttributes,
-	shouldValidate,
 	VALIDATION_UNDEFINED,
+	getScope,
 } from '@conform-to/dom';
 import {
 	type FormEvent,
@@ -161,12 +161,14 @@ export function useForm<
 			};
 		}
 
+		const scope = getScope(submission.intent);
+
 		return {
 			defaultValue: submission.payload as FieldValue<Schema> | undefined,
 			initialError: Object.entries(submission.error).reduce<
 				Record<string, string | string[]>
 			>((result, [name, message]) => {
-				if (name !== '' && shouldValidate(submission.intent, name)) {
+				if (name !== '' && (scope === null || scope === name)) {
 					result[name] = message;
 				}
 

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -21,7 +21,7 @@ import {
 	getValidationMessage,
 	getErrors,
 	getFormAttributes,
-	VALIDATION_UNDEFINED,
+	VALIDATION_UNDEFINED_MESSAGE,
 	getScope,
 } from '@conform-to/dom';
 import {
@@ -356,7 +356,7 @@ export function useForm<
 									message !== '' &&
 									!([] as string[])
 										.concat(message)
-										.includes(VALIDATION_UNDEFINED),
+										.includes(VALIDATION_UNDEFINED_MESSAGE),
 							)) ||
 						(typeof config.onValidate !== 'undefined' &&
 							(submission.intent.startsWith('validate') ||
@@ -365,7 +365,7 @@ export function useForm<
 								([, message]) =>
 									!([] as string[])
 										.concat(message)
-										.includes(VALIDATION_UNDEFINED),
+										.includes(VALIDATION_UNDEFINED_MESSAGE),
 							))
 					) {
 						const listCommand = parseListCommand(submission.intent);

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -21,8 +21,8 @@ import {
 	getValidationMessage,
 	getErrors,
 	getFormAttributes,
-	VALIDATION_UNDEFINED_MESSAGE,
 	getScope,
+	VALIDATION_UNDEFINED,
 } from '@conform-to/dom';
 import {
 	type FormEvent,
@@ -356,7 +356,7 @@ export function useForm<
 									message !== '' &&
 									!([] as string[])
 										.concat(message)
-										.includes(VALIDATION_UNDEFINED_MESSAGE),
+										.includes(VALIDATION_UNDEFINED),
 							)) ||
 						(typeof config.onValidate !== 'undefined' &&
 							(submission.intent.startsWith('validate') ||
@@ -365,7 +365,7 @@ export function useForm<
 								([, message]) =>
 									!([] as string[])
 										.concat(message)
-										.includes(VALIDATION_UNDEFINED_MESSAGE),
+										.includes(VALIDATION_UNDEFINED),
 							))
 					) {
 						const listCommand = parseListCommand(submission.intent);

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -9,5 +9,14 @@ export {
 	requestIntent,
 	isFieldElement,
 } from '@conform-to/dom';
-export { useForm, useFieldset, useFieldList, useInputEvent } from './hooks';
+export {
+	type Field,
+	type Fieldset,
+	type FieldsetConfig,
+	type FormConfig,
+	useForm,
+	useFieldset,
+	useFieldList,
+	useInputEvent,
+} from './hooks';
 export * as conform from './helpers';


### PR DESCRIPTION
Conform can already focus on first invalid field. But there is an exception I made originally to NOT changing the focus if you are already focusing on one of the field (i.e. pressing enter directly).

This PR removes the exception to align with how native error bubble works.