### PR TITLE
fix(ts): set payload to unknown value type

### DIFF
--- a/packages/conform-dom/parse.ts
+++ b/packages/conform-dom/parse.ts
@@ -3,7 +3,7 @@ import { INTENT, getIntent, parseIntent, updateList } from './intent.js';
 
 export type Submission<Schema = any> = {
 	intent: string;
-	payload: Record<string, any>;
+	payload: Record<string, unknown>;
 	error: Record<string, string[]>;
 	value?: Schema | null;
 };


### PR DESCRIPTION
The Jsonify utility used by Remix will make a `Record<string, any>` disappear in the type: https://github.com/remix-run/remix/issues/7246

But considering this further, "unknown" is a safer option for this type anyway because it avoids issues with accidentally accessing the values off the submission payload without first checking them. So I do think this change should be made.