### PR TITLE
feat(conform-react)!: stop deriving aria attribute by default

### DIFF
--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -44,10 +44,16 @@ interface TextareaProps extends FormControlProps {
 	defaultValue?: string;
 }
 
-type BaseOptions = {
-	description?: boolean;
-	hidden?: boolean;
-};
+type BaseOptions =
+	| {
+			ariaAttributes?: false;
+			hidden?: boolean;
+	  }
+	| {
+			ariaAttributes: true;
+			description?: boolean;
+			hidden?: boolean;
+	  };
 
 type InputOptions = BaseOptions &
 	(
@@ -60,22 +66,6 @@ type InputOptions = BaseOptions &
 				value?: never;
 		  }
 	);
-
-/**
- * Style to make the input element visually hidden
- * Based on the `sr-only` class from tailwindcss
- */
-const hiddenStyle: CSSProperties = {
-	position: 'absolute',
-	width: '1px',
-	height: '1px',
-	padding: 0,
-	margin: '-1px',
-	overflow: 'hidden',
-	clip: 'rect(0,0,0,0)',
-	whiteSpace: 'nowrap',
-	border: 0,
-};
 
 function getFormControlProps(
 	config: FieldConfig<any>,
@@ -92,30 +82,50 @@ function getFormControlProps(
 		props.id = config.id;
 	}
 
-	if (config.descriptionId && options?.description) {
-		props['aria-describedby'] = config.descriptionId;
-	}
+	if (options?.ariaAttributes) {
+		if (config.descriptionId && options?.description) {
+			props['aria-describedby'] = config.descriptionId;
+		}
 
-	if (config.errorId && config.error?.length) {
-		props['aria-invalid'] = true;
-		props['aria-describedby'] =
-			config.descriptionId && options?.description
-				? `${config.errorId} ${config.descriptionId}`
-				: config.errorId;
+		if (config.errorId && config.error?.length) {
+			props['aria-invalid'] = true;
+			props['aria-describedby'] =
+				config.descriptionId && options?.description
+					? `${config.errorId} ${config.descriptionId}`
+					: config.errorId;
+		}
 	}
 
 	if (config.initialError && Object.entries(config.initialError).length > 0) {
 		props.autoFocus = true;
 	}
 
-	if (options?.hidden) {
-		props.style = hiddenStyle;
-		props.tabIndex = -1;
-		props['aria-hidden'] = true;
-	}
-
-	return props;
+	return options?.hidden ? { ...props, ...hiddenProps } : props;
 }
+
+export const hiddenProps: {
+	hiddenStyle: CSSProperties;
+	tabIndex: number;
+	'aria-hidden': boolean;
+} = {
+	/**
+	 * Style to make the input element visually hidden
+	 * Based on the `sr-only` class from tailwindcss
+	 */
+	hiddenStyle: {
+		position: 'absolute',
+		width: '1px',
+		height: '1px',
+		padding: 0,
+		margin: '-1px',
+		overflow: 'hidden',
+		clip: 'rect(0,0,0,0)',
+		whiteSpace: 'nowrap',
+		border: 0,
+	},
+	tabIndex: -1,
+	'aria-hidden': true,
+};
 
 export function input<Schema extends Primitive | unknown>(
 	config: FieldConfig<Schema>,

--- a/playground/app/routes/input-attributes.tsx
+++ b/playground/app/routes/input-attributes.tsx
@@ -81,6 +81,7 @@ export default function Example() {
 					<input
 						{...conform.input(title, {
 							type: 'text',
+							ariaAttributes: true,
 							description: enableDescription,
 						})}
 					/>
@@ -88,6 +89,7 @@ export default function Example() {
 				<Field label="Description" config={description}>
 					<textarea
 						{...conform.textarea(description, {
+							ariaAttributes: true,
 							description: enableDescription,
 						})}
 					/>
@@ -96,12 +98,18 @@ export default function Example() {
 					<input
 						{...conform.input(images, {
 							type: 'file',
+							ariaAttributes: true,
 							description: enableDescription,
 						})}
 					/>
 				</Field>
 				<Field label="Tags" config={tags}>
-					<select {...conform.select(tags, { description: enableDescription })}>
+					<select
+						{...conform.select(tags, {
+							ariaAttributes: true,
+							description: enableDescription,
+						})}
+					>
 						<option value="">Please select</option>
 						<option value="action">Action</option>
 						<option value="adventure">Adventure</option>
@@ -116,6 +124,7 @@ export default function Example() {
 					<input
 						{...conform.input(rating, {
 							type: 'number',
+							ariaAttributes: true,
 							description: enableDescription,
 						})}
 					/>


### PR DESCRIPTION
```tsx
// Before
function Example() {
    const [form, { message }] = useForm();

    return (
        <form>
            <input
                {...conform.input(message, {
                    type: 'text',
                })}
            />
        </form>
    )
}

// After
function Example() {
    const [form, { message }] = useForm();

    return (
        <form>
            <input
                {...conform.input(message, {
                    type: 'text',
                    ariaAttributes: true, // default to `false`
                })}
            />
        </form>
    )
}
```