### PR TITLE
fix(conform-react): submission reply should not remove null from error

### DIFF
--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -7,7 +7,7 @@ import {
 	isPlainObject,
 	isPrefix,
 	setValue,
-	simplify,
+	normalize,
 } from './formdata';
 import {
 	type FieldElement,
@@ -374,7 +374,7 @@ function createStateProxy<State>(
 function createValueProxy(
 	value: Record<string, unknown>,
 ): Record<string, unknown> {
-	const val = simplify(value);
+	const val = normalize(value);
 	return createStateProxy((name, proxy) => {
 		if (name === '') {
 			return val;

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -162,23 +162,25 @@ export function isFile(obj: unknown): obj is File {
 }
 
 /**
- * Simplify value by removing empty object or array and null values
+ * Normalize value by removing empty object or array, empty string and null values
  */
-export function simplify<Type extends Record<string, unknown>>(
+export function normalize<Type extends Record<string, unknown>>(
 	value: Type | null,
-): Type | undefined;
-export function simplify<Type extends Array<unknown>>(
+): Type | null | undefined;
+export function normalize<Type extends Array<unknown>>(
 	value: Type | null,
-): Type | undefined;
-export function simplify(value: unknown): unknown | undefined;
-export function simplify<Type extends Record<string, unknown> | Array<unknown>>(
+): Type | null | undefined;
+export function normalize(value: unknown): unknown | undefined;
+export function normalize<
+	Type extends Record<string, unknown> | Array<unknown>,
+>(
 	value: Type | null,
-): Record<string, unknown> | Array<unknown> | undefined {
+): Record<string, unknown> | Array<unknown> | null | undefined {
 	if (isPlainObject(value)) {
 		const obj = Object.keys(value)
 			.sort()
 			.reduce<Record<string, unknown>>((result, key) => {
-				const data = simplify(value[key]);
+				const data = normalize(value[key]);
 
 				if (typeof data !== 'undefined') {
 					result[key] = data;
@@ -199,7 +201,7 @@ export function simplify<Type extends Record<string, unknown> | Array<unknown>>(
 			return undefined;
 		}
 
-		return value.map(simplify);
+		return value.map(normalize);
 	}
 
 	if (
@@ -227,7 +229,7 @@ export function flatten(
 	const resolve = options?.resolve ?? ((data) => data);
 
 	function setResult(data: unknown, name: string) {
-		const value = simplify(resolve(data));
+		const value = normalize(resolve(data));
 
 		if (typeof value !== 'undefined') {
 			result[name] = value;

--- a/playground/app/routes/async-validation.tsx
+++ b/playground/app/routes/async-validation.tsx
@@ -93,6 +93,7 @@ export default function EmployeeForm() {
 	const lastResult = useActionData<typeof action>();
 	const [form, fields] = useForm({
 		lastResult,
+		shouldRevalidate: 'onInput',
 		onValidate: !noClientValidate
 			? ({ formData }) =>
 					parseWithZod(formData, {

--- a/tests/integrations/async-validation.spec.ts
+++ b/tests/integrations/async-validation.spec.ts
@@ -8,7 +8,7 @@ function getFieldset(form: Locator) {
 	};
 }
 
-async function runValidationScenario(page: Page) {
+async function runTest(page: Page, javaScriptEnabled: boolean) {
 	const playground = getPlayground(page);
 	const fieldset = getFieldset(playground.container);
 
@@ -65,7 +65,9 @@ async function runValidationScenario(page: Page) {
 	]);
 
 	await fieldset.email.type('hey@conform.g');
-	await playground.submit.click();
+	if (!javaScriptEnabled) {
+		await playground.submit.click();
+	}
 
 	await expect(playground.error).toHaveText([
 		'Email is invalid',
@@ -75,7 +77,9 @@ async function runValidationScenario(page: Page) {
 	await fieldset.email.press('Control+a');
 	await fieldset.email.press('ArrowRight');
 	await fieldset.email.type('u');
-	await playground.submit.click();
+	if (!javaScriptEnabled) {
+		await playground.submit.click();
+	}
 
 	await expect(playground.error).toHaveText([
 		'Email is already used',
@@ -85,7 +89,9 @@ async function runValidationScenario(page: Page) {
 	await fieldset.email.press('Control+a');
 	await fieldset.email.press('ArrowRight');
 	await fieldset.email.type('i');
-	await playground.submit.click();
+	if (!javaScriptEnabled) {
+		await playground.submit.click();
+	}
 
 	await expect(playground.error).toHaveText([
 		'Email is already used',
@@ -95,7 +101,9 @@ async function runValidationScenario(page: Page) {
 	await fieldset.email.press('Control+a');
 	await fieldset.email.press('ArrowRight');
 	await fieldset.email.type('d');
-	await playground.submit.click();
+	if (!javaScriptEnabled) {
+		await playground.submit.click();
+	}
 
 	await expect(playground.error).toHaveText([
 		'Email is already used',
@@ -103,7 +111,9 @@ async function runValidationScenario(page: Page) {
 	]);
 
 	await fieldset.title.type('Software Developer');
-	await playground.submit.click();
+	if (!javaScriptEnabled) {
+		await playground.submit.click();
+	}
 
 	await expect(playground.error).toHaveText(['Email is already used', '']);
 
@@ -132,12 +142,12 @@ async function runValidationScenario(page: Page) {
 test.describe('With JS', () => {
 	test('Client Validation', async ({ page }) => {
 		await page.goto('/async-validation');
-		await runValidationScenario(page);
+		await runTest(page, true);
 	});
 
 	test('Server Validation', async ({ page }) => {
 		await page.goto('/async-validation?noClientValidate=yes');
-		await runValidationScenario(page);
+		await runTest(page, true);
 	});
 
 	test('Form reset', async ({ page }) => {
@@ -171,6 +181,6 @@ test.describe('No JS', () => {
 
 	test('Validation', async ({ page }) => {
 		await page.goto('/async-validation');
-		await runValidationScenario(page);
+		await runTest(page, false);
 	});
 });


### PR DESCRIPTION
We normalized the submission error and remove all `null` accidentally. This makes Conform fail to find out whether validation is skipped and consider the field valid instead.