### PR TITLE
refactor!: simplify intent setup

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,7 +104,7 @@ function Example() {
 }
 ```
 
-For information about modifying list (e.g. append / remove / reorder), see the [command](/docs/commands.md) section.
+For information about modifying list (e.g. append / remove / reorder), see the [Modifying a list](/docs/intent-button.md#modifying-a-list) section.
 
 ## Nested List
 

--- a/docs/intent-button.md
+++ b/docs/intent-button.md
@@ -9,7 +9,7 @@ A submit button can contribute to the form data when it triggers the submission 
 - [Submission Intent](#submission-intent)
 - [Modifying a list](#modifying-a-list)
 - [Validation](#validation)
-- [Triggering a command](#triggering-a-command)
+- [Triggering an intent](#triggering-an-intent)
 
 <!-- /aside -->
 
@@ -122,8 +122,6 @@ export default function Todos() {
       <input {...conform.input(email)} />
       {/* Validating field by name */}
       <button {...validate(email.name)}>Validate email</button>
-      {/* Validating the whole form */}
-      <button {...validate()}>Validate</button>
       <button>Send</button>
     </form>
   );

--- a/packages/conform-dom/dom.ts
+++ b/packages/conform-dom/dom.ts
@@ -203,22 +203,3 @@ export function focusFirstInvalidControl(form: HTMLFormElement) {
 		}
 	}
 }
-
-/**
- * Focus on the first form control with the provided name
- */
-export function focusFormControl(form: HTMLFormElement, name: string): void {
-	let element: unknown = form.elements.namedItem(name);
-
-	if (!element) {
-		return;
-	}
-
-	if (element instanceof RadioNodeList) {
-		element = element.item(0);
-	}
-
-	if (isFocusableFormControl(element)) {
-		element.focus();
-	}
-}

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -22,13 +22,10 @@ export {
 } from './formdata.js';
 
 export {
-	type ListCommand,
 	INTENT,
-	getScope,
-	isSubmitting,
+	parseIntent,
 	validate,
 	list,
-	parseListCommand,
 	updateList,
 	requestIntent,
 } from './intent.js';

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -8,7 +8,6 @@ export {
 	getFormEncType,
 	getFormMethod,
 	focusFirstInvalidControl,
-	focusFormControl,
 	createSubmitter,
 	requestSubmit,
 } from './dom.js';

--- a/packages/conform-dom/intent.ts
+++ b/packages/conform-dom/intent.ts
@@ -83,7 +83,7 @@ export function validate(field: string): IntentButtonProps {
 }
 
 export function requestIntent(
-	form: HTMLFormElement | undefined,
+	form: HTMLFormElement | null | undefined,
 	buttonProps: {
 		value: string;
 		formNoValidate?: boolean;

--- a/packages/conform-dom/parse.ts
+++ b/packages/conform-dom/parse.ts
@@ -60,7 +60,7 @@ export function parse<Schema>(
 	if (intent && intent.type === 'list') {
 		setValue(submission.payload, intent.payload.name, (list) => {
 			if (typeof list !== 'undefined' && !Array.isArray(list)) {
-				throw new Error('The list command can only be applied to a list');
+				throw new Error('The list intent can only be applied to a list');
 			}
 
 			return updateList(list ?? [], intent.payload);

--- a/packages/conform-dom/parse.ts
+++ b/packages/conform-dom/parse.ts
@@ -1,5 +1,5 @@
 import { resolve, setValue } from './formdata.js';
-import { getIntent, parseListCommand, updateList } from './intent.js';
+import { getIntent, parseIntent, updateList } from './intent.js';
 
 export type Submission<Schema = any> = {
 	intent: string;
@@ -55,15 +55,15 @@ export function parse<Schema>(
 		error: {},
 	};
 
-	const command = parseListCommand(submission.intent);
+	const intent = parseIntent(submission.intent);
 
-	if (command) {
-		setValue(submission.payload, command.scope, (list) => {
+	if (intent && intent.type === 'list') {
+		setValue(submission.payload, intent.payload.name, (list) => {
 			if (typeof list !== 'undefined' && !Array.isArray(list)) {
 				throw new Error('The list command can only be applied to a list');
 			}
 
-			return updateList(list ?? [], command);
+			return updateList(list ?? [], intent.payload);
 		});
 	}
 

--- a/packages/conform-dom/types.ts
+++ b/packages/conform-dom/types.ts
@@ -1,3 +1,5 @@
+export type Pretty<T> = { [K in keyof T]: T[K] } & {};
+
 export type FieldConstraint<Schema = any> = {
 	required?: boolean;
 	minLength?: number;

--- a/packages/conform-react/README.md
+++ b/packages/conform-react/README.md
@@ -507,7 +507,7 @@ export default function SignupForm() {
 
 ### list
 
-It provides serveral helpers to configure an intent button for [modifying a list](/docs/commands.md#modifying-a-list).
+It provides serveral helpers to configure an intent button for [modifying a list](/docs/intent-button.md#modifying-a-list).
 
 ```tsx
 import { list } from '@conform-to/react';
