### PR TITLE
feat(conform-react): custom revalidation

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -164,7 +164,7 @@ export default function LoginForm() {
 
     // Now Conform will start validating once user leave the field and
     // revalidate for any changes triggered later
-    initialReport: 'onBlur',
+    shouldValidate: 'onBlur',
 
     // Run the same validation logic on client
     onValidate({ formData }) {

--- a/examples/material-ui/src/App.tsx
+++ b/examples/material-ui/src/App.tsx
@@ -35,7 +35,7 @@ interface Schema {
 }
 
 export default function ExampleForm() {
-	const [form, fieldset] = useForm<Schema>({ initialReport: 'onBlur' });
+	const [form, fieldset] = useForm<Schema>({ shouldValidate: 'onBlur' });
 
 	return (
 		<Container maxWidth="sm">

--- a/examples/react-router/src/login.tsx
+++ b/examples/react-router/src/login.tsx
@@ -40,7 +40,7 @@ export function Component() {
 	const lastSubmission = useActionData() as Submission;
 	const [form, { email, password }] = useForm<Login>({
 		lastSubmission,
-		initialReport: 'onBlur',
+		shouldValidate: 'onBlur',
 		onValidate(context) {
 			return validateConstraint(context);
 		},

--- a/packages/conform-react/README.md
+++ b/packages/conform-react/README.md
@@ -47,7 +47,7 @@ function LoginForm() {
      *
      * Default to `onSubmit`.
      */
-    initialReport: 'onBlur',
+    shouldValidate: 'onBlur',
 
     /**
      * An object representing the initial value of the form.

--- a/packages/conform-react/README.md
+++ b/packages/conform-react/README.md
@@ -42,12 +42,20 @@ function LoginForm() {
     id: undefined,
 
     /**
-     * Define when the error should be reported initially.
+     * Define when conform should start validation.
      * Support "onSubmit", "onChange", "onBlur".
      *
      * Default to `onSubmit`.
      */
-    shouldValidate: 'onBlur',
+    shouldValidate: 'onSubmit',
+
+    /**
+     * Define when conform should revalidate again.
+     * Support "onSubmit", "onChange", "onBlur".
+     *
+     * Default to `onInput`.
+     */
+    shouldRevalidate: 'onInput',
 
     /**
      * An object representing the initial value of the form.

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -51,12 +51,20 @@ export interface FormConfig<
 	ref?: RefObject<HTMLFormElement>;
 
 	/**
-	 * Define when the error should be reported initially.
+	 * Define when conform should start validation.
 	 * Support "onSubmit", "onChange", "onBlur".
 	 *
 	 * Default to `onSubmit`.
 	 */
-	initialReport?: 'onSubmit' | 'onChange' | 'onBlur';
+	shouldValidate?: 'onSubmit' | 'onChange' | 'onBlur';
+
+	/**
+	 * Define when conform should revalidate again.
+	 * Support "onSubmit", "onChange", "onBlur".
+	 *
+	 * Default to `onSubmit`.
+	 */
+	shouldRevalidate?: 'onSubmit' | 'onChange' | 'onBlur';
 
 	/**
 	 * An object representing the initial value of the form.
@@ -234,14 +242,17 @@ export function useForm<
 			const field = event.target;
 			const form = ref.current;
 			const formConfig = configRef.current;
+			const { shouldValidate = 'onSubmit', shouldRevalidate = 'onChange' } =
+				formConfig;
 
 			if (!form || !isFieldElement(field) || field.form !== form) {
 				return;
 			}
 
 			if (
-				field.dataset.conformTouched ||
-				formConfig.initialReport === 'onChange'
+				field.dataset.conformTouched
+					? shouldRevalidate === 'onChange'
+					: shouldValidate === 'onChange'
 			) {
 				requestIntent(form, validate(field.name));
 			}
@@ -250,14 +261,17 @@ export function useForm<
 			const field = event.target;
 			const form = ref.current;
 			const formConfig = configRef.current;
+			const { shouldValidate = 'onSubmit', shouldRevalidate = 'onChange' } =
+				formConfig;
 
 			if (!form || !isFieldElement(field) || field.form !== form) {
 				return;
 			}
 
 			if (
-				formConfig.initialReport === 'onBlur' &&
-				!field.dataset.conformTouched
+				field.dataset.conformTouched
+					? shouldRevalidate === 'onBlur'
+					: shouldValidate === 'onBlur'
 			) {
 				requestIntent(form, validate(field.name));
 			}

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -249,9 +249,9 @@ export function useForm<
 			const formConfig = configRef.current;
 			const {
 				initialReport = 'onSubmit',
-				shouldValidate = initialReport !== 'onChange'
-					? initialReport
-					: 'onInput',
+				shouldValidate = initialReport === 'onChange'
+					? 'onInput'
+					: initialReport,
 				shouldRevalidate = 'onInput',
 			} = formConfig;
 
@@ -273,9 +273,9 @@ export function useForm<
 			const formConfig = configRef.current;
 			const {
 				initialReport = 'onSubmit',
-				shouldValidate = initialReport !== 'onChange'
-					? initialReport
-					: 'onInput',
+				shouldValidate = initialReport === 'onChange'
+					? 'onInput'
+					: initialReport,
 				shouldRevalidate = 'onInput',
 			} = formConfig;
 

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -51,20 +51,25 @@ export interface FormConfig<
 	ref?: RefObject<HTMLFormElement>;
 
 	/**
+	 * @deprecated Use `shouldValidate` and `shouldRevalidate` instead.
+	 */
+	initialReport?: 'onSubmit' | 'onChange' | 'onBlur';
+
+	/**
 	 * Define when conform should start validation.
 	 * Support "onSubmit", "onChange", "onBlur".
 	 *
 	 * Default to `onSubmit`.
 	 */
-	shouldValidate?: 'onSubmit' | 'onChange' | 'onBlur';
+	shouldValidate?: 'onSubmit' | 'onBlur' | 'onInput';
 
 	/**
 	 * Define when conform should revalidate again.
 	 * Support "onSubmit", "onChange", "onBlur".
 	 *
-	 * Default to `onSubmit`.
+	 * Default to `onInput`.
 	 */
-	shouldRevalidate?: 'onSubmit' | 'onChange' | 'onBlur';
+	shouldRevalidate?: 'onSubmit' | 'onBlur' | 'onInput';
 
 	/**
 	 * An object representing the initial value of the form.
@@ -242,8 +247,13 @@ export function useForm<
 			const field = event.target;
 			const form = ref.current;
 			const formConfig = configRef.current;
-			const { shouldValidate = 'onSubmit', shouldRevalidate = 'onChange' } =
-				formConfig;
+			const {
+				initialReport = 'onSubmit',
+				shouldValidate = initialReport !== 'onChange'
+					? initialReport
+					: 'onInput',
+				shouldRevalidate = 'onInput',
+			} = formConfig;
 
 			if (!form || !isFieldElement(field) || field.form !== form) {
 				return;
@@ -251,8 +261,8 @@ export function useForm<
 
 			if (
 				field.dataset.conformTouched
-					? shouldRevalidate === 'onChange'
-					: shouldValidate === 'onChange'
+					? shouldRevalidate === 'onInput'
+					: shouldValidate === 'onInput'
 			) {
 				requestIntent(form, validate(field.name));
 			}
@@ -261,8 +271,13 @@ export function useForm<
 			const field = event.target;
 			const form = ref.current;
 			const formConfig = configRef.current;
-			const { shouldValidate = 'onSubmit', shouldRevalidate = 'onChange' } =
-				formConfig;
+			const {
+				initialReport = 'onSubmit',
+				shouldValidate = initialReport !== 'onChange'
+					? initialReport
+					: 'onInput',
+				shouldRevalidate = 'onInput',
+			} = formConfig;
 
 			if (!form || !isFieldElement(field) || field.form !== form) {
 				return;

--- a/playground/app/config.ts
+++ b/playground/app/config.ts
@@ -2,7 +2,7 @@ import { ifNonEmptyString } from '@conform-to/zod';
 import { z } from 'zod';
 
 const formConfig = z.object({
-	shouldValidate: z.enum(['onSubmit', 'onChange', 'onBlur']).optional(),
+	initialReport: z.enum(['onSubmit', 'onChange', 'onBlur']).optional(),
 	defaultValue: z
 		.preprocess((value) => (value ? JSON.stringify(value) : undefined), z.any())
 		.optional(),

--- a/playground/app/config.ts
+++ b/playground/app/config.ts
@@ -2,7 +2,7 @@ import { ifNonEmptyString } from '@conform-to/zod';
 import { z } from 'zod';
 
 const formConfig = z.object({
-	initialReport: z.enum(['onSubmit', 'onChange', 'onBlur']).optional(),
+	shouldValidate: z.enum(['onSubmit', 'onChange', 'onBlur']).optional(),
 	defaultValue: z
 		.preprocess((value) => (value ? JSON.stringify(value) : undefined), z.any())
 		.optional(),

--- a/playground/app/routes/validation-flow.tsx
+++ b/playground/app/routes/validation-flow.tsx
@@ -1,0 +1,69 @@
+import { conform, useForm } from '@conform-to/react';
+import { parse } from '@conform-to/zod';
+import type { ActionArgs, LoaderArgs } from '@remix-run/node';
+import { json } from '@remix-run/node';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { z } from 'zod';
+import { Playground, Field } from '~/components';
+
+const schema = z
+	.object({
+		email: z.string().min(1, 'Email is required').email('Email is invalid'),
+		password: z
+			.string()
+			.min(1, 'Password is required')
+			.min(8, 'Password is too short'),
+		confirmPassword: z.string().min(1, 'Confirm password is required'),
+	})
+	.refine((data) => data.password === data.confirmPassword, {
+		message: 'Confirm password does not match',
+		path: ['confirmPassword'],
+	});
+
+export async function loader({ request }: LoaderArgs) {
+	const url = new URL(request.url);
+	const search = z.object({
+		noClientValidate: z.preprocess((value) => value === 'yes', z.boolean()),
+		shouldValidate: z.enum(['onSubmit', 'onBlur', 'onInput']).optional(),
+		shouldRevalidate: z.enum(['onSubmit', 'onBlur', 'onInput']).optional(),
+	});
+
+	return json(search.parse(Object.fromEntries(url.searchParams)));
+}
+
+export async function action({ request }: ActionArgs) {
+	const formData = await request.formData();
+	const submission = parse(formData, { schema });
+
+	return json(submission);
+}
+
+export default function ValidationFlow() {
+	const { noClientValidate, shouldValidate, shouldRevalidate } =
+		useLoaderData<typeof loader>();
+	const lastSubmission = useActionData();
+	const [form, { email, password, confirmPassword }] = useForm({
+		lastSubmission,
+		shouldValidate,
+		shouldRevalidate,
+		onValidate: !noClientValidate
+			? ({ formData }) => parse(formData, { schema })
+			: undefined,
+	});
+
+	return (
+		<Form method="post" {...form.props}>
+			<Playground title="Validation Flow" lastSubmission={lastSubmission}>
+				<Field label="Email" config={email}>
+					<input {...conform.input(email, { type: 'email' })} />
+				</Field>
+				<Field label="Password" config={password}>
+					<input {...conform.input(password, { type: 'password' })} />
+				</Field>
+				<Field label="Confirm password" config={confirmPassword}>
+					<input {...conform.input(confirmPassword, { type: 'password' })} />
+				</Field>
+			</Playground>
+		</Form>
+	);
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,8 +1,7 @@
 import type { Page, Locator, Response } from '@playwright/test';
-import { expect } from '@playwright/test';
 
 interface FormConfig {
-	shouldValidate?: 'onSubmit' | 'onChange' | 'onBlur';
+	initialReport?: 'onSubmit' | 'onChange' | 'onBlur';
 	defaultValue?: any;
 	fallbackNative?: boolean;
 	noValidate?: boolean;
@@ -16,8 +15,8 @@ export async function gotoForm(
 ): Promise<Locator> {
 	const searchParams = new URLSearchParams();
 
-	if (typeof config?.shouldValidate !== 'undefined') {
-		searchParams.set('shouldValidate', config.shouldValidate);
+	if (typeof config?.initialReport !== 'undefined') {
+		searchParams.set('initialReport', config.initialReport);
 	}
 
 	if (typeof config?.defaultValue !== 'undefined') {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -2,7 +2,7 @@ import type { Page, Locator, Response } from '@playwright/test';
 import { expect } from '@playwright/test';
 
 interface FormConfig {
-	initialReport?: 'onSubmit' | 'onChange' | 'onBlur';
+	shouldValidate?: 'onSubmit' | 'onChange' | 'onBlur';
 	defaultValue?: any;
 	fallbackNative?: boolean;
 	noValidate?: boolean;
@@ -16,8 +16,8 @@ export async function gotoForm(
 ): Promise<Locator> {
 	const searchParams = new URLSearchParams();
 
-	if (typeof config?.initialReport !== 'undefined') {
-		searchParams.set('initialReport', config.initialReport);
+	if (typeof config?.shouldValidate !== 'undefined') {
+		searchParams.set('shouldValidate', config.shouldValidate);
 	}
 
 	if (typeof config?.defaultValue !== 'undefined') {

--- a/tests/integrations/validation-flow.spec.ts
+++ b/tests/integrations/validation-flow.spec.ts
@@ -1,0 +1,212 @@
+import { type Locator, test, expect } from '@playwright/test';
+import { getPlayground } from '../helpers';
+
+function getFieldset(form: Locator) {
+	return {
+		email: form.locator('[name="email"]'),
+		password: form.locator('[name="password"]'),
+		confirmPassword: form.locator('[name="confirmPassword"]'),
+	};
+}
+
+test('shouldValidate: onSubmit', async ({ page }) => {
+	await page.goto('/validation-flow?shouldValidate=onSubmit');
+
+	const playground = getPlayground(page);
+	const { email, password, confirmPassword } = getFieldset(
+		playground.container,
+	);
+
+	await email.type('Invalid email');
+	await password.type('1234');
+	await confirmPassword.type('5678');
+
+	// To ensure it leaves the last field
+	await playground.form.press('Tab');
+
+	await expect(playground.error).toHaveText(['', '', '']);
+
+	await playground.submit.click();
+
+	await expect(playground.error).toHaveText([
+		'Email is invalid',
+		'Password is too short',
+		'Confirm password does not match',
+	]);
+});
+
+test('shouldValidate: onInput', async ({ page }) => {
+	await page.goto('/validation-flow?shouldValidate=onInput');
+
+	const playground = getPlayground(page);
+	const { email, password, confirmPassword } = getFieldset(
+		playground.container,
+	);
+
+	await email.type('Invalid email');
+	await expect(playground.error).toHaveText(['Email is invalid', '', '']);
+
+	await password.type('1234');
+	await expect(playground.error).toHaveText([
+		'Email is invalid',
+		'Password is too short',
+		'',
+	]);
+
+	await confirmPassword.type('5678');
+	await expect(playground.error).toHaveText([
+		'Email is invalid',
+		'Password is too short',
+		'Confirm password does not match',
+	]);
+});
+
+test('shouldValidate: onBlur', async ({ page }) => {
+	await page.goto('/validation-flow?shouldValidate=onBlur');
+
+	const playground = getPlayground(page);
+	const { email, password, confirmPassword } = getFieldset(
+		playground.container,
+	);
+
+	await email.type('Invalid email');
+	await expect(playground.error).toHaveText(['', '', '']);
+
+	await playground.form.press('Tab');
+	await expect(playground.error).toHaveText(['Email is invalid', '', '']);
+
+	await password.type('1234');
+	await expect(playground.error).toHaveText(['Email is invalid', '', '']);
+
+	await playground.form.press('Tab');
+	await expect(playground.error).toHaveText([
+		'Email is invalid',
+		'Password is too short',
+		'',
+	]);
+
+	await confirmPassword.type('5678');
+	await expect(playground.error).toHaveText([
+		'Email is invalid',
+		'Password is too short',
+		'',
+	]);
+
+	await playground.form.press('Tab');
+	await expect(playground.error).toHaveText([
+		'Email is invalid',
+		'Password is too short',
+		'Confirm password does not match',
+	]);
+});
+
+test('shouldRevalidate: onSubmit', async ({ page }) => {
+	await page.goto('/validation-flow?shouldRevalidate=onSubmit');
+
+	const playground = getPlayground(page);
+	const { email, password, confirmPassword } = getFieldset(
+		playground.container,
+	);
+
+	await playground.submit.click();
+
+	await expect(playground.error).toHaveText([
+		'Email is required',
+		'Password is required',
+		'Confirm password is required',
+	]);
+
+	await email.type('support@conform.guide');
+	await password.type('12345678');
+	await confirmPassword.type('12345678');
+	await expect(playground.error).toHaveText([
+		'Email is required',
+		'Password is required',
+		'Confirm password is required',
+	]);
+
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', '', '']);
+});
+
+test('shouldRevalidate: onInput', async ({ page }) => {
+	await page.goto('/validation-flow?shouldRevalidate=onInput');
+
+	const playground = getPlayground(page);
+	const { email, password, confirmPassword } = getFieldset(
+		playground.container,
+	);
+
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'Email is required',
+		'Password is required',
+		'Confirm password is required',
+	]);
+
+	await email.type('support@conform.guide');
+	await expect(playground.error).toHaveText([
+		'',
+		'Password is required',
+		'Confirm password is required',
+	]);
+	await password.type('12345678');
+	await expect(playground.error).toHaveText([
+		'',
+		'',
+		'Confirm password is required',
+	]);
+	await confirmPassword.type('12345678');
+	await expect(playground.error).toHaveText(['', '', '']);
+});
+
+test('shouldRevalidate: onBlur', async ({ page }) => {
+	await page.goto('/validation-flow?shouldRevalidate=onBlur');
+
+	const playground = getPlayground(page);
+	const { email, password, confirmPassword } = getFieldset(
+		playground.container,
+	);
+
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'Email is required',
+		'Password is required',
+		'Confirm password is required',
+	]);
+
+	await email.type('support@conform.guide');
+	await expect(playground.error).toHaveText([
+		'Email is required',
+		'Password is required',
+		'Confirm password is required',
+	]);
+	await playground.form.press('Tab');
+	await expect(playground.error).toHaveText([
+		'',
+		'Password is required',
+		'Confirm password is required',
+	]);
+
+	await password.type('12345678');
+	await expect(playground.error).toHaveText([
+		'',
+		'Password is required',
+		'Confirm password is required',
+	]);
+	await playground.form.press('Tab');
+	await expect(playground.error).toHaveText([
+		'',
+		'',
+		'Confirm password is required',
+	]);
+
+	await confirmPassword.type('12345678');
+	await expect(playground.error).toHaveText([
+		'',
+		'',
+		'Confirm password is required',
+	]);
+	await playground.form.press('Tab');
+	await expect(playground.error).toHaveText(['', '', '']);
+});

--- a/tests/react.spec.ts
+++ b/tests/react.spec.ts
@@ -397,9 +397,9 @@ test.describe('Server Validation', () => {
 });
 
 test.describe('Error Reporting', () => {
-	test('shouldValidate: onSubmit', async ({ page }) => {
+	test('initialReport: onSubmit', async ({ page }) => {
 		const form = await gotoForm(page, '/signup', {
-			shouldValidate: 'onSubmit',
+			initialReport: 'onSubmit',
 		});
 		const { email, password, confirmPassword } = getSignupFieldset(form);
 
@@ -421,9 +421,9 @@ test.describe('Error Reporting', () => {
 		]);
 	});
 
-	test('shouldValidate: onChange', async ({ page }) => {
+	test('initialReport: onChange', async ({ page }) => {
 		const form = await gotoForm(page, '/signup', {
-			shouldValidate: 'onChange',
+			initialReport: 'onChange',
 		});
 		const { email, password, confirmPassword } = getSignupFieldset(form);
 
@@ -449,8 +449,8 @@ test.describe('Error Reporting', () => {
 		]);
 	});
 
-	test('shouldValidate: onBlur', async ({ page }) => {
-		const form = await gotoForm(page, '/signup', { shouldValidate: 'onBlur' });
+	test('initialReport: onBlur', async ({ page }) => {
+		const form = await gotoForm(page, '/signup', { initialReport: 'onBlur' });
 		const { email, password, confirmPassword } = getSignupFieldset(form);
 
 		await email.type('Invalid email');

--- a/tests/react.spec.ts
+++ b/tests/react.spec.ts
@@ -397,8 +397,10 @@ test.describe('Server Validation', () => {
 });
 
 test.describe('Error Reporting', () => {
-	test('initialReport: onSubmit', async ({ page }) => {
-		const form = await gotoForm(page, '/signup', { initialReport: 'onSubmit' });
+	test('shouldValidate: onSubmit', async ({ page }) => {
+		const form = await gotoForm(page, '/signup', {
+			shouldValidate: 'onSubmit',
+		});
 		const { email, password, confirmPassword } = getSignupFieldset(form);
 
 		await email.type('Invalid email');
@@ -419,8 +421,10 @@ test.describe('Error Reporting', () => {
 		]);
 	});
 
-	test('initialReport: onChange', async ({ page }) => {
-		const form = await gotoForm(page, '/signup', { initialReport: 'onChange' });
+	test('shouldValidate: onChange', async ({ page }) => {
+		const form = await gotoForm(page, '/signup', {
+			shouldValidate: 'onChange',
+		});
 		const { email, password, confirmPassword } = getSignupFieldset(form);
 
 		await email.type('Invalid email');
@@ -445,8 +449,8 @@ test.describe('Error Reporting', () => {
 		]);
 	});
 
-	test('initialReport: onBlur', async ({ page }) => {
-		const form = await gotoForm(page, '/signup', { initialReport: 'onBlur' });
+	test('shouldValidate: onBlur', async ({ page }) => {
+		const form = await gotoForm(page, '/signup', { shouldValidate: 'onBlur' });
 		const { email, password, confirmPassword } = getSignupFieldset(form);
 
 		await email.type('Invalid email');


### PR DESCRIPTION
Resolves #125 

This introduces two new config on the `useForm` hooks:
```tsx
function Example() {
  const [form, { email, password }] = useForm({
    // This is now deprecated in favor of the new config
    initialReport: 'onBlur',

    // Define when Conform should start validation. Default `onSubmit`.
    shouldValidate: 'onBlur',

    // Define when Conform should revalidate again. Default `onInput`.
    shouldRevalidate: 'onBlur',
  });
}
```