### PR TITLE
Type fixes

### DIFF
--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -147,7 +147,7 @@ export type FormOptions<Schema, FormError = string[], FormValue = Schema> = {
 	/**
 	 * An object describing the result of the last submission
 	 */
-	lastResult?: SubmissionResult<FormError> | null;
+	lastResult?: SubmissionResult<FormError> | null | undefined;
 
 	/**
 	 * Define when conform should start validation.

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -46,7 +46,6 @@ type InputProps = Pretty<
 			| 'email'
 			| 'file'
 			| 'hidden'
-			| 'image'
 			| 'month'
 			| 'number'
 			| 'password'


### PR DESCRIPTION
- Remove `image` as an accepted value for input `type`.
- Add `undefined` as an accepted value for `lastResult`, for improved compatibility with TypeScript's `exactOptionalPropertyTypes`.