### PR TITLE
feat(conform-react)!: flatten field config

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ export default function LoginForm() {
     <Form method="post" {...form.props}>
       <div>
         <label>Email</label>
-        <input {...conform.input(email.config)} />
+        <input {...conform.input(email)} />
         <div>{email.error}</div>
       </div>
       <div>
         <label>Password</label>
-        <input {...conform.input(password.config)} />
+        <input {...conform.input(password)} />
         <div>{password.error}</div>
       </div>
       <button>Login</button>

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -27,9 +27,9 @@ function Example() {
 
     return (
         <form {...form.props}>
-            <label htmlFor={message.config.id}>
-            <input {...conform.input(message.config)}>
-            <div id={message.config.errorId} role="alert">
+            <label htmlFor={message.id}>
+            <input {...conform.input(message)}>
+            <div id={message.errorId} role="alert">
                 {message.error}
             </div>
             <button>Send</button>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,21 +51,18 @@ function Example() {
   // By providing a schema to useForm
   const [form, { address }] = useForm<Schema>();
   // All the field name will be checked with TypeScript
-  const { city, zipcode, street, country } = useFieldset(
-    form.ref,
-    address.config,
-  );
+  const { city, zipcode, street, country } = useFieldset(form.ref, address);
 
   return (
     <form {...form.props}>
       {/* These set the name to `address.street`, `address.zipcode` etc. */}
-      <input {...conform.input(street.config)} />
+      <input {...conform.input(street)} />
       <div>{street.error}</div>
-      <input {...conform.input(zipcode.config)} />
+      <input {...conform.input(zipcode)} />
       <div>{zipcode.error}</div>
-      <input {...conform.input(city.config)} />
+      <input {...conform.input(city)} />
       <div>{city.error}</div>
-      <input {...conform.input(country.config)} />
+      <input {...conform.input(country)} />
       <div>{country.error}</div>
     </form>
   );
@@ -89,7 +86,7 @@ function Example() {
   // By providing a schema to useForm
   const [form, { tasks }] = useForm<Schema>();
   // All the field name will be checked with TypeScript
-  const list = useFieldList(form.ref, tasks.config);
+  const list = useFieldList(form.ref, tasks);
 
   return (
     <form {...form.props}>
@@ -97,7 +94,7 @@ function Example() {
         {list.map((task) => (
           <li key={task.key}>
             {/* These set the name to `task[0]`, `tasks[1]` etc */}
-            <input {...conform.input(task.config)} />
+            <input {...conform.input(task)} />
             <div>{task.error}</div>
           </li>
         ))}
@@ -128,7 +125,7 @@ interface Schema {
 
 function Example() {
   const [form, { todos }] = useForm<Schema>();
-  const list = useFieldList(form.ref, todos.config);
+  const list = useFieldList(form.ref, todos);
 
   return (
     <form {...form.props}>
@@ -136,7 +133,7 @@ function Example() {
         {list.map((todo) => (
           <li key={todo.key}>
             {/* Pass the config to TodoFieldset */}
-            <TodoFieldset {...todo.config} />
+            <TodoFieldset {...todo} />
           </li>
         ))}
       </ul>
@@ -151,9 +148,9 @@ function TodoFieldset(config: FieldConfig<Todo>) {
 
   return (
     <fieldset ref={ref}>
-      <input {...conform.input(title.config)} />
+      <input {...conform.input(title)} />
       <div>{title.error}</div>
-      <input {...conform.input(notes.config)} />
+      <input {...conform.input(notes)} />
       <div>{notes.error}</div>
     </fieldset>
   );

--- a/docs/file-upload.md
+++ b/docs/file-upload.md
@@ -39,7 +39,7 @@ function Example() {
     <form encType="multipart/form-data" {...form.props}>
       <div>
         <label>File</label>
-        <input {...conform.input(file.config, { type: 'file' })} />
+        <input {...conform.input(file, { type: 'file' })} />
         <div>{file.error}</div>
       </div>
       <button>Upload</button>
@@ -113,7 +113,7 @@ function Example() {
     <form encType="multipart/form-data" {...form.props}>
       <div>
         <label>Mutliple Files</label>
-        <input {...conform.input(files.config, { type: 'file' })} multiple />
+        <input {...conform.input(files, { type: 'file' })} multiple />
         <div>{files.error}</div>
       </div>
       <button>Upload</button>

--- a/docs/focus-management.md
+++ b/docs/focus-management.md
@@ -23,7 +23,7 @@ function Example() {
 
   return (
     <form {...form.props}>
-      <input {...conform.input(message.config)} />
+      <input {...conform.input(message)} />
       <div>{message.error}</div>
       <button>Send</button>
     </form>
@@ -36,7 +36,7 @@ function Example() {
 Conform can also focus on custom control if it exposes a ref for you to focus manually. Here is an example snippet integrating with **react-select**:
 
 ```tsx
-function Select({ options, ...config }: SelectProps) {
+function Select({ options, .. }: SelectProps) {
   const [inputRef, control] = useInputEvent();
   const ref = useRef<HTMLInputElement>(null);
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -69,10 +69,7 @@ function Example() {
         {/*
           This is a shadow input which will be validated by Conform
         */}
-        <input
-          ref={inputRef}
-          {...conform.input(currency.config, { hidden: true })}
-        />
+        <input ref={inputRef} {...conform.input(currency, { hidden: true })} />
         {/*
           This makes the corresponding events to be dispatched
           from the element that the `inputRef` is set to.
@@ -84,7 +81,7 @@ function Example() {
               /*...*/
             ]
           }
-          defaultValue={currency.config.defaultValue ?? ''}
+          defaultValue={currency.defaultValue ?? ''}
           onChange={control.change}
           onBlur={control.blur}
         />
@@ -117,7 +114,7 @@ function Example() {
               /*...*/
             ]
           }
-          {...currency.config}
+          {...currency}
         />
         <div>{currency.error}</div>
       </div>
@@ -132,7 +129,7 @@ interface SelectProps extends FieldConfig<string> {
   options: Array<{ label: string; value: string }>;
 }
 
-function Select({ options, ...config }: SelectProps) {
+function Select({ options, .. }: SelectProps) {
   const [inputRef, control] = useInputEvent();
 
   return (
@@ -152,7 +149,7 @@ function Select({ options, ...config }: SelectProps) {
 If the custom control support manual focus, you can also hook it with the shadow input and let Conform focus on it when there is any error:
 
 ```tsx
-function Select({ options, ...config }: SelectProps) {
+function Select({ options, .. }: SelectProps) {
   const [inputRef, control] = useInputEvent();
   // The type of the ref might be different depends on the UI library
   const ref = useRef<HTMLInputElement>(null);
@@ -183,7 +180,7 @@ function Select({ options, ...config }: SelectProps) {
 The hook also provides support for the **reset** event if needed:
 
 ```tsx
-function Select({ options, ...config }: SelectProps) {
+function Select({ options, .. }: SelectProps) {
   const [value, setValue] = useState(config.defaultValue ?? '');
   const [inputRef, control] = useInputEvent({
     onReset: () => setValue(config.defaultValue ?? ''),

--- a/docs/intent-button.md
+++ b/docs/intent-button.md
@@ -86,22 +86,20 @@ import { useForm, useFieldList, conform, list } from '@conform-to/react';
 
 export default function Todos() {
   const [form, { tasks }] = useForm();
-  const taskList = useFieldList(form.ref, tasks.config);
+  const taskList = useFieldList(form.ref, tasks);
 
   return (
     <form {...form.props}>
       <ul>
         {taskList.map((task, index) => (
           <li key={task.key}>
-            <input {...conform.input(task.config)} />
-            <button {...list.remove(tasks.config.name, { index })}>
-              Delete
-            </button>
+            <input {...conform.input(task)} />
+            <button {...list.remove(tasks.name, { index })}>Delete</button>
           </li>
         ))}
       </ul>
       <div>
-        <button {...list.append(tasks.config.name)}>Add task</button>
+        <button {...list.append(tasks.name)}>Add task</button>
       </div>
       <button>Save</button>
     </form>
@@ -121,9 +119,9 @@ export default function Todos() {
 
   return (
     <form {...form.props}>
-      <input {...conform.input(email.config)} />
+      <input {...conform.input(email)} />
       {/* Validating field by name */}
-      <button {...validate(email.config.name)}>Validate email</button>
+      <button {...validate(email.name)}>Validate email</button>
       {/* Validating the whole form */}
       <button {...validate()}>Validate</button>
       <button>Send</button>
@@ -143,7 +141,7 @@ import { useEffect } from 'react';
 export default function Todos() {
   const [form, { tasks }] = useForm();
   const buttonRef = useRef<HTMLButtonElement>(null);
-  const taskList = useFieldList(form.ref, tasks.config);
+  const taskList = useFieldList(form.ref, tasks);
 
   useEffect(() => {
     if (taskList.length === 0) {
@@ -158,12 +156,12 @@ export default function Todos() {
       <ul>
         {taskList.map((task, index) => (
           <li key={task.key}>
-            <input {...conform.input(task.config)} />
+            <input {...conform.input(task)} />
           </li>
         ))}
       </ul>
       <div>
-        <button {...list.append(tasks.config.name)} ref={buttonRef}>
+        <button {...list.append(tasks.name)} ref={buttonRef}>
           Add task
         </button>
       </div>
@@ -187,7 +185,7 @@ import DragAndDrop from 'awesome-dnd-example';
 
 export default function Todos() {
   const [form, { tasks }] = useForm();
-  const taskList = useFieldList(form.ref, tasks.config);
+  const taskList = useFieldList(form.ref, tasks);
 
   const handleDrop = (from, to) =>
     requestIntent(form.ref.current, list.reorder({ from, to }));
@@ -197,7 +195,7 @@ export default function Todos() {
       <DragAndDrop onDrop={handleDrop}>
         {taskList.map((task, index) => (
           <div key={task.key}>
-            <input {...conform.input(task.config)} />
+            <input {...conform.input(task)} />
           </div>
         ))}
       </DragAndDrop>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -164,11 +164,7 @@ export default function LoginForm() {
     <Form method="post" {...form.props}>
       <div>
         <label>Email</label>
-        <input
-          type="email"
-          name="email"
-          defaultValue={email.config.defaultValue}
-        />
+        <input type="email" name="email" defaultValue={email.defaultValue} />
         <div>{email.error}</div>
       </div>
       <div>
@@ -315,12 +311,12 @@ export default function LoginForm() {
     <Form method="post" {...form.props}>
       <div>
         <label>Email</label>
-        <input {...conform.input(email.config, { type: 'email' })} />
+        <input {...conform.input(email, { type: 'email' })} />
         <div>{email.error}</div>
       </div>
       <div>
         <label>Password</label>
-        <input {...conform.input(password.config, { type: 'password' })} />
+        <input {...conform.input(password, { type: 'password' })} />
         <div>{password.error}</div>
       </div>
       <button type="submit">Login</button>

--- a/examples/chakra-ui/src/App.tsx
+++ b/examples/chakra-ui/src/App.tsx
@@ -63,14 +63,14 @@ export default function Example() {
 
 					<FormControl isInvalid={Boolean(fieldset.email.error)}>
 						<FormLabel>Email (Input)</FormLabel>
-						<Input type="email" name={fieldset.email.config.name} required />
+						<Input type="email" name={fieldset.email.name} required />
 						<FormErrorMessage>{fieldset.email.error}</FormErrorMessage>
 					</FormControl>
 
 					<FormControl isInvalid={Boolean(fieldset.language.error)}>
 						<FormLabel>Language (Select)</FormLabel>
 						<Select
-							name={fieldset.language.config.name}
+							name={fieldset.language.name}
 							placeholder="Select option"
 							required
 						>
@@ -83,14 +83,14 @@ export default function Example() {
 
 					<FormControl isInvalid={Boolean(fieldset.description.error)}>
 						<FormLabel>Description (Textarea)</FormLabel>
-						<Textarea name={fieldset.description.config.name} required />
+						<Textarea name={fieldset.description.name} required />
 						<FormErrorMessage>{fieldset.description.error}</FormErrorMessage>
 					</FormControl>
 
 					<FormControl isInvalid={Boolean(fieldset.quantity.error)}>
 						<FormLabel>Quantity (NumberInput)</FormLabel>
 						<ExampleNumberInput
-							name={fieldset.quantity.config.name}
+							name={fieldset.quantity.name}
 							required
 							min={1}
 							max={10}
@@ -102,7 +102,7 @@ export default function Example() {
 					<FormControl isInvalid={Boolean(fieldset.pin.error)}>
 						<FormLabel>PIN (PinInput)</FormLabel>
 						<ExamplePinInput
-							name={fieldset.pin.config.name}
+							name={fieldset.pin.name}
 							isInvalid={Boolean(fieldset.pin.error)}
 							required
 							pattern="[0-9]{4}"
@@ -113,22 +113,18 @@ export default function Example() {
 					<FormControl isInvalid={Boolean(fieldset.title.error)}>
 						<FormLabel>Title (Editable)</FormLabel>
 						<Editable
-							defaultValue={fieldset.title.config.defaultValue}
+							defaultValue={fieldset.title.defaultValue}
 							placeholder="No content"
 						>
 							<EditablePreview />
-							<EditableInput name={fieldset.title.config.name} required />
+							<EditableInput name={fieldset.title.name} required />
 						</Editable>
 						<FormErrorMessage>{fieldset.title.error}</FormErrorMessage>
 					</FormControl>
 
 					<FormControl isInvalid={Boolean(fieldset.subscribe.error)}>
 						<FormLabel>Subscribe (Checkbox)</FormLabel>
-						<Checkbox
-							name={fieldset.subscribe.config.name}
-							value="yes"
-							required
-						>
+						<Checkbox name={fieldset.subscribe.name} value="yes" required>
 							Newsletter
 						</Checkbox>
 						<FormErrorMessage>{fieldset.subscribe.error}</FormErrorMessage>
@@ -136,33 +132,30 @@ export default function Example() {
 
 					<FormControl isInvalid={Boolean(fieldset.enabled.error)}>
 						<FormLabel>Enabled (Switch)</FormLabel>
-						<Switch name={fieldset.enabled.config.name} required />
+						<Switch name={fieldset.enabled.name} required />
 						<FormErrorMessage>{fieldset.enabled.error}</FormErrorMessage>
 					</FormControl>
 
 					<FormControl isInvalid={Boolean(fieldset.progress.error)}>
 						<FormLabel>Progress (Slider)</FormLabel>
-						<ExampleSlider name={fieldset.progress.config.name} required />
+						<ExampleSlider name={fieldset.progress.name} required />
 						<FormErrorMessage>{fieldset.progress.error}</FormErrorMessage>
 					</FormControl>
 
 					<FormControl isInvalid={Boolean(fieldset.active.error)}>
 						<FormLabel>Active (Radio)</FormLabel>
 						<RadioGroup
-							name={fieldset.active.config.name}
-							defaultValue={fieldset.active.config.defaultValue}
+							name={fieldset.active.name}
+							defaultValue={fieldset.active.defaultValue}
 						>
 							<Stack spacing={5} direction="row">
 								<Radio
 									value="yes"
-									isRequired={fieldset.active.config.required ?? true}
+									isRequired={fieldset.active.required ?? true}
 								>
 									Yes
 								</Radio>
-								<Radio
-									value="no"
-									isRequired={fieldset.active.config.required ?? true}
-								>
+								<Radio value="no" isRequired={fieldset.active.required ?? true}>
 									No
 								</Radio>
 							</Stack>

--- a/examples/headless-ui/src/App.tsx
+++ b/examples/headless-ui/src/App.tsx
@@ -39,7 +39,7 @@ export default function Example() {
 									Owner (List box)
 								</label>
 								<div className="mt-1">
-									<ExampleListBox {...fieldset.owner.config} required />
+									<ExampleListBox {...fieldset.owner} required />
 								</div>
 								<p className="mt-2 text-sm text-red-500">
 									{fieldset.owner.error}
@@ -51,7 +51,7 @@ export default function Example() {
 									Assigned to (Combobox)
 								</label>
 								<div className="mt-1">
-									<ExampleCombobox {...fieldset.assignee.config} required />
+									<ExampleCombobox {...fieldset.assignee} required />
 								</div>
 								<p className="mt-2 text-sm text-red-500">
 									{fieldset.assignee.error}
@@ -63,7 +63,7 @@ export default function Example() {
 									Enabled (Switch)
 								</label>
 								<div className="mt-1">
-									<ExampleSwitch {...fieldset.enabled.config} required />
+									<ExampleSwitch {...fieldset.enabled} required />
 								</div>
 								<p className="mt-2 text-sm text-red-500">
 									{fieldset.enabled.error}
@@ -75,7 +75,7 @@ export default function Example() {
 									Color (Radio Group)
 								</label>
 								<div className="mt-1">
-									<ExampleRadioGroup {...fieldset.color.config} required />
+									<ExampleRadioGroup {...fieldset.color} required />
 								</div>
 								<p className="mt-2 text-sm text-red-500">
 									{fieldset.color.error}

--- a/examples/remix-async-validation/app/routes/index.tsx
+++ b/examples/remix-async-validation/app/routes/index.tsx
@@ -112,7 +112,7 @@ export default function Signup() {
 					<div>Username</div>
 					<input
 						className={username.error ? 'error' : ''}
-						{...conform.input(username.config)}
+						{...conform.input(username)}
 					/>
 					<div>{username.error}</div>
 				</label>
@@ -120,7 +120,7 @@ export default function Signup() {
 					<div>Password</div>
 					<input
 						className={password.error ? 'error' : ''}
-						{...conform.input(password.config, { type: 'password' })}
+						{...conform.input(password, { type: 'password' })}
 					/>
 					<div>{password.error}</div>
 				</label>
@@ -128,7 +128,7 @@ export default function Signup() {
 					<div>Confirm Password</div>
 					<input
 						className={confirmPassword.error ? 'error' : ''}
-						{...conform.input(confirmPassword.config, { type: 'password' })}
+						{...conform.input(confirmPassword, { type: 'password' })}
 					/>
 					<div>{confirmPassword.error}</div>
 				</label>

--- a/examples/remix-nested-list/app/routes/index.tsx
+++ b/examples/remix-nested-list/app/routes/index.tsx
@@ -44,7 +44,7 @@ export default function TodoForm() {
 			return parse(formData, { schema: todosSchema });
 		},
 	});
-	const taskList = useFieldList(form.ref, tasks.config);
+	const taskList = useFieldList(form.ref, tasks);
 
 	return (
 		<Form method="post" {...form.props}>
@@ -53,24 +53,20 @@ export default function TodoForm() {
 				<label>Title</label>
 				<input
 					className={title.error ? 'error' : ''}
-					{...conform.input(title.config)}
+					{...conform.input(title)}
 				/>
 				<div>{title.error}</div>
 			</div>
 			<ul>
 				{taskList.map((task, index) => (
 					<li key={task.key}>
-						<TaskFieldset title={`Task #${index + 1}`} {...task.config} />
-						<button {...list.remove(tasks.config.name, { index })}>
-							Delete
-						</button>
-						<button
-							{...list.reorder(tasks.config.name, { from: index, to: 0 })}
-						>
+						<TaskFieldset title={`Task #${index + 1}`} {...task} />
+						<button {...list.remove(tasks.name, { index })}>Delete</button>
+						<button {...list.reorder(tasks.name, { from: index, to: 0 })}>
 							Move to top
 						</button>
 						<button
-							{...list.replace(tasks.config.name, {
+							{...list.replace(tasks.name, {
 								index,
 								defaultValue: { content: '' },
 							})}
@@ -81,7 +77,7 @@ export default function TodoForm() {
 				))}
 			</ul>
 			<div>
-				<button {...list.append(tasks.config.name)}>Add task</button>
+				<button {...list.append(tasks.name)}>Add task</button>
 			</div>
 			<button type="submit">Save</button>
 		</Form>
@@ -102,7 +98,7 @@ function TaskFieldset({ title, ...config }: TaskFieldsetProps) {
 				<label>{title}</label>
 				<input
 					className={content.error ? 'error' : ''}
-					{...conform.input(content.config)}
+					{...conform.input(content)}
 				/>
 				<div>{content.error}</div>
 			</div>
@@ -111,7 +107,7 @@ function TaskFieldset({ title, ...config }: TaskFieldsetProps) {
 					<span>Completed</span>
 					<input
 						className={completed.error ? 'error' : ''}
-						{...conform.input(completed.config, {
+						{...conform.input(completed, {
 							type: 'checkbox',
 							value: 'yes',
 						})}

--- a/examples/remix/app/routes/index.tsx
+++ b/examples/remix/app/routes/index.tsx
@@ -87,7 +87,7 @@ export default function Signup() {
 				<label>Email</label>
 				<input
 					className={email.error ? 'error' : ''}
-					{...conform.input(email.config)}
+					{...conform.input(email)}
 				/>
 				<div>{email.error}</div>
 			</div>
@@ -95,7 +95,7 @@ export default function Signup() {
 				<label>Password</label>
 				<input
 					className={password.error ? 'error' : ''}
-					{...conform.input(password.config, { type: 'password' })}
+					{...conform.input(password, { type: 'password' })}
 				/>
 				<div>{password.error}</div>
 			</div>
@@ -103,7 +103,7 @@ export default function Signup() {
 				<label>Confirm Password</label>
 				<input
 					className={confirmPassword.error ? 'error' : ''}
-					{...conform.input(confirmPassword.config, { type: 'password' })}
+					{...conform.input(confirmPassword, { type: 'password' })}
 				/>
 				<div>{confirmPassword.error}</div>
 			</div>

--- a/examples/yup/app/routes/index.tsx
+++ b/examples/yup/app/routes/index.tsx
@@ -55,7 +55,7 @@ export default function SignupForm() {
 				<div>Email</div>
 				<input
 					className={email.error ? 'error' : ''}
-					{...conform.input(email.config)}
+					{...conform.input(email)}
 				/>
 				<div>{email.error}</div>
 			</label>
@@ -63,7 +63,7 @@ export default function SignupForm() {
 				<label>Password</label>
 				<input
 					className={password.error ? 'error' : ''}
-					{...conform.input(password.config, { type: 'password' })}
+					{...conform.input(password, { type: 'password' })}
 				/>
 				<div>{password.error}</div>
 			</div>
@@ -71,7 +71,7 @@ export default function SignupForm() {
 				<label>Confirm Password</label>
 				<input
 					className={confirmPassword.error ? 'error' : ''}
-					{...conform.input(confirmPassword.config, { type: 'password' })}
+					{...conform.input(confirmPassword, { type: 'password' })}
 				/>
 				<div>{confirmPassword.error}</div>
 			</div>

--- a/examples/zod/app/routes/index.tsx
+++ b/examples/zod/app/routes/index.tsx
@@ -59,7 +59,7 @@ export default function SignupForm() {
 				<div>Email</div>
 				<input
 					className={email.error ? 'error' : ''}
-					{...conform.input(email.config)}
+					{...conform.input(email)}
 				/>
 				<div>{email.error}</div>
 			</label>
@@ -67,7 +67,7 @@ export default function SignupForm() {
 				<label>Password</label>
 				<input
 					className={password.error ? 'error' : ''}
-					{...conform.input(password.config, { type: 'password' })}
+					{...conform.input(password, { type: 'password' })}
 				/>
 				<div>{password.error}</div>
 			</div>
@@ -75,7 +75,7 @@ export default function SignupForm() {
 				<label>Confirm Password</label>
 				<input
 					className={confirmPassword.error ? 'error' : ''}
-					{...conform.input(confirmPassword.config, { type: 'password' })}
+					{...conform.input(confirmPassword, { type: 'password' })}
 				/>
 				<div>{confirmPassword.error}</div>
 			</div>

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -13,6 +13,16 @@ export interface FieldConfig<Schema = unknown> extends FieldConstraint<Schema> {
 	initialError?: Record<string, string | string[]>;
 	form?: string;
 	errorId?: string;
+
+	/**
+	 * The frist error of the field
+	 */
+	error?: string;
+
+	/**
+	 * All of the field errors
+	 */
+	errors?: string[];
 }
 
 export type FieldValue<Schema> = Schema extends Primitive
@@ -61,6 +71,9 @@ export interface IntentButtonProps {
 	formNoValidate?: boolean;
 }
 
+/**
+ * Check if the provided reference is a form element (_input_ / _select_ / _textarea_ or _button_)
+ */
 export function isFieldElement(element: unknown): element is FieldElement {
 	return (
 		element instanceof Element &&
@@ -71,6 +84,11 @@ export function isFieldElement(element: unknown): element is FieldElement {
 	);
 }
 
+/**
+ * Find the corresponding paths based on the formatted name
+ * @param name formatted name
+ * @returns paths
+ */
 export function getPaths(name: string): Array<string | number> {
 	const pattern = /(\w*)\[(\d+)\]/;
 

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -219,7 +219,7 @@ export function getErrors(message: string | undefined): string[] {
 	return message.split(String.fromCharCode(31));
 }
 
-const FORM_ERROR_ELEMENT_NAME = '__form__';
+export const FORM_ERROR_ELEMENT_NAME = '__form__';
 export const INTENT = '__intent__';
 export const VALIDATION_UNDEFINED = '__undefined__';
 export const VALIDATION_SKIPPED = '__skipped__';

--- a/packages/conform-react/README.md
+++ b/packages/conform-react/README.md
@@ -164,20 +164,20 @@ function Example() {
   const [form, { address }] = useForm<{ address: Address }>();
   const { city, zipcode, street, country } = useFieldset(
     form.ref,
-    address.config,
+    address,
   );
 
   return (
     <form {...form.props}>
       <fieldset>
         <legned>Address</legend>
-        <input {...conform.input(street.config)} />
+        <input {...conform.input(street)} />
         <div>{street.error}</div>
-        <input {...conform.input(zipcode.config)} />
+        <input {...conform.input(zipcode)} />
         <div>{zipcode.error}</div>
-        <input {...conform.input(city.config)} />
+        <input {...conform.input(city)} />
         <div>{city.error}</div>
-        <input {...conform.input(country.config)} />
+        <input {...conform.input(country)} />
         <div>{country.error}</div>
       </fieldset>
       <button>Submit</button>
@@ -244,27 +244,25 @@ type Schema = {
 
 function Example() {
   const [form, { items }] = useForm<Schema>();
-  const itemsList = useFieldList(form.ref, items.config);
+  const itemsList = useFieldList(form.ref, items);
 
   return (
     <fieldset ref={ref}>
       {itemsList.map((item, index) => (
         <div key={item.key}>
           {/* Setup an input per item */}
-          <input {...conform.input(item.config)} />
+          <input {...conform.input(item)} />
 
           {/* Error of each item */}
           <span>{item.error}</span>
 
           {/* Setup a delete button (Note: It is `items` not `item`) */}
-          <button {...list.remove(items.config.name, { index })}>Delete</button>
+          <button {...list.remove(items.name, { index })}>Delete</button>
         </div>
       ))}
 
       {/* Setup a button that can append a new row with optional default value */}
-      <button {...list.append(items.config.name, { defaultValue: '' })}>
-        add
-      </button>
+      <button {...list.append(items.name, { defaultValue: '' })}>add</button>
     </fieldset>
   );
 }
@@ -283,9 +281,9 @@ import { useState, useRef } from 'react';
 
 function MuiForm() {
   const [form, { category }] = useForm();
-  const [value, setValue] = useState(category.config.defaultValue ?? '');
+  const [value, setValue] = useState(category.defaultValue ?? '');
   const [ref, control] = useInputEvent({
-    onReset: () => setValue(category.config.defaultValue ?? ''),
+    onReset: () => setValue(category.defaultValue ?? ''),
   });
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -294,7 +292,7 @@ function MuiForm() {
       {/* Render a shadow input somewhere */}
       <input
         ref={ref}
-        {...conform.input(category.config, { hidden: true })}
+        {...conform.input(category, { hidden: true })}
         onChange={(e) => setValue(e.target.value)}
         onFocus={() => inputRef.current?.focus()}
       />
@@ -338,31 +336,31 @@ function Example() {
     <form {...form.props}>
       <input
         type="text"
-        name={title.config.name}
-        form={title.config.form}
-        defaultValue={title.config.defaultValue}
-        requried={title.config.required}
-        minLength={title.config.minLength}
-        maxLength={title.config.maxLength}
-        min={title.config.min}
-        max={title.config.max}
-        multiple={title.config.multiple}
-        pattern={title.config.pattern}
+        name={title.name}
+        form={title.form}
+        defaultValue={title.defaultValue}
+        requried={title.required}
+        minLength={title.minLength}
+        maxLength={title.maxLength}
+        min={title.min}
+        max={title.max}
+        multiple={title.multiple}
+        pattern={title.pattern}
       />
       <textarea
-        name={description.config.name}
-        form={description.config.form}
-        defaultValue={description.config.defaultValue}
-        requried={description.config.required}
-        minLength={description.config.minLength}
-        maxLength={description.config.maxLength}
+        name={description.name}
+        form={description.form}
+        defaultValue={description.defaultValue}
+        requried={description.required}
+        minLength={description.minLength}
+        maxLength={description.maxLength}
       />
       <select
-        name={category.config.name}
-        form={category.config.form}
-        defaultValue={category.config.defaultValue}
-        requried={category.config.required}
-        multiple={category.config.multiple}
+        name={category.name}
+        form={category.form}
+        defaultValue={category.defaultValue}
+        requried={category.required}
+        multiple={category.multiple}
       >
         {/* ... */}
       </select>
@@ -381,9 +379,9 @@ function Example() {
 
   return (
     <form {...form.props}>
-      <input {...conform.input(title.config, { type: 'text' })} />
-      <textarea {...conform.textarea(description.config)} />
-      <select {...conform.select(category.config)}>{/* ... */}</select>
+      <input {...conform.input(title, { type: 'text' })} />
+      <textarea {...conform.textarea(description)} />
+      <select {...conform.select(category)}>{/* ... */}</select>
     </form>
   );
 }
@@ -570,7 +568,7 @@ import DragAndDrop from 'awesome-dnd-example';
 
 export default function Todos() {
   const [form, { tasks }] = useForm();
-  const taskList = useFieldList(form.ref, tasks.config);
+  const taskList = useFieldList(form.ref, tasks);
 
   const handleDrop = (from, to) =>
     requestIntent(form.ref.current, list.reorder({ from, to }));
@@ -580,7 +578,7 @@ export default function Todos() {
       <DragAndDrop onDrop={handleDrop}>
         {taskList.map((task, index) => (
           <div key={task.key}>
-            <input {...conform.input(task.config)} />
+            <input {...conform.input(task)} />
           </div>
         ))}
       </DragAndDrop>

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -14,7 +14,7 @@ interface FieldProps {
 	autoFocus?: boolean;
 	tabIndex?: number;
 	style?: CSSProperties;
-	'aria-invalid': boolean;
+	'aria-invalid'?: string;
 	'aria-describedby'?: string;
 	'aria-hidden'?: boolean;
 }
@@ -97,9 +97,12 @@ export function input<Schema>(
 		step: config.step,
 		pattern: config.pattern,
 		multiple: config.multiple,
-		'aria-invalid': Boolean(config.initialError?.length),
 		'aria-describedby': config.errorId,
 	};
+
+	if (config.errors?.length) {
+		attributes['aria-invalid'] = 'true';
+	}
 
 	if (options?.hidden) {
 		attributes.style = hiddenStyle;
@@ -136,9 +139,12 @@ export function select<Schema>(
 			: `${config.defaultValue ?? ''}`,
 		required: config.required,
 		multiple: config.multiple,
-		'aria-invalid': Boolean(config.initialError?.length),
 		'aria-describedby': config.errorId,
 	};
+
+	if (config.errors?.length) {
+		attributes['aria-invalid'] = 'true';
+	}
 
 	if (options?.hidden) {
 		attributes.style = hiddenStyle;
@@ -166,9 +172,12 @@ export function textarea<Schema>(
 		minLength: config.minLength,
 		maxLength: config.maxLength,
 		autoFocus: Boolean(config.initialError),
-		'aria-invalid': Boolean(config.initialError?.length),
 		'aria-describedby': config.errorId,
 	};
+
+	if (config.errors?.length) {
+		attributes['aria-invalid'] = 'true';
+	}
 
 	if (options?.hidden) {
 		attributes.style = hiddenStyle;

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -1,12 +1,13 @@
 import {
 	type FieldConfig,
+	type Primitive,
 	VALIDATION_UNDEFINED,
 	VALIDATION_SKIPPED,
 	INTENT,
 } from '@conform-to/dom';
 import type { CSSProperties, HTMLInputTypeAttribute } from 'react';
 
-interface FieldProps {
+interface FormControlProps {
 	id?: string;
 	name: string;
 	form?: string;
@@ -14,12 +15,12 @@ interface FieldProps {
 	autoFocus?: boolean;
 	tabIndex?: number;
 	style?: CSSProperties;
-	'aria-invalid'?: string;
 	'aria-describedby'?: string;
+	'aria-invalid'?: boolean;
 	'aria-hidden'?: boolean;
 }
 
-interface InputProps<Schema> extends FieldProps {
+interface InputProps<Schema> extends FormControlProps {
 	type?: HTMLInputTypeAttribute;
 	minLength?: number;
 	maxLength?: number;
@@ -33,12 +34,12 @@ interface InputProps<Schema> extends FieldProps {
 	defaultValue?: string;
 }
 
-interface SelectProps extends FieldProps {
+interface SelectProps extends FormControlProps {
 	defaultValue?: string | number | readonly string[] | undefined;
 	multiple?: boolean;
 }
 
-interface TextareaProps extends FieldProps {
+interface TextareaProps extends FormControlProps {
 	minLength?: number;
 	maxLength?: number;
 	defaultValue?: string;
@@ -72,24 +73,54 @@ const hiddenStyle: CSSProperties = {
 	border: 0,
 };
 
+function getFormControlProps(
+	config: FieldConfig<any>,
+	options?: { hidden?: boolean },
+): FormControlProps {
+	const props: FormControlProps = {
+		id: config.id,
+		name: config.name,
+		form: config.form,
+		required: config.required,
+	};
+
+	if (config.id) {
+		props.id = config.id;
+		props['aria-describedby'] = config.errorId;
+	}
+
+	if (config.errorId && config.error?.length) {
+		props['aria-invalid'] = true;
+	}
+
+	if (config.initialError && Object.entries(config.initialError).length > 0) {
+		props.autoFocus = true;
+	}
+
+	if (options?.hidden) {
+		props.style = hiddenStyle;
+		props.tabIndex = -1;
+		props['aria-hidden'] = true;
+	}
+
+	return props;
+}
+
 export function input<Schema extends File | File[]>(
 	config: FieldConfig<Schema>,
 	options: { type: 'file' },
 ): InputProps<Schema>;
-export function input<Schema extends any>(
+export function input<Schema extends Primitive>(
 	config: FieldConfig<Schema>,
 	options?: InputOptions,
 ): InputProps<Schema>;
-export function input<Schema>(
+export function input<Schema extends Primitive | File | File[]>(
 	config: FieldConfig<Schema>,
 	options: InputOptions = {},
 ): InputProps<Schema> {
-	const attributes: InputProps<Schema> = {
-		id: config.id,
+	const props: InputProps<Schema> = {
+		...getFormControlProps(config, options),
 		type: options.type,
-		name: config.name,
-		form: config.form,
-		required: config.required,
 		minLength: config.minLength,
 		maxLength: config.maxLength,
 		min: config.min,
@@ -97,99 +128,43 @@ export function input<Schema>(
 		step: config.step,
 		pattern: config.pattern,
 		multiple: config.multiple,
-		'aria-describedby': config.errorId,
 	};
-
-	if (config.errors?.length) {
-		attributes['aria-invalid'] = 'true';
-	}
-
-	if (options?.hidden) {
-		attributes.style = hiddenStyle;
-		attributes.tabIndex = -1;
-		attributes['aria-hidden'] = true;
-	}
-
-	if (config.initialError && Object.entries(config.initialError).length > 0) {
-		attributes.autoFocus = true;
-	}
 
 	if (options.type === 'checkbox' || options.type === 'radio') {
-		attributes.value = options.value ?? 'on';
-		attributes.defaultChecked = config.defaultValue === attributes.value;
+		props.value = options.value ?? 'on';
+		props.defaultChecked = config.defaultValue === props.value;
 	} else if (options.type !== 'file') {
-		attributes.defaultValue = config.defaultValue as string | undefined;
+		props.defaultValue = config.defaultValue as string | undefined;
 	}
 
-	return attributes;
+	return props;
 }
 
-export function select<Schema>(
-	config: FieldConfig<Schema>,
+export function select(
+	config: FieldConfig<Primitive | Primitive[]>,
 	options?: { hidden?: boolean },
 ): SelectProps {
-	const attributes: SelectProps = {
-		id: config.id,
-		name: config.name,
-		form: config.form,
-		defaultValue: config.multiple
-			? Array.isArray(config.defaultValue)
-				? config.defaultValue
-				: []
-			: `${config.defaultValue ?? ''}`,
-		required: config.required,
+	const props: SelectProps = {
+		...getFormControlProps(config, options),
+		defaultValue: config.defaultValue,
 		multiple: config.multiple,
-		'aria-describedby': config.errorId,
 	};
 
-	if (config.errors?.length) {
-		attributes['aria-invalid'] = 'true';
-	}
-
-	if (options?.hidden) {
-		attributes.style = hiddenStyle;
-		attributes.tabIndex = -1;
-		attributes['aria-hidden'] = true;
-	}
-
-	if (config.initialError && Object.entries(config.initialError).length > 0) {
-		attributes.autoFocus = true;
-	}
-
-	return attributes;
+	return props;
 }
 
-export function textarea<Schema>(
-	config: FieldConfig<Schema>,
+export function textarea(
+	config: FieldConfig<Primitive>,
 	options?: { hidden?: boolean },
 ): TextareaProps {
-	const attributes: TextareaProps = {
-		id: config.id,
-		name: config.name,
-		form: config.form,
-		defaultValue: `${config.defaultValue ?? ''}`,
-		required: config.required,
+	const props: TextareaProps = {
+		...getFormControlProps(config, options),
+		defaultValue: config.defaultValue,
 		minLength: config.minLength,
 		maxLength: config.maxLength,
-		autoFocus: Boolean(config.initialError),
-		'aria-describedby': config.errorId,
 	};
 
-	if (config.errors?.length) {
-		attributes['aria-invalid'] = 'true';
-	}
-
-	if (options?.hidden) {
-		attributes.style = hiddenStyle;
-		attributes.tabIndex = -1;
-		attributes['aria-hidden'] = true;
-	}
-
-	if (config.initialError && Object.entries(config.initialError).length > 0) {
-		attributes.autoFocus = true;
-	}
-
-	return attributes;
+	return props;
 }
 
 export { INTENT, VALIDATION_UNDEFINED, VALIDATION_SKIPPED };

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -488,7 +488,7 @@ export function useFieldset<Schema extends Record<string, any>>(
 			for (const [key, error] of Object.entries(
 				uncontrolledState.initialError,
 			)) {
-				result[key] = getErrors(getValidationMessage(error?.['']));
+				result[key] = ([] as string[]).concat(error?.[''] ?? []);
 			}
 
 			return result;
@@ -644,7 +644,7 @@ export function useFieldList<Payload = any>(
 	});
 	const [error, setError] = useState<Array<string[] | undefined>>(() =>
 		uncontrolledState.initialError.map((error) =>
-			getErrors(getValidationMessage(error?.[''])),
+			([] as string[]).concat(error?.[''] ?? []),
 		),
 	);
 	const [entries, setEntries] = useState<

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -399,19 +399,10 @@ export function useForm<
 }
 
 /**
- * All the information of the field, including state and config.
- */
-export type Field<Schema> = {
-	config: FieldConfig<Schema>;
-	error?: string;
-	errors?: string[];
-};
-
-/**
- * A set of field information.
+ * A set of field configuration
  */
 export type Fieldset<Schema extends Record<string, any>> = {
-	[Key in keyof Schema]-?: Field<Schema[Key]>;
+	[Key in keyof Schema]-?: FieldConfig<Schema[Key]>;
 };
 
 export interface FieldsetConfig<Schema extends Record<string, any>> {
@@ -436,7 +427,7 @@ export interface FieldsetConfig<Schema extends Record<string, any>> {
 	constraint?: FieldsetConstraint<Schema>;
 
 	/**
-	 * The id of the form, connecting each field to a form remotely.
+	 * The id of the form, connecting each field to a form remotely
 	 */
 	form?: string;
 }
@@ -603,21 +594,19 @@ export function useFieldset<Schema extends Record<string, any>>(
 				const fieldsetConfig = (config ?? {}) as FieldsetConfig<Schema>;
 				const constraint = fieldsetConfig.constraint?.[key];
 				const errors = error?.[key];
-				const field: Field<any> = {
-					config: {
-						name: fieldsetConfig.name ? `${fieldsetConfig.name}.${key}` : key,
-						defaultValue: uncontrolledState.defaultValue[key],
-						initialError: uncontrolledState.initialError[key],
-						...constraint,
-					},
+				const field: FieldConfig<any> = {
+					...constraint,
+					name: fieldsetConfig.name ? `${fieldsetConfig.name}.${key}` : key,
+					defaultValue: uncontrolledState.defaultValue[key],
+					initialError: uncontrolledState.initialError[key],
 					error: errors?.[0],
 					errors,
 				};
 
 				if (fieldsetConfig.form) {
-					field.config.form = fieldsetConfig.form;
-					field.config.id = `${fieldsetConfig.form}-${field.config.name}`;
-					field.config.errorId = `${field.config.id}-error`;
+					field.form = fieldsetConfig.form;
+					field.id = `${fieldsetConfig.form}-${field.name}`;
+					field.errorId = `${field.id}-error`;
 				}
 
 				return field;
@@ -635,12 +624,7 @@ export function useFieldset<Schema extends Record<string, any>>(
 export function useFieldList<Payload = any>(
 	ref: RefObject<HTMLFormElement | HTMLFieldSetElement>,
 	config: FieldConfig<Array<Payload>>,
-): Array<{
-	key: string;
-	error: string | undefined;
-	errors: string[] | undefined;
-	config: FieldConfig<Payload>;
-}> {
+): Array<{ key: string } & FieldConfig<Payload>> {
 	const configRef = useRef(config);
 	const [uncontrolledState, setUncontrolledState] = useState<{
 		defaultValue: FieldValue<Array<Payload>>;
@@ -807,10 +791,12 @@ export function useFieldList<Payload = any>(
 
 	return entries.map(([key, defaultValue], index) => {
 		const errors = error[index];
-		const fieldConfig: FieldConfig<any> = {
+		const fieldConfig: FieldConfig<Payload> = {
 			name: `${config.name}[${index}]`,
 			defaultValue: defaultValue ?? uncontrolledState.defaultValue[index],
 			initialError: uncontrolledState.initialError[index],
+			error: errors?.[0],
+			errors,
 		};
 
 		if (config.form) {
@@ -821,9 +807,7 @@ export function useFieldList<Payload = any>(
 
 		return {
 			key,
-			error: errors?.[0],
-			errors,
-			config: fieldConfig,
+			...fieldConfig,
 		};
 	});
 }

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -290,7 +290,6 @@ export function useForm<
 			for (const field of form.elements) {
 				if (isFieldElement(field)) {
 					delete field.dataset.conformTouched;
-					field.setAttribute('aria-invalid', 'false');
 					field.setCustomValidity('');
 				}
 			}
@@ -524,14 +523,6 @@ export function useFieldset<Schema extends Record<string, any>>(
 			// Update the error only if the field belongs to the fieldset
 			if (typeof key === 'string' && paths.length === 0) {
 				if (field.dataset.conformTouched) {
-					// Update the aria attribute only if it is set
-					if (field.getAttribute('aria-invalid')) {
-						field.setAttribute(
-							'aria-invalid',
-							field.validationMessage !== '' ? 'true' : 'false',
-						);
-					}
-
 					setError((prev) => {
 						const prevMessage = getValidationMessage(prev?.[key]);
 

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -10,7 +10,6 @@ export {
 	isFieldElement,
 } from '@conform-to/dom';
 export {
-	type Field,
 	type Fieldset,
 	type FieldsetConfig,
 	type FormConfig,

--- a/playground/app/components.tsx
+++ b/playground/app/components.tsx
@@ -91,12 +91,11 @@ export function Playground({
 interface FieldProps {
 	label: string;
 	inline?: boolean;
-	errors?: string[];
 	config?: FieldConfig<any>;
 	children: ReactNode;
 }
 
-export function Field({ label, inline, errors, config, children }: FieldProps) {
+export function Field({ label, inline, config, children }: FieldProps) {
 	return (
 		<div className="mb-4">
 			<div
@@ -115,10 +114,10 @@ export function Field({ label, inline, errors, config, children }: FieldProps) {
 				{children}
 			</div>
 			<div id={config?.errorId} className="my-1 space-y-0.5">
-				{!errors || errors.length === 0 ? (
+				{!config?.errors?.length ? (
 					<p className="text-pink-600 text-sm" />
 				) : (
-					errors.map((message) => (
+					config.errors.map((message) => (
 						<p className="text-pink-600 text-sm" key={message}>
 							{message}
 						</p>

--- a/playground/app/routes/async-validation.tsx
+++ b/playground/app/routes/async-validation.tsx
@@ -91,14 +91,14 @@ export default function EmployeeForm() {
 	return (
 		<Form method="post" {...form.props}>
 			<Playground title="Employee Form" state={state}>
-				<Field label="Email" {...email}>
+				<Field label="Email" config={email}>
 					<input
-						{...conform.input(email.config, { type: 'email' })}
+						{...conform.input(email, { type: 'email' })}
 						autoComplete="off"
 					/>
 				</Field>
-				<Field label="Title" {...title}>
-					<input {...conform.input(title.config, { type: 'text' })} />
+				<Field label="Title" config={title}>
+					<input {...conform.input(title, { type: 'text' })} />
 				</Field>
 			</Playground>
 		</Form>

--- a/playground/app/routes/file-upload.tsx
+++ b/playground/app/routes/file-upload.tsx
@@ -64,11 +64,11 @@ export default function FileUpload() {
 		<Form method="post" {...form.props} encType="multipart/form-data">
 			<Playground title="Employee Form" state={state}>
 				<Alert message={form.error} />
-				<Field label="Single file" {...file}>
-					<input {...conform.input(file.config, { type: 'file' })} />
+				<Field label="Single file" config={file}>
+					<input {...conform.input(file, { type: 'file' })} />
 				</Field>
-				<Field label="Multiple files" {...files}>
-					<input {...conform.input(files.config, { type: 'file' })} multiple />
+				<Field label="Multiple files" config={files}>
+					<input {...conform.input(files, { type: 'file' })} multiple />
 				</Field>
 			</Playground>
 		</Form>

--- a/playground/app/routes/input-attributes.tsx
+++ b/playground/app/routes/input-attributes.tsx
@@ -55,17 +55,17 @@ export default function Example() {
 	return (
 		<Form method="post" encType="multipart/form-data" {...form.props}>
 			<Playground title="Input attributes" state={state}>
-				<Field label="Title" {...title}>
-					<input {...conform.input(title.config, { type: 'text' })} />
+				<Field label="Title" config={title}>
+					<input {...conform.input(title, { type: 'text' })} />
 				</Field>
-				<Field label="Description" {...description}>
-					<textarea {...conform.textarea(description.config)} />
+				<Field label="Description" config={description}>
+					<textarea {...conform.textarea(description)} />
 				</Field>
-				<Field label="Image" {...images}>
-					<input {...conform.input(images.config, { type: 'file' })} />
+				<Field label="Image" config={images}>
+					<input {...conform.input(images, { type: 'file' })} />
 				</Field>
-				<Field label="Tags" {...tags}>
-					<select {...conform.select(tags.config)}>
+				<Field label="Tags" config={tags}>
+					<select {...conform.select(tags)}>
 						<option value="">Please select</option>
 						<option value="action">Action</option>
 						<option value="adventure">Adventure</option>
@@ -76,8 +76,8 @@ export default function Example() {
 						<option value="romance">Romance</option>
 					</select>
 				</Field>
-				<Field label="Rating" {...rating}>
-					<input {...conform.input(rating.config, { type: 'number' })} />
+				<Field label="Rating" config={rating}>
+					<input {...conform.input(rating, { type: 'number' })} />
 				</Field>
 			</Playground>
 		</Form>

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -79,14 +79,14 @@ export default function LoginForm() {
 		<Form method="post" {...form.props}>
 			<Playground title="Login Form" state={state}>
 				<Alert message={form.error} />
-				<Field label="Email" {...email}>
+				<Field label="Email" config={email}>
 					<input
-						{...conform.input(email.config, { type: 'email' })}
+						{...conform.input(email, { type: 'email' })}
 						autoComplete="off"
 					/>
 				</Field>
-				<Field label="Password" {...password}>
-					<input {...conform.input(password.config, { type: 'password' })} />
+				<Field label="Password" config={password}>
+					<input {...conform.input(password, { type: 'password' })} />
 				</Field>
 			</Playground>
 		</Form>

--- a/playground/app/routes/movie.tsx
+++ b/playground/app/routes/movie.tsx
@@ -155,14 +155,14 @@ export default function MovieForm() {
 		<Form method="post" {...form.props}>
 			<Playground title="Movie Form" state={state}>
 				<fieldset>
-					<Field label="Title" {...title}>
-						<input {...conform.input(title.config, { type: 'text' })} />
+					<Field label="Title" config={title}>
+						<input {...conform.input(title, { type: 'text' })} />
 					</Field>
-					<Field label="Description" {...description}>
-						<textarea {...conform.textarea(description.config)} />
+					<Field label="Description" config={description}>
+						<textarea {...conform.textarea(description)} />
 					</Field>
-					<Field label="Genre" {...genre}>
-						<select {...conform.select(genre.config)}>
+					<Field label="Genre" config={genre}>
+						<select {...conform.select(genre)}>
 							<option value="">Please select</option>
 							<option value="action">Action</option>
 							<option value="adventure">Adventure</option>
@@ -173,8 +173,8 @@ export default function MovieForm() {
 							<option value="romance">Romance</option>
 						</select>
 					</Field>
-					<Field label="Rating" {...rating}>
-						<input {...conform.input(rating.config, { type: 'number' })} />
+					<Field label="Rating" config={rating}>
+						<input {...conform.input(rating, { type: 'number' })} />
 					</Field>
 				</fieldset>
 			</Playground>

--- a/playground/app/routes/multiple-errors.tsx
+++ b/playground/app/routes/multiple-errors.tsx
@@ -147,8 +147,8 @@ export default function Example() {
 	return (
 		<Form method="post" {...form.props}>
 			<Playground title="Mutliple Errors" state={state}>
-				<Field label="Username" {...username}>
-					<input {...conform.input(username.config, { type: 'text' })} />
+				<Field label="Username" config={username}>
+					<input {...conform.input(username, { type: 'text' })} />
 				</Field>
 			</Playground>
 		</Form>

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -58,7 +58,7 @@ export default function PaymentForm() {
 			: undefined,
 	});
 	const { currency, value } = useFieldset(form.ref, {
-		...amount.config,
+		...amount,
 		constraint: getFieldsetConstraint(schema.shape.amount),
 	});
 
@@ -66,26 +66,26 @@ export default function PaymentForm() {
 		<Form method="post" {...form.props}>
 			<Playground title="Payment Form" state={state}>
 				<fieldset>
-					<Field label="IBAN" {...iban}>
-						<input {...conform.input(iban.config, { type: 'text' })} />
+					<Field label="IBAN" config={iban}>
+						<input {...conform.input(iban, { type: 'text' })} />
 					</Field>
-					<Field label="Currency" {...currency}>
-						<select {...conform.select(currency.config)}>
+					<Field label="Currency" config={currency}>
+						<select {...conform.select(currency)}>
 							<option value="">Please specify</option>
 							<option value="USD">USD</option>
 							<option value="EUR">EUR</option>
 							<option value="GBP">GBP</option>
 						</select>
 					</Field>
-					<Field label="Value" {...value}>
-						<input {...conform.input(value.config, { type: 'number' })} />
+					<Field label="Value" config={value}>
+						<input {...conform.input(value, { type: 'number' })} />
 					</Field>
-					<Field label="Timestamp" {...timestamp}>
-						<input {...conform.input(timestamp.config, { type: 'text' })} />
+					<Field label="Timestamp" config={timestamp}>
+						<input {...conform.input(timestamp, { type: 'text' })} />
 					</Field>
-					<Field label="Verified" {...verified} inline>
+					<Field label="Verified" config={verified} inline>
 						<input
-							{...conform.input(verified.config, {
+							{...conform.input(verified, {
 								type: 'checkbox',
 								value: 'Yes',
 							})}

--- a/playground/app/routes/radio-buttons.tsx
+++ b/playground/app/routes/radio-buttons.tsx
@@ -57,29 +57,21 @@ export default function Example() {
 	return (
 		<Form method="post" {...form.props}>
 			<Playground title="Attributes" state={state}>
-				<Field label="Multiple Choice" {...answer}>
+				<Field label="Multiple Choice" config={answer}>
 					<label>
-						<input
-							{...conform.input(answer.config, { type: 'radio', value: 'a' })}
-						/>
+						<input {...conform.input(answer, { type: 'radio', value: 'a' })} />
 						<span className="p-2">A</span>
 					</label>
 					<label className="inline-block">
-						<input
-							{...conform.input(answer.config, { type: 'radio', value: 'b' })}
-						/>
+						<input {...conform.input(answer, { type: 'radio', value: 'b' })} />
 						<span className="p-2">B</span>
 					</label>
 					<label className="inline-block">
-						<input
-							{...conform.input(answer.config, { type: 'radio', value: 'c' })}
-						/>
+						<input {...conform.input(answer, { type: 'radio', value: 'c' })} />
 						<span className="p-2">C</span>
 					</label>
 					<label className="inline-block">
-						<input
-							{...conform.input(answer.config, { type: 'radio', value: 'd' })}
-						/>
+						<input {...conform.input(answer, { type: 'radio', value: 'd' })} />
 						<span className="p-2">D</span>
 					</label>
 				</Field>

--- a/playground/app/routes/signup.tsx
+++ b/playground/app/routes/signup.tsx
@@ -83,19 +83,19 @@ export default function SignupForm() {
 	return (
 		<Playground title="Signup Form" form={form.id} state={state}>
 			<Form method="post" {...form.props} />
-			<Field label="Email" {...email}>
+			<Field label="Email" config={email}>
 				<input
-					{...conform.input(email.config, { type: 'email' })}
+					{...conform.input(email, { type: 'email' })}
 					autoComplete="off"
 					form="signup"
 				/>
 			</Field>
-			<Field label="Password" {...password}>
-				<input {...conform.input(password.config, { type: 'password' })} />
+			<Field label="Password" config={password}>
+				<input {...conform.input(password, { type: 'password' })} />
 			</Field>
-			<Field label="Confirm password" {...confirmPassword}>
+			<Field label="Confirm password" config={confirmPassword}>
 				<input
-					{...conform.input(confirmPassword.config, { type: 'password' })}
+					{...conform.input(confirmPassword, { type: 'password' })}
 					form="signup"
 				/>
 			</Field>

--- a/playground/app/routes/simple-list.tsx
+++ b/playground/app/routes/simple-list.tsx
@@ -40,7 +40,7 @@ export default function SimpleList() {
 			? ({ formData }) => parse(formData, { schema })
 			: undefined,
 	});
-	const itemsList = useFieldList(form.ref, items.config);
+	const itemsList = useFieldList(form.ref, items);
 
 	return (
 		<Form method="post" {...form.props}>
@@ -49,25 +49,25 @@ export default function SimpleList() {
 				<ol>
 					{itemsList.map((item, index) => (
 						<li key={item.key} className="border rounded-md p-4 mb-4">
-							<Field label={`Item #${index + 1}`} {...item}>
-								<input {...conform.input(item.config, { type: 'text' })} />
+							<Field label={`Item #${index + 1}`} config={item}>
+								<input {...conform.input(item, { type: 'text' })} />
 							</Field>
 							<div className="flex flex-row gap-2">
 								<button
 									className="rounded-md border p-2 hover:border-black"
-									{...list.remove(items.config.name, { index })}
+									{...list.remove(items.name, { index })}
 								>
 									Delete
 								</button>
 								<button
 									className="rounded-md border p-2 hover:border-black"
-									{...list.reorder(items.config.name, { from: index, to: 0 })}
+									{...list.reorder(items.name, { from: index, to: 0 })}
 								>
 									Move to top
 								</button>
 								<button
 									className="rounded-md border p-2 hover:border-black"
-									{...list.replace(items.config.name, {
+									{...list.replace(items.name, {
 										index,
 										defaultValue: '',
 									})}
@@ -81,13 +81,13 @@ export default function SimpleList() {
 				<div className="flex flex-row gap-2">
 					<button
 						className="rounded-md border p-2 hover:border-black"
-						{...list.prepend(items.config.name, { defaultValue: '' })}
+						{...list.prepend(items.name, { defaultValue: '' })}
 					>
 						Insert top
 					</button>
 					<button
 						className="rounded-md border p-2 hover:border-black"
-						{...list.append(items.config.name, { defaultValue: '' })}
+						{...list.append(items.name, { defaultValue: '' })}
 					>
 						Insert bottom
 					</button>

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -68,11 +68,11 @@ export function TaskFieldset(
 	});
 	return (
 		<fieldset ref={ref} form={config.form}>
-			<Field label="Content" {...content}>
-				<input {...conform.input(content.config, { type: 'text' })} />
+			<Field label="Content" config={content}>
+				<input {...conform.input(content, { type: 'text' })} />
 			</Field>
-			<Field label="Completed" error={completed.error} inline>
-				<input {...conform.input(completed.config, { type: 'checkbox' })} />
+			<Field label="Completed" config={completed} inline>
+				<input {...conform.input(completed, { type: 'checkbox' })} />
 			</Field>
 		</fieldset>
 	);
@@ -84,33 +84,33 @@ export function TodosFieldset(config: FieldsetConfig<z.infer<typeof schema>>) {
 		...config,
 		constraint: getFieldsetConstraint(schema),
 	});
-	const taskList = useFieldList(ref, tasks.config);
+	const taskList = useFieldList(ref, tasks);
 
 	return (
 		<fieldset ref={ref} form={config.form}>
-			<Field label="Title" {...title}>
-				<input {...conform.input(title.config, { type: 'text' })} />
+			<Field label="Title" config={title}>
+				<input {...conform.input(title, { type: 'text' })} />
 			</Field>
 			<ol>
 				{taskList.map((task, index) => (
 					<li key={task.key} className="border rounded-md p-4 mb-4">
-						<TaskFieldset {...task.config} />
+						<TaskFieldset {...task} />
 						<div className="flex flex-row gap-2">
 							<button
 								className="rounded-md border p-2 hover:border-black"
-								{...list.remove(tasks.config.name, { index })}
+								{...list.remove(tasks.name, { index })}
 							>
 								Delete
 							</button>
 							<button
 								className="rounded-md border p-2 hover:border-black"
-								{...list.reorder(tasks.config.name, { from: index, to: 0 })}
+								{...list.reorder(tasks.name, { from: index, to: 0 })}
 							>
 								Move to top
 							</button>
 							<button
 								className="rounded-md border p-2 hover:border-black"
-								{...list.replace(tasks.config.name, {
+								{...list.replace(tasks.name, {
 									index,
 									defaultValue: { content: '' },
 								})}
@@ -124,13 +124,13 @@ export function TodosFieldset(config: FieldsetConfig<z.infer<typeof schema>>) {
 			<div className="flex flex-row gap-2">
 				<button
 					className="rounded-md border p-2 hover:border-black"
-					{...list.prepend(tasks.config.name)}
+					{...list.prepend(tasks.name)}
 				>
 					Insert top
 				</button>
 				<button
 					className="rounded-md border p-2 hover:border-black"
-					{...list.append(tasks.config.name)}
+					{...list.append(tasks.name)}
 				>
 					Insert bottom
 				</button>

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -42,18 +42,68 @@ export let action = async ({ request }: ActionArgs) => {
 export default function TodosForm() {
 	const config = useLoaderData();
 	const state = useActionData();
-	const [form] = useForm({
+	const [form, { title, tasks }] = useForm<z.infer<typeof schema>>({
 		...config,
 		state,
+		constraint: getFieldsetConstraint(schema),
 		onValidate: config.validate
 			? ({ formData }) => parse(formData, { schema })
 			: undefined,
 	});
+	const taskList = useFieldList(form.ref, tasks);
 
 	return (
 		<Form method="post" {...form.props}>
 			<Playground title="Todos Form" state={state}>
-				<TodosFieldset {...form.config} />
+				<fieldset>
+					<Field label="Title" config={title}>
+						<input {...conform.input(title, { type: 'text' })} />
+					</Field>
+					<ol>
+						{taskList.map((task, index) => (
+							<li key={task.key} className="border rounded-md p-4 mb-4">
+								<TaskFieldset {...task} />
+								<div className="flex flex-row gap-2">
+									<button
+										className="rounded-md border p-2 hover:border-black"
+										{...list.remove(tasks.name, { index })}
+									>
+										Delete
+									</button>
+									<button
+										className="rounded-md border p-2 hover:border-black"
+										{...list.reorder(tasks.name, { from: index, to: 0 })}
+									>
+										Move to top
+									</button>
+									<button
+										className="rounded-md border p-2 hover:border-black"
+										{...list.replace(tasks.name, {
+											index,
+											defaultValue: { content: '' },
+										})}
+									>
+										Clear
+									</button>
+								</div>
+							</li>
+						))}
+					</ol>
+					<div className="flex flex-row gap-2">
+						<button
+							className="rounded-md border p-2 hover:border-black"
+							{...list.prepend(tasks.name)}
+						>
+							Insert top
+						</button>
+						<button
+							className="rounded-md border p-2 hover:border-black"
+							{...list.append(tasks.name)}
+						>
+							Insert bottom
+						</button>
+					</div>
+				</fieldset>
 			</Playground>
 		</Form>
 	);
@@ -74,67 +124,6 @@ export function TaskFieldset(
 			<Field label="Completed" config={completed} inline>
 				<input {...conform.input(completed, { type: 'checkbox' })} />
 			</Field>
-		</fieldset>
-	);
-}
-
-export function TodosFieldset(config: FieldsetConfig<z.infer<typeof schema>>) {
-	const ref = useRef<HTMLFieldSetElement>(null);
-	const { title, tasks } = useFieldset(ref, {
-		...config,
-		constraint: getFieldsetConstraint(schema),
-	});
-	const taskList = useFieldList(ref, tasks);
-
-	return (
-		<fieldset ref={ref} form={config.form}>
-			<Field label="Title" config={title}>
-				<input {...conform.input(title, { type: 'text' })} />
-			</Field>
-			<ol>
-				{taskList.map((task, index) => (
-					<li key={task.key} className="border rounded-md p-4 mb-4">
-						<TaskFieldset {...task} />
-						<div className="flex flex-row gap-2">
-							<button
-								className="rounded-md border p-2 hover:border-black"
-								{...list.remove(tasks.name, { index })}
-							>
-								Delete
-							</button>
-							<button
-								className="rounded-md border p-2 hover:border-black"
-								{...list.reorder(tasks.name, { from: index, to: 0 })}
-							>
-								Move to top
-							</button>
-							<button
-								className="rounded-md border p-2 hover:border-black"
-								{...list.replace(tasks.name, {
-									index,
-									defaultValue: { content: '' },
-								})}
-							>
-								Clear
-							</button>
-						</div>
-					</li>
-				))}
-			</ol>
-			<div className="flex flex-row gap-2">
-				<button
-					className="rounded-md border p-2 hover:border-black"
-					{...list.prepend(tasks.name)}
-				>
-					Insert top
-				</button>
-				<button
-					className="rounded-md border p-2 hover:border-black"
-					{...list.append(tasks.name)}
-				>
-					Insert bottom
-				</button>
-			</div>
 		</fieldset>
 	);
 }

--- a/playground/app/routes/validate-constraint.tsx
+++ b/playground/app/routes/validate-constraint.tsx
@@ -85,7 +85,7 @@ export default function Example() {
 		<Form method="post" {...form.props}>
 			<Playground title="Validate Constraint" state={state}>
 				<fieldset>
-					<Field label="Email" {...email}>
+					<Field label="Email" config={email}>
 						<input
 							name="email"
 							type="email"
@@ -93,7 +93,7 @@ export default function Example() {
 							pattern="[^@]+@example.com"
 						/>
 					</Field>
-					<Field label="Password" {...password}>
+					<Field label="Password" config={password}>
 						<input
 							name="password"
 							type="password"
@@ -102,7 +102,7 @@ export default function Example() {
 							pattern="(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[1-9]).*"
 						/>
 					</Field>
-					<Field label="Confirm Password" {...confirmPassword}>
+					<Field label="Confirm Password" config={confirmPassword}>
 						<input
 							name="confirmPassword"
 							type="password"

--- a/playground/app/routes/validate.tsx
+++ b/playground/app/routes/validate.tsx
@@ -39,16 +39,16 @@ export default function Validate() {
 	return (
 		<Form method="post" {...form.props}>
 			<Playground title="Validate" state={state}>
-				<Field label="Name" {...name}>
-					<input {...conform.input(name.config, { type: 'text' })} />
+				<Field label="Name" config={name}>
+					<input {...conform.input(name, { type: 'text' })} />
 				</Field>
-				<Field label="Message" {...message}>
-					<textarea {...conform.textarea(message.config)} />
+				<Field label="Message" config={message}>
+					<textarea {...conform.textarea(message)} />
 				</Field>
 				<div className="flex flex-row gap-2">
 					<button
 						className="rounded-md border p-2 hover:border-black"
-						{...validate(name.config.name)}
+						{...validate(name.name)}
 					>
 						Validate Name
 					</button>

--- a/tests/integrations/input-attributes.spec.ts
+++ b/tests/integrations/input-attributes.spec.ts
@@ -78,31 +78,34 @@ test('setup aria-attributes', async ({ page }) => {
 		'aria-describedby',
 		'test-title-error',
 	);
-	await expect(fieldset.title).toHaveAttribute('aria-invalid', 'false');
+	await expect(fieldset.title).not.toHaveAttribute('aria-invalid', 'true');
 	await expect(fieldset.description).toHaveAttribute('id', 'test-description');
 	await expect(fieldset.description).toHaveAttribute(
 		'aria-describedby',
 		'test-description-error',
 	);
-	await expect(fieldset.description).toHaveAttribute('aria-invalid', 'false');
+	await expect(fieldset.description).not.toHaveAttribute(
+		'aria-invalid',
+		'true',
+	);
 	await expect(fieldset.images).toHaveAttribute('id', 'test-images');
 	await expect(fieldset.images).toHaveAttribute(
 		'aria-describedby',
 		'test-images-error',
 	);
-	await expect(fieldset.images).toHaveAttribute('aria-invalid', 'false');
+	await expect(fieldset.images).not.toHaveAttribute('aria-invalid', 'true');
 	await expect(fieldset.tags).toHaveAttribute('id', 'test-tags');
 	await expect(fieldset.tags).toHaveAttribute(
 		'aria-describedby',
 		'test-tags-error',
 	);
-	await expect(fieldset.tags).toHaveAttribute('aria-invalid', 'false');
+	await expect(fieldset.tags).not.toHaveAttribute('aria-invalid', 'true');
 	await expect(fieldset.rating).toHaveAttribute('id', 'test-rating');
 	await expect(fieldset.rating).toHaveAttribute(
 		'aria-describedby',
 		'test-rating-error',
 	);
-	await expect(fieldset.rating).toHaveAttribute('aria-invalid', 'false');
+	await expect(fieldset.rating).not.toHaveAttribute('aria-invalid', 'true');
 
 	await playground.submit.click();
 	await expect(fieldset.title).toHaveAttribute('aria-invalid', 'true');
@@ -112,9 +115,12 @@ test('setup aria-attributes', async ({ page }) => {
 	await expect(fieldset.rating).toHaveAttribute('aria-invalid', 'true');
 
 	await playground.reset.click();
-	await expect(fieldset.title).toHaveAttribute('aria-invalid', 'false');
-	await expect(fieldset.description).toHaveAttribute('aria-invalid', 'false');
-	await expect(fieldset.images).toHaveAttribute('aria-invalid', 'false');
-	await expect(fieldset.tags).toHaveAttribute('aria-invalid', 'false');
-	await expect(fieldset.rating).toHaveAttribute('aria-invalid', 'false');
+	await expect(fieldset.title).not.toHaveAttribute('aria-invalid', 'true');
+	await expect(fieldset.description).not.toHaveAttribute(
+		'aria-invalid',
+		'true',
+	);
+	await expect(fieldset.images).not.toHaveAttribute('aria-invalid', 'true');
+	await expect(fieldset.tags).not.toHaveAttribute('aria-invalid', 'true');
+	await expect(fieldset.rating).not.toHaveAttribute('aria-invalid', 'true');
 });

--- a/tests/react.spec.ts
+++ b/tests/react.spec.ts
@@ -14,9 +14,7 @@ import {
 	getSignupFieldset,
 	hasFocus,
 	getTaskFieldset,
-	waitForDataResponse,
 	getTodosFieldset,
-	getEmployeeFieldset,
 } from './helpers';
 
 test.describe('Client Validation', () => {


### PR DESCRIPTION
This PR simplify the `Field` structure by extending the config structure directly, i.e.

```diff
function Example() {
  const [form, { message }] = useForm();

  return (
    <form>
-      <input {...conform.input(message.config)} />
+      <input {...conform.input(message)} />
      {message.error}
    </form>
  );
```  

Properly the last breaking change before v0.6.