### PR TITLE
feat(conform-zod): refine helper

### DIFF
--- a/examples/remix/app/routes/signup.tsx
+++ b/examples/remix/app/routes/signup.tsx
@@ -1,5 +1,5 @@
 import { conform, useForm } from '@conform-to/react';
-import { parse } from '@conform-to/zod';
+import { parse, refine } from '@conform-to/zod';
 import type { ActionArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import { Form, useActionData } from '@remix-run/react';
@@ -8,10 +8,10 @@ import { z } from 'zod';
 // Instead of sharing a schema, prepare a schema creator
 function createSchema(
 	intent: string,
-	// Note: the constraints parameter is optional
-	constarint?: {
-		isUsernameUnique: (username: string) => Promise<boolean>;
-	},
+	constarint: {
+		// isUsernameUnique is only defined on the server
+		isUsernameUnique?: (username: string) => Promise<boolean>;
+	} = {},
 ) {
 	return z
 		.object({
@@ -23,33 +23,13 @@ function createSchema(
 					'Invalid username: only letters or numbers are allowed',
 				)
 				// We use `.superRefine` instead of `.refine` for better control
-				.superRefine((value, ctx) => {
-					if (intent !== 'submit' && intent !== 'validate/username') {
-						// Validate only when necessary
-						ctx.addIssue({
-							code: z.ZodIssueCode.custom,
-							message: conform.VALIDATION_SKIPPED,
-						});
-					} else if (typeof constarint?.isUsernameUnique === 'undefined') {
-						// Validate only if the constraint is defined
-						ctx.addIssue({
-							code: z.ZodIssueCode.custom,
-							message: conform.VALIDATION_UNDEFINED,
-						});
-					} else {
-						// Tell zod it is an async validation by returning a promise
-						return constarint.isUsernameUnique(value).then((valid) => {
-							if (valid) {
-								return;
-							}
-
-							ctx.addIssue({
-								code: z.ZodIssueCode.custom,
-								message: 'Username is already used',
-							});
-						});
-					}
-				}),
+				.superRefine((username, ctx) =>
+					refine(ctx, {
+						validate: () => constarint.isUsernameUnique?.(username),
+						skip: intent !== 'submit' && intent !== 'validate/username',
+						message: 'Username is already used',
+					}),
+				),
 			password: z.string().min(1, 'Password is required'),
 			confirmPassword: z.string().min(1, 'Confirm Password is required'),
 		})

--- a/packages/conform-dom/index.ts
+++ b/packages/conform-dom/index.ts
@@ -30,7 +30,12 @@ export {
 	requestIntent,
 } from './intent.js';
 
-export { type Submission, parse } from './parse.js';
+export {
+	type Submission,
+	parse,
+	VALIDATION_SKIPPED,
+	VALIDATION_UNDEFINED,
+} from './parse.js';
 
 export {
 	type FieldConstraint,

--- a/packages/conform-dom/parse.ts
+++ b/packages/conform-dom/parse.ts
@@ -8,6 +8,9 @@ export type Submission<Schema = any> = {
 	value?: Schema | null;
 };
 
+export const VALIDATION_UNDEFINED = '__undefined__';
+export const VALIDATION_SKIPPED = '__skipped__';
+
 export function parse(payload: FormData | URLSearchParams): Submission;
 export function parse<Schema>(
 	payload: FormData | URLSearchParams,

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -1,10 +1,9 @@
-import { INTENT } from '@conform-to/dom';
 import {
-	type FieldConfig,
-	type Primitive,
+	INTENT,
 	VALIDATION_UNDEFINED,
 	VALIDATION_SKIPPED,
-} from './hooks.js';
+} from '@conform-to/dom';
+import type { FieldConfig, Primitive } from './hooks.js';
 import type { CSSProperties, HTMLInputTypeAttribute } from 'react';
 
 interface FormControlProps {

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -23,6 +23,8 @@ import {
 	focusFirstInvalidControl,
 	isFocusableFormControl,
 	parseIntent,
+	VALIDATION_SKIPPED,
+	VALIDATION_UNDEFINED,
 } from '@conform-to/dom';
 import {
 	type FormEvent,
@@ -1028,9 +1030,6 @@ export function useInputEvent<RefShape>(options?: {
 
 	return [ref, control];
 }
-
-export const VALIDATION_UNDEFINED = '__undefined__';
-export const VALIDATION_SKIPPED = '__skipped__';
 export const FORM_ERROR_ELEMENT_NAME = '__form__';
 
 /**


### PR DESCRIPTION
This helps reduce the boilerplate when setting up async validation with zod.


```ts
// Before
function createSchema(
  intent: string,
  constraints: {
    isEmailUnique?: (email) => Promise<boolean>;
  } = {},
) {
  return z.object({
    email: z
      .string()
      .min(1, 'Email is required')
      .email('Email is invalid')
      .superRefine((email, ctx) => {
        if (intent !== 'submit' && intent !== 'validate/username') {
          // Validate only when necessary
          ctx.addIssue({
            code: z.ZodIssueCode.custom,
            message: conform.VALIDATION_SKIPPED,
          });
	} else if (typeof constraints.isEmailUnique === 'undefined') {
          // Validate only if the constraint is defined
          ctx.addIssue({
            code: z.ZodIssueCode.custom,
            message: conform.VALIDATION_UNDEFINED,
          });
        } else {
          // Tell zod this is an async validation by returning the promise
          return constraints.isEmailUnique(value).then((isUnique) => {
            if (isUnique) {
              return;
            }
            ctx.addIssue({
              code: z.ZodIssueCode.custom,
              message: 'Email is already used',
            });
          });
        }
      }),
    // ...
  });
}

// After
import { refine } from '@conform-to/zod';

function createSchema(
  intent: string,
  constraints: {
    isEmailUnique?: (email) => Promise<boolean>;
  } = {},
) {
  return z.object({
    email: z
      .string()
      .min(1, 'Email is required')
      .email('Email is invalid')
      .superRefine((email, ctx) =>
        refine(ctx, {
          validate: () => constraints.isEmailUnique?.(email),
          skip: intent !== 'submit' && intent !== 'validate/username',
          message: 'Email is already used',
        }),
      ),
    // ...
  });
}
``` 