### PR TITLE
feat!: combine list intent

### DIFF
--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -68,6 +68,20 @@ export function formatPaths(paths: Array<string | number>): string {
 	}, '');
 }
 
+export function getValue(target: any, name: string): any {
+	let paths = getPaths(name);
+	let length = paths.length;
+	let index = -1;
+	let pointer = target;
+
+	while (pointer != null && ++index < length) {
+		let key = paths[index];
+		pointer = pointer[key];
+	}
+
+	return pointer;
+}
+
 /**
  * Assign a value to a target object by following the paths on the name
  */

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -19,6 +19,8 @@ export {
 	getFormData,
 	getValidationMessage,
 	getErrors,
+	getValue,
+	resolve,
 } from './formdata.js';
 
 export {

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -22,13 +22,10 @@ export {
 } from './formdata.js';
 
 export {
-	type ListCommand,
 	INTENT,
-	getScope,
-	isSubmitting,
+	parseIntent,
 	validate,
 	list,
-	parseListCommand,
 	updateList,
 	requestIntent,
 } from './intent.js';

--- a/packages/conform-dom/intent.ts
+++ b/packages/conform-dom/intent.ts
@@ -1,4 +1,5 @@
 import { createSubmitter, requestSubmit } from './dom.js';
+import { type Pretty } from './types.js';
 
 export interface IntentButtonProps {
 	name: typeof INTENT;
@@ -6,34 +7,58 @@ export interface IntentButtonProps {
 	formNoValidate?: boolean;
 }
 
-export type ListCommand<Schema = unknown> =
-	| { type: 'prepend'; scope: string; payload: { defaultValue: Schema } }
-	| { type: 'append'; scope: string; payload: { defaultValue: Schema } }
-	| {
-			type: 'replace';
-			scope: string;
-			payload: { defaultValue: Schema; index: number };
-	  }
-	| { type: 'remove'; scope: string; payload: { index: number } }
-	| { type: 'reorder'; scope: string; payload: { from: number; to: number } };
+export type ListIntentPayload<Schema = unknown> =
+	| { name: string; operation: 'prepend'; defaultValue?: Schema }
+	| { name: string; operation: 'append'; defaultValue?: Schema }
+	| { name: string; operation: 'replace'; defaultValue: Schema; index: number }
+	| { name: string; operation: 'remove'; index: number }
+	| { name: string; operation: 'reorder'; from: number; to: number };
 
 export interface ListCommandButtonBuilder {
 	append<Schema>(
 		name: string,
-		payload?: { defaultValue: Schema },
+		payload?: Pretty<
+			Omit<
+				Extract<ListIntentPayload<Schema>, { operation: 'append' }>,
+				'name' | 'operation'
+			>
+		>,
 	): IntentButtonProps;
 	prepend<Schema>(
 		name: string,
-		payload?: { defaultValue: Schema },
+		payload?: Pretty<
+			Omit<
+				Extract<ListIntentPayload<Schema>, { operation: 'prepend' }>,
+				'name' | 'operation'
+			>
+		>,
 	): IntentButtonProps;
 	replace<Schema>(
 		name: string,
-		payload: { defaultValue: Schema; index: number },
+		payload: Pretty<
+			Omit<
+				Extract<ListIntentPayload<Schema>, { operation: 'replace' }>,
+				'name' | 'operation'
+			>
+		>,
 	): IntentButtonProps;
-	remove(name: string, payload: { index: number }): IntentButtonProps;
+	remove(
+		name: string,
+		payload: Pretty<
+			Omit<
+				Extract<ListIntentPayload, { operation: 'remove' }>,
+				'name' | 'operation'
+			>
+		>,
+	): IntentButtonProps;
 	reorder(
 		name: string,
-		payload: { from: number; to: number },
+		payload: Pretty<
+			Omit<
+				Extract<ListIntentPayload, { operation: 'reorder' }>,
+				'name' | 'operation'
+			>
+		>,
 	): IntentButtonProps;
 }
 
@@ -65,10 +90,10 @@ export function getIntent(payload: FormData | URLSearchParams): string {
  *
  * @see https://conform.guide/api/react#validate
  */
-export function validate(field?: string): IntentButtonProps {
+export function validate(field: string): IntentButtonProps {
 	return {
 		name: INTENT,
-		value: field ? `validate/${field}` : 'validate',
+		value: `validate/${field}`,
 		formNoValidate: true,
 	};
 }
@@ -101,84 +126,62 @@ export function requestIntent(
  * @see https://conform.guide/api/react#list
  */
 export const list = new Proxy({} as ListCommandButtonBuilder, {
-	get(_target, type: any) {
-		return (scope: string, payload = {}): IntentButtonProps => ({
+	get(_target, operation: any) {
+		return (name: string, payload = {}): IntentButtonProps => ({
 			name: INTENT,
-			value: `list/${type}/${scope}/${JSON.stringify(payload)}`,
+			value: `list/${JSON.stringify({ name, operation, ...payload })}`,
 			formNoValidate: true,
 		});
 	},
 });
 
-export function isSubmitting(intent: string): boolean {
-	const [type] = intent.split('/', 1);
+export function parseIntent<Schema>(intent: string):
+	| {
+			type: 'validate';
+			payload: string;
+	  }
+	| {
+			type: 'list';
+			payload: ListIntentPayload<Schema> | Array<ListIntentPayload<Schema>>;
+	  }
+	| null {
+	const [type, payload] = intent.split('/', 2);
 
-	return type !== 'validate' && type !== 'list';
-}
-
-export function getScope(intent: string): string | null {
-	const [type, ...rest] = intent.split('/');
-
-	switch (type) {
-		case 'validate':
-			return rest.length > 0 ? rest.join('/') : null;
-		case 'list':
-			return parseListCommand(intent)?.scope ?? null;
-		default:
-			return null;
-	}
-}
-
-export function parseListCommand<Schema = unknown>(
-	intent: string,
-): ListCommand<Schema> | null {
-	try {
-		const [group, type, scope, json] = intent.split('/');
-
-		if (
-			group !== 'list' ||
-			!['prepend', 'append', 'replace', 'remove', 'reorder'].includes(type) ||
-			!scope
-		) {
-			return null;
+	if (typeof payload !== 'undefined') {
+		try {
+			switch (type) {
+				case 'validate':
+					return { type, payload };
+				case 'list':
+					return { type, payload: JSON.parse(payload) };
+			}
+		} catch (error) {
+			console.warn('Failed to parse intent;', error);
 		}
-
-		const payload = JSON.parse(json);
-
-		return {
-			// @ts-expect-error
-			type,
-			scope,
-			payload,
-		};
-	} catch (error) {
-		return null;
 	}
+
+	return null;
 }
 
 export function updateList<Schema>(
 	list: Array<Schema>,
-	command: ListCommand<Schema>,
+	payload: ListIntentPayload<Schema>,
 ): Array<Schema> {
-	switch (command.type) {
+	switch (payload.operation) {
 		case 'prepend':
-			list.unshift(command.payload.defaultValue);
+			list.unshift(payload.defaultValue as any);
 			break;
 		case 'append':
-			list.push(command.payload.defaultValue);
+			list.push(payload.defaultValue as any);
 			break;
 		case 'replace':
-			list.splice(command.payload.index, 1, command.payload.defaultValue);
+			list.splice(payload.index, 1, payload.defaultValue);
 			break;
 		case 'remove':
-			list.splice(command.payload.index, 1);
+			list.splice(payload.index, 1);
 			break;
 		case 'reorder':
-			list.splice(
-				command.payload.to,
-				0,
-				...list.splice(command.payload.from, 1),
-			);
+			list.splice(payload.to, 0, ...list.splice(payload.from, 1));
 			break;
 		default:
 			throw new Error('Unknown list command received');

--- a/packages/conform-dom/intent.ts
+++ b/packages/conform-dom/intent.ts
@@ -8,9 +8,25 @@ export interface IntentButtonProps {
 }
 
 export type ListIntentPayload<Schema = unknown> =
-	| { name: string; operation: 'prepend'; defaultValue?: Schema }
-	| { name: string; operation: 'append'; defaultValue?: Schema }
-	| { name: string; operation: 'replace'; defaultValue: Schema; index: number }
+	| {
+			name: string;
+			operation: 'prepend';
+			defaultValue?: Schema;
+			defaultValueFrom?: string;
+	  }
+	| {
+			name: string;
+			operation: 'append';
+			defaultValue?: Schema;
+			defaultValueFrom?: string;
+	  }
+	| {
+			name: string;
+			operation: 'replace';
+			defaultValue: Schema;
+			defaultValueFrom?: string;
+			index: number;
+	  }
 	| { name: string; operation: 'remove'; index: number }
 	| { name: string; operation: 'reorder'; from: number; to: number };
 
@@ -82,11 +98,11 @@ export function createIntent(type: string, payload: string): IntentButtonProps {
  * @see https://conform.guide/api/react#list
  */
 export const list = {
-	combine(...intents: string[]): IntentButtonProps {
+	combine(...intents: IntentButtonProps[]): IntentButtonProps {
 		let payload: Array<ListIntentPayload> = [];
 
 		for (const intent of intents) {
-			const parsed = parseIntent(intent);
+			const parsed = parseIntent(intent.value);
 
 			if (parsed?.type !== 'list') {
 				throw new Error('Only list intents can be combined');

--- a/packages/conform-dom/parse.ts
+++ b/packages/conform-dom/parse.ts
@@ -1,4 +1,4 @@
-import { resolve, setValue } from './formdata.js';
+import { getValue, resolve, setValue } from './formdata.js';
 import { getIntent, parseIntent, updateList } from './intent.js';
 
 export type Submission<Schema = any> = {
@@ -66,6 +66,19 @@ export function parse<Schema>(
 			setValue(submission.payload, payload.name, (list) => {
 				if (typeof list !== 'undefined' && !Array.isArray(list)) {
 					throw new Error('The list command can only be applied to a list');
+				}
+
+				if (
+					(payload.operation === 'append' ||
+						payload.operation === 'prepend' ||
+						payload.operation === 'replace') &&
+					payload.defaultValueFrom
+				) {
+					const value = getValue(submission.payload, payload.defaultValueFrom);
+
+					if (value) {
+						payload.defaultValue = value;
+					}
 				}
 
 				return updateList(list ?? [], payload);

--- a/packages/conform-dom/types.ts
+++ b/packages/conform-dom/types.ts
@@ -1,3 +1,5 @@
+export type Pretty<T> = { [K in keyof T]: T[K] } & {};
+
 export type FieldConstraint<Schema = any> = {
 	required?: boolean;
 	minLength?: number;

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -2,7 +2,6 @@ import {
 	type FieldConstraint,
 	type FieldElement,
 	type FieldsetConstraint,
-	type ListCommand,
 	type Submission,
 	type KeysOf,
 	type ResolveType,
@@ -12,22 +11,20 @@ import {
 	getPaths,
 	isFieldElement,
 	parse,
-	parseListCommand,
 	updateList,
 	validate,
 	requestIntent,
 	getValidationMessage,
 	getErrors,
-	getScope,
 	getFormAction,
 	getFormEncType,
 	getFormMethod,
 	getFormControls,
 	focusFirstInvalidControl,
 	isFocusableFormControl,
-	isSubmitting,
 	focusFormControl,
 	INTENT,
+	parseIntent,
 } from '@conform-to/dom';
 import {
 	type FormEvent,
@@ -383,10 +380,31 @@ export function useForm<
 			return {};
 		}
 
-		const scope = getScope(submission.intent);
-		return scope === null
-			? submission.error
-			: { [scope]: submission.error[scope] };
+		const intent = parseIntent(submission.intent);
+		const names: string[] = [];
+
+		switch (intent?.type) {
+			case 'validate':
+				names.push(intent.payload);
+				break;
+			case 'list':
+				names.push(
+					...(Array.isArray(intent.payload)
+						? intent.payload.map(({ name }) => name)
+						: [intent.payload.name]),
+				);
+				break;
+		}
+
+		if (names.length === 0) {
+			return submission.error;
+		}
+
+		return names.reduce<Record<string, string | string[]>>((result, name) => {
+			result[name] = submission.error[name];
+
+			return result;
+		}, {});
 	}, [config.lastSubmission]);
 	const fieldset = useFieldset(ref, {
 		defaultValue:
@@ -514,7 +532,7 @@ export function useForm<
 
 					if (
 						hasClientValidation &&
-						(isSubmitting(submission.intent)
+						(parseIntent(submission.intent) === null
 							? shouldValidate && !isValid
 							: !shouldFallbackToServer)
 					) {
@@ -691,35 +709,46 @@ export function useFieldList<Schema extends Array<any> | undefined>(
 				return;
 			}
 
-			const command = parseListCommand<
-				ListCommand<FieldValue<Schema extends Array<infer Item> ? Item : never>>
+			const intent = parseIntent<
+				FieldValue<Schema extends Array<infer Item> ? Item : never>
 			>(event.detail);
 
-			if (command?.scope !== configRef.current.name) {
+			if (intent?.type !== 'list') {
 				// Ensure the scope of the listener are limited to specific field name
 				return;
 			}
 
+			const changes = Array.isArray(intent.payload)
+				? intent.payload
+				: [intent.payload];
+			const intents = changes.filter(
+				(payload) => payload.name === configRef.current.name,
+			);
+
+			if (intents.length === 0) {
+				return;
+			}
+
 			setEntries((entries) => {
-				switch (command.type) {
-					case 'append':
-					case 'prepend':
-					case 'replace':
-						return updateList([...(entries ?? [])], {
-							...command,
-							payload: {
-								...command.payload,
-								defaultValue: [
-									`${Date.now()}`,
-									// @ts-expect-error unknown type as it is sent through network
-									command.payload.defaultValue,
-								],
-							},
-						});
-					default: {
-						return updateList([...(entries ?? [])], command);
+				let list = [...entries];
+
+				for (const payload of intents) {
+					switch (payload.operation) {
+						case 'append':
+						case 'prepend':
+						case 'replace':
+							list = updateList(list, {
+								...payload,
+								defaultValue: [`${Date.now()}`, payload.defaultValue],
+							});
+							break;
+						default:
+							list = updateList([...(entries ?? [])], payload);
+							break;
 					}
 				}
+
+				return list;
 			});
 			setError((error) => {
 				let errorList: Array<string[] | undefined> = [];
@@ -730,21 +759,19 @@ export function useFieldList<Schema extends Array<any> | undefined>(
 					}
 				}
 
-				switch (command.type) {
-					case 'append':
-					case 'prepend':
-					case 'replace':
-						errorList = updateList(errorList, {
-							...command,
-							payload: {
-								...command.payload,
+				for (const payload of intents) {
+					switch (payload.operation) {
+						case 'append':
+						case 'prepend':
+						case 'replace':
+							errorList = updateList(errorList, {
+								...payload,
 								defaultValue: undefined,
-							},
-						} as ListCommand<string[] | undefined>);
-						break;
-					default: {
-						errorList = updateList(errorList, command);
-						break;
+							});
+							break;
+						default:
+							errorList = updateList(errorList, payload);
+							break;
 					}
 				}
 
@@ -1193,14 +1220,15 @@ export function reportSubmission(
 		}
 	}
 
-	const scope = getScope(submission.intent);
+	const intent = parseIntent(submission.intent);
+	const names = getNames(intent);
 
 	for (const element of getFormControls(form)) {
 		const elementName =
 			element.name !== FORM_ERROR_ELEMENT_NAME ? element.name : '';
 		const messages = normalizeError(submission.error[elementName]);
 
-		if (scope === null || scope === elementName) {
+		if (names.length === 0 || names.includes(elementName)) {
 			element.dataset.conformTouched = 'true';
 		}
 
@@ -1215,15 +1243,10 @@ export function reportSubmission(
 		}
 	}
 
-	if (
-		isSubmitting(submission.intent) ||
-		isFocusedOnIntentButton(form, submission.intent)
-	) {
-		if (scope) {
-			focusFormControl(form, scope);
-		} else {
-			focusFirstInvalidControl(form);
-		}
+	if (!intent) {
+		focusFirstInvalidControl(form);
+	} else if (isFocusedOnIntentButton(form, submission.intent)) {
+		focusFormControl(form, names[0]);
 	}
 }
 
@@ -1243,4 +1266,23 @@ export function isFocusedOnIntentButton(
 		element.name === INTENT &&
 		element.value === intent
 	);
+}
+
+export function getNames(intent: ReturnType<typeof parseIntent>): string[] {
+	const names: string[] = [];
+
+	switch (intent?.type) {
+		case 'validate':
+			names.push(intent.payload);
+			break;
+		case 'list':
+			names.push(
+				...(Array.isArray(intent.payload)
+					? intent.payload.map(({ name }) => name)
+					: [intent.payload.name]),
+			);
+			break;
+	}
+
+	return names;
 }

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -381,20 +381,7 @@ export function useForm<
 		}
 
 		const intent = parseIntent(submission.intent);
-		const names: string[] = [];
-
-		switch (intent?.type) {
-			case 'validate':
-				names.push(intent.payload);
-				break;
-			case 'list':
-				names.push(
-					...(Array.isArray(intent.payload)
-						? intent.payload.map(({ name }) => name)
-						: [intent.payload.name]),
-				);
-				break;
-		}
+		const names = getNames(intent);
 
 		if (names.length === 0) {
 			return submission.error;

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -25,6 +25,8 @@ import {
 	focusFormControl,
 	INTENT,
 	parseIntent,
+	resolve,
+	getValue,
 } from '@conform-to/dom';
 import {
 	type FormEvent,
@@ -716,6 +718,9 @@ export function useFieldList<Schema extends Array<any> | undefined>(
 				return;
 			}
 
+			const formData = new FormData(form);
+			const data = resolve(formData);
+
 			setEntries((entries) => {
 				let list = [...entries];
 
@@ -723,12 +728,21 @@ export function useFieldList<Schema extends Array<any> | undefined>(
 					switch (payload.operation) {
 						case 'append':
 						case 'prepend':
-						case 'replace':
+						case 'replace': {
+							if (payload.defaultValueFrom) {
+								const value = getValue(data, payload.defaultValueFrom);
+
+								if (value) {
+									payload.defaultValue = value;
+								}
+							}
+
 							list = updateList(list, {
 								...payload,
 								defaultValue: [`${Date.now()}`, payload.defaultValue],
 							});
 							break;
+						}
 						default:
 							list = updateList([...(entries ?? [])], payload);
 							break;

--- a/playground/app/components.tsx
+++ b/playground/app/components.tsx
@@ -101,7 +101,7 @@ interface FieldProps {
 
 export function Field({ label, inline, config, children }: FieldProps) {
 	return (
-		<div className="mb-4">
+		<div className="flex-1 mb-4">
 			<div
 				className={
 					inline

--- a/playground/app/routes/multiple-lists.tsx
+++ b/playground/app/routes/multiple-lists.tsx
@@ -1,0 +1,157 @@
+import { conform, useFieldList, useForm, list } from '@conform-to/react';
+import { parse } from '@conform-to/zod';
+import type { ActionArgs, LoaderArgs } from '@remix-run/node';
+import { json } from '@remix-run/node';
+import { Form, useActionData, useLoaderData } from '@remix-run/react';
+import { z } from 'zod';
+import { Playground, Field, Alert } from '~/components';
+
+const schema = z.object({
+	task: z.string(),
+	pending: z.string().array().optional(),
+	todos: z.string().array().optional(),
+});
+
+export async function loader({ request }: LoaderArgs) {
+	const url = new URL(request.url);
+
+	return {
+		noClientValidate: url.searchParams.get('noClientValidate') === 'yes',
+	};
+}
+
+export async function action({ request }: ActionArgs) {
+	const formData = await request.formData();
+	const submission = parse(formData, { schema });
+
+	return json(submission);
+}
+
+export default function SimpleList() {
+	const { noClientValidate } = useLoaderData<typeof loader>();
+	const lastSubmission = useActionData();
+	const [form, { task, pending, todos }] = useForm({
+		lastSubmission,
+		onValidate: !noClientValidate
+			? ({ formData }) => parse(formData, { schema })
+			: undefined,
+	});
+	console.log('rendered');
+	const pendingList = useFieldList(form.ref, {
+		...pending,
+		defaultValue: pending.defaultValue ?? [],
+	});
+	const todoList = useFieldList(form.ref, {
+		...todos,
+		defaultValue: todos.defaultValue ?? [],
+	});
+
+	return (
+		<Form method="post" {...form.props}>
+			<Playground title="Multiple lists" lastSubmission={lastSubmission}>
+				<div className="flex flex-row items-end gap-2">
+					<Field label="Task" config={task}>
+						<input
+							className="h-10"
+							{...conform.input(task, { type: 'text' })}
+							autoComplete="off"
+						/>
+					</Field>
+					<div className="mb-4">
+						<button
+							className="rounded-md border p-2 my-1 h-10 hover:border-black"
+							{...list.append(pending.name, { defaultValueFrom: task.name })}
+						>
+							Add
+						</button>
+					</div>
+				</div>
+
+				<Field label="Pending tasks" config={pending}>
+					<div className="my-2">
+						{pendingList.length === 0 ? (
+							<div className="rounded flex items-center justify-center h-10 bg-gray-100 text-gray-500">
+								No tasks
+							</div>
+						) : (
+							<ol className="flex-1">
+								{pendingList.map((item, index) => (
+									<li key={item.key} className="border rounded-md p-4 mb-4">
+										<input {...conform.input(item, { hidden: true })} />
+										<Field label={`Pending #${index + 1}`}>
+											{item.defaultValue}
+										</Field>
+										<div className="flex flex-row gap-2">
+											<button
+												className="rounded-md border p-2 hover:border-black"
+												{...list.combine(
+													list.append(todos.name, {
+														defaultValueFrom: item.name,
+													}),
+													list.remove(pending.name, { index }),
+												)}
+											>
+												Priortize
+											</button>
+											{index > 0 ? (
+												<button
+													className="rounded-md border p-2 hover:border-black"
+													{...list.reorder(pending.name, {
+														from: index,
+														to: 0,
+													})}
+												>
+													Move to top
+												</button>
+											) : null}
+										</div>
+									</li>
+								))}
+							</ol>
+						)}
+					</div>
+				</Field>
+
+				<Field label="Urgent tasks" config={todos}>
+					<div className="my-2">
+						{todoList.length === 0 ? (
+							<div className="rounded flex items-center justify-center h-10 bg-gray-100 text-gray-500">
+								No tasks
+							</div>
+						) : (
+							<ol className="flex-1">
+								{todoList.map((item, index) => (
+									<li key={item.key} className="border rounded-md p-4 mb-4">
+										<input {...conform.input(item, { hidden: true })} />
+										<Field label={`Todo #${index + 1}`}>
+											{item.defaultValue}
+										</Field>
+										<div className="flex flex-row gap-2">
+											<button
+												className="rounded-md border p-2 hover:border-black"
+												{...list.remove(todos.name, { index })}
+											>
+												Complete
+											</button>
+											<button
+												className="rounded-md border p-2 hover:border-black"
+												{...list.combine(
+													list.prepend(pending.name, {
+														defaultValueFrom: item.name,
+													}),
+													list.remove(todos.name, { index }),
+												)}
+											>
+												Depriortize
+											</button>
+										</div>
+									</li>
+								))}
+							</ol>
+						)}
+					</div>
+				</Field>
+			</Playground>
+		</Form>
+	);
+}

--- a/playground/app/routes/validate.tsx
+++ b/playground/app/routes/validate.tsx
@@ -54,9 +54,9 @@ export default function Validate() {
 					</button>
 					<button
 						className="rounded-md border p-2 hover:border-black"
-						{...validate()}
+						{...validate(message.name)}
 					>
-						Validate Form
+						Validate Message
 					</button>
 				</div>
 			</Playground>

--- a/tests/integrations/validate.spec.ts
+++ b/tests/integrations/validate.spec.ts
@@ -6,7 +6,7 @@ function getFieldset(form: Locator) {
 		name: form.locator('[name="name"]'),
 		message: form.locator('[name="message"]'),
 		validateName: form.locator('button:text("Validate Name")'),
-		validateForm: form.locator('button:text("Validate Form")'),
+		validateMessage: form.locator('button:text("Validate Message")'),
 	};
 }
 
@@ -24,12 +24,12 @@ async function runValidationScenario(page: Page) {
 	await fieldset.validateName.click();
 	await expect(playground.error).toHaveText(['', '']);
 
-	await fieldset.validateForm.click();
+	await fieldset.validateMessage.click();
 	await expect(playground.error).toHaveText(['', 'Message is required']);
 	await expect(fieldset.message).toBeFocused();
 
 	await fieldset.message.type('A form validation library');
-	await fieldset.validateForm.click();
+	await fieldset.validateMessage.click();
 	await expect(playground.error).toHaveText(['', '']);
 
 	await playground.submit.click();
@@ -77,11 +77,8 @@ test.describe('With JS', () => {
 		await playground.reset.click();
 		await expect(playground.error).toHaveText(['', '']);
 
-		await fieldset.validateForm.click();
-		await expect(playground.error).toHaveText([
-			'Name is required',
-			'Message is required',
-		]);
+		await fieldset.validateMessage.click();
+		await expect(playground.error).toHaveText(['', 'Message is required']);
 
 		await playground.reset.click();
 		await expect(playground.error).toHaveText(['', '']);


### PR DESCRIPTION
This is just a draft. But the idea is to add support of combing multiple intents by running each intent in sequence and commit the changes in one go.

```tsx
// Configuring as a button (Works without JS)
<button
  {...list.combine(
    list.append('right', { defaultValue: '' }),
    list.remove('left', { index: 3 }), // It support updating different lists as well
  )}
>
  Move to right
</button>

// Or triggering it imperatively
requestIntent(formElement, list.combine(
    list.append('list1', { defaultValue: '' }),
    list.remove('list2', { index: 3 }),
));
```