### PR TITLE
Intent to ship: @conform-to/validitystate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@babel/preset-env": "^7.20.2",
 				"@babel/preset-react": "^7.18.6",
 				"@babel/preset-typescript": "^7.20.2",
-				"@playwright/test": "^1.31.2",
+				"@playwright/test": "^1.32.1",
 				"@remix-run/eslint-config": "^1.14.0",
 				"@remix-run/node": "^1.14.0",
 				"@rollup/plugin-babel": "^5.3.1",
@@ -3348,6 +3348,10 @@
 			"resolved": "packages/conform-react",
 			"link": true
 		},
+		"node_modules/@conform-to/validitystate": {
+			"resolved": "packages/conform-validitystate",
+			"link": true
+		},
 		"node_modules/@conform-to/yup": {
 			"resolved": "packages/conform-yup",
 			"link": true
@@ -5935,13 +5939,13 @@
 			"dev": true
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.31.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.2.tgz",
-			"integrity": "sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==",
+			"version": "1.32.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.1.tgz",
+			"integrity": "sha512-FTwjCuhlm1qHUGf4hWjfr64UMJD/z0hXYbk+O387Ioe6WdyZQ+0TBDAc6P+pHjx2xCv1VYNgrKbYrNixFWy4Dg==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
-				"playwright-core": "1.31.2"
+				"playwright-core": "1.32.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -20943,9 +20947,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.31.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.2.tgz",
-			"integrity": "sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==",
+			"version": "1.32.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.1.tgz",
+			"integrity": "sha512-KZYUQC10mXD2Am1rGlidaalNGYk3LU1vZqqNk0gT4XPty1jOqgup8KDP8l2CUlqoNKhXM5IfGjWgW37xvGllBA==",
 			"dev": true,
 			"bin": {
 				"playwright": "cli.js"
@@ -27709,6 +27713,11 @@
 				"react": ">=16.8"
 			}
 		},
+		"packages/conform-validitystate": {
+			"name": "@conform-to/validitystate",
+			"version": "0.0.1",
+			"license": "MIT"
+		},
 		"packages/conform-yup": {
 			"name": "@conform-to/yup",
 			"version": "0.6.1",
@@ -27737,6 +27746,7 @@
 			"name": "@conform-to/playground",
 			"dependencies": {
 				"@conform-to/react": "*",
+				"@conform-to/validitystate": "*",
 				"@conform-to/zod": "*",
 				"@remix-run/node": "^1.14.0",
 				"@remix-run/react": "^1.14.0",
@@ -30079,6 +30089,7 @@
 			"version": "file:playground",
 			"requires": {
 				"@conform-to/react": "*",
+				"@conform-to/validitystate": "*",
 				"@conform-to/zod": "*",
 				"@remix-run/dev": "^1.14.0",
 				"@remix-run/eslint-config": "^1.14.0",
@@ -30101,6 +30112,9 @@
 			"requires": {
 				"@conform-to/dom": "0.6.1"
 			}
+		},
+		"@conform-to/validitystate": {
+			"version": "file:packages/conform-validitystate"
 		},
 		"@conform-to/yup": {
 			"version": "file:packages/conform-yup",
@@ -31833,14 +31847,14 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.31.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.2.tgz",
-			"integrity": "sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==",
+			"version": "1.32.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.1.tgz",
+			"integrity": "sha512-FTwjCuhlm1qHUGf4hWjfr64UMJD/z0hXYbk+O387Ioe6WdyZQ+0TBDAc6P+pHjx2xCv1VYNgrKbYrNixFWy4Dg==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
 				"fsevents": "2.3.2",
-				"playwright-core": "1.31.2"
+				"playwright-core": "1.32.1"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -42744,9 +42758,9 @@
 			}
 		},
 		"playwright-core": {
-			"version": "1.31.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.2.tgz",
-			"integrity": "sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==",
+			"version": "1.32.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.1.tgz",
+			"integrity": "sha512-KZYUQC10mXD2Am1rGlidaalNGYk3LU1vZqqNk0gT4XPty1jOqgup8KDP8l2CUlqoNKhXM5IfGjWgW37xvGllBA==",
 			"dev": true
 		},
 		"postcss": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
 		"watch:ts": "npm run build:ts -- --watch",
 		"guide": "npm run dev --workspace=guide",
 		"playground": "npm run dev --workspace=playground",
-		"test": "npm run build --workspace=playground && playwright test",
+		"pretest": "npm run build --workspace=playground",
+		"test": "playwright test",
 		"lint": "eslint --ignore-path .gitignore --cache --ext .js,.jsx,.ts,.tsx .",
 		"prepare": "husky install"
 	},
@@ -26,7 +27,7 @@
 		"@babel/preset-env": "^7.20.2",
 		"@babel/preset-react": "^7.18.6",
 		"@babel/preset-typescript": "^7.20.2",
-		"@playwright/test": "^1.31.2",
+		"@playwright/test": "^1.32.1",
 		"@remix-run/eslint-config": "^1.14.0",
 		"@remix-run/node": "^1.14.0",
 		"@rollup/plugin-babel": "^5.3.1",

--- a/packages/conform-validitystate/.npmignore
+++ b/packages/conform-validitystate/.npmignore
@@ -1,0 +1,8 @@
+# ignore all .ts, .tsx files except .d.ts
+*.ts
+*.tsx
+!*.d.ts
+
+# config / build result
+tsconfig.json
+*.tsbuildinfo

--- a/packages/conform-validitystate/README.md
+++ b/packages/conform-validitystate/README.md
@@ -1,1 +1,27 @@
 # @conform-to/validitystate
+
+Validate on the server using the same rules as the browser
+
+## Status
+
+> `month` and `week` inputs are not implemented due to limited browser support
+
+| Support        | type | required | minLength | maxLength | pattern | min | max | step | multiple |
+| :------------- | :--: | :------: | :-------: | :-------: | :-----: | :-: | :-: | :--: | :------: |
+| text           |      |    🟢    |    🟢     |    🟢     |   🟢    |     |     |      |          |
+| email          |  🟢  |    🟢    |    🟢     |    🟢     |   🟢    |     |     |      |          |
+| password       |      |    🟢    |    🟢     |    🟢     |   🟢    |     |     |      |          |
+| url            |  🟢  |    🟢    |    🟢     |    🟢     |   🟢    |     |     |      |          |
+| tel            |      |    🟢    |    🟢     |    🟢     |   🟢    |     |     |      |          |
+| search         |      |    🟢    |    🟢     |    🟢     |   🟢    |     |     |      |          |
+| datetime-local |      |    🟢    |           |           |         | 🟢  | 🟢  |  🟢  |          |
+| date           |      |    🟢    |           |           |         | 🟢  | 🟢  |  🟢  |          |
+| time           |      |    🟢    |           |           |         | 🟢  | 🟢  |  🟢  |          |
+| select         |      |    🟢    |           |           |         |     |     |      |    🟢    |
+| textarea       |      |    🟢    |    🟢     |    🟢     |         |     |     |      |          |
+| radio          |      |    🟢    |           |           |         |     |     |      |          |
+| color          |      |    🟢    |           |           |         |     |     |      |          |
+| checkbox       |      |    🟢    |           |           |         |     |     |      |          |
+| number         |      |    🟢    |           |           |         | 🟢  | 🟢  |  🟢  |          |
+| range          |      |    🟢    |           |           |         | 🟢  | 🟢  |  🟢  |          |
+| file           |      |    🟢    |           |           |         |     |     |      |    🟢    |

--- a/packages/conform-validitystate/README.md
+++ b/packages/conform-validitystate/README.md
@@ -1,0 +1,1 @@
+# @conform-to/validitystate

--- a/packages/conform-validitystate/index.ts
+++ b/packages/conform-validitystate/index.ts
@@ -103,10 +103,10 @@ export type Submission<Schema extends FormSchema, ErrorType> =
 					? File[]
 					: Schema[Key] extends OptionalField<FileArrayConstraint>
 					? File[] | undefined
-					: Schema[Key] extends RequiredField<BooleanConstraint>
+					: Schema[Key] extends
+							| RequiredField<BooleanConstraint>
+							| OptionalField<BooleanConstraint>
 					? boolean
-					: Schema[Key] extends OptionalField<BooleanConstraint>
-					? boolean | undefined
 					: any;
 			};
 	  };

