### PR TITLE
build: ESM types masquerading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ pids
 # Build result
 /packages/*/*.js
 /packages/*/*.cjs
+/packages/*/*.mjs
 /packages/*/*.d.ts
 /packages/*/LICENSE
 /packages/*/_virtual

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"watch:ts": "npm run build:ts -- --watch",
 		"guide": "npm run dev --workspace=guide",
 		"playground": "npm run dev --workspace=playground",
-		"prebuild": "rimraf --glob ./packages/**/*.{d.ts,cjs,js,tsbuildinfo}",
+		"prebuild": "rimraf --glob ./packages/**/*.{d.ts,cjs,mjs,js,tsbuildinfo}",
 		"pretest": "npm run build --workspace=playground",
 		"test": "playwright test",
 		"lint": "eslint --ignore-path .gitignore --cache --ext .js,.jsx,.ts,.tsx .",

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -11,7 +11,7 @@ export {
 	focusFormControl,
 	createSubmitter,
 	requestSubmit,
-} from './dom';
+} from './dom.js';
 
 export {
 	formatPaths as getName,
@@ -19,7 +19,7 @@ export {
 	getFormData,
 	getValidationMessage,
 	getErrors,
-} from './formdata';
+} from './formdata.js';
 
 export {
 	type ListCommand,
@@ -31,13 +31,13 @@ export {
 	parseListCommand,
 	updateList,
 	requestIntent,
-} from './intent';
+} from './intent.js';
 
-export { type Submission, parse } from './parse';
+export { type Submission, parse } from './parse.js';
 
 export {
 	type FieldConstraint,
 	type FieldsetConstraint,
 	type ResolveType,
 	type KeysOf,
-} from './types';
+} from './types.js';

