### PR TITLE
fix(react): ensure forms with server-side validations can be submitted

### DIFF
--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -510,12 +510,12 @@ export function useForm<
 					const shouldFallbackToServer =
 						messages.includes(VALIDATION_UNDEFINED);
 					const hasClientValidation = typeof config.onValidate !== 'undefined';
-					const isValid = messages.length === 0;
+					const isClientValid = messages.filter(m => m !== VALIDATION_UNDEFINED);
 
 					if (
 						hasClientValidation &&
 						(isSubmitting(submission.intent)
-							? shouldValidate && !isValid
+							? shouldValidate && !isClientValid
 							: !shouldFallbackToServer)
 					) {
 						report(form, submission);


### PR DESCRIPTION
Without this change, my form that has server validations will not submit when the client-side is valid but there are some server validations needed.

I'm running on the latest pre-release of `0.7.0-pre-1`.