### PR TITLE
fix(conform-zod): avoid using preprocess

### DIFF
--- a/examples/remix/package.json
+++ b/examples/remix/package.json
@@ -18,7 +18,7 @@
 		"isbot": "latest",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"zod": "^3.21.0"
+		"zod": "^3.22.2"
 	},
 	"devDependencies": {
 		"@remix-run/dev": "^1.19.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -250,7 +250,7 @@
 				"isbot": "latest",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
-				"zod": "^3.21.0"
+				"zod": "^3.22.2"
 			},
 			"devDependencies": {
 				"@remix-run/dev": "^1.19.3",
@@ -30031,9 +30031,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.21.0.tgz",
-			"integrity": "sha512-UYdykTcVxB6lfdyLzAqLyyYAlOcpoluECvjsdoaqfQmz9p+3LRaIqYcNiL/J2kFYp66fBM8wwBvIGVEjq7KtZw==",
+			"version": "3.22.2",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
+			"integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -30086,7 +30086,7 @@
 			"version": "0.8.0",
 			"license": "MIT",
 			"devDependencies": {
-				"zod": "^3.21.0"
+				"zod": "^3.22.2"
 			},
 			"peerDependencies": {
 				"@conform-to/dom": "0.8.0",
@@ -32495,7 +32495,7 @@
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"typescript": "^4.9.5",
-				"zod": "^3.21.0"
+				"zod": "^3.22.2"
 			}
 		},
 		"@conform-to/dom": {
@@ -32545,7 +32545,7 @@
 		"@conform-to/zod": {
 			"version": "file:packages/conform-zod",
 			"requires": {
-				"zod": "^3.21.0"
+				"zod": "^3.22.2"
 			}
 		},
 		"@csstools/normalize.css": {
@@ -51268,9 +51268,9 @@
 			}
 		},
 		"zod": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.21.0.tgz",
-			"integrity": "sha512-UYdykTcVxB6lfdyLzAqLyyYAlOcpoluECvjsdoaqfQmz9p+3LRaIqYcNiL/J2kFYp66fBM8wwBvIGVEjq7KtZw=="
+			"version": "3.22.2",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
+			"integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg=="
 		},
 		"zwitch": {
 			"version": "2.0.2",

--- a/packages/conform-zod/package.json
+++ b/packages/conform-zod/package.json
@@ -29,7 +29,7 @@
 		"zod": "^3.21.0"
 	},
 	"devDependencies": {
-		"zod": "^3.21.0"
+		"zod": "^3.22.2"
 	},
 	"keywords": [
 		"constraint-validation",


### PR DESCRIPTION
This seems to get around the current bug on __zod v3.22__ with regards to `.preprocess()`.

Fix #271, #280

References:
- https://github.com/colinhacks/zod/issues/2677
- https://github.com/colinhacks/zod/issues/2671