### PR TITLE
refactor: utilize submission payload for form reset instead

### DIFF
--- a/playground/app/routes/reset-default-value.tsx
+++ b/playground/app/routes/reset-default-value.tsx
@@ -52,22 +52,23 @@ export let action = async ({ request }: ActionArgs) => {
 	});
 
 	if (!submission.value || submission.intent !== 'submit') {
-		return json({ submission, success: false });
+		return json(submission);
 	}
 
 	// We can also skip sending the submission back to the client on success
 	// As the form value shuold be reset anyway
-	return json({ submission, success: true });
+	return json({
+		...submission,
+		payload: {},
+	});
 };
 
 export default function ExampleForm() {
 	const { color, defaultValue } = useLoaderData<typeof loader>();
-	const actionData = useActionData<typeof action>();
+	const lastSubmission = useActionData<typeof action>();
 	const [form, fieldset] = useForm({
 		defaultValue,
-		// Avoid passing the last submission on success
-		// To ensure that the form is reset
-		lastSubmission: !actionData?.success ? actionData?.submission : null,
+		lastSubmission,
 	});
 
 	useEffect(() => {
@@ -100,7 +101,7 @@ export default function ExampleForm() {
 						</ul>
 					</div>
 				}
-				lastSubmission={actionData?.submission}
+				lastSubmission={lastSubmission}
 			>
 				<Field label="Name" config={fieldset.name}>
 					<input {...conform.input(fieldset.name, { type: 'text' })} />

--- a/playground/app/routes/reset-default-value.tsx
+++ b/playground/app/routes/reset-default-value.tsx
@@ -59,7 +59,7 @@ export let action = async ({ request }: ActionArgs) => {
 	// As the form value shuold be reset anyway
 	return json({
 		...submission,
-		payload: {},
+		payload: null,
 	});
 };
 


### PR DESCRIPTION
Fix #191

On [v0.7.0](https://github.com/edmundhung/conform/releases/tag/v0.7.0), we introduced an approach to reset the form automatically by tracking when the last submission value is cleared.

```tsx
const actionData = useActionData();
const [form, fields] = useForm({
  // Pass the submission only if the action was failed
  // Or, skip sending the submission back on success
  lastSubmission: !actionData?.success ? actionData?.submission : null,
});
```

But there is a pitfall here which I overlooked. If the submission has been successful consecutively, the internal `useEffect` call will not be executed as it is still receiving the same `null` value and thus no reset happens.

This PR use a different approach to trigger form reset:
```tsx

export let action = async ({ request }: ActionArgs) => {
    const formData = await request.formData();
    const submission = parse(formData, { schema });

    if (submission.intent !== 'submit' || !submission.value) {
        return json(submission);
    }

    return json({
        ...submission,
        // Notify the client to reset the form using `null`
        payload: null,
    });
};

export default function Component() {
    const lastSubmission = useActionData<typeof action>();
    const [form, { message }] = useForm({
        // The last submission should be updated regardless the submission is successful or not
        // If the submission payload is empty:
        // 1. the form will be reset automatically
        // 2. the default value of the form will also be reset if the document is reloaded (e.g. nojs)
        lastSubmission,
    })

    // ...
}
``` 