### PR TITLE
docs: Add closing </div> tags to HTML snippet

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -24,12 +24,12 @@ function Example() {
             <div>
                 <label>Title</label>
                 <input type="text" name="title" />
-                <div>{title.error}
+                <div>{title.error}</div>
             </div>
             <div>
                 <label>Description</label>
                 <textarea name="description" />
-                <div>{description.error}
+                <div>{description.error}</div>
             </div>
             <div>
                 <label>Color</label>


### PR DESCRIPTION
I was reading through the docs and based on the indentation, it seems the elements that were supposed to contain the error messages from `confirm` were not closed.
