### PR TITLE
feat(conform-react): add support of descriptionId

### DIFF
--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -12,6 +12,7 @@ export interface FieldConfig<Schema = unknown> extends FieldConstraint<Schema> {
 	defaultValue?: FieldValue<Schema>;
 	initialError?: Record<string, string | string[]>;
 	form?: string;
+	descriptionId?: string;
 	errorId?: string;
 
 	/**

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -45,17 +45,22 @@ interface TextareaProps extends FormControlProps {
 	defaultValue?: string;
 }
 
-type InputOptions =
-	| {
-			type: 'checkbox' | 'radio';
-			hidden?: boolean;
-			value?: string;
-	  }
-	| {
-			type?: Exclude<HTMLInputTypeAttribute, 'button' | 'submit' | 'hidden'>;
-			hidden?: boolean;
-			value?: never;
-	  };
+type BaseOptions = {
+	description?: boolean;
+	hidden?: boolean;
+};
+
+type InputOptions = BaseOptions &
+	(
+		| {
+				type: 'checkbox' | 'radio';
+				value?: string;
+		  }
+		| {
+				type?: Exclude<HTMLInputTypeAttribute, 'button' | 'submit' | 'hidden'>;
+				value?: never;
+		  }
+	);
 
 /**
  * Style to make the input element visually hidden
@@ -75,7 +80,7 @@ const hiddenStyle: CSSProperties = {
 
 function getFormControlProps(
 	config: FieldConfig<any>,
-	options?: { hidden?: boolean },
+	options?: BaseOptions,
 ): FormControlProps {
 	const props: FormControlProps = {
 		id: config.id,
@@ -86,11 +91,18 @@ function getFormControlProps(
 
 	if (config.id) {
 		props.id = config.id;
-		props['aria-describedby'] = config.errorId;
+	}
+
+	if (config.descriptionId && options?.description) {
+		props['aria-describedby'] = config.descriptionId;
 	}
 
 	if (config.errorId && config.error?.length) {
 		props['aria-invalid'] = true;
+		props['aria-describedby'] =
+			config.descriptionId && options?.description
+				? `${config.errorId} ${config.descriptionId}`
+				: config.errorId;
 	}
 
 	if (config.initialError && Object.entries(config.initialError).length > 0) {
@@ -108,7 +120,7 @@ function getFormControlProps(
 
 export function input<Schema extends File | File[]>(
 	config: FieldConfig<Schema>,
-	options: { type: 'file' },
+	options: InputOptions & { type: 'file' },
 ): InputProps<Schema>;
 export function input<Schema extends Primitive>(
 	config: FieldConfig<Schema>,
@@ -142,7 +154,7 @@ export function input<Schema extends Primitive | File | File[]>(
 
 export function select(
 	config: FieldConfig<Primitive | Primitive[]>,
-	options?: { hidden?: boolean },
+	options?: BaseOptions,
 ): SelectProps {
 	const props: SelectProps = {
 		...getFormControlProps(config, options),
@@ -155,7 +167,7 @@ export function select(
 
 export function textarea(
 	config: FieldConfig<Primitive>,
-	options?: { hidden?: boolean },
+	options?: BaseOptions,
 ): TextareaProps {
 	const props: TextareaProps = {
 		...getFormControlProps(config, options),

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -417,11 +417,11 @@ export function useForm<
 		form.id = config.id;
 		form.errorId = `${config.id}-error`;
 		form.props.id = form.id;
-		form.props['aria-describedby'] = form.errorId;
 	}
 
 	if (form.errorId && form.errors.length > 0) {
 		form.props['aria-invalid'] = 'true';
+		form.props['aria-describedby'] = form.errorId;
 	}
 
 	return [form, fieldset];
@@ -606,6 +606,7 @@ export function useFieldset<Schema extends Record<string, any>>(
 					field.form = fieldsetConfig.form;
 					field.id = `${fieldsetConfig.form}-${field.name}`;
 					field.errorId = `${field.id}-error`;
+					field.descriptionId = `${field.id}-description`;
 				}
 
 				return field;
@@ -791,6 +792,7 @@ export function useFieldList<Payload = any>(
 			fieldConfig.form = config.form;
 			fieldConfig.id = `${config.form}-${config.name}`;
 			fieldConfig.errorId = `${fieldConfig.id}-error`;
+			fieldConfig.descriptionId = `${fieldConfig.id}-description`;
 		}
 
 		return {

--- a/playground/app/routes/input-attributes.tsx
+++ b/playground/app/routes/input-attributes.tsx
@@ -1,6 +1,6 @@
 import { conform, useForm, parse } from '@conform-to/react';
-import { json, type ActionArgs } from '@remix-run/node';
-import { Form, useActionData } from '@remix-run/react';
+import { json, type ActionArgs, type LoaderArgs } from '@remix-run/node';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { useRef } from 'react';
 import { Playground, Field, Alert } from '~/components';
 
@@ -10,6 +10,14 @@ interface Schema {
 	rating: number;
 	images: File[];
 	tags: string[];
+}
+
+export async function loader({ request }: LoaderArgs) {
+	const url = new URL(request.url);
+
+	return json({
+		enableDescription: url.searchParams.get('enableDescription') === 'yes',
+	});
 }
 
 export async function action({ request }: ActionArgs) {
@@ -25,6 +33,7 @@ export async function action({ request }: ActionArgs) {
 }
 
 export default function Example() {
+	const { enableDescription } = useLoaderData<typeof loader>();
 	const lastSubmission = useActionData<typeof action>();
 	const ref = useRef<HTMLFormElement>(null);
 	const [form, { title, description, images, rating, tags }] = useForm<Schema>({
@@ -69,16 +78,30 @@ export default function Example() {
 			<Playground title="Input attributes" lastSubmission={lastSubmission}>
 				<Alert id={form.errorId} errors={form.errors} />
 				<Field label="Title" config={title}>
-					<input {...conform.input(title, { type: 'text' })} />
+					<input
+						{...conform.input(title, {
+							type: 'text',
+							description: enableDescription,
+						})}
+					/>
 				</Field>
 				<Field label="Description" config={description}>
-					<textarea {...conform.textarea(description)} />
+					<textarea
+						{...conform.textarea(description, {
+							description: enableDescription,
+						})}
+					/>
 				</Field>
 				<Field label="Image" config={images}>
-					<input {...conform.input(images, { type: 'file' })} />
+					<input
+						{...conform.input(images, {
+							type: 'file',
+							description: enableDescription,
+						})}
+					/>
 				</Field>
 				<Field label="Tags" config={tags}>
-					<select {...conform.select(tags)}>
+					<select {...conform.select(tags, { description: enableDescription })}>
 						<option value="">Please select</option>
 						<option value="action">Action</option>
 						<option value="adventure">Adventure</option>
@@ -90,7 +113,12 @@ export default function Example() {
 					</select>
 				</Field>
 				<Field label="Rating" config={rating}>
-					<input {...conform.input(rating, { type: 'number' })} />
+					<input
+						{...conform.input(rating, {
+							type: 'number',
+							description: enableDescription,
+						})}
+					/>
 				</Field>
 			</Playground>
 		</Form>

--- a/tests/integrations/input-attributes.spec.ts
+++ b/tests/integrations/input-attributes.spec.ts
@@ -11,11 +11,9 @@ function getFieldset(form: Locator) {
 	};
 }
 
-test.beforeEach(async ({ page }) => {
-	await page.goto('/input-attributes');
-});
-
 test('setup validation attributes', async ({ page }) => {
+	await page.goto('/input-attributes');
+
 	const playground = getPlayground(page);
 	const fieldset = getFieldset(playground.container);
 
@@ -68,47 +66,49 @@ test('setup validation attributes', async ({ page }) => {
 	await expect(fieldset.rating).toHaveJSProperty('step', '0.5');
 });
 
-test('setup aria-attributes', async ({ page }) => {
+test('setup field id correctly', async ({ page }) => {
+	await page.goto('/input-attributes');
+
 	const playground = getPlayground(page);
 	const fieldset = getFieldset(playground.container);
 
 	await expect(playground.form).toHaveAttribute('id', 'test');
-	await expect(playground.form).toHaveAttribute(
-		'aria-describedby',
-		'test-error',
-	);
 	await expect(fieldset.title).toHaveAttribute('id', 'test-title');
-	await expect(fieldset.title).toHaveAttribute(
-		'aria-describedby',
-		'test-title-error',
-	);
-	await expect(fieldset.title).not.toHaveAttribute('aria-invalid', 'true');
 	await expect(fieldset.description).toHaveAttribute('id', 'test-description');
-	await expect(fieldset.description).toHaveAttribute(
-		'aria-describedby',
-		'test-description-error',
-	);
+	await expect(fieldset.images).toHaveAttribute('id', 'test-images');
+	await expect(fieldset.tags).toHaveAttribute('id', 'test-tags');
+	await expect(fieldset.rating).toHaveAttribute('id', 'test-rating');
+
+	await playground.submit.click();
+	await expect(playground.form).toHaveAttribute('id', 'test');
+	await expect(fieldset.title).toHaveAttribute('id', 'test-title');
+	await expect(fieldset.description).toHaveAttribute('id', 'test-description');
+	await expect(fieldset.images).toHaveAttribute('id', 'test-images');
+	await expect(fieldset.tags).toHaveAttribute('id', 'test-tags');
+	await expect(fieldset.rating).toHaveAttribute('id', 'test-rating');
+
+	await playground.reset.click();
+	await expect(playground.form).toHaveAttribute('id', 'test');
+	await expect(fieldset.title).toHaveAttribute('id', 'test-title');
+	await expect(fieldset.description).toHaveAttribute('id', 'test-description');
+	await expect(fieldset.images).toHaveAttribute('id', 'test-images');
+	await expect(fieldset.tags).toHaveAttribute('id', 'test-tags');
+	await expect(fieldset.rating).toHaveAttribute('id', 'test-rating');
+});
+
+test('setup aria-invalid correctly', async ({ page }) => {
+	await page.goto('/input-attributes');
+
+	const playground = getPlayground(page);
+	const fieldset = getFieldset(playground.container);
+
+	await expect(fieldset.title).not.toHaveAttribute('aria-invalid', 'true');
 	await expect(fieldset.description).not.toHaveAttribute(
 		'aria-invalid',
 		'true',
 	);
-	await expect(fieldset.images).toHaveAttribute('id', 'test-images');
-	await expect(fieldset.images).toHaveAttribute(
-		'aria-describedby',
-		'test-images-error',
-	);
 	await expect(fieldset.images).not.toHaveAttribute('aria-invalid', 'true');
-	await expect(fieldset.tags).toHaveAttribute('id', 'test-tags');
-	await expect(fieldset.tags).toHaveAttribute(
-		'aria-describedby',
-		'test-tags-error',
-	);
 	await expect(fieldset.tags).not.toHaveAttribute('aria-invalid', 'true');
-	await expect(fieldset.rating).toHaveAttribute('id', 'test-rating');
-	await expect(fieldset.rating).toHaveAttribute(
-		'aria-describedby',
-		'test-rating-error',
-	);
 	await expect(fieldset.rating).not.toHaveAttribute('aria-invalid', 'true');
 
 	await playground.submit.click();
@@ -129,4 +129,162 @@ test('setup aria-attributes', async ({ page }) => {
 	await expect(fieldset.images).not.toHaveAttribute('aria-invalid', 'true');
 	await expect(fieldset.tags).not.toHaveAttribute('aria-invalid', 'true');
 	await expect(fieldset.rating).not.toHaveAttribute('aria-invalid', 'true');
+});
+
+test('setup aria-describedby without description correctly', async ({
+	page,
+}) => {
+	await page.goto('/input-attributes');
+
+	const playground = getPlayground(page);
+	const fieldset = getFieldset(playground.container);
+
+	await expect(playground.form).not.toHaveAttribute(
+		'aria-describedby',
+		'test-error',
+	);
+	await expect(fieldset.title).not.toHaveAttribute(
+		'aria-describedby',
+		'test-title-error',
+	);
+	await expect(fieldset.description).not.toHaveAttribute(
+		'aria-describedby',
+		'test-description-error',
+	);
+	await expect(fieldset.images).not.toHaveAttribute(
+		'aria-describedby',
+		'test-images-error',
+	);
+	await expect(fieldset.tags).not.toHaveAttribute(
+		'aria-describedby',
+		'test-tags-error',
+	);
+	await expect(fieldset.rating).not.toHaveAttribute(
+		'aria-describedby',
+		'test-rating-error',
+	);
+
+	await playground.submit.click();
+
+	await expect(fieldset.description).toHaveAttribute(
+		'aria-describedby',
+		'test-description-error',
+	);
+	await expect(fieldset.title).toHaveAttribute(
+		'aria-describedby',
+		'test-title-error',
+	);
+	await expect(fieldset.images).toHaveAttribute(
+		'aria-describedby',
+		'test-images-error',
+	);
+	await expect(fieldset.tags).toHaveAttribute(
+		'aria-describedby',
+		'test-tags-error',
+	);
+	await expect(fieldset.rating).toHaveAttribute(
+		'aria-describedby',
+		'test-rating-error',
+	);
+
+	await playground.reset.click();
+
+	await expect(fieldset.title).not.toHaveAttribute(
+		'aria-describedby',
+		'test-title-error',
+	);
+	await expect(fieldset.description).not.toHaveAttribute(
+		'aria-describedby',
+		'test-description-error',
+	);
+	await expect(fieldset.images).not.toHaveAttribute(
+		'aria-describedby',
+		'test-images-error',
+	);
+	await expect(fieldset.tags).not.toHaveAttribute(
+		'aria-describedby',
+		'test-tags-error',
+	);
+	await expect(fieldset.rating).not.toHaveAttribute(
+		'aria-describedby',
+		'test-rating-error',
+	);
+});
+
+test('setup aria-describedby with description correctly', async ({ page }) => {
+	await page.goto('/input-attributes?enableDescription=yes');
+
+	const playground = getPlayground(page);
+	const fieldset = getFieldset(playground.container);
+
+	await expect(playground.form).not.toHaveAttribute(
+		'aria-describedby',
+		'test-error',
+	);
+	await expect(fieldset.title).not.toHaveAttribute(
+		'aria-describedby',
+		'test-title-error test-title-description',
+	);
+	await expect(fieldset.description).not.toHaveAttribute(
+		'aria-describedby',
+		'test-description-error test-description-description',
+	);
+	await expect(fieldset.images).not.toHaveAttribute(
+		'aria-describedby',
+		'test-images-error test-image-description',
+	);
+	await expect(fieldset.tags).not.toHaveAttribute(
+		'aria-describedby',
+		'test-tags-error text-tags-description',
+	);
+	await expect(fieldset.rating).not.toHaveAttribute(
+		'aria-describedby',
+		'test-rating-error text-rating-description',
+	);
+
+	await playground.submit.click();
+
+	await expect(fieldset.description).toHaveAttribute(
+		'aria-describedby',
+		'test-description-error test-description-description',
+	);
+	await expect(fieldset.title).toHaveAttribute(
+		'aria-describedby',
+		'test-title-error test-title-description',
+	);
+	await expect(fieldset.images).toHaveAttribute(
+		'aria-describedby',
+		'test-images-error test-images-description',
+	);
+	await expect(fieldset.tags).toHaveAttribute(
+		'aria-describedby',
+		'test-tags-error test-tags-description',
+	);
+	await expect(fieldset.rating).toHaveAttribute(
+		'aria-describedby',
+		'test-rating-error test-rating-description',
+	);
+
+	await playground.reset.click();
+
+	await expect(fieldset.title).not.toHaveAttribute(
+		'aria-describedby',
+		'test-title-error test-title-description',
+	);
+	await expect(fieldset.description).not.toHaveAttribute(
+		'aria-describedby',
+		'test-description-error test-description-description',
+	);
+	await expect(fieldset.images).not.toHaveAttribute(
+		'aria-describedby',
+		'test-images-error test-images-description',
+	);
+	await expect(fieldset.tags).not.toHaveAttribute(
+		'aria-describedby',
+		'test-tags-error test-tags-description',
+	);
+	await expect(fieldset.rating).not.toHaveAttribute(
+		'aria-describedby',
+		'test-rating-error test-rating-description',
+	);
 });


### PR DESCRIPTION
Resolve #120

This adds support of `descriptionId` which could be used to setup an input hint similar to the existing `errorId`. But to utilize it, it is also required to provide an extra option `description: true` to the conform helpers which will setup the `aria-describedby` accordingly.

```tsx
<input {...conform.input(email, { type: "email" })} />
// If valid, no aria attributes will be set
// If invalid, aria-invalid="true" aria-describedby="errorId"

<input {...conform.input(email, { type: "email", description: true })} />
// If valid, aria-describedby="descriptionId"
// If invalid, aria-invalid="true" aria-describedby="errorId descriptionId"
```

