### PR TITLE
Pass Output type to Submission in onSubmit

### DIFF
--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -156,7 +156,7 @@ export interface FormConfig<
 		event: FormEvent<HTMLFormElement>,
 		context: {
 			formData: FormData;
-			submission: Submission;
+			submission: Submission<Output>;
 			action: string;
 			encType: ReturnType<typeof getFormEncType>;
 			method: ReturnType<typeof getFormMethod>;


### PR DESCRIPTION
Hello,

I apply this patch on my projects and i think it can be useful.

Make `context.submission` aware of the `Output` type.

Now we should be able to have intellisense with `onSubmit` `context` param.

Ex:
```ts
onSubmit(event, context) {
   // it has type
    if (context.submission.value?.step === "send-otp") {
        // do something
    }
},
```