### PR TITLE
feat(conform-react)!: improve default shouldRevalidate config

### DIFF
--- a/packages/conform-react/README.md
+++ b/packages/conform-react/README.md
@@ -53,7 +53,7 @@ function LoginForm() {
      * Define when conform should revalidate again.
      * Support "onSubmit", "onChange", "onBlur".
      *
-     * Default to `onInput`.
+     * Default based on `shouldValidate`
      */
     shouldRevalidate: 'onInput',
 

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -90,7 +90,7 @@ export interface FormConfig<
 	 * Define when conform should start validation.
 	 * Support "onSubmit", "onChange", "onBlur".
 	 *
-	 * Default to `onSubmit`.
+	 * @default "onSubmit"
 	 */
 	shouldValidate?: 'onSubmit' | 'onBlur' | 'onInput';
 
@@ -98,7 +98,7 @@ export interface FormConfig<
 	 * Define when conform should revalidate again.
 	 * Support "onSubmit", "onChange", "onBlur".
 	 *
-	 * Default to `onInput`.
+	 * @default shouldValidate, or "onSubmit" if shouldValidate is not provided.
 	 */
 	shouldRevalidate?: 'onSubmit' | 'onBlur' | 'onInput';
 
@@ -412,7 +412,7 @@ export function useForm<
 		const createValidateHandler = (type: string) => (event: Event) => {
 			const field = event.target;
 			const form = ref.current;
-			const { shouldValidate = 'onSubmit', shouldRevalidate = 'onInput' } =
+			const { shouldValidate = 'onSubmit', shouldRevalidate = shouldValidate } =
 				configRef.current;
 
 			if (

--- a/playground/app/routes/movie.tsx
+++ b/playground/app/routes/movie.tsx
@@ -149,6 +149,7 @@ export default function MovieForm() {
 					return submission;
 			  }
 			: undefined,
+		shouldRevalidate: 'onInput',
 	});
 
 	return (

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -56,6 +56,7 @@ export default function PaymentForm() {
 		onValidate: config.validate
 			? ({ formData }) => parse(formData, { schema })
 			: undefined,
+		shouldRevalidate: 'onInput',
 	});
 	const { currency, value } = useFieldset(form.ref, {
 		...amount,

--- a/playground/app/routes/signup.tsx
+++ b/playground/app/routes/signup.tsx
@@ -78,6 +78,7 @@ export default function SignupForm() {
 		onValidate: config.validate
 			? ({ formData }) => parseSignupForm(formData)
 			: undefined,
+		shouldRevalidate: 'onInput',
 	});
 
 	return (

--- a/playground/app/routes/validate-constraint.tsx
+++ b/playground/app/routes/validate-constraint.tsx
@@ -32,6 +32,7 @@ export default function Example() {
 		useLoaderData<typeof loader>();
 	const [form, { email, password, confirmPassword }] = useForm<Schema>({
 		fallbackNative: true,
+		shouldRevalidate: 'onInput',
 		onValidate(context) {
 			return validateConstraint({
 				...context,

--- a/tests/integrations/custom-inputs.spec.ts
+++ b/tests/integrations/custom-inputs.spec.ts
@@ -23,6 +23,7 @@ async function runValidationScenario(page: Page) {
 
 	await playground.container.getByText('Please select').click();
 	await playground.container.getByText('Deutsch').click();
+	await playground.submit.click();
 
 	await expect(playground.error).toHaveText([
 		'',

--- a/tests/integrations/validation-flow.spec.ts
+++ b/tests/integrations/validation-flow.spec.ts
@@ -34,6 +34,24 @@ test('shouldValidate: onSubmit', async ({ page }) => {
 		'Password is too short',
 		'Confirm password does not match',
 	]);
+
+	await email.clear();
+	await email.type('example@conform.guide');
+	await password.clear();
+	await password.type('secretpassword');
+	await confirmPassword.clear();
+	await confirmPassword.type('secretpassword');
+
+	// To check if revalidate defaults to onSubmit as well
+	await playground.form.press('Tab');
+	await expect(playground.error).toHaveText([
+		'Email is invalid',
+		'Password is too short',
+		'Confirm password does not match',
+	]);
+
+	await playground.submit.click();
+	await expect(playground.error).toHaveText(['', '', '']);
 });
 
 test('shouldValidate: onInput', async ({ page }) => {
@@ -68,6 +86,29 @@ test('shouldValidate: onInput', async ({ page }) => {
 		'Confirm password does not match',
 		'',
 	]);
+
+	// To check if revalidate defaults to onInput as well
+	await email.clear();
+	await email.type('example@conform.guide');
+	await expect(playground.error).toHaveText([
+		'',
+		'Password is too short',
+		'Confirm password does not match',
+		'',
+	]);
+
+	await password.clear();
+	await password.type('secretpassword');
+	await expect(playground.error).toHaveText([
+		'',
+		'',
+		'Confirm password does not match',
+		'',
+	]);
+
+	await confirmPassword.clear();
+	await confirmPassword.type('secretpassword');
+	await expect(playground.error).toHaveText(['', '', '', '']);
 });
 
 test('shouldValidate: onBlur', async ({ page }) => {
@@ -107,6 +148,47 @@ test('shouldValidate: onBlur', async ({ page }) => {
 		'Password is too short',
 		'Confirm password does not match',
 	]);
+
+	await email.clear();
+	await email.type('example@conform.guide');
+	await expect(playground.error).toHaveText([
+		'Email is invalid',
+		'Password is too short',
+		'Confirm password does not match',
+	]);
+
+	await playground.form.press('Tab');
+	await expect(playground.error).toHaveText([
+		'',
+		'Password is too short',
+		'Confirm password does not match',
+	]);
+
+	await password.clear();
+	await password.type('secretpassword');
+	await expect(playground.error).toHaveText([
+		'',
+		'Password is too short',
+		'Confirm password does not match',
+	]);
+
+	await playground.form.press('Tab');
+	await expect(playground.error).toHaveText([
+		'',
+		'',
+		'Confirm password does not match',
+	]);
+
+	await confirmPassword.clear();
+	await confirmPassword.type('secretpassword');
+	await expect(playground.error).toHaveText([
+		'',
+		'',
+		'Confirm password does not match',
+	]);
+
+	await playground.form.press('Tab');
+	await expect(playground.error).toHaveText(['', '', '']);
 });
 
 test('shouldRevalidate: onSubmit', async ({ page }) => {


### PR DESCRIPTION
This changes the default of the `shouldRevalidate` config on the `useForm` hook from `onInput` to be based on the current `shouldValidate` config.

- If `shouldValidate` is not configured, the default would be `onSubmit` and so `shouldRevalidate` will also default to `onSubmit`
- If `shouldValidate` is set to `onBlur` or `onInput`, then `shouldRevalidate` will default to `onBlur` or `onInput` resepectively.