--- a/packages/conform-dom/intent.ts
+++ b/packages/conform-dom/intent.ts
@@ -1,4 +1,4 @@
-import { createSubmitter, requestSubmit } from './dom';
+import { createSubmitter, requestSubmit } from './dom.js';
 
 export interface IntentButtonProps {
 	name: typeof INTENT;

--- a/packages/conform-dom/package.json
+++ b/packages/conform-dom/package.json
@@ -4,17 +4,16 @@
 	"homepage": "https://conform.guide",
 	"license": "MIT",
 	"version": "0.7.0-pre.0",
-	"type": "module",
-	"main": "index.cjs",
-	"module": "index.js",
+	"main": "index.js",
+	"module": "index.mjs",
 	"types": "index.d.ts",
 	"exports": {
 		".": {
 			"types": "./index.d.ts",
-			"module": "./index.js",
-			"import": "./index.js",
-			"require": "./index.cjs",
-			"default": "./index.js"
+			"module": "./index.mjs",
+			"import": "./index.mjs",
+			"require": "./index.js",
+			"default": "./index.mjs"
 		}
 	},
 	"repository": {

--- a/packages/conform-dom/parse.ts
+++ b/packages/conform-dom/parse.ts
@@ -1,5 +1,5 @@
-import { resolve, setValue } from './formdata';
-import { getIntent, parseListCommand, updateList } from './intent';
+import { resolve, setValue } from './formdata.js';
+import { getIntent, parseListCommand, updateList } from './intent.js';
 
 export type Submission<Schema = any> = {
 	intent: string;

--- a/packages/conform-dom/tsconfig.json
+++ b/packages/conform-dom/tsconfig.json
@@ -1,10 +1,9 @@
 {
 	"compilerOptions": {
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"lib": ["ESNext", "DOM", "DOM.Iterable"],
 		"target": "ES2020",
-		"module": "ES2020",
-		"moduleResolution": "node",
-		"allowSyntheticDefaultImports": true,
+		"moduleResolution": "node16",
+		"allowSyntheticDefaultImports": false,
 		"strict": true,
 		"declaration": true,
 		"emitDeclarationOnly": true,

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -4,7 +4,7 @@ import {
 	type Primitive,
 	VALIDATION_UNDEFINED,
 	VALIDATION_SKIPPED,
-} from './hooks';
+} from './hooks.js';
 import type { CSSProperties, HTMLInputTypeAttribute } from 'react';
 
 interface FormControlProps {

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -17,5 +17,5 @@ export {
 	useFieldList,
 	useInputEvent,
 	validateConstraint,
-} from './hooks';
-export * as conform from './helpers';
+} from './hooks.js';
+export * as conform from './helpers.js';

--- a/packages/conform-react/package.json
+++ b/packages/conform-react/package.json
@@ -4,17 +4,16 @@
 	"homepage": "https://conform.guide",
 	"license": "MIT",
 	"version": "0.7.0-pre.0",
-	"type": "module",
-	"main": "index.cjs",
-	"module": "index.js",
+	"main": "index.js",
+	"module": "index.mjs",
 	"types": "index.d.ts",
 	"exports": {
 		".": {
 			"types": "./index.d.ts",
-			"module": "./index.js",
-			"import": "./index.js",
-			"require": "./index.cjs",
-			"default": "./index.js"
+			"module": "./index.mjs",
+			"import": "./index.mjs",
+			"require": "./index.js",
+			"default": "./index.mjs"
 		}
 	},
 	"repository": {

--- a/packages/conform-react/tsconfig.json
+++ b/packages/conform-react/tsconfig.json
@@ -1,10 +1,9 @@
 {
 	"compilerOptions": {
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"lib": ["ESNext", "DOM", "DOM.Iterable"],
 		"target": "ES2020",
-		"module": "ES2020",
-		"moduleResolution": "node",
-		"allowSyntheticDefaultImports": true,
+		"moduleResolution": "node16",
+		"allowSyntheticDefaultImports": false,
 		"strict": true,
 		"declaration": true,
 		"emitDeclarationOnly": true,

--- a/packages/conform-validitystate/package.json
+++ b/packages/conform-validitystate/package.json
@@ -4,17 +4,16 @@
 	"homepage": "https://conform.guide",
 	"license": "MIT",
 	"version": "0.2.0",
-	"type": "module",
-	"main": "index.cjs",
-	"module": "index.js",
+	"main": "index.js",
+	"module": "index.mjs",
 	"types": "index.d.ts",
 	"exports": {
 		".": {
 			"types": "./index.d.ts",
-			"module": "./index.js",
-			"import": "./index.js",
-			"require": "./index.cjs",
-			"default": "./index.js"
+			"module": "./index.mjs",
+			"import": "./index.mjs",
+			"require": "./index.js",
+			"default": "./index.mjs"
 		}
 	},
 	"repository": {

--- a/packages/conform-validitystate/tsconfig.json
+++ b/packages/conform-validitystate/tsconfig.json
@@ -1,10 +1,9 @@
 {
 	"compilerOptions": {
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"lib": ["ESNext", "DOM", "DOM.Iterable"],
 		"target": "ES2020",
-		"module": "ES2020",
-		"moduleResolution": "node",
-		"allowSyntheticDefaultImports": true,
+		"moduleResolution": "node16",
+		"allowSyntheticDefaultImports": false,
 		"strict": true,
 		"declaration": true,
 		"emitDeclarationOnly": true,

--- a/packages/conform-yup/package.json
+++ b/packages/conform-yup/package.json
@@ -4,17 +4,16 @@
 	"homepage": "https://conform.guide",
 	"license": "MIT",
 	"version": "0.7.0-pre.0",
-	"type": "module",
-	"main": "index.cjs",
-	"module": "index.js",
+	"main": "index.js",
+	"module": "index.mjs",
 	"types": "index.d.ts",
 	"exports": {
 		".": {
 			"types": "./index.d.ts",
-			"module": "./index.js",
-			"import": "./index.js",
-			"require": "./index.cjs",
-			"default": "./index.js"
+			"module": "./index.mjs",
+			"import": "./index.mjs",
+			"require": "./index.js",
+			"default": "./index.mjs"
 		}
 	},
 	"repository": {

--- a/packages/conform-yup/tsconfig.json
+++ b/packages/conform-yup/tsconfig.json
@@ -1,10 +1,9 @@
 {
 	"compilerOptions": {
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"lib": ["ESNext", "DOM", "DOM.Iterable"],
 		"target": "ES2020",
-		"module": "ES2020",
-		"moduleResolution": "node",
-		"allowSyntheticDefaultImports": true,
+		"moduleResolution": "node16",
+		"allowSyntheticDefaultImports": false,
 		"strict": true,
 		"declaration": true,
 		"emitDeclarationOnly": true,

--- a/packages/conform-zod/package.json
+++ b/packages/conform-zod/package.json
@@ -4,17 +4,16 @@
 	"homepage": "https://conform.guide",
 	"license": "MIT",
 	"version": "0.7.0-pre.0",
-	"type": "module",
-	"main": "index.cjs",
-	"module": "index.js",
+	"main": "index.js",
+	"module": "index.mjs",
 	"types": "index.d.ts",
 	"exports": {
 		".": {
 			"types": "./index.d.ts",
-			"module": "./index.js",
-			"import": "./index.js",
-			"require": "./index.cjs",
-			"default": "./index.js"
+			"module": "./index.mjs",
+			"import": "./index.mjs",
+			"require": "./index.js",
+			"default": "./index.mjs"
 		}
 	},
 	"repository": {

--- a/packages/conform-zod/tsconfig.json
+++ b/packages/conform-zod/tsconfig.json
@@ -1,10 +1,9 @@
 {
 	"compilerOptions": {
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"lib": ["ESNext", "DOM", "DOM.Iterable"],
 		"target": "ES2020",
-		"module": "ES2020",
-		"moduleResolution": "node",
-		"allowSyntheticDefaultImports": true,
+		"moduleResolution": "node16",
+		"allowSyntheticDefaultImports": false,
 		"strict": true,
 		"declaration": true,
 		"emitDeclarationOnly": true,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,6 +18,7 @@ function configurePackage(name) {
 			dir: outputDir,
 			format: 'esm',
 			preserveModules: true,
+			entryFileNames: '[name].mjs',
 		},
 		plugins: [
 			babel({
@@ -44,7 +45,6 @@ function configurePackage(name) {
 			dir: outputDir,
 			format: 'cjs',
 			preserveModules: true,
-			entryFileNames: '[name].cjs',
 			exports: 'auto',
 		},
 		plugins: [


### PR DESCRIPTION
This tries to fix the type issues from #159 by masquerading the types as CJS as explained on https://github.com/gvergnaud/ts-pattern/pull/155#issuecomment-1537135616.

Another reference on how typescript works with ESM/CJS: https://github.com/microsoft/TypeScript/issues/49299