### PR TITLE
Update hooks.ts lastsubmission to accept null value

### DIFF
--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -116,7 +116,7 @@ export interface FormConfig<
 	/**
 	 * An object describing the result of the last submission
 	 */
-	lastSubmission?: SubmissionResult;
+	lastSubmission?: SubmissionResult | null;
 
 	/**
 	 * An object describing the constraint of each field
@@ -218,7 +218,7 @@ function useConfigRef<Config>(config: Config) {
 
 function useFormReporter(
 	ref: RefObject<HTMLFormElement>,
-	lastSubmission: SubmissionResult | undefined,
+	lastSubmission: SubmissionResult | undefined | null,
 ) {
 	const [submission, setSubmission] = useState(lastSubmission);
 	const report = useCallback(


### PR DESCRIPTION
In Remix, there may be times when you need to return json(null), which is often what Remix expects. If you return json(undefined), the loaders are not refetched. To resolve this issue, accepting null for "lastsubmission" keeps TypeScript happy and ensures the loader is refetched.