### PR TITLE
docs: update comments for (re)validation

### DIFF
--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -94,7 +94,7 @@ export interface FormConfig<
 
 	/**
 	 * Define when conform should start validation.
-	 * Support "onSubmit", "onChange", "onBlur".
+	 * Support "onSubmit", "onInput", "onBlur".
 	 *
 	 * @default "onSubmit"
 	 */
@@ -102,7 +102,7 @@ export interface FormConfig<
 
 	/**
 	 * Define when conform should revalidate again.
-	 * Support "onSubmit", "onChange", "onBlur".
+	 * Support "onSubmit", "onInput", "onBlur".
 	 *
 	 * @default shouldValidate, or "onSubmit" if shouldValidate is not provided.
 	 */


### PR DESCRIPTION
Original comment suggests that `"onChange"` is allowed, while it's actually `"onInput"`