### PR TITLE
feat(conform-zod): support intersection with getFieldsetConstraint

### DIFF
--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -19,6 +19,11 @@ export function getFieldsetConstraint<Source extends z.ZodTypeAny>(
 			return getSchemaShape(schema.innerType());
 		} else if (schema instanceof z.ZodOptional) {
 			return getSchemaShape(schema.unwrap());
+		} else if (schema instanceof z.ZodIntersection) {
+			return {
+				...getSchemaShape(schema._def.left),
+				...getSchemaShape(schema._def.right),
+			};
 		}
 
 		return null;

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -131,9 +131,14 @@ test.describe('conform-zod', () => {
 
 		// // Union is supported too
 		expect(
-			getFieldsetConstraint(schema.and(z.object({ something: z.string() }))),
+			getFieldsetConstraint(
+				schema.and(
+					z.object({ text: z.string().optional(), something: z.string() }),
+				),
+			),
 		).toEqual({
 			...constraint,
+			text: { required: false },
 			something: { required: true },
 		});
 

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -91,7 +91,7 @@ test.describe('conform-zod', () => {
 	};
 
 	test('getFieldsetConstraint', () => {
-		expect(getFieldsetConstraint(schema)).toEqual({
+		const constraint = {
 			text: {
 				required: true,
 				minLength: 1,
@@ -121,7 +121,31 @@ test.describe('conform-zod', () => {
 				required: true,
 				multiple: true,
 			},
+		};
+
+		expect(getFieldsetConstraint(schema)).toEqual(constraint);
+
+		// Non-object schemas will be ignored
+		expect(getFieldsetConstraint(z.string())).toEqual({});
+		expect(getFieldsetConstraint(z.string().array())).toEqual({});
+
+		// // Union is supported too
+		expect(
+			getFieldsetConstraint(schema.and(z.object({ something: z.string() }))),
+		).toEqual({
+			...constraint,
+			something: { required: true },
 		});
+
+		// Discriminated union is not supported at the moment
+		expect(
+			getFieldsetConstraint(
+				z.discriminatedUnion('type', [
+					z.object({ type: z.literal('a'), foo: z.string().min(1, 'min') }),
+					z.object({ type: z.literal('b'), bar: z.string().min(1, 'min') }),
+				]),
+			),
+		).toEqual({});
 	});
 
 	test('parse', () => {


### PR DESCRIPTION
It should merge the derived constraint from both side with the right one override the left one.
 
```tsx
const constraint = getFieldsetConstraint(
    z
    .object({ a: z.string() })
    .and(z.object({ a: z.string().optional(), b: z.string() }))
);
// { a: { required: false }, b: { required: true } }
```