### PR TITLE
feat: restrict boolean coercion

### DIFF
--- a/docs/checkbox-and-radio-group.md
+++ b/docs/checkbox-and-radio-group.md
@@ -6,17 +6,17 @@ Conform provides a set of [conform](/packages/conform-react/README.md#conform) h
 
 ## On this page
 
-- [Radio button](#radio-button)
+- [Radio Group](#radio-group)
 - [Checkbox](#checkbox)
 
 <!-- /aside -->
 
-## Radio button
+## Radio Group
 
 Setting up a radio group is no different from other inputs. You just need to pass the list of options to the helper and each option will be set as the value of the input. The helper will also derive the `defaultChecked` property and manage the `id` and aria attributes for you.
 
 ```tsx
-import { useForm } from '@conform-to/react';
+import { conform, useForm } from '@conform-to/react';
 import { parse } from '@conform-to/zod';
 import { z } from 'zod';
 
@@ -59,7 +59,7 @@ function Example() {
 Setting up a checkbox group would be similar to a radio group except the `type` is set to `checkbox`.
 
 ```tsx
-import { useForm } from '@conform-to/react';
+import { conform, useForm } from '@conform-to/react';
 import { parse } from '@conform-to/zod';
 import { z } from 'zod';
 
@@ -94,6 +94,45 @@ function Example() {
           )))}
         <div>{answer.error}</div>
       </legend>
+      <button>Submit</button>
+    </form>
+  );
+}
+```
+
+However, if you are using checkbox as a boolean, you can use the `input` helper instead.
+
+```tsx
+import { conform, useForm } from '@conform-to/react';
+import { parse } from '@conform-to/zod';
+import { z } from 'zod';
+
+const schema = z.object({
+  acceptTerms: z.boolean({
+    required_error: 'You must accept the terms and conditions',
+  }),
+  subscribeNewsletter: z.boolean().optional(),
+});
+
+function Example() {
+  const [form, { acceptTerms, subscribeNewsletter }] = useForm({
+    onValidate({ formData }) {
+      return parse(formData, { schema });
+    },
+  });
+
+  return (
+    <form {...form.props}>
+      <div>
+        <label>Terms and conditions</label>
+        <input {...conform.input(acceptTerms, { type: 'checkbox' })} />
+        <div>{acceptTerms.error}</div>
+      </div>
+      <div>
+        <label>Subscribe Newsletter</label>
+        <input {...conform.input(subscribeNewsletter, { type: 'checkbox' })} />
+        <div>{subscribeNewsletter.error}</div>
+      </div>
       <button>Submit</button>
     </form>
   );

--- a/examples/react-router/src/todos.tsx
+++ b/examples/react-router/src/todos.tsx
@@ -97,7 +97,6 @@ function TaskFieldset({ title, ...config }: TaskFieldsetProps) {
 						className={completed.error ? 'error' : ''}
 						type="checkbox"
 						name={completed.name}
-						value="yes"
 					/>
 				</label>
 			</div>

--- a/packages/conform-zod/coercion.ts
+++ b/packages/conform-zod/coercion.ts
@@ -111,7 +111,10 @@ export function enableTypeCoercion<Type extends ZodTypeAny>(
 	} else if (type instanceof ZodNumber) {
 		schema = preprocess((value) => coerceString(value, Number), type);
 	} else if (type instanceof ZodBoolean) {
-		schema = preprocess((value) => coerceString(value, Boolean), type);
+		schema = preprocess(
+			(value) => coerceString(value, (text) => (text === 'on' ? true : text)),
+			type,
+		);
 	} else if (type instanceof ZodDate) {
 		schema = preprocess(
 			(value) =>

--- a/playground/app/routes/payment.tsx
+++ b/playground/app/routes/payment.tsx
@@ -76,7 +76,6 @@ export default function PaymentForm() {
 						<input
 							{...conform.input(verified, {
 								type: 'checkbox',
-								value: 'Yes',
 							})}
 						/>
 					</Field>

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -371,6 +371,15 @@ test.describe('conform-zod', () => {
 			).toEqual({
 				intent: 'submit',
 				payload: { test: 'abc' },
+				error: { test: ['invalid'] },
+			});
+			expect(
+				parse(createFormData([['test', 'on']]), {
+					schema,
+				}),
+			).toEqual({
+				intent: 'submit',
+				payload: { test: 'on' },
 				error: {},
 				value: {
 					test: true,

--- a/tests/react.spec.ts
+++ b/tests/react.spec.ts
@@ -255,7 +255,7 @@ test.describe('Client Validation', () => {
 					value: '1',
 				},
 				timestamp,
-				verified: 'Yes',
+				verified: 'on',
 			},
 			error: {},
 			value: {


### PR DESCRIPTION
I think it would be too aggresive if conform coerce anything truthy to true. This restrict it to `on` only (i.e. the default value of checkbox). If there is a need to use custom value, it is better to be explicit:

```tsx
import { conform, useForm } from '@conform-to/react';
import { parse } from '@conform-to/zod';
import { z } from 'zod';

const schema = z.object({
  confirmed: z.string().transform(value => value === 'yes'),
});

function Example() {
  const [form, { confirmed }] = useForm({
    onValidate({ formData }) {
      return parse(formData, { schema });
    },
  });

  return (
    <form {...form.props}>
      {/* Example 1: Custom checkbox value */}
      <div>
        <label>Confirm</label>
        <input {...conform.input(confirmed, { type: 'checkbox', value: 'yes' })} />
        <div>{confirmed.error}</div>
      </div>
      {/* Example 2: Confirmation text */}
      <div>
        <label>Type "yes" to confirm</label>
        <input {...conform.input(confirmed, { type: 'text' })} />
        <div>{confirmed.error}</div>
      </div>
      <button>Submit</button>
    </form>
  );
}
```