### PR TITLE
feat(conform-react): form aria-attributes support

### DIFF
--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -113,14 +113,17 @@ export interface FormConfig<
  * Properties to be applied to the form element
  */
 interface FormProps {
-	ref: RefObject<HTMLFormElement>;
 	id?: string;
+	ref: RefObject<HTMLFormElement>;
 	onSubmit: (event: FormEvent<HTMLFormElement>) => void;
 	noValidate: boolean;
+	'aria-invalid'?: 'true';
+	'aria-describedby'?: string;
 }
 
 interface Form {
 	id?: string;
+	errorId?: string;
 	error: string;
 	errors: string[];
 	ref: RefObject<HTMLFormElement>;
@@ -391,7 +394,13 @@ export function useForm<
 
 	if (config.id) {
 		form.id = config.id;
+		form.errorId = `${config.id}-error`;
 		form.props.id = form.id;
+		form.props['aria-describedby'] = form.errorId;
+	}
+
+	if (form.errorId && form.errors.length > 0) {
+		form.props['aria-invalid'] = 'true';
 	}
 
 	return [form, fieldset];

--- a/playground/app/components.tsx
+++ b/playground/app/components.tsx
@@ -130,7 +130,7 @@ export function Field({ label, inline, config, children }: FieldProps) {
 
 interface AlertProps {
 	id?: string;
-	errors: string[];
+	errors: string[] | undefined;
 }
 
 export function Alert({ id, errors }: AlertProps) {
@@ -138,15 +138,15 @@ export function Alert({ id, errors }: AlertProps) {
 		<div
 			id={id}
 			className={
-				errors.length > 0
+				errors?.length
 					? 'flex gap-4 bg-red-100 text-red-500 text-sm p-4 mb-4 rounded align-top'
 					: 'hidden'
 			}
 		>
 			<span>❌</span>
 			<div className="space-y-1">
-				{errors.length === 0 ? (
-					<p />
+				{!errors?.length ? (
+					<p></p>
 				) : (
 					errors.map((message, index) => <p key={index}>{message}</p>)
 				)}

--- a/playground/app/components.tsx
+++ b/playground/app/components.tsx
@@ -129,20 +129,28 @@ export function Field({ label, inline, config, children }: FieldProps) {
 }
 
 interface AlertProps {
-	message: string;
+	id?: string;
+	errors: string[];
 }
 
-export function Alert({ message }: AlertProps) {
+export function Alert({ id, errors }: AlertProps) {
 	return (
-		<label
+		<div
+			id={id}
 			className={
-				message
-					? 'flex gap-4 bg-red-100 text-red-500 text-sm p-4 mb-4 rounded'
+				errors.length > 0
+					? 'flex gap-4 bg-red-100 text-red-500 text-sm p-4 mb-4 rounded align-top'
 					: 'hidden'
 			}
 		>
 			<span>❌</span>
-			<p>{message}</p>
-		</label>
+			<div className="space-y-1">
+				{errors.length === 0 ? (
+					<p />
+				) : (
+					errors.map((message, index) => <p key={index}>{message}</p>)
+				)}
+			</div>
+		</div>
 	);
 }

--- a/playground/app/routes/file-upload.tsx
+++ b/playground/app/routes/file-upload.tsx
@@ -63,7 +63,7 @@ export default function FileUpload() {
 	return (
 		<Form method="post" {...form.props} encType="multipart/form-data">
 			<Playground title="Employee Form" state={state}>
-				<Alert message={form.error} />
+				<Alert errors={form.errors} />
 				<Field label="Single file" config={file}>
 					<input {...conform.input(file, { type: 'file' })} />
 				</Field>

--- a/playground/app/routes/input-attributes.tsx
+++ b/playground/app/routes/input-attributes.tsx
@@ -1,7 +1,7 @@
 import { conform, useForm, parse } from '@conform-to/react';
 import { json, type ActionArgs } from '@remix-run/node';
 import { Form, useActionData } from '@remix-run/react';
-import { Playground, Field } from '~/components';
+import { Playground, Field, Alert } from '~/components';
 
 interface Schema {
 	title: string;
@@ -15,7 +15,12 @@ export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parse(formData);
 
-	return json(submission);
+	return json({
+		...submission,
+		error: {
+			'': 'Submitted',
+		},
+	});
 }
 
 export default function Example() {
@@ -55,6 +60,7 @@ export default function Example() {
 	return (
 		<Form method="post" encType="multipart/form-data" {...form.props}>
 			<Playground title="Input attributes" state={state}>
+				<Alert message={form.error} />
 				<Field label="Title" config={title}>
 					<input {...conform.input(title, { type: 'text' })} />
 				</Field>

--- a/playground/app/routes/input-attributes.tsx
+++ b/playground/app/routes/input-attributes.tsx
@@ -60,7 +60,7 @@ export default function Example() {
 	return (
 		<Form method="post" encType="multipart/form-data" {...form.props}>
 			<Playground title="Input attributes" state={state}>
-				<Alert message={form.error} />
+				<Alert id={form.errorId} errors={form.errors} />
 				<Field label="Title" config={title}>
 					<input {...conform.input(title, { type: 'text' })} />
 				</Field>

--- a/playground/app/routes/login.tsx
+++ b/playground/app/routes/login.tsx
@@ -78,7 +78,7 @@ export default function LoginForm() {
 	return (
 		<Form method="post" {...form.props}>
 			<Playground title="Login Form" state={state}>
-				<Alert message={form.error} />
+				<Alert errors={form.errors} />
 				<Field label="Email" config={email}>
 					<input
 						{...conform.input(email, { type: 'email' })}

--- a/playground/app/routes/simple-list.tsx
+++ b/playground/app/routes/simple-list.tsx
@@ -45,7 +45,7 @@ export default function SimpleList() {
 	return (
 		<Form method="post" {...form.props}>
 			<Playground title="Simple list" state={state}>
-				<Alert errors={form.errors} />
+				<Alert errors={items.errors} />
 				<ol>
 					{itemsList.map((item, index) => (
 						<li key={item.key} className="border rounded-md p-4 mb-4">

--- a/playground/app/routes/simple-list.tsx
+++ b/playground/app/routes/simple-list.tsx
@@ -45,7 +45,7 @@ export default function SimpleList() {
 	return (
 		<Form method="post" {...form.props}>
 			<Playground title="Simple list" state={state}>
-				<Alert message={items.error ?? ''} />
+				<Alert errors={form.errors} />
 				<ol>
 					{itemsList.map((item, index) => (
 						<li key={item.key} className="border rounded-md p-4 mb-4">

--- a/tests/integrations/input-attributes.spec.ts
+++ b/tests/integrations/input-attributes.spec.ts
@@ -73,6 +73,10 @@ test('setup aria-attributes', async ({ page }) => {
 	const fieldset = getFieldset(playground.container);
 
 	await expect(playground.form).toHaveAttribute('id', 'test');
+	await expect(playground.form).toHaveAttribute(
+		'aria-describedby',
+		'test-error',
+	);
 	await expect(fieldset.title).toHaveAttribute('id', 'test-title');
 	await expect(fieldset.title).toHaveAttribute(
 		'aria-describedby',
@@ -108,6 +112,7 @@ test('setup aria-attributes', async ({ page }) => {
 	await expect(fieldset.rating).not.toHaveAttribute('aria-invalid', 'true');
 
 	await playground.submit.click();
+	await expect(playground.form).toHaveAttribute('aria-invalid', 'true');
 	await expect(fieldset.title).toHaveAttribute('aria-invalid', 'true');
 	await expect(fieldset.description).toHaveAttribute('aria-invalid', 'true');
 	await expect(fieldset.images).toHaveAttribute('aria-invalid', 'true');
@@ -115,6 +120,7 @@ test('setup aria-attributes', async ({ page }) => {
 	await expect(fieldset.rating).toHaveAttribute('aria-invalid', 'true');
 
 	await playground.reset.click();
+	await expect(playground.form).not.toHaveAttribute('aria-invalid', 'true');
 	await expect(fieldset.title).not.toHaveAttribute('aria-invalid', 'true');
 	await expect(fieldset.description).not.toHaveAttribute(
 		'aria-invalid',


### PR DESCRIPTION
As requested on #108, Conform will set both `aria-invalid` and `aria-describedby` to the form element if there is any form error. It also provides `form.errorId` to be used as the id of the form error element.

The current implementation relies on `aria-describedby` due to [limited support](https://a11ysupport.io/tech/aria/aria-errormessage_attribute) on `aria-errormessage`