### PR TITLE
feat(conform-react): auto reset when last submission reset

### DIFF
--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -396,14 +396,18 @@ export function useForm<
 		constraint: config.constraint,
 		form: config.id,
 	});
-	const isHydrated = useRef(false);
+
+	const lastSubmissionRef = useRef(config.lastSubmission);
 
 	useSafeLayoutEffect(() => {
-		if (isHydrated.current && !config.lastSubmission) {
+		if (
+			lastSubmissionRef.current !== config.lastSubmission &&
+			config.lastSubmission === null
+		) {
 			ref.current?.reset();
 		}
 
-		isHydrated.current = true;
+		lastSubmissionRef.current = config.lastSubmission;
 	}, [ref, config.lastSubmission]);
 
 	useEffect(() => {

--- a/playground/app/components.tsx
+++ b/playground/app/components.tsx
@@ -43,7 +43,7 @@ export function Playground({
 					<h3 className="text-lg font-medium leading-6 text-gray-900">
 						{title}
 					</h3>
-					<p className="mt-1 mb-2 text-sm text-gray-600">{description}</p>
+					<div className="mt-1 mb-2 text-sm text-gray-600">{description}</div>
 				</header>
 				{submission ? (
 					<details open={true}>

--- a/tests/integrations/reset-default-value.spec.ts
+++ b/tests/integrations/reset-default-value.spec.ts
@@ -26,6 +26,21 @@ async function runValidationScenario(page: Page) {
 
 	await expect(fieldset.name).toHaveValue('Blue');
 	await expect(fieldset.code).toHaveValue('#0000ff');
+
+	await fieldset.name.fill('Yellow');
+	await playground.submit.click();
+
+	await expect(playground.error).toHaveText(['', 'The color is invalid']);
+
+	await expect(fieldset.name).toHaveValue('Yellow');
+	await expect(fieldset.code).toHaveValue('#0000ff');
+
+	await fieldset.name.fill('Red');
+	await fieldset.code.fill('#ff0000');
+	await playground.submit.click();
+
+	await expect(fieldset.name).toHaveValue('Blue');
+	await expect(fieldset.code).toHaveValue('#0000ff');
 }
 
 test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
Before this change, the idiomatic way to reset a form when the submission is successful is done by triggering form reset just like how the Remix community suggested generally:

```ts
const actionData = useActionData();
const navigation = useNavigation();
const [form, fields] = useForm({
  lastSubmission: actionData?.submission,
});

useEffect(() => {
    if (navigation.state === 'idle' && actionData?.success) {
      formRef.current?.reset();
    }
}, [actionData?.success, navigation.state])
```

However, this does not work in a NoJS environement as the effect will never run while the form is still using the last submission as the default value of the form. Here is the new solution:

```ts
const actionData = useActionData();
const [form, fields] = useForm({
  // Pass the submission only if the action was failed
  // Or, skip sending the submission back on success
  lastSubmission: !actionData?.success ? actionData?.submission : null,
});

// There is no need to setup an useEffect anymore.
// As Conform will track when the lastSubmission is reset and
// trigger a form reset automatically!
```




 
