### PR TITLE
feat(conform-zod): strip empty value

### DIFF
--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -100,22 +100,38 @@ export function setValue(
  */
 export function resolve(
 	payload: FormData | URLSearchParams,
-	ignoreKeys?: string[],
+	options: {
+		ignoreKeys?: string[];
+		stripEmptyValues?: boolean;
+	} = {},
 ) {
 	const data = {};
 
 	for (let [key, value] of payload.entries()) {
-		if (ignoreKeys?.includes(key)) {
+		if (options.ignoreKeys?.includes(key)) {
 			continue;
+		}
+
+		let next: FormDataEntryValue | undefined = value;
+
+		if (
+			options.stripEmptyValues &&
+			(typeof next === 'string'
+				? next === ''
+				: next.name === '' && next.size === 0)
+		) {
+			next = undefined;
 		}
 
 		setValue(data, key, (prev) => {
 			if (!prev) {
-				return value;
+				return next;
+			} else if (!next) {
+				return prev;
 			} else if (Array.isArray(prev)) {
-				return prev.concat(value);
+				return prev.concat(next);
 			} else {
-				return [prev, value];
+				return [prev, next];
 			}
 		});
 	}

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -102,7 +102,7 @@ export function resolve(
 	payload: FormData | URLSearchParams,
 	options: {
 		ignoreKeys?: string[];
-		stripEmptyValues?: boolean;
+		stripEmptyValue?: boolean;
 	} = {},
 ) {
 	const data = {};
@@ -115,11 +115,13 @@ export function resolve(
 		let next: FormDataEntryValue | undefined = value;
 
 		if (
-			options.stripEmptyValues &&
+			options.stripEmptyValue &&
 			(typeof next === 'string'
 				? next === ''
 				: next.name === '' && next.size === 0)
 		) {
+			// Set the value to undefined instead of skipping it
+			// to maintain the data structure
 			next = undefined;
 		}
 

--- a/packages/conform-dom/parse.ts
+++ b/packages/conform-dom/parse.ts
@@ -19,6 +19,7 @@ export function parse<Schema>(
 			payload: Record<string, any>,
 			intent: string,
 		) => { value?: Schema; error?: Record<string, string | string[]> };
+		stripEmptyValues?: boolean;
 	},
 ): Submission<Schema>;
 export function parse<Schema>(
@@ -28,6 +29,7 @@ export function parse<Schema>(
 			payload: Record<string, any>,
 			intent: string,
 		) => Promise<{ value?: Schema; error?: Record<string, string | string[]> }>;
+		stripEmptyValues?: boolean;
 	},
 ): Promise<Submission<Schema>>;
 export function parse<Schema>(
@@ -39,6 +41,7 @@ export function parse<Schema>(
 		) =>
 			| { value?: Schema; error?: Record<string, string | string[]> }
 			| Promise<{ value?: Schema; error?: Record<string, string | string[]> }>;
+		stripEmptyValues?: boolean;
 	},
 ): Submission<Schema> | Promise<Submission<Schema>>;
 export function parse<Schema>(
@@ -50,11 +53,15 @@ export function parse<Schema>(
 		) =>
 			| { value?: Schema; error?: Record<string, string | string[]> }
 			| Promise<{ value?: Schema; error?: Record<string, string | string[]> }>;
+		stripEmptyValues?: boolean;
 	},
 ): Submission<Schema> | Promise<Submission<Schema>> {
 	const submission: Submission = {
 		intent: getIntent(payload),
-		payload: resolve(payload, [INTENT]),
+		payload: resolve(payload, {
+			ignoreKeys: [INTENT],
+			stripEmptyValues: options?.stripEmptyValues,
+		}),
 		error: {},
 	};
 

--- a/packages/conform-dom/parse.ts
+++ b/packages/conform-dom/parse.ts
@@ -19,7 +19,7 @@ export function parse<Schema>(
 			payload: Record<string, any>,
 			intent: string,
 		) => { value?: Schema; error?: Record<string, string | string[]> };
-		stripEmptyValues?: boolean;
+		stripEmptyValue?: boolean;
 	},
 ): Submission<Schema>;
 export function parse<Schema>(
@@ -29,7 +29,7 @@ export function parse<Schema>(
 			payload: Record<string, any>,
 			intent: string,
 		) => Promise<{ value?: Schema; error?: Record<string, string | string[]> }>;
-		stripEmptyValues?: boolean;
+		stripEmptyValue?: boolean;
 	},
 ): Promise<Submission<Schema>>;
 export function parse<Schema>(
@@ -41,7 +41,7 @@ export function parse<Schema>(
 		) =>
 			| { value?: Schema; error?: Record<string, string | string[]> }
 			| Promise<{ value?: Schema; error?: Record<string, string | string[]> }>;
-		stripEmptyValues?: boolean;
+		stripEmptyValue?: boolean;
 	},
 ): Submission<Schema> | Promise<Submission<Schema>>;
 export function parse<Schema>(
@@ -53,14 +53,14 @@ export function parse<Schema>(
 		) =>
 			| { value?: Schema; error?: Record<string, string | string[]> }
 			| Promise<{ value?: Schema; error?: Record<string, string | string[]> }>;
-		stripEmptyValues?: boolean;
+		stripEmptyValue?: boolean;
 	},
 ): Submission<Schema> | Promise<Submission<Schema>> {
 	const submission: Submission = {
 		intent: getIntent(payload),
 		payload: resolve(payload, {
 			ignoreKeys: [INTENT],
-			stripEmptyValues: options?.stripEmptyValues,
+			stripEmptyValue: options?.stripEmptyValue,
 		}),
 		error: {},
 	};

--- a/packages/conform-zod/README.md
+++ b/packages/conform-zod/README.md
@@ -54,7 +54,10 @@ const schema = z.object({
 function ExampleForm() {
   const [form, { email, password }] = useForm({
     onValidate({ formData }) {
-      return parse(formData, { schema });
+      return parse(formData, {
+        schema,
+        stripEmptyValue: true,
+      });
     },
   });
 
@@ -78,6 +81,9 @@ export async function action({ request }) {
   const submission = await parse(formData, {
     // If you need extra validation on server side
     schema: schema.refine(/* ... */),
+
+    // Recommended: this will be the default in the future
+    stripEmptyValue: true,
 
     // If the schema definition includes async validation
     async: true,

--- a/packages/conform-zod/README.md
+++ b/packages/conform-zod/README.md
@@ -24,8 +24,8 @@ import { getFieldsetConstraint } from '@conform-to/zod';
 import { z } from 'zod';
 
 const schema = z.object({
-  email: z.string().min(1, 'Email is required'),
-  password: z.string().min(1, 'Password is required'),
+  email: z.string({ required_error: 'Email is required' }),
+  password: z.string({ required_error: 'Password is required' }),
 });
 
 function Example() {
@@ -47,8 +47,8 @@ import { parse } from '@conform-to/zod';
 import { z } from 'zod';
 
 const schema = z.object({
-  email: z.string().min(1, 'Email is required'),
-  password: z.string().min(1, 'Password is required'),
+  email: z.string({ required_error: 'Email is required' }),
+  password: z.string({ required_error: 'Password is required' }),
 });
 
 function ExampleForm() {
@@ -107,8 +107,7 @@ function createSchema(
 ) {
   return z.object({
     email: z
-      .string()
-      .min(1, 'Email is required')
+      .string({ required_error: 'Email is required' })
       .email('Email is invalid')
       .superRefine((email, ctx) =>
         refine(ctx, {

--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -225,7 +225,7 @@ export function parse<Schema extends z.ZodTypeAny>(
 	},
 ): Submission<z.output<Schema>> | Promise<Submission<z.output<Schema>>> {
 	return baseParse<z.output<Schema>>(payload, {
-		stripEmptyValue: config.stripEmptyValue ?? true,
+		stripEmptyValue: config.stripEmptyValue,
 		resolve(payload, intent) {
 			const schema =
 				typeof config.schema === 'function'

--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -19,6 +19,10 @@ export function getFieldsetConstraint<Source extends z.ZodTypeAny>(
 			constraint = {
 				...inferConstraint(schema.innerType()),
 			};
+		} else if (schema instanceof z.ZodPipeline) {
+			constraint = {
+				...inferConstraint(schema._def.out),
+			};
 		} else if (schema instanceof z.ZodOptional) {
 			constraint = {
 				...inferConstraint(schema.unwrap()),
@@ -181,6 +185,7 @@ export function parse<Schema extends z.ZodTypeAny>(
 		}) => boolean;
 		async?: false;
 		errorMap?: z.ZodErrorMap;
+		stripEmptyValues?: boolean;
 	},
 ): Submission<z.output<Schema>>;
 export function parse<Schema extends z.ZodTypeAny>(
@@ -198,6 +203,7 @@ export function parse<Schema extends z.ZodTypeAny>(
 		}) => boolean;
 		async: true;
 		errorMap?: z.ZodErrorMap;
+		stripEmptyValues?: boolean;
 	},
 ): Promise<Submission<z.output<Schema>>>;
 export function parse<Schema extends z.ZodTypeAny>(
@@ -215,9 +221,11 @@ export function parse<Schema extends z.ZodTypeAny>(
 		}) => boolean;
 		async?: boolean;
 		errorMap?: z.ZodErrorMap;
+		stripEmptyValues?: boolean;
 	},
 ): Submission<z.output<Schema>> | Promise<Submission<z.output<Schema>>> {
 	return baseParse<z.output<Schema>>(payload, {
+		stripEmptyValues: config.stripEmptyValues ?? true,
 		resolve(payload, intent) {
 			const schema =
 				typeof config.schema === 'function'

--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -185,7 +185,7 @@ export function parse<Schema extends z.ZodTypeAny>(
 		}) => boolean;
 		async?: false;
 		errorMap?: z.ZodErrorMap;
-		stripEmptyValues?: boolean;
+		stripEmptyValue?: boolean;
 	},
 ): Submission<z.output<Schema>>;
 export function parse<Schema extends z.ZodTypeAny>(
@@ -203,7 +203,7 @@ export function parse<Schema extends z.ZodTypeAny>(
 		}) => boolean;
 		async: true;
 		errorMap?: z.ZodErrorMap;
-		stripEmptyValues?: boolean;
+		stripEmptyValue?: boolean;
 	},
 ): Promise<Submission<z.output<Schema>>>;
 export function parse<Schema extends z.ZodTypeAny>(
@@ -221,11 +221,11 @@ export function parse<Schema extends z.ZodTypeAny>(
 		}) => boolean;
 		async?: boolean;
 		errorMap?: z.ZodErrorMap;
-		stripEmptyValues?: boolean;
+		stripEmptyValue?: boolean;
 	},
 ): Submission<z.output<Schema>> | Promise<Submission<z.output<Schema>>> {
 	return baseParse<z.output<Schema>>(payload, {
-		stripEmptyValues: config.stripEmptyValues ?? true,
+		stripEmptyValue: config.stripEmptyValue ?? true,
 		resolve(payload, intent) {
 			const schema =
 				typeof config.schema === 'function'

--- a/playground/app/routes/async-validation.tsx
+++ b/playground/app/routes/async-validation.tsx
@@ -51,6 +51,7 @@ export async function action({ request }: ActionArgs) {
 					});
 				},
 			}),
+		stripEmptyValue: true,
 		async: true,
 	});
 
@@ -66,6 +67,7 @@ export default function EmployeeForm() {
 			? ({ formData }) =>
 					parse(formData, {
 						schema: (intent) => createSchema(intent),
+						stripEmptyValue: true,
 					})
 			: undefined,
 	});

--- a/playground/app/routes/async-validation.tsx
+++ b/playground/app/routes/async-validation.tsx
@@ -14,8 +14,7 @@ function createSchema(
 ) {
 	return z.object({
 		email: z
-			.string()
-			.min(1, 'Email is required')
+			.string({ required_error: 'Email is required' })
 			.email('Email is invalid')
 			.superRefine((email, ctx) =>
 				refine(ctx, {
@@ -24,7 +23,9 @@ function createSchema(
 					message: 'Email is already used',
 				}),
 			),
-		title: z.string().min(1, 'Title is required').max(20, 'Title is too long'),
+		title: z
+			.string({ required_error: 'Title is required' })
+			.max(20, 'Title is too long'),
 	});
 }
 

--- a/playground/app/routes/custom-inputs.tsx
+++ b/playground/app/routes/custom-inputs.tsx
@@ -11,7 +11,7 @@ import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid';
 import * as Checkbox from '@radix-ui/react-checkbox';
 
 const schema = z.object({
-	language: z.string().min(1, 'Language is required'),
+	language: z.string({ required_error: 'Language is required' }),
 	tos: z
 		.string({ required_error: 'Please accept the terms of service' })
 		.transform((value) => value === 'on'),

--- a/playground/app/routes/custom-inputs.tsx
+++ b/playground/app/routes/custom-inputs.tsx
@@ -27,7 +27,7 @@ export async function loader({ request }: LoaderArgs) {
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = parse(formData, { schema });
+	const submission = parse(formData, { schema, stripEmptyValue: true });
 
 	return json(submission);
 }
@@ -39,7 +39,7 @@ export default function Example() {
 		id: 'example',
 		lastSubmission,
 		onValidate: !noClientValidate
-			? ({ formData }) => parse(formData, { schema })
+			? ({ formData }) => parse(formData, { schema, stripEmptyValue: true })
 			: undefined,
 	});
 

--- a/playground/app/routes/file-upload.tsx
+++ b/playground/app/routes/file-upload.tsx
@@ -7,23 +7,19 @@ import { z } from 'zod';
 import { Playground, Field, Alert } from '~/components';
 
 const JsonFile = z
-	.instanceof(File)
-	.refine((file) => file.name !== '' && file.size !== 0, 'File is required')
+	.instanceof(File, { message: 'File is required' })
 	.refine(
 		(file) => file.type === 'application/json',
 		'Only JSON file is accepted',
 	);
 
 const schema = z.object({
-	file: z.preprocess(
-		(value) => (value === '' ? new File([], '') : value),
-		JsonFile,
-	),
+	file: JsonFile,
 	files: z
 		.preprocess((value) => {
 			if (Array.isArray(value)) {
 				return value;
-			} else if (value instanceof File && value.name !== '' && value.size > 0) {
+			} else if (value instanceof File) {
 				return [value];
 			} else {
 				return [];

--- a/playground/app/routes/file-upload.tsx
+++ b/playground/app/routes/file-upload.tsx
@@ -41,7 +41,7 @@ export async function loader({ request }: LoaderArgs) {
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = parse(formData, { schema });
+	const submission = parse(formData, { schema, stripEmptyValue: true });
 
 	return json(submission);
 }
@@ -52,7 +52,7 @@ export default function FileUpload() {
 	const [form, { file, files }] = useForm({
 		lastSubmission,
 		onValidate: !noClientValidate
-			? ({ formData }) => parse(formData, { schema })
+			? ({ formData }) => parse(formData, { schema, stripEmptyValue: true })
 			: undefined,
 	});
 

--- a/playground/app/routes/index.tsx
+++ b/playground/app/routes/index.tsx
@@ -20,7 +20,7 @@ export async function loader({ request }: LoaderArgs) {
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = parse(formData, { schema });
+	const submission = parse(formData, { schema, stripEmptyValue: true });
 
 	return json(submission);
 }
@@ -31,7 +31,7 @@ export default function Example() {
 	const [form, { name }] = useForm({
 		lastSubmission,
 		onValidate: !noClientValidate
-			? ({ formData }) => parse(formData, { schema })
+			? ({ formData }) => parse(formData, { schema, stripEmptyValue: true })
 			: undefined,
 	});
 

--- a/playground/app/routes/index.tsx
+++ b/playground/app/routes/index.tsx
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import { Playground, Field } from '~/components';
 
 const schema = z.object({
-	name: z.string().min(1, 'Name is required'),
+	name: z.string({ required_error: 'Name is required' }),
 });
 
 export async function loader({ request }: LoaderArgs) {

--- a/playground/app/routes/multiple-errors.tsx
+++ b/playground/app/routes/multiple-errors.tsx
@@ -61,6 +61,7 @@ function parseForm(formData: FormData, validator: string | null) {
 						)
 						.refine((username) => username.match(/[0-9]/), 'At least 1 number'),
 				}),
+				stripEmptyValue: true,
 				acceptMultipleErrors({ name }) {
 					return name === 'username';
 				},

--- a/playground/app/routes/multiple-errors.tsx
+++ b/playground/app/routes/multiple-errors.tsx
@@ -49,24 +49,17 @@ function parseForm(formData: FormData, validator: string | null) {
 			return parseWithZod(formData, {
 				schema: z.object({
 					username: z
-						.string()
-						.min(1, 'Username is required')
+						.string({ required_error: 'Username is required' })
+						.min(5, 'Min. 5 characters')
 						.refine(
-							(username) => !username || username.length > 5,
-							'Min. 5 characters',
-						)
-						.refine(
-							(username) => !username || username.toUpperCase() !== username,
+							(username) => username.toUpperCase() !== username,
 							'At least 1 lowercase character',
 						)
 						.refine(
-							(username) => !username || username.toLowerCase() !== username,
+							(username) => username.toLowerCase() !== username,
 							'At least 1 uppercase character',
 						)
-						.refine(
-							(username) => !username || username.match(/[0-9]/),
-							'At least 1 number',
-						),
+						.refine((username) => username.match(/[0-9]/), 'At least 1 number'),
 				}),
 				acceptMultipleErrors({ name }) {
 					return name === 'username';

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -12,14 +12,15 @@ import { parseConfig } from '~/config';
 
 const schema = z.object({
 	iban: z
-		.string()
-		.min(1, 'IBAN is required')
+		.string({ required_error: 'IBAN is required' })
 		.regex(
 			/^[A-Z]{2}[0-9]{2}(?:[ ]?[0-9]{4}){4}(?:[ ]?[0-9]{1,2})?$/,
 			'Please provide a valid IBAN',
 		),
 	amount: z.object({
-		currency: z.string().min(3, 'Please select a currency'),
+		currency: z
+			.string({ required_error: 'Please select a currency' })
+			.min(3, 'Please select a currency'),
 		value: z.preprocess(
 			ifNonEmptyString(Number),
 			z.number({ required_error: 'Value is required' }).min(1),

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -42,7 +42,7 @@ export async function loader({ request }: LoaderArgs) {
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = parse(formData, { schema });
+	const submission = parse(formData, { schema, stripEmptyValue: true });
 
 	return json(submission);
 }
@@ -55,7 +55,7 @@ export default function PaymentForm() {
 		lastSubmission,
 		constraint: getFieldsetConstraint(schema),
 		onValidate: config.validate
-			? ({ formData }) => parse(formData, { schema })
+			? ({ formData }) => parse(formData, { schema, stripEmptyValue: true })
 			: undefined,
 		shouldRevalidate: 'onInput',
 	});

--- a/playground/app/routes/reset-default-value.tsx
+++ b/playground/app/routes/reset-default-value.tsx
@@ -49,6 +49,7 @@ export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parse(formData, {
 		schema,
+		stripEmptyValue: true,
 	});
 
 	if (!submission.value || submission.intent !== 'submit') {

--- a/playground/app/routes/reset-default-value.tsx
+++ b/playground/app/routes/reset-default-value.tsx
@@ -9,7 +9,7 @@ import { Field, Playground } from '~/components';
 
 const schema = z
 	.object({
-		name: z.string().min(1, 'Name is required'),
+		name: z.string({ required_error: 'Name is required' }),
 		code: z.string().regex(/^#[A-Fa-f0-9]{6}$/, 'The code is invalid'),
 	})
 	.refine(

--- a/playground/app/routes/simple-list.tsx
+++ b/playground/app/routes/simple-list.tsx
@@ -8,8 +8,7 @@ import { Playground, Field, Alert } from '~/components';
 
 const schema = z.object({
 	items: z
-		.string()
-		.min(1, 'The field is required')
+		.string({ required_error: 'The field is required' })
 		.regex(/^[^0-9]+$/, 'Number is not allowed')
 		.array()
 		.min(1, 'At least one item is required')

--- a/playground/app/routes/simple-list.tsx
+++ b/playground/app/routes/simple-list.tsx
@@ -27,7 +27,7 @@ export async function loader({ request }: LoaderArgs) {
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = parse(formData, { schema });
+	const submission = parse(formData, { schema, stripEmptyValue: true });
 
 	return json(submission);
 }
@@ -41,7 +41,7 @@ export default function SimpleList() {
 			? { items: ['default item 0', 'default item 1'] }
 			: undefined,
 		onValidate: !noClientValidate
-			? ({ formData }) => parse(formData, { schema })
+			? ({ formData }) => parse(formData, { schema, stripEmptyValue: true })
 			: undefined,
 	});
 	const itemsList = useFieldList(form.ref, items);

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -16,10 +16,10 @@ import { Playground, Field } from '~/components';
 import { parseConfig } from '~/config';
 
 const schema = z.object({
-	title: z.string().min(1, 'Title is required'),
+	title: z.string({ required_error: 'Title is required' }),
 	tasks: z.array(
 		z.object({
-			content: z.string().min(1, 'Content is required'),
+			content: z.string({ required_error: 'Content is required' }),
 			completed: z
 				.string()
 				.optional()

--- a/playground/app/routes/todos.tsx
+++ b/playground/app/routes/todos.tsx
@@ -34,7 +34,7 @@ export async function loader({ request }: LoaderArgs) {
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = parse(formData, { schema });
+	const submission = parse(formData, { schema, stripEmptyValue: true });
 
 	return json(submission);
 }
@@ -47,7 +47,7 @@ export default function TodosForm() {
 		lastSubmission,
 		constraint: getFieldsetConstraint(schema),
 		onValidate: config.validate
-			? ({ formData }) => parse(formData, { schema })
+			? ({ formData }) => parse(formData, { schema, stripEmptyValue: true })
 			: undefined,
 	});
 	const taskList = useFieldList(form.ref, tasks);

--- a/playground/app/routes/validate.tsx
+++ b/playground/app/routes/validate.tsx
@@ -7,8 +7,8 @@ import { z } from 'zod';
 import { Playground, Field } from '~/components';
 
 const schema = z.object({
-	name: z.string().min(1, 'Name is required'),
-	message: z.string().min(1, 'Message is required'),
+	name: z.string({ required_error: 'Name is required' }),
+	message: z.string({ required_error: 'Message is required' }),
 });
 
 export async function loader({ request }: LoaderArgs) {

--- a/playground/app/routes/validate.tsx
+++ b/playground/app/routes/validate.tsx
@@ -21,7 +21,7 @@ export async function loader({ request }: LoaderArgs) {
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = parse(formData, { schema });
+	const submission = parse(formData, { schema, stripEmptyValue: true });
 
 	return json(submission);
 }
@@ -32,7 +32,7 @@ export default function Validate() {
 	const [form, { name, message }] = useForm({
 		lastSubmission,
 		onValidate: !noClientValidate
-			? ({ formData }) => parse(formData, { schema })
+			? ({ formData }) => parse(formData, { schema, stripEmptyValue: true })
 			: undefined,
 	});
 

--- a/playground/app/routes/validation-flow.tsx
+++ b/playground/app/routes/validation-flow.tsx
@@ -8,12 +8,15 @@ import { Playground, Field } from '~/components';
 
 const schema = z
 	.object({
-		email: z.string().min(1, 'Email is required').email('Email is invalid'),
+		email: z
+			.string({ required_error: 'Email is required' })
+			.email('Email is invalid'),
 		password: z
-			.string()
-			.min(1, 'Password is required')
+			.string({ required_error: 'Password is required' })
 			.min(8, 'Password is too short'),
-		confirmPassword: z.string().min(1, 'Confirm password is required'),
+		confirmPassword: z.string({
+			required_error: 'Confirm password is required',
+		}),
 	})
 	.refine((data) => data.password === data.confirmPassword, {
 		message: 'Confirm password does not match',

--- a/playground/app/routes/validation-flow.tsx
+++ b/playground/app/routes/validation-flow.tsx
@@ -37,7 +37,7 @@ export async function loader({ request }: LoaderArgs) {
 
 export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
-	const submission = parse(formData, { schema });
+	const submission = parse(formData, { schema, stripEmptyValue: true });
 
 	return json(submission);
 }
@@ -55,7 +55,7 @@ export default function ValidationFlow() {
 		shouldValidate,
 		shouldRevalidate,
 		onValidate: !noClientValidate
-			? ({ formData }) => parse(formData, { schema })
+			? ({ formData }) => parse(formData, { schema, stripEmptyValue: true })
 			: undefined,
 	});
 

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -225,7 +225,7 @@ test.describe('conform-zod', () => {
 			'list[0].key': 'required',
 		};
 
-		expect(parse(formData, { schema, stripEmptyValues: true })).toEqual({
+		expect(parse(formData, { schema, stripEmptyValue: true })).toEqual({
 			intent: 'submit',
 			payload,
 			error,
@@ -233,7 +233,7 @@ test.describe('conform-zod', () => {
 		expect(
 			parse(formData, {
 				schema,
-				stripEmptyValues: true,
+				stripEmptyValue: true,
 				acceptMultipleErrors: () => false,
 			}),
 		).toEqual({
@@ -244,7 +244,7 @@ test.describe('conform-zod', () => {
 		expect(
 			parse(formData, {
 				schema,
-				stripEmptyValues: true,
+				stripEmptyValue: true,
 				acceptMultipleErrors: () => true,
 			}),
 		).toEqual({
@@ -296,7 +296,7 @@ test.describe('conform-zod', () => {
 			'': 'refine',
 		};
 
-		expect(parse(formData, { schema, stripEmptyValues: false })).toEqual({
+		expect(parse(formData, { schema, stripEmptyValue: false })).toEqual({
 			intent: 'submit',
 			payload,
 			error,
@@ -304,7 +304,7 @@ test.describe('conform-zod', () => {
 		expect(
 			parse(formData, {
 				schema,
-				stripEmptyValues: false,
+				stripEmptyValue: false,
 				acceptMultipleErrors: () => false,
 			}),
 		).toEqual({
@@ -315,7 +315,7 @@ test.describe('conform-zod', () => {
 		expect(
 			parse(formData, {
 				schema,
-				stripEmptyValues: false,
+				stripEmptyValue: false,
 				acceptMultipleErrors: () => true,
 			}),
 		).toEqual({

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -1,10 +1,5 @@
 import { test, expect } from '@playwright/test';
-import {
-	getFieldsetConstraint,
-	parse,
-	ifNonEmptyString,
-	refine,
-} from '@conform-to/zod';
+import { getFieldsetConstraint, parse, refine } from '@conform-to/zod';
 import { z } from 'zod';
 import { installGlobals } from '@remix-run/node';
 
@@ -18,35 +13,29 @@ function createFormData(entries: Array<[string, string | File]>): FormData {
 	return formData;
 }
 
-test.beforeAll(() => {
-	installGlobals();
-});
-
-test.describe('conform-zod', () => {
-	const schema = z
+function createSchema() {
+	return z
 		.object({
 			text: z
-				.string()
-				.min(1, 'min')
+				.string({ required_error: 'required' })
+				.min(10, 'min')
 				.max(100, 'max')
 				.regex(/^[A-Z]{1-100}$/, 'regex')
 				.refine(() => false, 'refine'),
-			number: z.preprocess(
-				ifNonEmptyString(Number),
-				z.number().min(1, 'min').max(10, 'max').step(2, 'step'),
-			),
-			timestamp: z.preprocess(
-				ifNonEmptyString((value) => new Date(value)),
-				z
-					.date()
-					.min(new Date(1), 'min')
-					.max(new Date(), 'max')
-					.default(new Date()),
-			),
-			flag: z.preprocess(
-				ifNonEmptyString((value) => value === 'Yes'),
-				z.boolean().optional(),
-			),
+			number: z
+				.string({ required_error: 'required' })
+				.pipe(z.coerce.number().min(1, 'min').max(10, 'max').step(2, 'step')),
+			timestamp: z
+				.string()
+				.optional()
+				.pipe(
+					z.coerce
+						.date()
+						.min(new Date(1), 'min')
+						.max(new Date(), 'max')
+						.default(new Date()),
+				),
+			flag: z.coerce.boolean().optional(),
 			options: z
 				.array(z.enum(['a', 'b', 'c']).refine(() => false, 'refine'))
 				.min(3, 'min'),
@@ -59,43 +48,34 @@ test.describe('conform-zod', () => {
 				.array(
 					z
 						.object({
-							key: z.string().refine(() => false, 'refine'),
+							key: z
+								.string({ required_error: 'required' })
+								.refine(() => false, 'refine'),
 						})
 						.refine(() => false, 'refine'),
 				)
 				.max(0, 'max'),
+			files: z.preprocess(
+				(value) => (!value || Array.isArray(value) ? value : [value]),
+				z.array(z.instanceof(File, { message: 'file message' }), {
+					required_error: 'required',
+				}),
+			),
 		})
 		.refine(() => false, 'refine');
+}
 
-	const payload = {
-		text: '',
-		number: '3',
-		timestamp: new Date(0).toISOString(),
-		flag: 'no',
-		options: ['a', 'b'],
-		nested: { key: '' },
-		list: [{ key: '' }],
-	};
-	const error = {
-		text: 'min',
-		number: 'step',
-		timestamp: 'min',
-		options: 'min',
-		'options[0]': 'refine',
-		'options[1]': 'refine',
-		'nested.key': 'refine',
-		nested: 'refine',
-		list: 'max',
-		'list[0].key': 'refine',
-		'list[0]': 'refine',
-		'': 'refine',
-	};
+test.beforeAll(() => {
+	installGlobals();
+});
 
+test.describe('conform-zod', () => {
 	test('getFieldsetConstraint', () => {
+		const schema = createSchema();
 		const constraint = {
 			text: {
 				required: true,
-				minLength: 1,
+				minLength: 10,
 				maxLength: 100,
 				pattern: '^[A-Z]{1-100}$',
 			},
@@ -113,6 +93,10 @@ test.describe('conform-zod', () => {
 			options: {
 				required: true,
 				pattern: 'a|b|c',
+				multiple: true,
+			},
+			files: {
+				required: true,
 				multiple: true,
 			},
 			nested: {
@@ -204,32 +188,136 @@ test.describe('conform-zod', () => {
 		});
 	});
 
-	test('parse', () => {
+	test('parse with empty value stripped', () => {
+		const schema = createSchema();
 		const formData = createFormData([
-			['text', payload.text],
-			['number', payload.number],
-			['timestamp', payload.timestamp],
-			['flag', payload.flag],
-			['options[0]', payload.options[0]],
-			['options[1]', payload.options[1]],
-			['nested.key', payload.nested.key],
-			['list[0].key', payload.list[0].key],
+			['text', 'xyz'],
+			['number', '3'],
+			['timestamp', new Date(0).toISOString()],
+			['flag', 'no'],
+			['options[0]', 'a'],
+			['options[1]', 'b'],
+			['nested.key', 'foobar'],
+			['list[0].key', ''],
+			['files', new File([''], '')],
 		]);
+		const payload = {
+			text: 'xyz',
+			number: '3',
+			timestamp: new Date(0).toISOString(),
+			flag: 'no',
+			options: ['a', 'b'],
+			files: undefined,
+			nested: { key: 'foobar' },
+			list: [{ key: undefined }],
+		};
+		const error = {
+			text: 'min',
+			number: 'step',
+			timestamp: 'min',
+			options: 'min',
+			'options[0]': 'refine',
+			'options[1]': 'refine',
+			'nested.key': 'refine',
+			files: 'required',
+			nested: 'refine',
+			list: 'max',
+			'list[0].key': 'required',
+		};
 
-		expect(parse(formData, { schema })).toEqual({
+		expect(parse(formData, { schema, stripEmptyValues: true })).toEqual({
 			intent: 'submit',
 			payload,
 			error,
 		});
 		expect(
-			parse(formData, { schema, acceptMultipleErrors: () => false }),
+			parse(formData, {
+				schema,
+				stripEmptyValues: true,
+				acceptMultipleErrors: () => false,
+			}),
 		).toEqual({
 			intent: 'submit',
 			payload,
 			error,
 		});
 		expect(
-			parse(formData, { schema, acceptMultipleErrors: () => true }),
+			parse(formData, {
+				schema,
+				stripEmptyValues: true,
+				acceptMultipleErrors: () => true,
+			}),
+		).toEqual({
+			intent: 'submit',
+			payload,
+			error: {
+				...error,
+				text: ['min', 'regex', 'refine'],
+			},
+		});
+	});
+
+	test('parse without empty value stripped', () => {
+		const schema = createSchema();
+		const emptyFile = new File([''], '');
+		const formData = createFormData([
+			['text', 'xyz'],
+			['number', '3'],
+			['timestamp', new Date(0).toISOString()],
+			['flag', 'no'],
+			['options[0]', 'a'],
+			['options[1]', 'b'],
+			['nested.key', 'foobar'],
+			['list[0].key', ''],
+			['files', emptyFile],
+		]);
+		const payload = {
+			text: 'xyz',
+			number: '3',
+			timestamp: new Date(0).toISOString(),
+			flag: 'no',
+			options: ['a', 'b'],
+			files: emptyFile,
+			nested: { key: 'foobar' },
+			list: [{ key: '' }],
+		};
+		const error = {
+			text: 'min',
+			number: 'step',
+			timestamp: 'min',
+			options: 'min',
+			'options[0]': 'refine',
+			'options[1]': 'refine',
+			'nested.key': 'refine',
+			nested: 'refine',
+			list: 'max',
+			'list[0].key': 'refine',
+			'list[0]': 'refine',
+			'': 'refine',
+		};
+
+		expect(parse(formData, { schema, stripEmptyValues: false })).toEqual({
+			intent: 'submit',
+			payload,
+			error,
+		});
+		expect(
+			parse(formData, {
+				schema,
+				stripEmptyValues: false,
+				acceptMultipleErrors: () => false,
+			}),
+		).toEqual({
+			intent: 'submit',
+			payload,
+			error,
+		});
+		expect(
+			parse(formData, {
+				schema,
+				stripEmptyValues: false,
+				acceptMultipleErrors: () => true,
+			}),
 		).toEqual({
 			intent: 'submit',
 			payload,
@@ -242,16 +330,16 @@ test.describe('conform-zod', () => {
 
 	test('parse with errorMap', () => {
 		const schema = z.object({
-			text: z.string().min(1),
+			text: z.string().min(5),
 		});
-		const formData = createFormData([['text', '']]);
+		const formData = createFormData([['text', 'abc']]);
 
 		expect(
 			parse(formData, {
 				schema,
 				errorMap(error, ctx) {
-					if (error.code === 'too_small' && error.minimum === 1) {
-						return { message: 'The field is required' };
+					if (error.code === 'too_small' && error.minimum === 5) {
+						return { message: 'The field is too short' };
 					}
 
 					// fall back to default message!
@@ -261,10 +349,10 @@ test.describe('conform-zod', () => {
 		).toEqual({
 			intent: 'submit',
 			payload: {
-				text: '',
+				text: 'abc',
 			},
 			error: {
-				text: 'The field is required',
+				text: 'The field is too short',
 			},
 		});
 	});


### PR DESCRIPTION
Fix #196.

This adds an extra option on `parse` to strip all empty value. This is an opt-in feature for now and very likely the default on v0.8.

```tsx
// Instead of this:
const schema = z.object({
  text: z.string().min(1, 'Email is required');
});

const submission = parse(formData, { schema });

// Do this:
const schema = z.object({
  email: z.string({ required_error: 'Email is required'),
});

const submission = parse(formData, { schema, stripEmptyValue: true });
```
