### PR TITLE
fix(conform-zod): refine should be run by default

### DIFF
--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -294,7 +294,7 @@ export function refine(
 		path?: z.IssueData['path'];
 	},
 ): void | Promise<void> {
-	if (!options.when) {
+	if (typeof options.when !== 'undefined' && !options.when) {
 		ctx.addIssue({
 			code: z.ZodIssueCode.custom,
 			message: VALIDATION_SKIPPED,


### PR DESCRIPTION
Fix #207.

The refine helper should run the refinement if the `when` option is undefined.