@@ -540,7 +540,7 @@ function Example() {
 
 ### validate
 
-It returns the properties required to configure an intent button for [validation](/docs/commands.md#validation).
+It returns the properties required to configure an intent button for [validation](/docs/intent-button.md#validation).
 
 ```tsx
 import { validate } from '@conform-to/react';
@@ -562,7 +562,7 @@ function Example() {
 
 ### requestIntent
 
-It lets you [trigger an intent](/docs/commands.md#triggering-an-intent) without requiring users to click on a button. It supports both [list](#list) and [validate](#validate) intent.
+It lets you [trigger an intent](/docs/intent-button.md#triggering-an-intent) without requiring users to click on a button. It supports both [list](#list) and [validate](#validate) intent.
 
 ```tsx
 import {

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -694,7 +694,7 @@ export function useFieldList<Schema extends Array<any> | undefined>(
 
 			if (
 				intent?.type !== 'list' ||
-				intent?.payload?.name !== configRef.current.name
+				intent?.payload.name !== configRef.current.name
 			) {
 				return;
 			}
@@ -706,17 +706,13 @@ export function useFieldList<Schema extends Array<any> | undefined>(
 					case 'append':
 					case 'prepend':
 					case 'replace':
-						list = updateList(list, {
+						return updateList(list, {
 							...intent.payload,
 							defaultValue: [`${Date.now()}`, intent.payload.defaultValue],
 						});
-						break;
 					default:
-						list = updateList([...(entries ?? [])], intent.payload);
-						break;
+						return updateList(list, intent.payload);
 				}
-
-				return list;
 			});
 			setError((error) => {
 				let errorList: Array<string[] | undefined> = [];

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -708,7 +708,11 @@ export function useFieldList<Schema extends Array<any> | undefined>(
 					case 'replace':
 						return updateList(list, {
 							...intent.payload,
-							defaultValue: [`${Date.now()}`, intent.payload.defaultValue],
+							defaultValue: [
+								// Generate a random key to avoid conflicts
+								crypto.getRandomValues(new Uint32Array(1))[0].toString(36),
+								intent.payload.defaultValue,
+							],
 						});
 					default:
 						return updateList(list, intent.payload);

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -22,8 +22,6 @@ import {
 	getFormControls,
 	focusFirstInvalidControl,
 	isFocusableFormControl,
-	focusFormControl,
-	INTENT,
 	parseIntent,
 } from '@conform-to/dom';
 import {
@@ -1211,29 +1209,9 @@ export function reportSubmission(
 		}
 	}
 
-	if (!scope) {
+	if (!intent) {
 		focusFirstInvalidControl(form);
-	} else if (isFocusedOnIntentButton(form, submission.intent)) {
-		focusFormControl(form, scope);
 	}
-}
-
-/**
- * Check if the current focus is on a intent button.
- */
-export function isFocusedOnIntentButton(
-	form: HTMLFormElement,
-	intent: string,
-): boolean {
-	const element = document.activeElement;
-
-	return (
-		isFieldElement(element) &&
-		element.type === 'submit' &&
-		element.form === form &&
-		element.name === INTENT &&
-		element.value === intent
-	);
 }
 
 export function getScope(

--- a/playground/app/routes/validate.tsx
+++ b/playground/app/routes/validate.tsx
@@ -54,9 +54,9 @@ export default function Validate() {
 					</button>
 					<button
 						className="rounded-md border p-2 hover:border-black"
-						{...validate()}
+						{...validate(message.name)}
 					>
-						Validate Form
+						Validate Message
 					</button>
 				</div>
 			</Playground>

--- a/tests/conform-dom.spec.ts
+++ b/tests/conform-dom.spec.ts
@@ -102,18 +102,18 @@ test.describe('conform-dom', () => {
 			});
 		});
 
-		test('Command submission', () => {
+		test('Processing submission intent', () => {
 			expect(
 				parse(
 					createFormData([
-						['title', 'Test command'],
-						['__intent__', 'command value'],
+						['title', 'Test intent'],
+						['__intent__', 'intent value'],
 					]),
 				),
 			).toEqual({
-				intent: 'command value',
+				intent: 'intent value',
 				payload: {
-					title: 'Test command',
+					title: 'Test intent',
 				},
 				error: {},
 			});
@@ -133,7 +133,7 @@ test.describe('conform-dom', () => {
 			});
 		});
 
-		test('List command', () => {
+		test('List intent', () => {
 			const entries: Array<[string, string]> = [
 				['tasks[0].content', 'Test some stuffs'],
 				['tasks[0].completed', 'Yes'],
@@ -145,98 +145,98 @@ test.describe('conform-dom', () => {
 				error: {},
 			};
 
-			const command1 = list.prepend('tasks');
+			const intent1 = list.prepend('tasks');
 
 			expect(
-				parse(createFormData([...entries, [command1.name, command1.value]])),
+				parse(createFormData([...entries, [intent1.name, intent1.value]])),
 			).toEqual({
 				...result,
-				intent: command1.value,
+				intent: intent1.value,
 				payload: {
 					tasks: [undefined, ...result.payload.tasks],
 				},
 			});
 
-			const command2 = list.prepend('tasks', {
+			const intent2 = list.prepend('tasks', {
 				defaultValue: { content: 'Something' },
 			});
 
 			expect(
-				parse(createFormData([...entries, [command2.name, command2.value]])),
+				parse(createFormData([...entries, [intent2.name, intent2.value]])),
 			).toEqual({
 				...result,
-				intent: command2.value,
+				intent: intent2.value,
 				payload: {
 					tasks: [{ content: 'Something' }, ...result.payload.tasks],
 				},
 			});
 
-			const command3 = list.append('tasks');
+			const intent3 = list.append('tasks');
 
 			expect(
-				parse(createFormData([...entries, [command3.name, command3.value]])),
+				parse(createFormData([...entries, [intent3.name, intent3.value]])),
 			).toEqual({
 				...result,
-				intent: command3.value,
+				intent: intent3.value,
 				payload: {
 					tasks: [...result.payload.tasks, undefined],
 				},
 			});
 
-			const command4 = list.append('tasks', {
+			const intent4 = list.append('tasks', {
 				defaultValue: { content: 'Something' },
 			});
 
 			expect(
-				parse(createFormData([...entries, [command4.name, command4.value]])),
+				parse(createFormData([...entries, [intent4.name, intent4.value]])),
 			).toEqual({
 				...result,
-				intent: command4.value,
+				intent: intent4.value,
 				payload: {
 					tasks: [...result.payload.tasks, { content: 'Something' }],
 				},
 			});
 
-			const command5 = list.replace('tasks', {
+			const intent5 = list.replace('tasks', {
 				defaultValue: { content: 'Something' },
 				index: 0,
 			});
 
 			expect(
-				parse(createFormData([...entries, [command5.name, command5.value]])),
+				parse(createFormData([...entries, [intent5.name, intent5.value]])),
 			).toEqual({
 				...result,
-				intent: command5.value,
+				intent: intent5.value,
 				payload: {
 					tasks: [{ content: 'Something' }],
 				},
 			});
 
-			const command6 = list.remove('tasks', { index: 0 });
+			const intent6 = list.remove('tasks', { index: 0 });
 
 			expect(
-				parse(createFormData([...entries, [command6.name, command6.value]])),
+				parse(createFormData([...entries, [intent6.name, intent6.value]])),
 			).toEqual({
 				...result,
-				intent: command6.value,
+				intent: intent6.value,
 				payload: {
 					tasks: [],
 				},
 			});
 
-			const command7 = list.reorder('tasks', { from: 0, to: 1 });
+			const intent7 = list.reorder('tasks', { from: 0, to: 1 });
 
 			expect(
 				parse(
 					createFormData([
 						...entries,
 						['tasks[1].content', 'Test more stuffs'],
-						[command7.name, command7.value],
+						[intent7.name, intent7.value],
 					]),
 				),
 			).toEqual({
 				...result,
-				intent: command7.value,
+				intent: intent7.value,
 				payload: {
 					tasks: [{ content: 'Test more stuffs' }, ...result.payload.tasks],
 				},

--- a/tests/conform-dom.spec.ts
+++ b/tests/conform-dom.spec.ts
@@ -117,20 +117,14 @@ test.describe('conform-dom', () => {
 				},
 				error: {},
 			});
-			expect(
+			expect(() =>
 				parse(
 					createFormData([
 						['title', ''],
 						['__intent__', 'list/helloworld'],
 					]),
 				),
-			).toEqual({
-				intent: 'list/helloworld',
-				payload: {
-					title: '',
-				},
-				error: {},
-			});
+			).toThrow('Failed parsing intent: list/helloworld');
 		});
 
 		test('List intent', () => {

--- a/tests/integrations/validate.spec.ts
+++ b/tests/integrations/validate.spec.ts
@@ -6,7 +6,7 @@ function getFieldset(form: Locator) {
 		name: form.locator('[name="name"]'),
 		message: form.locator('[name="message"]'),
 		validateName: form.locator('button:text("Validate Name")'),
-		validateForm: form.locator('button:text("Validate Form")'),
+		validateMessage: form.locator('button:text("Validate Message")'),
 	};
 }
 
@@ -24,12 +24,12 @@ async function runValidationScenario(page: Page) {
 	await fieldset.validateName.click();
 	await expect(playground.error).toHaveText(['', '']);
 
-	await fieldset.validateForm.click();
+	await fieldset.validateMessage.click();
 	await expect(playground.error).toHaveText(['', 'Message is required']);
 	await expect(fieldset.message).toBeFocused();
 
 	await fieldset.message.type('A form validation library');
-	await fieldset.validateForm.click();
+	await fieldset.validateMessage.click();
 	await expect(playground.error).toHaveText(['', '']);
 
 	await playground.submit.click();
@@ -77,11 +77,8 @@ test.describe('With JS', () => {
 		await playground.reset.click();
 		await expect(playground.error).toHaveText(['', '']);
 
-		await fieldset.validateForm.click();
-		await expect(playground.error).toHaveText([
-			'Name is required',
-			'Message is required',
-		]);
+		await fieldset.validateMessage.click();
+		await expect(playground.error).toHaveText(['', 'Message is required']);
 
 		await playground.reset.click();
 		await expect(playground.error).toHaveText(['', '']);

--- a/tests/integrations/validate.spec.ts
+++ b/tests/integrations/validate.spec.ts
@@ -18,7 +18,6 @@ async function runValidationScenario(page: Page) {
 
 	await fieldset.validateName.click();
 	await expect(playground.error).toHaveText(['Name is required', '']);
-	await expect(fieldset.name).toBeFocused();
 
 	await fieldset.name.type('Conform');
 	await fieldset.validateName.click();
@@ -26,7 +25,6 @@ async function runValidationScenario(page: Page) {
 
 	await fieldset.validateMessage.click();
 	await expect(playground.error).toHaveText(['', 'Message is required']);
-	await expect(fieldset.message).toBeFocused();
 
 	await fieldset.message.type('A form validation library');
 	await fieldset.validateMessage.click();


### PR DESCRIPTION
This includes two breaking changes that I believe no one is relying on 😅 
- Drop support of form validate intent (i.e. `validate()`). This shouldn't exist from the start as we can achieve the same thing with a custom intent.
- Drop support of autofocus when clicking on a button with the field validate intent (i.e. `validate(name)`). This requires a fair amount of code to work currently which doesn't justify its usage.