### PR TITLE
fix(conform-dom): form update value should be serialized

### DIFF
--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -311,7 +311,7 @@ function handleIntent<Error>(
 		case 'update': {
 			if (typeof intent.payload.value !== 'undefined') {
 				const name = intent.payload.name ?? '';
-				const value = intent.payload.value;
+				const value = serialize(intent.payload.value);
 
 				updateValue(meta, name, value);
 			}

--- a/packages/conform-dom/submission.ts
+++ b/packages/conform-dom/submission.ts
@@ -165,7 +165,8 @@ export function parse<FormValue, FormError>(
 				}
 				break;
 			case 'update': {
-				const { name, value, validated } = intent.payload;
+				const { name, validated } = intent.payload;
+				const value = serialize(intent.payload.value);
 
 				if (typeof value !== 'undefined') {
 					if (name) {

--- a/playground/app/routes/form-control.tsx
+++ b/playground/app/routes/form-control.tsx
@@ -16,6 +16,7 @@ import { Playground, Field } from '~/components';
 const schema = z.object({
 	name: z.string({ required_error: 'Name is required' }),
 	message: z.string({ required_error: 'Message is required' }),
+	number: z.number({ required_error: 'Number is required' }),
 });
 
 export async function loader({ request }: LoaderArgs) {
@@ -54,6 +55,9 @@ export default function FormControl() {
 					<Field label="Message" meta={fields.message}>
 						<textarea {...getTextareaProps(fields.message)} />
 					</Field>
+					<Field label="Number" meta={fields.number}>
+						<input {...getInputProps(fields.number, { type: 'number' })} />
+					</Field>
 					<div className="flex flex-col gap-2">
 						<button
 							className="rounded-md border p-2 hover:border-black"
@@ -77,6 +81,15 @@ export default function FormControl() {
 							})}
 						>
 							Update message
+						</button>
+						<button
+							className="rounded-md border p-2 hover:border-black"
+							{...form.update.getButtonProps({
+								name: fields.number.name,
+								value: 123,
+							})}
+						>
+							Update number
 						</button>
 						<button
 							className="rounded-md border p-2 hover:border-black"

--- a/tests/integrations/form-control.spec.ts
+++ b/tests/integrations/form-control.spec.ts
@@ -5,9 +5,11 @@ function getFieldset(form: Locator) {
 	return {
 		name: form.locator('[name="name"]'),
 		message: form.locator('[name="message"]'),
+		number: form.locator('[name="number"]'),
 		validateForm: form.locator('button:text("Validate Form")'),
 		validateMessage: form.locator('button:text("Validate Message")'),
 		updateMessage: form.locator('button:text("Update message")'),
+		updateNumber: form.locator('button:text("Update number")'),
 		clearMessage: form.locator('button:text("Clear message")'),
 		resetMessage: form.locator('button:text("Reset message")'),
 		resetForm: form.locator('button:text("Reset form")'),
@@ -18,36 +20,41 @@ async function runValidationScenario(page: Page) {
 	const playground = getPlayground(page);
 	const fieldset = getFieldset(playground.container);
 
-	await expect(playground.error).toHaveText(['', '']);
+	await expect(playground.error).toHaveText(['', '', '']);
 
 	await fieldset.validateMessage.click();
-	await expect(playground.error).toHaveText(['', 'Message is required']);
+	await expect(playground.error).toHaveText(['', 'Message is required', '']);
 
 	await fieldset.updateMessage.click();
 	await expect(fieldset.name).toHaveValue('');
 	await expect(fieldset.message).toHaveValue('Hello World');
-	await expect(playground.error).toHaveText(['', '']);
+	await expect(playground.error).toHaveText(['', '', '']);
 
 	await fieldset.clearMessage.click();
 	await expect(fieldset.name).toHaveValue('');
 	await expect(fieldset.message).toHaveValue('');
-	await expect(playground.error).toHaveText(['', 'Message is required']);
+	await expect(playground.error).toHaveText(['', 'Message is required', '']);
 
 	await fieldset.resetMessage.click();
 	await expect(fieldset.name).toHaveValue('');
 	await expect(fieldset.message).toHaveValue('');
-	await expect(playground.error).toHaveText(['', '']);
+	await expect(playground.error).toHaveText(['', '', '']);
+
+	await fieldset.updateNumber.click();
+	await expect(fieldset.number).toHaveValue('123');
 
 	await fieldset.validateForm.click();
 	await expect(playground.error).toHaveText([
 		'Name is required',
 		'Message is required',
+		'',
 	]);
 
 	await fieldset.resetForm.click();
 	await expect(fieldset.name).toHaveValue('');
+	await expect(fieldset.number).toHaveValue('');
 	await expect(fieldset.message).toHaveValue('');
-	await expect(playground.error).toHaveText(['', '']);
+	await expect(playground.error).toHaveText(['', '', '']);
 }
 
 test.describe('With JS', () => {


### PR DESCRIPTION
All value within Conform should be serialized.

This fix an issue with `form.update` not working properly with non string value. As `getInputProps` skip setting the default value if the `initialValue` is not string.