--- a/packages/conform-validitystate/index.ts
+++ b/packages/conform-validitystate/index.ts
@@ -1,0 +1,437 @@
+type Required<T> = undefined extends T
+	? { required?: false }
+	: { required: true };
+
+export type Schema<
+	Shape extends Record<
+		string,
+		string | number | boolean | Date | File | File[]
+	>,
+> = {
+	[Key in keyof Shape]: File[] extends Shape[Key]
+		? Required<Shape[Key]> & {
+				type: 'file';
+				multiple: true;
+		  }
+		: File extends Shape[Key]
+		? Required<Shape[Key]> & {
+				type: 'file';
+				multiple?: false;
+		  }
+		: Date extends Shape[Key]
+		? Required<Shape[Key]> & {
+				type: 'datetime-local';
+				min?: string;
+				max?: string;
+				step?: number;
+		  }
+		: number extends Shape[Key]
+		? Required<Shape[Key]> & {
+				type: 'number' | 'range';
+				required?: boolean;
+				min?: number;
+				max?: number;
+				step?: number;
+		  }
+		: boolean extends Shape[Key]
+		? {
+				type: 'checkbox';
+				required?: boolean;
+				value?: string;
+		  }
+		: string extends Shape[Key]
+		? Required<Shape[Key]> &
+				(
+					| {
+							type: 'text' | 'email' | 'password' | 'url' | 'tel' | 'search';
+							minLength?: number;
+							maxLength?: number;
+							pattern?: string;
+					  }
+					| {
+							type: 'date' | 'month' | 'week' | 'time';
+							min?: string;
+							max?: string;
+							step?: string;
+					  }
+					| {
+							type: 'radio' | 'color';
+					  }
+				)
+		: never;
+};
+
+export type SchemaValidity<Shape extends Record<string, string[]>> =
+	| {
+			payload: Record<string, string | undefined>;
+			error: Record<string, string[]>;
+	  }
+	| {
+			payload: Record<string, string | undefined>;
+			error: null;
+			value: Shape;
+	  };
+
+export function ensureSingleTextValue(
+	data: FormData | URLSearchParams,
+	name: string,
+): string {
+	if (!data.has(name)) {
+		throw new Error(`${name} is missing`);
+	}
+
+	const [text, ...rest] = data.getAll(name);
+
+	if (rest.length > 1) {
+		throw new Error(`${name} is not configured for multiple values`);
+	}
+
+	if (typeof text !== 'string') {
+		throw new Error(`${name} is not a string`);
+	}
+
+	return text;
+}
+
+/**
+ * Check if the file is empty
+ */
+export function isEmptyFile(file: File): boolean {
+	return file.name === '' && file.size === 0;
+}
+
+/**
+ * Check URL validity as if url input type
+ */
+export function isValidURL(url: string): boolean {
+	try {
+		new URL(url);
+	} catch (e) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Check email validity as if email input type
+ * @see https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+ */
+export function isValidEmail(email: string): boolean {
+	return /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(
+		email,
+	);
+}
+
+/**
+ * Check if the text matches the pattern as if pattern input attribute
+ */
+export function matchPattern(pattern: string, text: string): boolean {
+	if (pattern === '') {
+		return text === '';
+	}
+
+	// TODO: ensure pattern will match the whole text
+	return new RegExp(pattern).test(text);
+}
+
+export function validate<Shape extends Record<string, any>>(
+	data: FormData | URLSearchParams,
+	schema: Schema<Shape>,
+): SchemaValidity<Shape> {
+	const payload = new Map<keyof Shape, string | undefined>();
+	const error = new Map<keyof Shape, string[]>();
+	const value = new Map<keyof Shape, any>();
+
+	for (const name in schema) {
+		const constraint = schema[name];
+		const messages = new Set<string>();
+
+		switch (constraint.type) {
+			case 'text':
+			case 'email':
+			case 'password':
+			case 'url':
+			case 'tel':
+			case 'search': {
+				const text = ensureSingleTextValue(data, name);
+
+				if (constraint.required && text === '') {
+					messages.add('required');
+				}
+
+				if (text !== '') {
+					switch (constraint.type) {
+						case 'email':
+							if (!isValidEmail(text)) {
+								messages.add('type');
+							}
+							break;
+						case 'url':
+							if (!isValidURL(text)) {
+								messages.add('type');
+							}
+							break;
+					}
+
+					if (text !== '') {
+						if (
+							typeof constraint.minLength !== 'undefined' &&
+							text.length < constraint.minLength
+						) {
+							messages.add('minlength');
+						}
+
+						if (
+							typeof constraint.maxLength !== 'undefined' &&
+							text.length > constraint.maxLength
+						) {
+							messages.add('maxlength');
+						}
+
+						if (
+							typeof constraint.pattern !== 'undefined' &&
+							!matchPattern(constraint.pattern, text)
+						) {
+							messages.add('pattern');
+						}
+					}
+
+					payload.set(name, text);
+					value.set(name, text);
+				}
+				break;
+			}
+			case 'number':
+			case 'range': {
+				const text = ensureSingleTextValue(data, name);
+
+				if (constraint.required && text === '') {
+					messages.add('required');
+				}
+
+				if (text !== '') {
+					const number = Number(text);
+
+					if (Number.isNaN(number)) {
+						messages.add('type');
+					} else {
+						if (
+							typeof constraint.min !== 'undefined' &&
+							number < constraint.min
+						) {
+							messages.add('min');
+						}
+
+						if (
+							typeof constraint.max !== 'undefined' &&
+							number > constraint.max
+						) {
+							messages.add('max');
+						}
+
+						if (
+							typeof constraint.step !== 'undefined' &&
+							number % constraint.step !== 0
+						) {
+							messages.add('step');
+						}
+
+						value.set(name, number);
+					}
+				}
+
+				payload.set(name, text);
+				break;
+			}
+			case 'checkbox': {
+				const [item, ...rest] = data.getAll(name);
+
+				if (rest.length > 0) {
+					throw new Error(`${name} is not configured for multiple values`);
+				}
+
+				if (item && item !== (constraint.value ?? 'on')) {
+					throw new Error(
+						`${name} is not configured with value ${constraint.value}`,
+					);
+				}
+
+				const flag = typeof item !== 'undefined';
+
+				if (constraint.required && !flag) {
+					messages.add('required');
+				}
+
+				value.set(name, flag);
+				payload.set(name, item);
+				break;
+			}
+			case 'datetime-local': {
+				const text = ensureSingleTextValue(data, name);
+
+				// TODO: validate text format
+
+				if (constraint.required && text === '') {
+					messages.add('required');
+				}
+
+				if (text !== '') {
+					const date = new Date(text);
+
+					if (Number.isNaN(date.valueOf())) {
+						messages.add('type');
+					} else {
+						if (
+							typeof constraint.min !== 'undefined' &&
+							date < new Date(constraint.min)
+						) {
+							messages.add('min');
+						}
+
+						if (
+							typeof constraint.max !== 'undefined' &&
+							date > new Date(constraint.max)
+						) {
+							messages.add('max');
+						}
+
+						if (
+							typeof constraint.step !== 'undefined' &&
+							date.valueOf() % (constraint.step * 1000) !== 0
+						) {
+							messages.add('step');
+						}
+
+						value.set(name, text);
+					}
+				}
+
+				payload.set(name, text);
+				break;
+			}
+			case 'date':
+			case 'month':
+			case 'week':
+			case 'time': {
+				const text = ensureSingleTextValue(data, name);
+
+				if (constraint.required && text === '') {
+					messages.add('required');
+				}
+
+				// TODO: handle each text format
+
+				value.set(name, text);
+				payload.set(name, text);
+				break;
+			}
+			case 'radio':
+			case 'color': {
+				const text = ensureSingleTextValue(data, name);
+
+				if (constraint.required && text === '') {
+					messages.add('required');
+				}
+
+				// TODO: handle color format
+
+				value.set(name, text);
+				payload.set(name, text);
+				break;
+			}
+			case 'file': {
+				const files = data.getAll(name);
+
+				if (!constraint.multiple && files.length > 1) {
+					throw new Error(`${name} is not configured for multiple files`);
+				}
+
+				if (!files.every((file): file is File => file instanceof File)) {
+					throw new Error(`${name} is not a file`);
+				}
+
+				const nonEmptyFiles = files.filter((file) => !isEmptyFile(file));
+
+				if (constraint.required && nonEmptyFiles.length === 0) {
+					messages.add('required');
+				}
+
+				if (constraint.multiple || nonEmptyFiles.length > 0) {
+					value.set(
+						name,
+						constraint.multiple ? nonEmptyFiles : nonEmptyFiles[0],
+					);
+				}
+				break;
+			}
+		}
+
+		if (messages.size > 0) {
+			error.set(name, [...messages]);
+		}
+	}
+
+	if (error.size > 0) {
+		return {
+			payload: Object.fromEntries(payload),
+			error: Object.fromEntries(error),
+		};
+	}
+
+	return {
+		payload: Object.fromEntries(payload),
+		error: null,
+		value: Object.fromEntries(value) as Shape,
+	};
+}
+
+export function getMessages(
+	validity: ValidityState,
+	validationMessage?: string,
+	delimiter?: string,
+): string[] {
+	const messages = [] as string[];
+
+	if (validity.valueMissing) {
+		messages.push('required');
+	}
+
+	if (validity.typeMismatch || validity.badInput) {
+		messages.push('type');
+	}
+
+	if (validity.rangeOverflow) {
+		messages.push('max');
+	}
+
+	if (validity.rangeUnderflow) {
+		messages.push('min');
+	}
+
+	if (validity.stepMismatch) {
+		messages.push('step');
+	}
+
+	if (validity.tooShort) {
+		messages.push('minlength');
+	}
+
+	if (validity.tooLong) {
+		messages.push('maxlength');
+	}
+
+	if (validity.patternMismatch) {
+		messages.push('pattern');
+	}
+
+	if (validity.customError && validationMessage) {
+		if (delimiter) {
+			messages.push(...validationMessage.split(delimiter));
+		} else {
+			messages.push(validationMessage);
+		}
+	}
+
+	return messages;
+}

--- a/packages/conform-validitystate/index.ts
+++ b/packages/conform-validitystate/index.ts
@@ -111,7 +111,7 @@ export type Submission<Schema extends FormSchema, ErrorType> =
 			};
 	  };
 
