### PR TITLE
fix(conform-react): useInputControl should populate initial value and support mult select

### DIFF
--- a/examples/headless-ui/src/App.tsx
+++ b/examples/headless-ui/src/App.tsx
@@ -152,18 +152,26 @@ function classNames(...classes: Array<string | boolean>): string {
 	return classes.filter(Boolean).join(' ');
 }
 
-function ExampleListBox(props: { name: FieldName<string> }) {
+function ExampleListBox(props: { name: FieldName<string[]> }) {
 	const [meta] = useField(props.name);
 	const control = useInputControl(meta);
+	const value =
+		typeof control.value === 'undefined'
+			? []
+			: Array.isArray(control.value)
+			? control.value
+			: [control.value];
 
 	return (
-		<Listbox value={control.value} onChange={control.change}>
-			<input type="hidden" name={meta.name} value={control.value} />
+		<Listbox value={value} onChange={control.change} multiple>
 			<div className="relative mt-1">
 				<Listbox.Button className="relative w-full cursor-default rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 text-left shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm">
 					<span className="block truncate">
-						{people.find((p) => control.value === `${p.id}`)?.name ??
-							'Please select'}
+						{value.length === 0
+							? 'Please select'
+							: value
+									.map((id) => people.find((p) => p.id.toString() === id)?.name)
+									.join(', ')}
 					</span>
 					<span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
 						<ChevronUpDownIcon
@@ -173,7 +181,7 @@ function ExampleListBox(props: { name: FieldName<string> }) {
 					</span>
 				</Listbox.Button>
 				<Listbox.Options className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
-					{[{ id: '', name: 'Please select' }, ...people].map((person) => (
+					{people.map((person) => (
 						<Listbox.Option
 							key={person.id}
 							className={({ active }) =>
@@ -195,7 +203,7 @@ function ExampleListBox(props: { name: FieldName<string> }) {
 										{person.name}
 									</span>
 
-									{person.id !== '' && selected ? (
+									{selected ? (
 										<span
 											className={classNames(
 												active ? 'text-white' : 'text-indigo-600',
@@ -226,8 +234,12 @@ function ExampleCombobox(props: { name: FieldName<string> }) {
 		  );
 
 	return (
-		<Combobox as="div" value={control.value} onChange={control.change} nullable>
-			<input type="hidden" name={meta.name} value={control.value} />
+		<Combobox
+			as="div"
+			value={control.value ?? ''}
+			onChange={control.change}
+			nullable
+		>
 			<div className="relative mt-1">
 				<Combobox.Input
 					className="w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm"
@@ -301,7 +313,6 @@ function ExampleSwitch(props: { name: FieldName<boolean> }) {
 				'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2',
 			)}
 		>
-			<input type="hidden" name={meta.name} value={control.value} />
 			<span className="sr-only">Use setting</span>
 			<span
 				aria-hidden="true"
@@ -334,8 +345,7 @@ function ExampleRadioGroup(props: { name: FieldName<string> }) {
 	];
 
 	return (
-		<RadioGroup value={control.value} onChange={control.change}>
-			<input type="hidden" name={meta.name} value={control.value} />
+		<RadioGroup value={control.value ?? ''} onChange={control.change}>
 			<div className="mt-4 flex items-center space-x-3">
 				{colors.map((color) => (
 					<RadioGroup.Option

--- a/examples/headless-ui/src/App.tsx
+++ b/examples/headless-ui/src/App.tsx
@@ -156,11 +156,7 @@ function ExampleListBox(props: { name: FieldName<string[]> }) {
 	const [meta] = useField(props.name);
 	const control = useInputControl(meta);
 	const value =
-		typeof control.value === 'undefined'
-			? []
-			: Array.isArray(control.value)
-			? control.value
-			: [control.value];
+		typeof control.value === 'string' ? [control.value] : control.value ?? [];
 
 	return (
 		<Listbox value={value} onChange={control.change} multiple>

--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -74,7 +74,7 @@ export type FormValue<Schema> = Schema extends
 	: Schema extends File
 	? File | undefined
 	: Schema extends Array<infer Item>
-	? string | Array<Exclude<FormValue<Item>, undefined>> | undefined
+	? string | Array<FormValue<Item>> | undefined
 	: Schema extends Record<string, any>
 	?
 			| { [Key in UnionKeyof<Schema>]?: FormValue<UnionKeyType<Schema, Key>> }

--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -74,7 +74,7 @@ export type FormValue<Schema> = Schema extends
 	: Schema extends File
 	? File | undefined
 	: Schema extends Array<infer Item>
-	? Array<FormValue<Item>> | undefined
+	? string | Array<Exclude<FormValue<Item>, undefined>> | undefined
 	: Schema extends Record<string, any>
 	?
 			| { [Key in UnionKeyof<Schema>]?: FormValue<UnionKeyType<Schema, Key>> }

--- a/packages/conform-react/integrations.ts
+++ b/packages/conform-react/integrations.ts
@@ -1,85 +1,204 @@
-import { type FieldElement, isFieldElement } from '@conform-to/dom';
 import { type Key, useRef, useState, useMemo, useEffect } from 'react';
 
-export type InputControl = {
-	value: string | undefined;
-	change: (value: string) => void;
+export type InputControl<Value> = {
+	value: Value | undefined;
+	change: (value: Value) => void;
 	focus: () => void;
 	blur: () => void;
 };
 
-export function getFieldElement(
-	formId: string,
+export function getFormElement(formId: string): HTMLFormElement {
+	const element = document.forms.namedItem(formId);
+
+	if (!element) {
+		throw new Error('Form not found');
+	}
+
+	return element;
+}
+
+export function getFieldElements(
+	form: HTMLFormElement,
 	name: string,
-	match: (element: FieldElement) => boolean = () => true,
-): FieldElement | null {
-	const element = document.forms.namedItem(formId)?.elements.namedItem(name);
+): Array<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement> {
+	const field = form.elements.namedItem(name);
+	const elements = !field
+		? []
+		: field instanceof Element
+		? [field]
+		: Array.from(field.values());
 
-	if (element) {
-		const items =
-			element instanceof Element ? [element] : Array.from(element.values());
+	return elements.filter(
+		(
+			element,
+		): element is HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement =>
+			element instanceof HTMLInputElement ||
+			element instanceof HTMLSelectElement ||
+			element instanceof HTMLTextAreaElement,
+	);
+}
 
-		for (const item of items) {
-			if (isFieldElement(item) && match(item)) {
-				return item;
+export function getEventTarget(
+	form: HTMLFormElement,
+	name: string,
+): HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | null {
+	const elements = getFieldElements(form, name);
+
+	return elements[0] ?? null;
+}
+
+export function createDummySelect(
+	form: HTMLFormElement,
+	name: string,
+	value?: string | string[] | undefined,
+): HTMLSelectElement {
+	const select = document.createElement('select');
+	const options = Array.isArray(value) ? value : [value ?? ''];
+
+	select.name = name;
+	select.multiple = true;
+	select.dataset.conform = 'true';
+
+	// To make sure the input is hidden but still focusable
+	select.setAttribute('aria-hidden', 'true');
+	select.tabIndex = -1;
+	select.style.position = 'absolute';
+	select.style.width = '1px';
+	select.style.height = '1px';
+	select.style.padding = '0';
+	select.style.margin = '-1px';
+	select.style.overflow = 'hidden';
+	select.style.clip = 'rect(0,0,0,0)';
+	select.style.whiteSpace = 'nowrap';
+	select.style.border = '0';
+
+	for (const option of options) {
+		select.options.add(new Option(option, option, true, true));
+	}
+
+	form.appendChild(select);
+
+	return select;
+}
+
+export function isDummySelect(
+	element: HTMLElement,
+): element is HTMLSelectElement {
+	return element.dataset.conform === 'true';
+}
+
+export function updateFieldValue(
+	element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement,
+	value: string | string[],
+): void {
+	if (
+		element instanceof HTMLInputElement &&
+		(element.type === 'checkbox' || element.type === 'radio')
+	) {
+		element.checked = element.value === value;
+	} else if (element instanceof HTMLSelectElement && element.multiple) {
+		const selectedValue = Array.isArray(value) ? [...value] : [value];
+
+		for (const option of element.options) {
+			const index = selectedValue.indexOf(option.value);
+			const selected = index > -1;
+
+			// Update the selected state of the option
+			option.selected = selected;
+			// Remove the option from the selected array
+			if (selected) {
+				selectedValue.splice(index, 1);
+			}
+		}
+
+		// Add the remaining options to the select element only if it's a dummy element managed by conform
+		if (isDummySelect(element)) {
+			for (const option of selectedValue) {
+				element.options.add(new Option(option, option, false, true));
+			}
+		}
+	} else if (element.value !== value) {
+		// No `change` event will be triggered on React if `element.value` is already updated
+
+		/**
+		 * Triggering react custom change event
+		 * Solution based on dom-testing-library
+		 * @see https://github.com/facebook/react/issues/10135#issuecomment-401496776
+		 * @see https://github.com/testing-library/dom-testing-library/blob/main/src/events.js#L104-L123
+		 */
+		const { set: valueSetter } =
+			Object.getOwnPropertyDescriptor(element, 'value') || {};
+		const prototype = Object.getPrototypeOf(element);
+		const { set: prototypeValueSetter } =
+			Object.getOwnPropertyDescriptor(prototype, 'value') || {};
+
+		if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
+			prototypeValueSetter.call(element, value);
+		} else {
+			if (valueSetter) {
+				valueSetter.call(element, value);
+			} else {
+				throw new Error('The given element does not have a value setter');
 			}
 		}
 	}
-
-	return null;
 }
 
-export function getEventTarget(formId: string, name: string): FieldElement {
-	const element = getFieldElement(formId, name);
-
-	if (element) {
-		return element;
-	}
-
-	const form = document.forms.namedItem(formId);
-	const input = document.createElement('input');
-
-	input.type = 'hidden';
-	input.name = name;
-
-	form?.appendChild(input);
-
-	return input;
-}
-
-export type InputControlOptions = {
+export function useInputControl<
+	Value extends string | string[],
+>(metaOrOptions: {
 	key?: Key | null | undefined;
 	name: string;
 	formId: string;
-	initialValue?: string | undefined;
-};
-
-export function useInputControl(
-	metaOrOptions: InputControlOptions,
-): InputControl {
+	initialValue?: Value | undefined;
+}): InputControl<Value> {
 	const eventDispatched = useRef({
 		change: false,
 		focus: false,
 		blur: false,
 	});
 	const [key, setKey] = useState(metaOrOptions.key);
-	const [value, setValue] = useState(() => metaOrOptions.initialValue);
+	const [initialValue, setInitialValue] = useState(metaOrOptions.initialValue);
+	const [value, setValue] = useState(metaOrOptions.initialValue);
 
 	if (key !== metaOrOptions.key) {
 		setValue(metaOrOptions.initialValue);
+		setInitialValue(metaOrOptions.initialValue);
 		setKey(metaOrOptions.key);
 	}
 
 	useEffect(() => {
+		const form = getFormElement(metaOrOptions.formId);
+
+		if (getEventTarget(form, metaOrOptions.name)) {
+			return;
+		}
+
+		createDummySelect(form, metaOrOptions.name, initialValue);
+
+		return () => {
+			const elements = getFieldElements(form, metaOrOptions.name);
+
+			for (const element of elements) {
+				if (isDummySelect(element)) {
+					element.remove();
+				}
+			}
+		};
+	}, [metaOrOptions.formId, metaOrOptions.name, initialValue]);
+
+	useEffect(() => {
 		const createEventListener = (listener: 'change' | 'focus' | 'blur') => {
 			return (event: Event) => {
-				const element = getFieldElement(
-					metaOrOptions.formId,
-					metaOrOptions.name,
-					(element) => element === event.target,
-				);
+				const element = event.target;
 
-				if (element) {
+				if (
+					(element instanceof HTMLInputElement ||
+						element instanceof HTMLSelectElement ||
+						element instanceof HTMLTextAreaElement) &&
+					element.name === metaOrOptions.name &&
+					element.form?.id === metaOrOptions.formId
+				) {
 					eventDispatched.current[listener] = true;
 				}
 			};
@@ -99,92 +218,62 @@ export function useInputControl(
 		};
 	}, [metaOrOptions.formId, metaOrOptions.name]);
 
-	const handlers = useMemo<Omit<InputControl, 'value'>>(() => {
+	const handlers = useMemo<Omit<InputControl<Value>, 'value'>>(() => {
 		return {
 			change(value) {
 				if (!eventDispatched.current.change) {
-					const element = getEventTarget(
-						metaOrOptions.formId,
-						metaOrOptions.name,
-					);
-
 					eventDispatched.current.change = true;
 
-					if (
-						element instanceof HTMLInputElement &&
-						(element.type === 'checkbox' || element.type === 'radio')
-					) {
-						element.checked = element.value === value;
-					} else if (element.value !== value) {
-						// No change event will be triggered on React if `element.value` is already updated
+					const form = getFormElement(metaOrOptions.formId);
+					const element = getEventTarget(form, metaOrOptions.name);
 
-						/**
-						 * Triggering react custom change event
-						 * Solution based on dom-testing-library
-						 * @see https://github.com/facebook/react/issues/10135#issuecomment-401496776
-						 * @see https://github.com/testing-library/dom-testing-library/blob/main/src/events.js#L104-L123
-						 */
-						const { set: valueSetter } =
-							Object.getOwnPropertyDescriptor(element, 'value') || {};
-						const prototype = Object.getPrototypeOf(element);
-						const { set: prototypeValueSetter } =
-							Object.getOwnPropertyDescriptor(prototype, 'value') || {};
+					if (element) {
+						updateFieldValue(element, value);
 
-						if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
-							prototypeValueSetter.call(element, value);
-						} else {
-							if (valueSetter) {
-								valueSetter.call(element, value);
-							} else {
-								throw new Error(
-									'The given element does not have a value setter',
-								);
-							}
-						}
+						// Dispatch input event with the updated input value
+						element.dispatchEvent(new InputEvent('input', { bubbles: true }));
+						// Dispatch change event (necessary for select to update the selected option)
+						element.dispatchEvent(new Event('change', { bubbles: true }));
 					}
-
-					// Dispatch input event with the updated input value
-					element.dispatchEvent(new InputEvent('input', { bubbles: true }));
-					// Dispatch change event (necessary for select to update the selected option)
-					element.dispatchEvent(new Event('change', { bubbles: true }));
 				}
 
 				setValue(value);
-
 				eventDispatched.current.change = false;
 			},
 			focus() {
 				if (!eventDispatched.current.focus) {
-					const element = getEventTarget(
-						metaOrOptions.formId,
-						metaOrOptions.name,
-					);
-
 					eventDispatched.current.focus = true;
-					element.dispatchEvent(
-						new FocusEvent('focusin', {
-							bubbles: true,
-						}),
-					);
-					element.dispatchEvent(new FocusEvent('focus'));
+
+					const form = getFormElement(metaOrOptions.formId);
+					const element = getEventTarget(form, metaOrOptions.name);
+
+					if (element) {
+						element.dispatchEvent(
+							new FocusEvent('focusin', {
+								bubbles: true,
+							}),
+						);
+						element.dispatchEvent(new FocusEvent('focus'));
+					}
 				}
 
 				eventDispatched.current.focus = false;
 			},
 			blur() {
 				if (!eventDispatched.current.blur) {
-					const element = getEventTarget(
-						metaOrOptions.formId,
-						metaOrOptions.name,
-					);
-
 					eventDispatched.current.blur = true;
-					element.dispatchEvent(
-						new FocusEvent('focusout', {
-							bubbles: true,
-						}),
-					);
-					element.dispatchEvent(new FocusEvent('blur'));
+
+					const form = getFormElement(metaOrOptions.formId);
+					const element = getEventTarget(form, metaOrOptions.name);
+
+					if (element) {
+						element.dispatchEvent(
+							new FocusEvent('focusout', {
+								bubbles: true,
+							}),
+						);
+						element.dispatchEvent(new FocusEvent('blur'));
+					}
 				}
 
 				eventDispatched.current.blur = false;

--- a/packages/conform-react/integrations.ts
+++ b/packages/conform-react/integrations.ts
@@ -53,7 +53,7 @@ export function createDummySelect(
 	value?: string | string[] | undefined,
 ): HTMLSelectElement {
 	const select = document.createElement('select');
-	const options = Array.isArray(value) ? value : [value ?? ''];
+	const options = typeof value === 'string' ? [value] : value ?? [];
 
 	select.name = name;
 	select.multiple = true;


### PR DESCRIPTION
This fixes #389 and #401.

But there is one minor issue with multi select. As the `initialValue` could be `string` instead of `string[]` in one edge case in which user select only one item AND submit the form AND a full document reload happened. This is because conform have no idea this field is an array and only find one entry from the FormData. 😅 

There are a few options:
1. Let user deal with it like how I did on the `headless-ui` example:
```tsx
const control = useInputControl(meta);
// To make it an array...
const value = typeof control.value === 'undefined'
  ? []
  : Array.isArray(control.value)
  ? control.value
  : [control.value];
```
2. Add a new properties to the `control` object which wraps the logic above, e.g. `control.valueAsArray`
3. Help user lie 😅 This is an edge case, especially in combination with `useInputControl` which will requires JS anyway and it's weird to expect full document reload to work well..?
