### PR TITLE
feat(conform-react): ensure form reset approach is backward compatible

### DIFF
--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -116,7 +116,7 @@ export interface FormConfig<
 	/**
 	 * An object describing the result of the last submission
 	 */
-	lastSubmission?: SubmissionResult;
+	lastSubmission?: SubmissionResult | null;
 
 	/**
 	 * An object describing the constraint of each field
@@ -230,7 +230,7 @@ function useConfigRef<Config>(config: Config) {
 
 function useFormReporter(
 	ref: RefObject<HTMLFormElement>,
-	lastSubmission: SubmissionResult | undefined,
+	lastSubmission: SubmissionResult | null | undefined,
 ) {
 	const [submission, setSubmission] = useState(lastSubmission);
 	const report = useCallback(
@@ -246,11 +246,11 @@ function useFormReporter(
 	useEffect(() => {
 		const form = ref.current;
 
-		if (!form || !lastSubmission) {
+		if (!form || typeof lastSubmission === 'undefined') {
 			return;
 		}
 
-		if (!lastSubmission.payload) {
+		if (!lastSubmission?.payload) {
 			// If the default value is empty, we can safely reset the form.
 			// This ensure the behavior is consistent with and without JS.
 			form.reset();

--- a/playground/app/routes/reset-default-value.tsx
+++ b/playground/app/routes/reset-default-value.tsx
@@ -38,10 +38,14 @@ const colors = [
 export let loader = async ({ request }: ActionArgs) => {
 	const url = new URL(request.url);
 	const color = url.searchParams.get('color');
+	// This is used to confirm the original approach on clearing the submission is working
+	const shouldClearSubmission =
+		url.searchParams.get('shouldClearSubmission') === 'yes';
 
 	return json({
 		color,
 		defaultValue: colors.find((c) => color === c.name.toLowerCase()),
+		shouldClearSubmission,
 	});
 };
 
@@ -64,11 +68,16 @@ export let action = async ({ request }: ActionArgs) => {
 };
 
 export default function ExampleForm() {
-	const { color, defaultValue } = useLoaderData<typeof loader>();
+	const { color, defaultValue, shouldClearSubmission } =
+		useLoaderData<typeof loader>();
 	const lastSubmission = useActionData<typeof action>();
 	const [form, fieldset] = useForm({
 		defaultValue,
-		lastSubmission,
+		lastSubmission: shouldClearSubmission
+			? lastSubmission?.payload === null
+				? null
+				: lastSubmission
+			: lastSubmission,
 	});
 
 	useEffect(() => {
@@ -84,17 +93,32 @@ export default function ExampleForm() {
 						Please choose a color
 						<ul>
 							<li>
-								<Link className="text-red-600" to="?color=red">
+								<Link
+									className="text-red-600"
+									to={`?color=red&shouldClearSubmission=${
+										shouldClearSubmission ? 'yes' : 'no'
+									}`}
+								>
 									Red
 								</Link>
 							</li>
 							<li>
-								<Link className="text-green-600" to="?color=green">
+								<Link
+									className="text-green-600"
+									to={`?color=green&shouldClearSubmission=${
+										shouldClearSubmission ? 'yes' : 'no'
+									}`}
+								>
 									Green
 								</Link>
 							</li>
 							<li>
-								<Link className="text-blue-600" to="?color=blue">
+								<Link
+									className="text-blue-600"
+									to={`?color=blue&shouldClearSubmission=${
+										shouldClearSubmission ? 'yes' : 'no'
+									}`}
+								>
 									Blue
 								</Link>
 							</li>

--- a/tests/integrations/reset-default-value.spec.ts
+++ b/tests/integrations/reset-default-value.spec.ts
@@ -43,12 +43,14 @@ async function runValidationScenario(page: Page) {
 	await expect(fieldset.code).toHaveValue('#0000ff');
 }
 
-test.beforeEach(async ({ page }) => {
-	await page.goto('/reset-default-value');
-});
-
 test.describe('With JS', () => {
 	test('Validation', async ({ page }) => {
+		await page.goto('/reset-default-value');
+		await runValidationScenario(page);
+	});
+
+	test('Validation with the submission cleared', async ({ page }) => {
+		await page.goto('/reset-default-value?shouldClearSubmission=yes');
 		await runValidationScenario(page);
 	});
 });
@@ -57,6 +59,12 @@ test.describe('No JS', () => {
 	test.use({ javaScriptEnabled: false });
 
 	test('Validation', async ({ page }) => {
+		await page.goto('/reset-default-value');
+		await runValidationScenario(page);
+	});
+
+	test('Validation with the submission cleared', async ({ page }) => {
+		await page.goto('/reset-default-value?shouldClearSubmission=yes');
 		await runValidationScenario(page);
 	});
 });


### PR DESCRIPTION
On v0.7.2, I introduced a breaking change on how to reset the form. With the original approach being new (which was introduced only last week and so adoption should be low), I think it was acceptable to break it directly, considering the solution was not working as intentional already. I have also updated the release note on v0.7.0 and mention the approach has changed on v0.7.2.

But, maybe it is still a bad idea to break it. It wasn't too hard to make it compatible as it was anyway 😓 