-export function ensureSingleValue(
+function ensureSingleValue(
 	data: FormData | URLSearchParams,
 	name: string,
 ): FormDataEntryValue {
@@ -128,10 +128,7 @@ export function ensureSingleValue(
 	return text;
 }
 
-export function invariant(
-	condition: boolean,
-	message: string,
-): asserts condition {
+function invariant(condition: boolean, message: string): asserts condition {
 	if (!condition) {
 		throw new Error(message);
 	}
@@ -140,14 +137,14 @@ export function invariant(
 /**
  * Check if the file is empty
  */
-export function isEmptyFile(file: File): boolean {
+function isEmptyFile(file: File): boolean {
 	return file.name === '' && file.size === 0;
 }
 
 /**
  * Check URL validity as if url input type
  */
-export function isValidURL(url: string): boolean {
+function isValidURL(url: string): boolean {
 	try {
 		new URL(url);
 	} catch (e) {
@@ -161,7 +158,7 @@ export function isValidURL(url: string): boolean {
  * Check email validity as if email input type
  * @see https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
  */
-export function isValidEmail(email: string): boolean {
+function isValidEmail(email: string): boolean {
 	return /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(
 		email,
 	);
@@ -170,7 +167,7 @@ export function isValidEmail(email: string): boolean {
 /**
  * Check if the text matches the pattern as if pattern input attribute
  */
-export function matchPattern(pattern: string, text: string): boolean {
+function matchPattern(pattern: string, text: string): boolean {
 	if (pattern === '') {
 		return text === '';
 	}
@@ -188,7 +185,7 @@ export function matchPattern(pattern: string, text: string): boolean {
 	return new RegExp(patternString).test(text);
 }
 
-export function getDateConstraint(
+function getDateConstraint(
 	text: string,
 	constraint: {
 		type: 'datetime-local' | 'date' | 'time';

--- a/packages/conform-validitystate/index.ts
+++ b/packages/conform-validitystate/index.ts
@@ -516,34 +516,34 @@ export function formatValidity(validity: ValidityState): string[] {
 
 	if (validity.valueMissing) {
 		messages.push('required');
-	} else {
-		if (validity.typeMismatch || validity.badInput) {
-			messages.push('type');
-		}
+	}
 
-		if (validity.rangeOverflow) {
-			messages.push('max');
-		}
+	if (validity.typeMismatch || validity.badInput) {
+		messages.push('type');
+	}
 
-		if (validity.rangeUnderflow) {
-			messages.push('min');
-		}
+	if (validity.rangeOverflow) {
+		messages.push('max');
+	}
 
-		if (validity.stepMismatch) {
-			messages.push('step');
-		}
+	if (validity.rangeUnderflow) {
+		messages.push('min');
+	}
 
-		if (validity.tooShort) {
-			messages.push('minlength');
-		}
+	if (validity.stepMismatch) {
+		messages.push('step');
+	}
 
-		if (validity.tooLong) {
-			messages.push('maxlength');
-		}
+	if (validity.tooShort) {
+		messages.push('minlength');
+	}
 
-		if (validity.patternMismatch) {
-			messages.push('pattern');
-		}
+	if (validity.tooLong) {
+		messages.push('maxlength');
+	}
+
+	if (validity.patternMismatch) {
+		messages.push('pattern');
 	}
 
 	return messages;

--- a/packages/conform-validitystate/index.ts
+++ b/packages/conform-validitystate/index.ts
@@ -242,38 +242,38 @@ export interface Control {
 }
 
 function parseField(
-	data: FormData,
+	data: FormData | URLSearchParams,
 	name: string,
 	constraint: RequiredField<StringConstraint> | OptionalField<StringConstraint>,
 ): { payload: string; value: string };
 function parseField(
-	data: FormData,
+	data: FormData | URLSearchParams,
 	name: string,
 	constraint:
 		| RequiredField<StringConstraint | StringArrayConstraint>
 		| OptionalField<StringConstraint | StringArrayConstraint>,
 ): { payload: string | string[]; value: string | string[] };
 function parseField(
-	data: FormData,
+	data: FormData | URLSearchParams,
 	name: string,
 	constraint:
 		| RequiredField<BooleanConstraint>
 		| OptionalField<BooleanConstraint>,
 ): { payload: string | undefined; value: boolean };
 function parseField(
-	data: FormData,
+	data: FormData | URLSearchParams,
 	name: string,
 	constraint: RequiredField<NumberConstraint> | OptionalField<NumberConstraint>,
 ): { payload: string; value: number | undefined };
 function parseField(
-	data: FormData,
+	data: FormData | URLSearchParams,
 	name: string,
 	constraint:
 		| RequiredField<FileConstraint | FileArrayConstraint>
 		| OptionalField<FileConstraint | FileArrayConstraint>,
 ): { payload: File[] | File | undefined; value: File[] | File | undefined };
 function parseField(
-	data: FormData,
+	data: FormData | URLSearchParams,
 	name: string,
 	constraint: RequiredField<FieldConstraint> | OptionalField<FieldConstraint>,
 ): {
@@ -281,7 +281,7 @@ function parseField(
 	value: string | string[] | number | boolean | File[] | File | undefined;
 };
 function parseField(
-	data: FormData,
+	data: FormData | URLSearchParams,
 	name: string,
 	constraint: RequiredField<FieldConstraint> | OptionalField<FieldConstraint>,
 ) {

--- a/packages/conform-validitystate/index.ts
+++ b/packages/conform-validitystate/index.ts
@@ -415,7 +415,7 @@ export function parse<
 	data: FormData | URLSearchParams,
 	config: {
 		schema: Schema;
-		formatValidity?: (
+		formatMessage?: (
 			control: Control,
 			value: Partial<InferType<Schema>>,
 		) => ErrorType;
@@ -429,7 +429,7 @@ export function parse<
 	const format: (
 		control: Control,
 		value: Partial<InferType<Schema>>,
-	) => ErrorType = config.formatValidity ?? formatValidity;
+	) => ErrorType = config.formatMessage ?? formatMessage;
 
 	for (const name in config.schema) {
 		const constraint = config.schema[name];
@@ -671,7 +671,7 @@ export function validate<Schema extends FormSchema>(
 	form: HTMLFormElement,
 	config: {
 		schema: Schema;
-		formatValidity?: (
+		formatMessage: (
 			control: Control,
 			value: Partial<InferType<Schema>>,
 		) => string | string[];
@@ -689,7 +689,6 @@ export function validate<Schema extends FormSchema>(
 
 		return result;
 	}, {} as Partial<InferType<Schema>>);
-	const format = config.formatValidity ?? formatValidity;
 
 	for (const element of form.elements) {
 		const control = element as
@@ -699,14 +698,16 @@ export function validate<Schema extends FormSchema>(
 			| HTMLButtonElement;
 
 		if (control.name && control.willValidate) {
-			const messages = ([] as string[]).concat(format(control, value));
+			const messages = ([] as string[]).concat(
+				config.formatMessage(control, value),
+			);
 
 			control.setCustomValidity(messages.join(String.fromCharCode(31)));
 		}
 	}
 }
 
-export function formatValidity({ validity }: Control): string[] {
+export function formatMessage({ validity }: Control): string[] {
 	const messages = [] as string[];
 
 	if (validity.valueMissing) {

--- a/packages/conform-validitystate/index.ts
+++ b/packages/conform-validitystate/index.ts
@@ -446,9 +446,15 @@ export function validate<Shape extends Record<string, any>>(
 				break;
 			}
 			case 'file': {
-				const files = constraint.multiple
+				let files = constraint.multiple
 					? data.getAll(name)
 					: [ensureSingleValue(data, name)];
+
+				// This is a workaround for a bug on @remix-run/web-fetch
+				// @see https://github.com/remix-run/web-std-io/pull/28
+				if (files.length === 1 && files[0] === '') {
+					files = [new File([], '')];
+				}
 
 				invariant(
 					files.every((file): file is File => file instanceof File),

--- a/packages/conform-validitystate/index.ts
+++ b/packages/conform-validitystate/index.ts
@@ -39,7 +39,7 @@ export type Schema<
 							pattern?: string;
 					  }
 					| {
-							type: 'datetime-local' | 'date' | 'month' | 'week' | 'time';
+							type: 'datetime-local' | 'date' | 'time';
 							min?: string;
 							max?: string;
 							step?: string;
@@ -281,8 +281,6 @@ export function validate<Shape extends Record<string, any>>(
 			}
 			case 'datetime-local':
 			case 'date':
-			case 'month':
-			case 'week':
 			case 'time': {
 				const text = ensureSingleTextValue(data, name);
 
@@ -346,12 +344,6 @@ export function validate<Shape extends Record<string, any>>(
 									? constraint.step * 1000
 									: null;
 							break;
-						}
-						default: {
-							// TODO: implement month and week validation
-							payload.set(name, text);
-							value.set(name, text);
-							continue;
 						}
 					}
 

--- a/packages/conform-validitystate/index.ts
+++ b/packages/conform-validitystate/index.ts
@@ -184,7 +184,7 @@ export function getDateConstraint(
 			break;
 		case 'datetime-local':
 			invariant(
-				/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$/.test(text),
+				/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}$/.test(text),
 				'Invalid datetime',
 			);
 			format = (datetime) => datetime;

--- a/packages/conform-validitystate/index.ts
+++ b/packages/conform-validitystate/index.ts
@@ -203,20 +203,41 @@ export function getDateConstraint(
 	};
 }
 
+type ValidityKey = Exclude<keyof ValidityState, 'customError' | 'valid'>;
+
 export function validate<Shape extends Record<string, any>>(
 	data: FormData | URLSearchParams,
-	schema: Schema<Shape>,
+	config: {
+		schema: Schema<Shape>;
+		formatValidity?: (validity: ValidityState) => string[];
+	},
 ): SchemaValidity<Shape> {
 	const payload = new Map<keyof Shape, string | string[] | undefined>();
 	const error = new Map<keyof Shape, string[]>();
 	const value = new Map<keyof Shape, SupportedTypes>();
+	const format = config.formatValidity ?? formatValidity;
 
-	for (const name in schema) {
-		const constraint = schema[name];
-		const messages = new Set<string>();
-		const validate = (message: string, condition: boolean) => {
+	for (const name in config.schema) {
+		const constraint = config.schema[name];
+		const validity: ValidityState = {
+			valueMissing: false,
+			badInput: false,
+			typeMismatch: false,
+			patternMismatch: false,
+			tooShort: false,
+			tooLong: false,
+			rangeUnderflow: false,
+			rangeOverflow: false,
+			stepMismatch: false,
+			customError: false,
+			valid: true,
+		};
+		const validate = (key: ValidityKey, condition: boolean) => {
 			if (!condition) {
-				messages.add(message);
+				// @ts-expect-error - ValidityState is immutable
+				validity[key] = true;
+				// @ts-expect-error - ValidityState is immutable
+				validity.valid = false;
 			}
 		};
 
@@ -234,18 +255,24 @@ export function validate<Shape extends Record<string, any>>(
 				payload.set(name, text);
 				value.set(name, text);
 
-				validate('required', !constraint.required || text !== '');
+				validate('valueMissing', !constraint.required || text !== '');
 
 				if (text !== '') {
-					validate('type', constraint.type !== 'email' || isValidEmail(text));
-					validate('type', constraint.type !== 'url' || isValidURL(text));
-					validate('minlength', text.length >= (constraint.minLength ?? 0));
 					validate(
-						'maxlength',
+						'typeMismatch',
+						constraint.type !== 'email' || isValidEmail(text),
+					);
+					validate(
+						'typeMismatch',
+						constraint.type !== 'url' || isValidURL(text),
+					);
+					validate('tooShort', text.length >= (constraint.minLength ?? 0));
+					validate(
+						'tooLong',
 						text.length <= (constraint.maxLength ?? Infinity),
 					);
 					validate(
-						'pattern',
+						'patternMismatch',
 						!constraint.pattern || matchPattern(constraint.pattern ?? '', text),
 					);
 				}
@@ -259,21 +286,21 @@ export function validate<Shape extends Record<string, any>>(
 
 				payload.set(name, text);
 
-				validate('required', !constraint.required || text !== '');
+				validate('valueMissing', !constraint.required || text !== '');
 
 				if (text !== '') {
 					const number = Number(text);
 					const isNumber = !Number.isNaN(number);
 
-					validate('type', isNumber);
+					validate('badInput', isNumber);
 
 					if (isNumber) {
 						const { min = 0, max = Infinity, step = 1 } = constraint;
 						value.set(name, number);
 
-						validate('min', number >= min);
-						validate('max', number <= max);
-						validate('step', (number - min) % step === 0);
+						validate('rangeUnderflow', number >= min);
+						validate('rangeOverflow', number <= max);
+						validate('stepMismatch', (number - min) % step === 0);
 					}
 				}
 				break;
@@ -295,7 +322,7 @@ export function validate<Shape extends Record<string, any>>(
 
 				value.set(name, flag);
 
-				validate('required', !constraint.required || flag);
+				validate('valueMissing', !constraint.required || flag);
 				break;
 			}
 			case 'datetime-local':
@@ -307,22 +334,22 @@ export function validate<Shape extends Record<string, any>>(
 
 				payload.set(name, text);
 
-				validate('required', !constraint.required || text !== '');
+				validate('valueMissing', !constraint.required || text !== '');
 
 				if (text !== '') {
 					const { date, min, max, step } = getDateConstraint(text, constraint);
 
 					const isValidDate = !Number.isNaN(date.valueOf());
 
-					validate('type', isValidDate);
+					validate('typeMismatch', isValidDate);
 
 					if (isValidDate) {
 						value.set(name, text);
 
-						validate('min', min === null || date >= min);
-						validate('max', max === null || date <= max);
+						validate('rangeUnderflow', min === null || date >= min);
+						validate('rangeOverflow', max === null || date <= max);
 						validate(
-							'step',
+							'stepMismatch',
 							step === null ||
 								(date.valueOf() - (min?.valueOf() ?? 0)) % step === 0,
 						);
@@ -341,7 +368,7 @@ export function validate<Shape extends Record<string, any>>(
 				}
 
 				validate(
-					'required',
+					'valueMissing',
 					!constraint.required || typeof text !== 'undefined',
 				);
 				break;
@@ -355,7 +382,7 @@ export function validate<Shape extends Record<string, any>>(
 				value.set(name, text);
 				payload.set(name, text);
 
-				validate('required', !constraint.required || text !== '');
+				validate('valueMissing', !constraint.required || text !== '');
 				break;
 			}
 			case 'select': {
@@ -380,9 +407,9 @@ export function validate<Shape extends Record<string, any>>(
 
 				if (constraint.required) {
 					if (isArray) {
-						validate('required', options.length > 0);
+						validate('valueMissing', options.length > 0);
 					} else {
-						validate('required', options !== '');
+						validate('valueMissing', options !== '');
 					}
 				}
 				break;
@@ -395,12 +422,12 @@ export function validate<Shape extends Record<string, any>>(
 				value.set(name, text);
 				payload.set(name, text);
 
-				validate('required', !constraint.required || text !== '');
+				validate('valueMissing', !constraint.required || text !== '');
 
 				if (text) {
-					validate('minlength', text.length >= (constraint.minLength ?? 0));
+					validate('tooShort', text.length >= (constraint.minLength ?? 0));
 					validate(
-						'maxlength',
+						'tooLong',
 						text.length <= (constraint.maxLength ?? Infinity),
 					);
 				}
@@ -424,7 +451,10 @@ export function validate<Shape extends Record<string, any>>(
 
 				const nonEmptyFiles = files.filter((file) => !isEmptyFile(file));
 
-				validate('required', !constraint.required || nonEmptyFiles.length > 0);
+				validate(
+					'valueMissing',
+					!constraint.required || nonEmptyFiles.length > 0,
+				);
 
 				if (constraint.multiple || nonEmptyFiles.length > 0) {
 					value.set(
@@ -436,8 +466,8 @@ export function validate<Shape extends Record<string, any>>(
 			}
 		}
 
-		if (messages.size > 0) {
-			error.set(name, [...messages]);
+		if (!validity.valid) {
+			error.set(name, [...format(validity)]);
 		}
 	}
 
@@ -455,11 +485,7 @@ export function validate<Shape extends Record<string, any>>(
 	};
 }
 
-export function getMessages(
-	validity: ValidityState,
-	validationMessage?: string,
-	delimiter?: string,
-): string[] {
+export function formatValidity(validity: ValidityState): string[] {
 	const messages = [] as string[];
 
 	if (validity.valueMissing) {
@@ -491,14 +517,6 @@ export function getMessages(
 
 		if (validity.patternMismatch) {
 			messages.push('pattern');
-		}
-
-		if (validity.customError && validationMessage) {
-			if (delimiter) {
-				messages.push(...validationMessage.split(delimiter));
-			} else {
-				messages.push(validationMessage);
-			}
 		}
 	}
 

--- a/packages/conform-validitystate/index.ts
+++ b/packages/conform-validitystate/index.ts
@@ -197,13 +197,13 @@ function getDateConstraint(
 	switch (constraint.type) {
 		case 'date':
 			invariant(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(text), 'Invalid date');
-			format = (date) => `${date}T00:00:00`;
-			baseStep = 86400000;
+			format = (date) => `${date}T00:00:00Z`;
+			baseStep = 24 * 60 * 60 * 1000;
 			break;
 		case 'time':
 			invariant(/^[0-9]{2}:[0-9]{2}$/.test(text), 'Invalid time');
 			const today = new Date().toISOString().slice(0, 10);
-			format = (time) => `${today}T${time}`;
+			format = (time) => `${today}T${time}Z`;
 			baseStep = 1000;
 			break;
 		case 'datetime-local':
@@ -211,7 +211,7 @@ function getDateConstraint(
 				/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}$/.test(text),
 				'Invalid datetime',
 			);
-			format = (datetime) => datetime;
+			format = (datetime) => `${datetime}Z`;
 			baseStep = 1000;
 			break;
 	}
@@ -227,7 +227,7 @@ function getDateConstraint(
 	};
 }
 
-interface Control {
+export interface Control {
 	name: string;
 	value: string | string[];
 	validity: ValidityState;
@@ -698,7 +698,7 @@ export function validate<Schema extends FormSchema>(
 			| HTMLTextAreaElement
 			| HTMLButtonElement;
 
-		if (control.willValidate) {
+		if (control.name && control.willValidate) {
 			const messages = ([] as string[]).concat(format(control, value));
 
 			control.setCustomValidity(messages.join(String.fromCharCode(31)));

--- a/packages/conform-validitystate/index.ts
+++ b/packages/conform-validitystate/index.ts
@@ -131,8 +131,18 @@ export function matchPattern(pattern: string, text: string): boolean {
 		return text === '';
 	}
 
+	let patternString = pattern;
+
+	if (!pattern.startsWith('^')) {
+		patternString = `^${patternString}`;
+	}
+
+	if (!pattern.endsWith('$')) {
+		patternString = `${patternString}$`;
+	}
+
 	// TODO: ensure pattern will match the whole text
-	return new RegExp(pattern).test(text);
+	return new RegExp(patternString).test(text);
 }
 
 export function validate<Shape extends Record<string, any>>(
@@ -232,7 +242,7 @@ export function validate<Shape extends Record<string, any>>(
 
 						if (
 							typeof constraint.step !== 'undefined' &&
-							number % constraint.step !== 0
+							(number - (constraint.min ?? 0)) % constraint.step !== 0
 						) {
 							messages.add('step');
 						}
@@ -257,6 +267,10 @@ export function validate<Shape extends Record<string, any>>(
 					);
 				}
 
+				if (item) {
+					payload.set(name, item);
+				}
+
 				const flag = typeof item !== 'undefined';
 
 				if (constraint.required && !flag) {
@@ -264,7 +278,6 @@ export function validate<Shape extends Record<string, any>>(
 				}
 
 				value.set(name, flag);
-				payload.set(name, item);
 				break;
 			}
 			case 'datetime-local': {

--- a/packages/conform-validitystate/index.ts
+++ b/packages/conform-validitystate/index.ts
@@ -115,15 +115,11 @@ function ensureSingleValue(
 	data: FormData | URLSearchParams,
 	name: string,
 ): FormDataEntryValue {
-	if (!data.has(name)) {
-		throw new Error(`${name} is missing`);
-	}
+	invariant(data.has(name), `${name} is missing`);
 
 	const [text, ...rest] = data.getAll(name);
 
-	if (rest.length > 1) {
-		throw new Error(`${name} is not configured for multiple values`);
-	}
+	invariant(rest.length === 0, `${name} is not configured for multiple values`);
 
 	return text;
 }

--- a/packages/conform-validitystate/package.json
+++ b/packages/conform-validitystate/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@conform-to/validitystate",
+	"description": "Validate on the server using the same rules as the browser",
+	"homepage": "https://conform.guide",
+	"license": "MIT",
+	"version": "0.0.1",
+	"main": "index.js",
+	"module": "module/index.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/edmundhung/conform",
+		"directory": "packages/conform-validitystate"
+	},
+	"author": {
+		"name": "Edmund Hung",
+		"email": "me@edmund.dev",
+		"url": "https://edmund.dev"
+	},
+	"bugs": {
+		"url": "https://github.com/edmundhung/conform/issues"
+	},
+	"keywords": [
+		"constraint-validation",
+		"form",
+		"form-validation",
+		"html",
+		"progressive-enhancement",
+		"validation",
+		"dom"
+	],
+	"sideEffects": false
+}

--- a/packages/conform-validitystate/tsconfig.json
+++ b/packages/conform-validitystate/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"target": "ES2020",
+		"module": "ES2020",
+		"moduleResolution": "node",
+		"allowSyntheticDefaultImports": true,
+		"strict": true,
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		"composite": true,
+		"skipLibCheck": true
+	}
+}

--- a/playground/app/components.tsx
+++ b/playground/app/components.tsx
@@ -1,8 +1,12 @@
-import type { FieldConfig, Submission } from '@conform-to/react';
+import type { FieldConfig } from '@conform-to/react';
 import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 
-interface PlaygroundProps {
+interface PlaygroundProps<
+	Submission extends {
+		error: Record<string, string | string[]> | null;
+	},
+> {
 	title: string;
 	description?: ReactNode;
 	form?: string;
@@ -22,7 +26,7 @@ export function Playground({
 	formMethod,
 	formEncType,
 	children,
-}: PlaygroundProps) {
+}: PlaygroundProps<any>) {
 	const [submission, setSubmission] = useState(lastSubmission ?? null);
 
 	useEffect(() => {
@@ -46,7 +50,7 @@ export function Playground({
 						<summary>Submission</summary>
 						<pre
 							className={`m-4 border-l-4 overflow-x-scroll ${
-								Object.entries(submission.error).length > 0
+								!submission.error || Object.entries(submission.error).length > 0
 									? 'border-pink-600'
 									: 'border-emerald-500'
 							} pl-4 py-2 mt-4`}

--- a/playground/app/components.tsx
+++ b/playground/app/components.tsx
@@ -91,7 +91,7 @@ export function Playground({
 interface FieldProps {
 	label: string;
 	inline?: boolean;
-	config?: FieldConfig<any>;
+	config?: Partial<FieldConfig<any>>;
 	children: ReactNode;
 }
 

--- a/playground/app/routes/validitystate.tsx
+++ b/playground/app/routes/validitystate.tsx
@@ -1,4 +1,4 @@
-import { validate, formatValidity } from '@conform-to/validitystate';
+import { parse, formatValidity } from '@conform-to/validitystate';
 import { json, type ActionArgs, type LoaderArgs } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { useEffect, useState } from 'react';
@@ -22,7 +22,7 @@ export async function loader({ request }: LoaderArgs) {
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = validate(formData, {
+	const submission = parse(formData, {
 		schema: { field: getSchema(request) },
 	});
 

--- a/playground/app/routes/validitystate.tsx
+++ b/playground/app/routes/validitystate.tsx
@@ -1,4 +1,4 @@
-import { validate, getMessages } from '@conform-to/validitystate';
+import { validate, formatValidity } from '@conform-to/validitystate';
 import { json, type ActionArgs, type LoaderArgs } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { useEffect, useState } from 'react';
@@ -22,7 +22,9 @@ export async function loader({ request }: LoaderArgs) {
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = validate(formData, { field: getSchema(request) } as any);
+	const submission = validate(formData, {
+		schema: { field: getSchema(request) },
+	});
 
 	return json(submission);
 }
@@ -56,7 +58,7 @@ export default function Example() {
 					| HTMLInputElement
 					| HTMLSelectElement
 					| HTMLTextAreaElement;
-				const messages = getMessages(input.validity);
+				const messages = formatValidity(input.validity);
 
 				setError((error) => ({
 					...error,

--- a/playground/app/routes/validitystate.tsx
+++ b/playground/app/routes/validitystate.tsx
@@ -3,7 +3,7 @@ import {
 	parse,
 	validate,
 	formatValidationMessage,
-	formatValidity as defaultFormat,
+	formatMessage,
 } from '@conform-to/validitystate';
 import { json, type ActionArgs, type LoaderArgs } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
@@ -22,9 +22,9 @@ function getSecret(url: URL) {
 	return url.searchParams.get('secret');
 }
 
-function createFormatValidity(secret: string | null) {
+function createFormatMessage(secret: string | null) {
 	return (control: Control, value: Partial<{ field: any }>): string[] => {
-		const messages = defaultFormat(control);
+		const messages = formatMessage(control);
 
 		if (
 			secret !== null &&
@@ -52,10 +52,10 @@ export async function action({ request }: ActionArgs) {
 	const url = new URL(request.url);
 	const secret = getSecret(url);
 	const formData = await request.formData();
-	const formatValidity = createFormatValidity(secret);
+	const formatMessage = createFormatMessage(secret);
 	const submission = parse(formData, {
 		schema: { field: getSchema(url) },
-		formatValidity,
+		formatMessage,
 	});
 
 	return json(submission);
@@ -90,7 +90,7 @@ export default function Example() {
 
 				validate(event.currentTarget, {
 					schema: { field: schema },
-					formatValidity: createFormatValidity(secret),
+					formatMessage: createFormatMessage(secret),
 				});
 
 				if (!event.currentTarget.reportValidity()) {

--- a/playground/app/routes/validitystate.tsx
+++ b/playground/app/routes/validitystate.tsx
@@ -1,0 +1,175 @@
+import { type Schema, validate, getMessages } from '@conform-to/validitystate';
+import { json, type ActionArgs } from '@remix-run/node';
+import { Form, useActionData } from '@remix-run/react';
+import { useEffect, useState } from 'react';
+import { Playground, Field } from '~/components';
+
+const schema: Schema<{
+	/* string */
+	text?: string;
+	email: string;
+	password: string;
+	url?: string;
+	tel?: string;
+	search: string;
+
+	/* string */
+	// date: string;
+	// month: string;
+	// week: string;
+	// time: string;
+
+	/* string */
+	// radio: string;
+	// color: string;
+
+	/* number */
+	number: number;
+	// range: number;
+
+	/* boolean */
+	checkbox: boolean;
+
+	/* File */
+	file: File;
+	files?: File[];
+}> = {
+	text: {
+		type: 'text',
+		minLength: 3,
+		maxLength: 10,
+		pattern: '[a-z]{3}',
+	},
+	email: {
+		type: 'email',
+		required: true,
+	},
+	password: {
+		type: 'password',
+		required: true,
+		minLength: 8,
+	},
+	url: {
+		type: 'url',
+	},
+	tel: {
+		type: 'tel',
+	},
+	search: {
+		type: 'search',
+		required: true,
+	},
+	number: {
+		type: 'number',
+		required: true,
+		min: 0.5,
+		max: 5,
+		step: 0.5,
+	},
+	checkbox: {
+		type: 'checkbox',
+		value: 'yes',
+	},
+	file: {
+		type: 'file',
+		required: true,
+	},
+	files: {
+		type: 'file',
+		multiple: true,
+	},
+};
+
+export async function action({ request }: ActionArgs) {
+	const formData = await request.formData();
+	const submission = validate(formData, schema);
+
+	return json(submission);
+}
+
+export default function Example() {
+	const submission = useActionData<typeof action>();
+	const [error, setError] = useState(submission?.error ?? {});
+
+	useEffect(() => {
+		if (submission?.error) {
+			setError(submission.error);
+		}
+	}, [submission]);
+
+	return (
+		<Form
+			method="post"
+			encType="multipart/form-data"
+			onSubmit={(event) => {
+				// Reset all error
+				setError({});
+
+				if (!event.currentTarget.reportValidity()) {
+					event.preventDefault();
+				}
+			}}
+			onInvalidCapture={(event) => {
+				const input = event.target as
+					| HTMLInputElement
+					| HTMLSelectElement
+					| HTMLTextAreaElement;
+				const messages = getMessages(input.validity);
+
+				// Prevent default error bubble
+				event.preventDefault();
+
+				// Update the error based on the input name
+				setError((error) => ({
+					...error,
+					[input.name]: messages,
+				}));
+			}}
+			noValidate
+		>
+			<Playground
+				title="Validity State"
+				lastSubmission={
+					submission
+						? {
+								payload: submission.payload,
+								error: submission.error ?? {},
+								intent: 'submit',
+						  }
+						: undefined
+				}
+			>
+				<Field label="Text" config={{ errors: error.text }}>
+					<input name="text" {...schema.text} />
+				</Field>
+				<Field label="Email" config={{ errors: error.email }}>
+					<input name="email" {...schema.email} />
+				</Field>
+				<Field label="Password" config={{ errors: error.password }}>
+					<input name="password" {...schema.password} />
+				</Field>
+				<Field label="URL" config={{ errors: error.url }}>
+					<input name="url" {...schema.url} />
+				</Field>
+				<Field label="Tel" config={{ errors: error.tel }}>
+					<input name="tel" {...schema.tel} />
+				</Field>
+				<Field label="Search" config={{ errors: error.search }}>
+					<input name="search" {...schema.search} />
+				</Field>
+				<Field label="Number" config={{ errors: error.number }}>
+					<input name="number" {...schema.number} />
+				</Field>
+				<Field label="Checkbox" config={{ errors: error.checkbox }}>
+					<input name="checkbox" {...schema.checkbox} />
+				</Field>
+				<Field label="File" config={{ errors: error.file }}>
+					<input name="file" {...schema.file} />
+				</Field>
+				<Field label="Files" config={{ errors: error.files }}>
+					<input name="files" {...schema.files} />
+				</Field>
+			</Playground>
+		</Form>
+	);
+}

--- a/playground/app/routes/validitystate.tsx
+++ b/playground/app/routes/validitystate.tsx
@@ -1,4 +1,8 @@
-import { parse, formatValidity } from '@conform-to/validitystate';
+import {
+	parse,
+	validate,
+	formatValidationMessage,
+} from '@conform-to/validitystate';
 import { json, type ActionArgs, type LoaderArgs } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { useEffect, useState } from 'react';
@@ -49,6 +53,10 @@ export default function Example() {
 				// Reset all error
 				setError({});
 
+				validate(event.currentTarget, {
+					schema: { field: schema },
+				});
+
 				if (!event.currentTarget.reportValidity()) {
 					event.preventDefault();
 				}
@@ -58,11 +66,10 @@ export default function Example() {
 					| HTMLInputElement
 					| HTMLSelectElement
 					| HTMLTextAreaElement;
-				const messages = formatValidity(input.validity);
 
 				setError((error) => ({
 					...error,
-					[input.name]: messages,
+					[input.name]: formatValidationMessage(input.validationMessage),
 				}));
 				event.preventDefault();
 			}}

--- a/playground/app/routes/validitystate.tsx
+++ b/playground/app/routes/validitystate.tsx
@@ -82,7 +82,9 @@ export default function Example() {
 							defaultValue={submission?.payload.field ?? ''}
 							{...schema}
 						>
-							<option value="">Select an option</option>
+							{schema.multiple ? null : (
+								<option value="">Select an option</option>
+							)}
 							<option value="a">Option A</option>
 							<option value="b">Option B</option>
 							<option value="c">Option C</option>

--- a/playground/app/routes/validitystate.tsx
+++ b/playground/app/routes/validitystate.tsx
@@ -68,7 +68,38 @@ export default function Example() {
 		>
 			<Playground title="Validity State" lastSubmission={submission}>
 				<Field label="Field" config={{ errors: error.field }}>
-					<input name="field" {...schema} />
+					{schema.type === 'checkbox' || schema.type === 'radio' ? (
+						<input
+							name="field"
+							defaultChecked={
+								(schema.value ?? 'on') === submission?.payload.field
+							}
+							{...schema}
+						/>
+					) : schema.type === 'select' ? (
+						<select
+							name="field"
+							defaultValue={submission?.payload.field ?? ''}
+							{...schema}
+						>
+							<option value="">Select an option</option>
+							<option value="a">Option A</option>
+							<option value="b">Option B</option>
+							<option value="c">Option C</option>
+						</select>
+					) : schema.type === 'textarea' ? (
+						<textarea
+							name="field"
+							defaultValue={submission?.payload.field ?? ''}
+							{...schema}
+						/>
+					) : (
+						<input
+							name="field"
+							defaultValue={submission?.payload.field ?? ''}
+							{...schema}
+						/>
+					)}
 				</Field>
 			</Playground>
 		</Form>

--- a/playground/app/routes/validitystate.tsx
+++ b/playground/app/routes/validitystate.tsx
@@ -1,93 +1,34 @@
-import { type Schema, validate, getMessages } from '@conform-to/validitystate';
-import { json, type ActionArgs } from '@remix-run/node';
-import { Form, useActionData } from '@remix-run/react';
+import { validate, getMessages } from '@conform-to/validitystate';
+import { json, type ActionArgs, type LoaderArgs } from '@remix-run/node';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
 import { useEffect, useState } from 'react';
 import { Playground, Field } from '~/components';
 
-const schema: Schema<{
-	/* string */
-	text?: string;
-	email: string;
-	password: string;
-	url?: string;
-	tel?: string;
-	search: string;
+function getSchema(request: Request) {
+	const url = new URL(request.url);
 
-	/* string */
-	// date: string;
-	// month: string;
-	// week: string;
-	// time: string;
+	if (url.searchParams.has('schema')) {
+		return JSON.parse(url.searchParams.get('schema') as string);
+	}
 
-	/* string */
-	// radio: string;
-	// color: string;
+	return {};
+}
 
-	/* number */
-	number: number;
-	// range: number;
-
-	/* boolean */
-	checkbox: boolean;
-
-	/* File */
-	file: File;
-	files?: File[];
-}> = {
-	text: {
-		type: 'text',
-		minLength: 3,
-		maxLength: 10,
-		pattern: '[a-z]{3}',
-	},
-	email: {
-		type: 'email',
-		required: true,
-	},
-	password: {
-		type: 'password',
-		required: true,
-		minLength: 8,
-	},
-	url: {
-		type: 'url',
-	},
-	tel: {
-		type: 'tel',
-	},
-	search: {
-		type: 'search',
-		required: true,
-	},
-	number: {
-		type: 'number',
-		required: true,
-		min: 0.5,
-		max: 5,
-		step: 0.5,
-	},
-	checkbox: {
-		type: 'checkbox',
-		value: 'yes',
-	},
-	file: {
-		type: 'file',
-		required: true,
-	},
-	files: {
-		type: 'file',
-		multiple: true,
-	},
-};
+export async function loader({ request }: LoaderArgs) {
+	return json({
+		schema: getSchema(request),
+	});
+}
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = validate(formData, schema);
+	const submission = validate(formData, { field: getSchema(request) } as any);
 
 	return json(submission);
 }
 
 export default function Example() {
+	const { schema } = useLoaderData();
 	const submission = useActionData<typeof action>();
 	const [error, setError] = useState(submission?.error ?? {});
 
@@ -100,7 +41,8 @@ export default function Example() {
 	return (
 		<Form
 			method="post"
-			encType="multipart/form-data"
+			encType={schema.type === 'file' ? 'multipart/form-data' : undefined}
+			action={`?schema=${JSON.stringify(schema)}`}
 			onSubmit={(event) => {
 				// Reset all error
 				setError({});
@@ -116,58 +58,17 @@ export default function Example() {
 					| HTMLTextAreaElement;
 				const messages = getMessages(input.validity);
 
-				// Prevent default error bubble
-				event.preventDefault();
-
-				// Update the error based on the input name
 				setError((error) => ({
 					...error,
 					[input.name]: messages,
 				}));
+				event.preventDefault();
 			}}
 			noValidate
 		>
-			<Playground
-				title="Validity State"
-				lastSubmission={
-					submission
-						? {
-								payload: submission.payload,
-								error: submission.error ?? {},
-								intent: 'submit',
-						  }
-						: undefined
-				}
-			>
-				<Field label="Text" config={{ errors: error.text }}>
-					<input name="text" {...schema.text} />
-				</Field>
-				<Field label="Email" config={{ errors: error.email }}>
-					<input name="email" {...schema.email} />
-				</Field>
-				<Field label="Password" config={{ errors: error.password }}>
-					<input name="password" {...schema.password} />
-				</Field>
-				<Field label="URL" config={{ errors: error.url }}>
-					<input name="url" {...schema.url} />
-				</Field>
-				<Field label="Tel" config={{ errors: error.tel }}>
-					<input name="tel" {...schema.tel} />
-				</Field>
-				<Field label="Search" config={{ errors: error.search }}>
-					<input name="search" {...schema.search} />
-				</Field>
-				<Field label="Number" config={{ errors: error.number }}>
-					<input name="number" {...schema.number} />
-				</Field>
-				<Field label="Checkbox" config={{ errors: error.checkbox }}>
-					<input name="checkbox" {...schema.checkbox} />
-				</Field>
-				<Field label="File" config={{ errors: error.file }}>
-					<input name="file" {...schema.file} />
-				</Field>
-				<Field label="Files" config={{ errors: error.files }}>
-					<input name="files" {...schema.files} />
+			<Playground title="Validity State" lastSubmission={submission}>
+				<Field label="Field" config={{ errors: error.field }}>
+					<input name="field" {...schema} />
 				</Field>
 			</Playground>
 		</Form>

--- a/playground/package.json
+++ b/playground/package.json
@@ -13,6 +13,7 @@
 	},
 	"dependencies": {
 		"@conform-to/react": "*",
+		"@conform-to/validitystate": "*",
 		"@conform-to/zod": "*",
 		"@remix-run/node": "^1.14.0",
 		"@remix-run/react": "^1.14.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -65,6 +65,7 @@ export default function rollup() {
 	const packages = [
 		// Base
 		'conform-dom',
+		'conform-validitystate',
 
 		// Schema resolver
 		'conform-zod',

--- a/tests/integrations/validitystate.spec.ts
+++ b/tests/integrations/validitystate.spec.ts
@@ -581,6 +581,57 @@ function runTests(javaScriptEnabled: boolean) {
 			});
 	});
 
+	test('select', async ({ page }) => {
+		const { submit, error, field, getSubmission, updateSchema } =
+			await setupField(page, {
+				type: 'select',
+			});
+
+		await submit.click();
+		await expect(error).toHaveText(['']);
+
+		await updateSchema({ required: true });
+		await expect(error).toHaveText(['required']);
+
+		await field.selectOption('a');
+		await submit.click();
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: { field: 'a' },
+				value: { field: 'a' },
+				error: null,
+			});
+	});
+
+	test('textarea', async ({ page }) => {
+		const { submit, error, type, getSubmission, updateSchema } =
+			await setupField(page, {
+				type: 'textarea',
+				minLength: 10,
+			});
+
+		await submit.click();
+		await expect(error).toHaveText(['']);
+
+		await updateSchema({ required: true });
+		await expect(error).toHaveText(['required']);
+
+		await type('hello');
+		await expect(error).toHaveText(['minlength']);
+
+		await type('This is a long paragraph');
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: { field: 'This is a long paragraph' },
+				value: { field: 'This is a long paragraph' },
+				error: null,
+			});
+	});
+
 	test('file input', async ({ page }) => {
 		const { submit, error, field, getSubmission, updateSchema } =
 			await setupField(page, {

--- a/tests/integrations/validitystate.spec.ts
+++ b/tests/integrations/validitystate.spec.ts
@@ -597,6 +597,23 @@ function runTests(javaScriptEnabled: boolean) {
 				value: { field: 'a' },
 				error: null,
 			});
+
+		await updateSchema({ multiple: true });
+		await expect(error).toHaveText(['']);
+
+		await updateSchema({ multiple: true, required: true });
+		await expect(error).toHaveText(['required']);
+
+		await field.selectOption(['b', 'c']);
+		await submit.click();
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: { field: ['b', 'c'] },
+				value: { field: ['b', 'c'] },
+				error: null,
+			});
 	});
 
 	test('textarea', async ({ page }) => {

--- a/tests/integrations/validitystate.spec.ts
+++ b/tests/integrations/validitystate.spec.ts
@@ -1,71 +1,364 @@
-import { type Page, type Locator, test, expect } from '@playwright/test';
+import { type Page, test, expect } from '@playwright/test';
 import { getPlayground } from '../helpers';
 
-function getFieldset(form: Locator) {
+async function setupField(page: Page, schema: object) {
+	const playground = getPlayground(page);
+	const field = playground.container.locator('[name="field"]');
+
+	await page.goto(`/validitystate?schema=${JSON.stringify(schema)}`);
+
 	return {
-		// All the possibile input type
-		text: form.locator('[name="text"]'),
-		email: form.locator('[name="email"]'),
-		password: form.locator('[name="password"]'),
-		url: form.locator('[name="url"]'),
-		tel: form.locator('[name="tel"]'),
-		search: form.locator('[name="search"]'),
-		number: form.locator('[name="number"]'),
-		checkbox: form.locator('[name="checkbox"]'),
-		file: form.locator('[name="file"]'),
-		files: form.locator('[name="files"]'),
+		...playground,
+		field,
+		async type(value: string) {
+			await field.fill('');
+			await field.type(value);
+			await playground.submit.click();
+		},
+		async setRequired(flag = true) {
+			await page.goto(
+				`/validitystate?schema=${JSON.stringify({
+					...schema,
+					required: flag,
+				})}`,
+			);
+			await playground.submit.click();
+		},
+		async updateSchema(changed: object) {
+			await page.goto(
+				`/validitystate?schema=${JSON.stringify({ ...schema, ...changed })}`,
+			);
+			await playground.submit.click();
+		},
+		async getSubmission() {
+			return JSON.parse(await playground.submission.innerText());
+		},
 	};
 }
 
-async function runValidationScenario(page: Page) {
-	const playground = getPlayground(page);
-	const fieldset = getFieldset(playground.container);
+function runTests(javaScriptEnabled: boolean) {
+	test.use({ javaScriptEnabled });
 
-	await playground.submit.click();
-	await expect(playground.error).toHaveText([
-		'',
-		'required',
-		'required',
-		'',
-		'',
-		'required',
-		'required',
-		'',
-		'required',
-		'',
-	]);
+	test('text input', async ({ page }) => {
+		const { submit, error, type, updateSchema, getSubmission } =
+			await setupField(page, {
+				type: 'text',
+				minLength: 3,
+				pattern: '[A-Za-z]{3,10}',
+			});
 
-	await fieldset.text.type('a');
-	await playground.submit.click();
-	await expect(playground.error).toHaveText([
-		'minlength',
-		'pattern',
-		'required',
-		'required',
-		'',
-		'',
-		'required',
-		'required',
-		'',
-		'required',
-		'',
-	]);
+		await submit.click();
+		await expect(error).toHaveText(['']);
+
+		await updateSchema({ required: true });
+		await expect(error).toHaveText(['required']);
+
+		await type('1');
+		await expect(error).toHaveText(['minlength', 'pattern']);
+
+		await type('123');
+		await expect(error).toHaveText(['pattern']);
+
+		await type('Abc');
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: { field: 'Abc' },
+				value: { field: 'Abc' },
+				error: null,
+			});
+	});
+
+	test('password input', async ({ page }) => {
+		const { submit, error, type, updateSchema, getSubmission } =
+			await setupField(page, {
+				type: 'password',
+				minLength: 5,
+				pattern: '(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z]).*',
+			});
+
+		await submit.click();
+		await expect(error).toHaveText(['']);
+
+		await updateSchema({ required: true });
+		await expect(error).toHaveText(['required']);
+
+		await type('a');
+		await expect(error).toHaveText(['minlength', 'pattern']);
+
+		await type('12345');
+		await expect(error).toHaveText(['pattern']);
+
+		await type('ABC1234z');
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: { field: 'ABC1234z' },
+				value: { field: 'ABC1234z' },
+				error: null,
+			});
+	});
+
+	test('email input', async ({ page }) => {
+		const { submit, error, type, updateSchema, getSubmission } =
+			await setupField(page, {
+				type: 'email',
+			});
+
+		await submit.click();
+		await expect(error).toHaveText(['']);
+
+		await updateSchema({ required: true });
+		await expect(error).toHaveText(['required']);
+
+		await type('test');
+		await expect(error).toHaveText(['type']);
+
+		await type('test@');
+		await expect(error).toHaveText(['type']);
+
+		await type('test@example');
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: { field: 'test@example' },
+				value: { field: 'test@example' },
+				error: null,
+			});
+	});
+
+	test('url input', async ({ page }) => {
+		const { submit, error, type, updateSchema, getSubmission } =
+			await setupField(page, {
+				type: 'url',
+				minLength: 2,
+				pattern: 'https://.*',
+			});
+
+		await submit.click();
+		await expect(error).toHaveText(['']);
+
+		await updateSchema({ required: true });
+		await expect(error).toHaveText(['required']);
+
+		await type('test');
+		await expect(error).toHaveText(['type', 'pattern']);
+
+		await type('http://');
+		await expect(error).toHaveText(['type', 'pattern']);
+
+		await type('http://example');
+		await expect(error).toHaveText(['pattern']);
+
+		await type('https://test');
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: { field: 'https://test' },
+				value: { field: 'https://test' },
+				error: null,
+			});
+	});
+
+	test('tel input', async ({ page }) => {
+		const { submit, error, type, updateSchema, getSubmission } =
+			await setupField(page, {
+				type: 'tel',
+				minLength: 3,
+				pattern: '[0-9]{3,10}',
+			});
+
+		await submit.click();
+		await expect(error).toHaveText(['']);
+
+		await updateSchema({ required: true });
+		await expect(error).toHaveText(['required']);
+
+		await type('cc');
+		await expect(error).toHaveText(['minlength', 'pattern']);
+
+		await type('test');
+		await expect(error).toHaveText(['pattern']);
+
+		await type('0123456');
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: { field: '0123456' },
+				value: { field: '0123456' },
+				error: null,
+			});
+	});
+
+	test('search input', async ({ page }) => {
+		const { submit, error, type, updateSchema, getSubmission } =
+			await setupField(page, {
+				type: 'search',
+				minLength: 3,
+				pattern: '[A-Za-z0-9]{3,10}',
+			});
+
+		await submit.click();
+		await expect(error).toHaveText(['']);
+
+		await updateSchema({ required: true });
+		await expect(error).toHaveText(['required']);
+
+		await type('no');
+		await expect(error).toHaveText(['minlength', 'pattern']);
+
+		await type('hellow world');
+		await expect(error).toHaveText(['pattern']);
+
+		await type('anything');
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: { field: 'anything' },
+				value: { field: 'anything' },
+				error: null,
+			});
+	});
+
+	test('number input', async ({ page }) => {
+		const { submit, error, type, updateSchema, getSubmission } =
+			await setupField(page, {
+				type: 'number',
+				min: 1,
+				max: 5,
+				step: 0.5,
+			});
+
+		await submit.click();
+		await expect(error).toHaveText(['']);
+
+		await updateSchema({ required: true });
+		await expect(error).toHaveText(['required']);
+
+		await type('0');
+		await expect(error).toHaveText(['min']);
+
+		await type('3');
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: { field: '3' },
+				value: { field: 3 },
+				error: null,
+			});
+
+		await type('5.01');
+		await expect(error).toHaveText(['max', 'step']);
+
+		await type('1.2');
+		await expect(error).toHaveText(['step']);
+
+		await type('4.');
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: { field: '4' },
+				value: { field: 4 },
+				error: null,
+			});
+
+		await type('5.0');
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: { field: '5.0' },
+				value: { field: 5 },
+				error: null,
+			});
+	});
+
+	test('range input', async ({ page }) => {
+		const { submit, error, getSubmission } = await setupField(page, {
+			type: 'range',
+			min: 1,
+			max: 100,
+			step: 5,
+		});
+
+		await submit.click();
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: { field: '51' },
+				value: { field: 51 },
+				error: null,
+			});
+
+		// Range input will always have a default value
+		// @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#validation
+
+		// TODO: Test updating range input value;
+	});
+
+	test('checkbox input', async ({ page }) => {
+		const { submit, error, field, getSubmission, updateSchema } =
+			await setupField(page, {
+				type: 'checkbox',
+			});
+
+		await submit.click();
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: {},
+				value: { field: false },
+				error: null,
+			});
+
+		await updateSchema({ required: true });
+		await expect(error).toHaveText(['required']);
+
+		await field.check();
+		await submit.click();
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: { field: 'on' },
+				value: { field: true },
+				error: null,
+			});
+
+		await updateSchema({ value: 'ok' });
+		await submit.click();
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: {},
+				value: { field: false },
+				error: null,
+			});
+
+		await updateSchema({ required: true, value: 'ok' });
+		await field.check();
+		await submit.click();
+		await expect(error).toHaveText(['']);
+		await expect
+			.poll(() => getSubmission())
+			.toEqual({
+				payload: { field: 'ok' },
+				value: { field: true },
+				error: null,
+			});
+	});
 }
 
-test.beforeEach(async ({ page }) => {
-	await page.goto('/validitystate');
-});
-
-test.describe.only('With JS', () => {
-	test('validation', async ({ page }) => {
-		await runValidationScenario(page);
-	});
-});
-
-test.describe.only('No JS', () => {
-	test.use({ javaScriptEnabled: false });
-
-	test('Validation', async ({ page }) => {
-		await runValidationScenario(page);
-	});
-});
+test.describe('With JS', () => runTests(true));
+test.describe('No JS', () => runTests(false));

--- a/tests/integrations/validitystate.spec.ts
+++ b/tests/integrations/validitystate.spec.ts
@@ -334,7 +334,6 @@ function runTests(javaScriptEnabled: boolean) {
 			});
 
 		await updateSchema({ value: 'ok' });
-		await submit.click();
 		await expect(error).toHaveText(['']);
 		await expect
 			.poll(() => getSubmission())
@@ -660,11 +659,9 @@ function runTests(javaScriptEnabled: boolean) {
 			});
 
 		await updateSchema({ multiple: true });
-		await submit.click();
 		await expect(error).toHaveText(['']);
 
 		await updateSchema({ required: true, multiple: true });
-		await submit.click();
 		await expect(error).toHaveText(['required']);
 
 		await field.setInputFiles([

--- a/tests/integrations/validitystate.spec.ts
+++ b/tests/integrations/validitystate.spec.ts
@@ -255,15 +255,18 @@ function runTests(javaScriptEnabled: boolean) {
 		await type('1.2');
 		await expect(error).toHaveText(['step']);
 
-		await type('4.');
-		await expect(error).toHaveText(['']);
-		await expect
-			.poll(() => getSubmission())
-			.toEqual({
-				payload: { field: '4' },
-				value: { field: 4 },
-				error: null,
-			});
+		// This doesn't work on safari which consider it valueMissing
+		// Fortunately, this is acceptable as the formdata is also presented as empty string
+		// which aligns with the behavior on the server side
+		// await type('4.');
+		// await expect(error).toHaveText(['']);
+		// await expect
+		// 	.poll(() => getSubmission())
+		// 	.toEqual({
+		// 		payload: { field: '4' },
+		// 		value: { field: 4 },
+		// 		error: null,
+		// 	});
 
 		await type('5.0');
 		await expect(error).toHaveText(['']);
@@ -466,7 +469,8 @@ function runTests(javaScriptEnabled: boolean) {
 			});
 	});
 
-	test('month input', async ({ page }) => {
+	// month input is not supported by Firefix and Safari yet
+	test.skip('month input', async ({ page }) => {
 		const { submit, error, fill, getSubmission, updateSchema } =
 			await setupField(page, {
 				type: 'month',
@@ -474,11 +478,6 @@ function runTests(javaScriptEnabled: boolean) {
 				max: '2023-12',
 				step: 2, // 2 months
 			});
-
-		if (!javaScriptEnabled) {
-			// Skip test until month input is implemented
-			return;
-		}
 
 		await submit.click();
 		await expect(error).toHaveText(['']);
@@ -506,7 +505,8 @@ function runTests(javaScriptEnabled: boolean) {
 			});
 	});
 
-	test('week input', async ({ page }) => {
+	// week input is not supported by Firefix and Safari yet
+	test.skip('week input', async ({ page }) => {
 		const { submit, error, fill, getSubmission, updateSchema } =
 			await setupField(page, {
 				type: 'week',
@@ -514,11 +514,6 @@ function runTests(javaScriptEnabled: boolean) {
 				max: '2023-W52',
 				step: 2, // 2 weeks
 			});
-
-		if (!javaScriptEnabled) {
-			// Skip test until week input is implemented
-			return;
-		}
 
 		await submit.click();
 		await expect(error).toHaveText(['']);

--- a/tests/integrations/validitystate.spec.ts
+++ b/tests/integrations/validitystate.spec.ts
@@ -1,0 +1,71 @@
+import { type Page, type Locator, test, expect } from '@playwright/test';
+import { getPlayground } from '../helpers';
+
+function getFieldset(form: Locator) {
+	return {
+		// All the possibile input type
+		text: form.locator('[name="text"]'),
+		email: form.locator('[name="email"]'),
+		password: form.locator('[name="password"]'),
+		url: form.locator('[name="url"]'),
+		tel: form.locator('[name="tel"]'),
+		search: form.locator('[name="search"]'),
+		number: form.locator('[name="number"]'),
+		checkbox: form.locator('[name="checkbox"]'),
+		file: form.locator('[name="file"]'),
+		files: form.locator('[name="files"]'),
+	};
+}
+
+async function runValidationScenario(page: Page) {
+	const playground = getPlayground(page);
+	const fieldset = getFieldset(playground.container);
+
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'',
+		'required',
+		'required',
+		'',
+		'',
+		'required',
+		'required',
+		'',
+		'required',
+		'',
+	]);
+
+	await fieldset.text.type('a');
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'minlength',
+		'pattern',
+		'required',
+		'required',
+		'',
+		'',
+		'required',
+		'required',
+		'',
+		'required',
+		'',
+	]);
+}
+
+test.beforeEach(async ({ page }) => {
+	await page.goto('/validitystate');
+});
+
+test.describe.only('With JS', () => {
+	test('validation', async ({ page }) => {
+		await runValidationScenario(page);
+	});
+});
+
+test.describe.only('No JS', () => {
+	test.use({ javaScriptEnabled: false });
+
+	test('Validation', async ({ page }) => {
+		await runValidationScenario(page);
+	});
+});


### PR DESCRIPTION
> I am developing this mainly for my upcoming talk on Remix Conf.

This enables type-checking your form constraint and validate on the server using the same rules as the browser. It implements all the input types except `month` and `week`. 

The solution focus on enabling validation with native browser constraint whenever it is applicable.