### PR TITLE
Resolve #145: Change initialError, descriptionId, and errorId to all-lowercase

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -29,7 +29,7 @@ function Example() {
         <form {...form.props}>
             <label htmlFor={message.id}>
             <input {...conform.input(message)}>
-            <div id={message.errorId} role="alert">
+            <div id={message.errorid} role="alert">
                 {message.error}
             </div>
             <button>Send</button>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -231,11 +231,11 @@ export default function LoginForm() {
           type="email"
           name={email.name}
           defaultValue={email.defaultValue}
-          autoFocus={Boolean(email.initialError)}
+          autoFocus={Boolean(email.initialerror)}
           aria-invalid={email.error ? true : undefined}
-          aria-describedby={email.errorId}
+          aria-describedby={email.errorid}
         />
-        <div id={email.errorId}>{email.error}</div>
+        <div id={email.errorid}>{email.error}</div>
       </div>
       <div>
         <label htmlFor={password.id}>Password</label>
@@ -243,11 +243,11 @@ export default function LoginForm() {
           type="password"
           id={password.id}
           name={password.name}
-          autoFocus={Boolean(password.initialError)}
+          autoFocus={Boolean(password.initialerror)}
           aria-invalid={password.error ? true : undefined}
-          aria-describedby={password.errorId}
+          aria-describedby={password.errorid}
         />
-        <div id={password.errorId}>{password.error}</div>
+        <div id={password.errorid}>{password.error}</div>
       </div>
       <button>Login</button>
     </Form>
@@ -269,12 +269,12 @@ export default function LoginForm() {
       <div>
         <label htmlFor={email.id}>Email</label>
         <input {...conform.input(email, { type: 'email' })} />
-        <div id={email.errorId}>{email.error}</div>
+        <div id={email.errorid}>{email.error}</div>
       </div>
       <div>
         <label htmlFor={password.id}>Password</label>
         <input {...conform.input(password, { type: 'password' })} />
-        <div id={password.errorId}>{password.error}</div>
+        <div id={password.errorid}>{password.error}</div>
       </div>
       <button>Login</button>
     </Form>

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -10,10 +10,10 @@ export interface FieldConfig<Schema = unknown> extends FieldConstraint<Schema> {
 	id?: string;
 	name: string;
 	defaultValue?: FieldValue<Schema>;
-	initialError?: Record<string, string | string[]>;
+	initialerror?: Record<string, string | string[]>;
 	form?: string;
-	descriptionId?: string;
-	errorId?: string;
+	descriptionid?: string;
+	errorid?: string;
 
 	/**
 	 * The frist error of the field

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -93,19 +93,19 @@ function getFormControlProps(
 		props.id = config.id;
 	}
 
-	if (config.descriptionId && options?.description) {
-		props['aria-describedby'] = config.descriptionId;
+	if (config.descriptionid && options?.description) {
+		props['aria-describedby'] = config.descriptionid;
 	}
 
-	if (config.errorId && config.error?.length) {
+	if (config.errorid && config.error?.length) {
 		props['aria-invalid'] = true;
 		props['aria-describedby'] =
-			config.descriptionId && options?.description
-				? `${config.errorId} ${config.descriptionId}`
-				: config.errorId;
+			config.descriptionid && options?.description
+				? `${config.errorid} ${config.descriptionid}`
+				: config.errorid;
 	}
 
-	if (config.initialError && Object.entries(config.initialError).length > 0) {
+	if (config.initialerror && Object.entries(config.initialerror).length > 0) {
 		props.autoFocus = true;
 	}
 

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -141,7 +141,7 @@ interface FormProps {
 
 interface Form {
 	id?: string;
-	errorId?: string;
+	errorid?: string;
 	error: string;
 	errors: string[];
 	ref: RefObject<HTMLFormElement>;
@@ -170,7 +170,7 @@ export function useForm<
 
 		return ([] as string[]).concat(config.lastSubmission.error['']);
 	});
-	const initialError = useMemo(() => {
+	const initialerror = useMemo(() => {
 		const submission = config.lastSubmission;
 
 		if (!submission) {
@@ -194,7 +194,7 @@ export function useForm<
 		defaultValue:
 			(config.lastSubmission?.payload as FieldValue<Schema>) ??
 			config.defaultValue,
-		initialError,
+		initialerror,
 		constraint: config.constraint,
 		form: config.id,
 	});
@@ -415,13 +415,13 @@ export function useForm<
 
 	if (config.id) {
 		form.id = config.id;
-		form.errorId = `${config.id}-error`;
+		form.errorid = `${config.id}-error`;
 		form.props.id = form.id;
 	}
 
-	if (form.errorId && form.errors.length > 0) {
+	if (form.errorid && form.errors.length > 0) {
 		form.props['aria-invalid'] = 'true';
-		form.props['aria-describedby'] = form.errorId;
+		form.props['aria-describedby'] = form.errorid;
 	}
 
 	return [form, fieldset];
@@ -448,7 +448,7 @@ export interface FieldsetConfig<Schema extends Record<string, any>> {
 	/**
 	 * An object describing the initial error of each field
 	 */
-	initialError?: Record<string, string | string[]>;
+	initialerror?: Record<string, string | string[]>;
 
 	/**
 	 * An object describing the constraint of each field
@@ -481,15 +481,15 @@ export function useFieldset<Schema extends Record<string, any>>(
 	const configRef = useRef(config);
 	const [error, setError] = useState<Record<string, string[] | undefined>>(
 		() => {
-			const initialError = config?.initialError;
+			const initialerror = config?.initialerror;
 
-			if (!initialError) {
+			if (!initialerror) {
 				return {};
 			}
 
 			const result: Record<string, string[]> = {};
 
-			for (const [name, message] of Object.entries(initialError)) {
+			for (const [name, message] of Object.entries(initialerror)) {
 				const [key, ...paths] = getPaths(name);
 
 				if (typeof key === 'string' && paths.length === 0) {
@@ -582,8 +582,8 @@ export function useFieldset<Schema extends Record<string, any>>(
 				const fieldsetConfig = config as FieldsetConfig<Schema>;
 				const constraint = fieldsetConfig.constraint?.[key];
 				const errors = error?.[key];
-				const initialError = Object.entries(
-					fieldsetConfig.initialError ?? {},
+				const initialerror = Object.entries(
+					fieldsetConfig.initialerror ?? {},
 				).reduce((result, [name, message]) => {
 					const [field, ...paths] = getPaths(name);
 
@@ -597,7 +597,7 @@ export function useFieldset<Schema extends Record<string, any>>(
 					...constraint,
 					name: fieldsetConfig.name ? `${fieldsetConfig.name}.${key}` : key,
 					defaultValue: fieldsetConfig.defaultValue?.[key],
-					initialError,
+					initialerror,
 					error: errors?.[0],
 					errors,
 				};
@@ -605,8 +605,8 @@ export function useFieldset<Schema extends Record<string, any>>(
 				if (fieldsetConfig.form) {
 					field.form = fieldsetConfig.form;
 					field.id = `${fieldsetConfig.form}-${field.name}`;
-					field.errorId = `${field.id}-error`;
-					field.descriptionId = `${field.id}-description`;
+					field.errorid = `${field.id}-error`;
+					field.descriptionid = `${field.id}-description`;
 				}
 
 				return field;
@@ -627,17 +627,17 @@ export function useFieldList<Payload = any>(
 ): Array<{ key: string } & FieldConfig<Payload>> {
 	const configRef = useRef(config);
 	const [error, setError] = useState(() => {
-		const initialError: Array<string[] | undefined> = [];
+		const initialerror: Array<string[] | undefined> = [];
 
-		for (const [name, message] of Object.entries(config?.initialError ?? {})) {
+		for (const [name, message] of Object.entries(config?.initialerror ?? {})) {
 			const [index, ...paths] = getPaths(name);
 
 			if (typeof index === 'number' && paths.length === 0) {
-				initialError[index] = ([] as string[]).concat(message ?? []);
+				initialerror[index] = ([] as string[]).concat(message ?? []);
 			}
 		}
 
-		return initialError;
+		return initialerror;
 	});
 	const [entries, setEntries] = useState<
 		Array<[string, FieldValue<Payload> | undefined]>
@@ -768,7 +768,7 @@ export function useFieldList<Payload = any>(
 
 	return entries.map(([key, defaultValue], index) => {
 		const errors = error[index];
-		const initialError = Object.entries(config.initialError ?? {}).reduce(
+		const initialerror = Object.entries(config.initialerror ?? {}).reduce(
 			(result, [name, message]) => {
 				const [field, ...paths] = getPaths(name);
 
@@ -783,7 +783,7 @@ export function useFieldList<Payload = any>(
 		const fieldConfig: FieldConfig<Payload> = {
 			name: `${config.name}[${index}]`,
 			defaultValue: defaultValue ?? config.defaultValue?.[index],
-			initialError,
+			initialerror,
 			error: errors?.[0],
 			errors,
 		};
@@ -791,8 +791,8 @@ export function useFieldList<Payload = any>(
 		if (config.form) {
 			fieldConfig.form = config.form;
 			fieldConfig.id = `${config.form}-${config.name}`;
-			fieldConfig.errorId = `${fieldConfig.id}-error`;
-			fieldConfig.descriptionId = `${fieldConfig.id}-description`;
+			fieldConfig.errorid = `${fieldConfig.id}-error`;
+			fieldConfig.descriptionid = `${fieldConfig.id}-description`;
 		}
 
 		return {

--- a/playground/app/components.tsx
+++ b/playground/app/components.tsx
@@ -117,7 +117,7 @@ export function Field({ label, inline, config, children }: FieldProps) {
 				</label>
 				{children}
 			</div>
-			<div id={config?.errorId} className="my-1 space-y-0.5">
+			<div id={config?.errorid} className="my-1 space-y-0.5">
 				{!config?.errors?.length ? (
 					<p className="text-pink-600 text-sm" />
 				) : (

--- a/playground/app/routes/input-attributes.tsx
+++ b/playground/app/routes/input-attributes.tsx
@@ -76,7 +76,7 @@ export default function Example() {
 	return (
 		<Form method="post" encType="multipart/form-data" {...form.props}>
 			<Playground title="Input attributes" lastSubmission={lastSubmission}>
-				<Alert id={form.errorId} errors={form.errors} />
+				<Alert id={form.errorid} errors={form.errors} />
 				<Field label="Title" config={title}>
 					<input
 						{...conform.input(title, {


### PR DESCRIPTION
This resolves [Issue-145](https://github.com/edmundhung/conform/issues/145) by renaming all instances of `initialError`, `descriptionId`, and `errorId` to all lowercase. 

It's also worth mentioning the [HTML Spec](https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes) says that all attributes get lowercased automatically _anyway_, so having attributes as lowercased at the source better matches that spec. 

If readability needed to be improved, the props could be changed to snake-case?