### PR TITLE
feat(conform-react): unstable useControl hook

### DIFF
--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -1,10 +1,4 @@
-import type {
-	FormMetadata,
-	FieldMetadata,
-	Metadata,
-	Pretty,
-	Primitive,
-} from './context';
+import type { FormMetadata, FieldMetadata, Metadata, Pretty } from './context';
 
 type FormControlProps = {
 	key: string | undefined;
@@ -246,7 +240,7 @@ export function getFormControlProps<Schema>(
  * <input {...getInputProps(metadata, { type: 'radio', value: false })} />
  * ```
  */
-export function getInputProps<Schema extends Primitive | File[]>(
+export function getInputProps<Schema>(
 	metadata: FieldMetadata<Schema, any, any>,
 	options: InputOptions,
 ): InputProps {
@@ -292,12 +286,7 @@ export function getInputProps<Schema extends Primitive | File[]>(
  * <select {...getSelectProps(metadata, { value: false })} />
  * ```
  */
-export function getSelectProps<
-	Schema extends
-		| Exclude<Primitive, File>
-		| Array<Exclude<Primitive, File>>
-		| undefined,
->(
+export function getSelectProps<Schema>(
 	metadata: FieldMetadata<Schema, any, any>,
 	options: SelectOptions = {},
 ): SelectProps {
@@ -308,8 +297,8 @@ export function getSelectProps<
 
 	if (typeof options.value === 'undefined' || options.value) {
 		props.defaultValue = Array.isArray(metadata.initialValue)
-			? metadata.initialValue.map((item) => `${item ?? ''}`)
-			: metadata.initialValue;
+			? metadata.initialValue.map((item: string | undefined) => `${item ?? ''}`)
+			: metadata.initialValue?.toString();
 	}
 
 	return simplify(props);
@@ -330,9 +319,7 @@ export function getSelectProps<
  * <textarea {...getTextareaProps(metadata, { value: false })} />
  * ```
  */
-export function getTextareaProps<
-	Schema extends Exclude<Primitive, File> | undefined,
->(
+export function getTextareaProps<Schema>(
 	metadata: FieldMetadata<Schema, any, any>,
 	options: TextareaOptions = {},
 ): TextareaProps {
@@ -343,7 +330,7 @@ export function getTextareaProps<
 	};
 
 	if (typeof options.value === 'undefined' || options.value) {
-		props.defaultValue = metadata.initialValue;
+		props.defaultValue = metadata.initialValue?.toString();
 	}
 
 	return simplify(props);

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -14,7 +14,10 @@ export {
 	FormStateInput,
 } from './context';
 export { useForm, useFormMetadata, useField } from './hooks';
-export { useInputControl } from './integrations';
+export {
+	useInputControl,
+	useControl as unstable_useControl,
+} from './integrations';
 export {
 	getFormProps,
 	getFieldsetProps,

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -15,6 +15,7 @@ export {
 } from './context';
 export { useForm, useFormMetadata, useField } from './hooks';
 export {
+	Control as unstable_Control,
 	useControl as unstable_useControl,
 	useInputControl,
 } from './integrations';

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -15,8 +15,8 @@ export {
 } from './context';
 export { useForm, useFormMetadata, useField } from './hooks';
 export {
+	useInputEvent as unstable_useInputEvent,
 	useInputControl,
-	useControl as unstable_useControl,
 } from './integrations';
 export {
 	getFormProps,

--- a/packages/conform-react/index.ts
+++ b/packages/conform-react/index.ts
@@ -15,7 +15,7 @@ export {
 } from './context';
 export { useForm, useFormMetadata, useField } from './hooks';
 export {
-	useInputEvent as unstable_useInputEvent,
+	useControl as unstable_useControl,
 	useInputControl,
 } from './integrations';
 export {

--- a/packages/conform-react/integrations.ts
+++ b/packages/conform-react/integrations.ts
@@ -296,8 +296,8 @@ export function useInputValue<
 
 export function useControl<
 	Value extends string | string[] | Array<string | undefined>,
->(options: { key?: Key | null | undefined; initialValue?: Value | undefined }) {
-	const [value, setValue] = useInputValue(options);
+>(meta: { key?: Key | null | undefined; initialValue?: Value | undefined }) {
+	const [value, setValue] = useInputValue(meta);
 	const { register, change, focus, blur } = useInputEvent();
 	const handleChange = (
 		value: Value extends string ? Value : string | string[],
@@ -380,10 +380,10 @@ export function useInputControl<
 export function Control<
 	Value extends string | string[] | Array<string | undefined>,
 >(props: {
-	options: { key?: Key | null | undefined; initialValue?: Value | undefined };
+	meta: { key?: Key | null | undefined; initialValue?: Value | undefined };
 	render: (control: ReturnType<typeof useControl<Value>>) => React.ReactNode;
 }) {
-	const control = useControl(props.options);
+	const control = useControl(props.meta);
 
 	return props.render(control);
 }

--- a/packages/conform-react/integrations.ts
+++ b/packages/conform-react/integrations.ts
@@ -286,6 +286,25 @@ export function useInputValue<
 	return [value, setValue] as const;
 }
 
+export function useControl<
+	Value extends string | string[] | Array<string | undefined>,
+>(meta: { key?: Key | null | undefined; initialValue?: Value | undefined }) {
+	const [value, setValue] = useInputValue(meta);
+	const { register, change, focus, blur } = useInputEvent();
+	const handleChange = (value: string | string[]) => {
+		setValue(value);
+		change(value);
+	};
+
+	return {
+		register,
+		value,
+		change: handleChange,
+		focus,
+		blur,
+	};
+}
+
 export function useInputControl<
 	Value extends string | string[] | Array<string | undefined>,
 >(meta: {
@@ -295,7 +314,7 @@ export function useInputControl<
 	initialValue?: Value | undefined;
 }) {
 	const [value, setValue] = useInputValue(meta);
-	const [hydrated, setHydrated] = useState(false);
+	const initializedRef = useRef(false);
 	const { register, change, focus, blur } = useInputEvent();
 
 	useEffect(() => {
@@ -321,10 +340,10 @@ export function useInputControl<
 
 		register(element);
 
-		if (hydrated) {
-			change(value ?? '');
+		if (!initializedRef.current) {
+			initializedRef.current = true;
 		} else {
-			setHydrated(true);
+			change(value ?? '');
 		}
 
 		return () => {
@@ -338,7 +357,7 @@ export function useInputControl<
 				}
 			}
 		};
-	}, [meta.formId, meta.name, value, change, register, hydrated]);
+	}, [meta.formId, meta.name, value, change, register]);
 
 	return {
 		value,

--- a/playground/app/routes/custom-inputs.tsx
+++ b/playground/app/routes/custom-inputs.tsx
@@ -3,8 +3,12 @@ import {
 	FormProvider,
 	useForm,
 	useField,
+	unstable_useControl as useControl,
+	unstable_Control as Control,
 	useInputControl,
 	getFormProps,
+	getSelectProps,
+	getCollectionProps,
 } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
@@ -14,7 +18,7 @@ import { z } from 'zod';
 import { Playground, Field } from '~/components';
 import { Listbox } from '@headlessui/react';
 import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid';
-import * as Checkbox from '@radix-ui/react-checkbox';
+import * as RadixCheckbox from '@radix-ui/react-checkbox';
 
 const schema = z.object({
 	color: z.enum(['red', 'green', 'blue'], {
@@ -29,6 +33,7 @@ export async function loader({ request }: LoaderArgs) {
 	const url = new URL(request.url);
 
 	return {
+		legacy: url.searchParams.get('legacy') === 'yes',
 		noClientValidate: url.searchParams.get('noClientValidate') === 'yes',
 	};
 }
@@ -41,7 +46,7 @@ export async function action({ request }: ActionArgs) {
 }
 
 export default function Example() {
-	const { noClientValidate } = useLoaderData<typeof loader>();
+	const { legacy, noClientValidate } = useLoaderData<typeof loader>();
 	const lastResult = useActionData<typeof action>();
 	const [form, fields] = useForm({
 		id: 'example',
@@ -57,31 +62,62 @@ export default function Example() {
 			<Form method="post" {...getFormProps(form)}>
 				<Playground title="Custom Inputs" result={lastResult}>
 					<Field label="Headless ListBox (Single)" meta={fields.color}>
-						<CustomSelect
-							name={fields.color.name}
-							options={['red', 'green', 'blue']}
-							placeholder="Select a color"
-						/>
+						{legacy ? (
+							<OldCustomSelect
+								name={fields.color.name}
+								options={['red', 'green', 'blue']}
+								placeholder="Select a color"
+							/>
+						) : (
+							<Select
+								name={fields.color.name}
+								options={['red', 'green', 'blue']}
+								placeholder="Select a color"
+							/>
+						)}
 					</Field>
 					<Field label="Headless ListBox (Multiple)" meta={fields.languages}>
-						<CustomSelect
-							name={fields.languages.name}
-							options={['English', 'Spanish', 'French']}
-							placeholder="Select languages"
-							multiple
-						/>
+						{legacy ? (
+							<OldCustomSelect
+								name={fields.languages.name}
+								options={['English', 'Spanish', 'French']}
+								placeholder="Select languages"
+								multiple
+							/>
+						) : (
+							<Select
+								name={fields.languages.name}
+								options={['English', 'Spanish', 'French']}
+								placeholder="Select languages"
+								multiple
+							/>
+						)}
 					</Field>
 					<Field label="Radix Checkbox (Single)" meta={fields.tos}>
-						<CustomCheckbox
-							label="I accept the terms of service"
-							name={fields.tos.name}
-						/>
+						{legacy ? (
+							<OldCustomCheckbox
+								label="I accept the terms of service"
+								name={fields.tos.name}
+							/>
+						) : (
+							<Checkbox
+								name={fields.tos.name}
+								label="I accept the terms of service"
+							/>
+						)}
 					</Field>
 					<Field label="Radix Checkbox (Multiple)" meta={fields.options}>
-						<CustomMultipleCheckbox
-							name={fields.options.name}
-							options={['a', 'b', 'c', 'd']}
-						/>
+						{legacy ? (
+							<OldCustomMultipleCheckbox
+								name={fields.options.name}
+								options={['a', 'b', 'c', 'd']}
+							/>
+						) : (
+							<CheckboxGroup
+								name={fields.options.name}
+								options={['a', 'b', 'c', 'd']}
+							/>
+						)}
 					</Field>
 				</Playground>
 			</Form>
@@ -93,7 +129,7 @@ function classNames(...classes: Array<string | boolean>): string {
 	return classes.filter(Boolean).join(' ');
 }
 
-function CustomSelect({
+function OldCustomSelect({
 	name,
 	options,
 	placeholder,
@@ -170,7 +206,7 @@ function CustomSelect({
 	);
 }
 
-function CustomCheckbox({
+function OldCustomCheckbox({
 	name,
 	label,
 }: {
@@ -182,7 +218,7 @@ function CustomCheckbox({
 
 	return (
 		<div className="flex items-center py-2">
-			<Checkbox.Root
+			<RadixCheckbox.Root
 				type="button"
 				className="flex h-[25px] w-[25px] appearance-none items-center justify-center rounded-[4px] bg-white outline-none shadow-[0_0_0_2px_black]"
 				id={field.id}
@@ -190,10 +226,10 @@ function CustomCheckbox({
 				onCheckedChange={(state) => control.change(state.valueOf() ? 'on' : '')}
 				onBlur={control.blur}
 			>
-				<Checkbox.Indicator>
+				<RadixCheckbox.Indicator>
 					<CheckIcon className="w-4 h-4" />
-				</Checkbox.Indicator>
-			</Checkbox.Root>
+				</RadixCheckbox.Indicator>
+			</RadixCheckbox.Root>
 			<label htmlFor={field.id} className="pl-[15px] text-[15px] leading-none">
 				{label}
 			</label>
@@ -201,7 +237,7 @@ function CustomCheckbox({
 	);
 }
 
-function CustomMultipleCheckbox({
+function OldCustomMultipleCheckbox({
 	name,
 	options,
 }: {
@@ -217,7 +253,7 @@ function CustomMultipleCheckbox({
 		<div className="py-2 space-y-4">
 			{options.map((option) => (
 				<div key={option} className="flex items-center">
-					<Checkbox.Root
+					<RadixCheckbox.Root
 						type="button"
 						className="flex h-[25px] w-[25px] appearance-none items-center justify-center rounded-[4px] bg-white outline-none shadow-[0_0_0_2px_black]"
 						id={`${field.id}-${option}`}
@@ -232,10 +268,10 @@ function CustomMultipleCheckbox({
 						}
 						onBlur={control.blur}
 					>
-						<Checkbox.Indicator>
+						<RadixCheckbox.Indicator>
 							<CheckIcon className="w-4 h-4" />
-						</Checkbox.Indicator>
-					</Checkbox.Root>
+						</RadixCheckbox.Indicator>
+					</RadixCheckbox.Root>
 					<label
 						htmlFor={`${field.id}-${option}`}
 						className="pl-[15px] text-[15px] leading-none"
@@ -243,6 +279,186 @@ function CustomMultipleCheckbox({
 						{option}
 					</label>
 				</div>
+			))}
+		</div>
+	);
+}
+
+function Select({
+	name,
+	options,
+	placeholder,
+	multiple,
+}: {
+	name: FieldName<string | string[]>;
+	placeholder: string;
+	options: string[];
+	multiple?: boolean;
+}) {
+	const [field] = useField(name);
+	const control = useControl(field);
+	const value =
+		typeof control.value === 'string' ? [control.value] : control.value ?? [];
+
+	return (
+		<Listbox
+			value={control.value ?? (multiple ? [] : '')}
+			onChange={control.change}
+			multiple={multiple}
+		>
+			<select
+				className="sr-only"
+				aria-hidden
+				tabIndex={-1}
+				ref={control.register}
+				multiple={multiple}
+				{...getSelectProps(field)}
+			>
+				<option value="" />
+				{options.map((option) => (
+					<option key={option} value={option} />
+				))}
+			</select>
+			<div className="relative mt-1">
+				<Listbox.Button className="relative w-full cursor-default rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 text-left shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm">
+					<span className="block truncate">
+						{value.length === 0 ? placeholder : value.join(', ')}
+					</span>
+					<span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+						<ChevronUpDownIcon
+							className="h-5 w-5 text-gray-400"
+							aria-hidden="true"
+						/>
+					</span>
+				</Listbox.Button>
+				<Listbox.Options className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+					{options.map((option) => (
+						<Listbox.Option
+							key={option}
+							className={({ active }) =>
+								classNames(
+									active ? 'text-white bg-indigo-600' : 'text-gray-900',
+									'relative cursor-default select-none py-2 pl-3 pr-9',
+								)
+							}
+							value={option}
+						>
+							{({ selected, active }) => (
+								<>
+									<span
+										className={classNames(
+											selected ? 'font-semibold' : 'font-normal',
+											'block truncate',
+										)}
+									>
+										{option}
+									</span>
+
+									{option !== '' && selected ? (
+										<span
+											className={classNames(
+												active ? 'text-white' : 'text-indigo-600',
+												'absolute inset-y-0 right-0 flex items-center pr-4',
+											)}
+										>
+											<CheckIcon className="h-5 w-5" aria-hidden="true" />
+										</span>
+									) : null}
+								</>
+							)}
+						</Listbox.Option>
+					))}
+				</Listbox.Options>
+			</div>
+		</Listbox>
+	);
+}
+
+function Checkbox({
+	name,
+	label,
+}: {
+	name: FieldName<boolean>;
+	label: string;
+}) {
+	const [field] = useField(name);
+	const control = useControl(field);
+
+	return (
+		<div
+			className="flex items-center py-2"
+			ref={(element) => control.register(element?.querySelector('input'))}
+		>
+			<RadixCheckbox.Root
+				type="button"
+				className="flex h-[25px] w-[25px] appearance-none items-center justify-center rounded-[4px] bg-white outline-none shadow-[0_0_0_2px_black]"
+				id={field.id}
+				name={name}
+				checked={control.value === 'on'}
+				onCheckedChange={(state) => control.change(state.valueOf() ? 'on' : '')}
+				onBlur={control.blur}
+			>
+				<RadixCheckbox.Indicator>
+					<CheckIcon className="w-4 h-4" />
+				</RadixCheckbox.Indicator>
+			</RadixCheckbox.Root>
+			<label htmlFor={field.id} className="pl-[15px] text-[15px] leading-none">
+				{label}
+			</label>
+		</div>
+	);
+}
+
+function CheckboxGroup({
+	name,
+	options,
+}: {
+	name: FieldName<string[]>;
+	options: string[];
+}) {
+	const [field] = useField(name);
+
+	return (
+		<div className="py-2 space-y-4">
+			{getCollectionProps(field, {
+				type: 'checkbox',
+				options,
+			}).map((props) => (
+				<Control
+					key={props.key}
+					options={props}
+					render={(control) => (
+						<div
+							className="flex items-center"
+							ref={(element) =>
+								control.register(element?.querySelector('input'))
+							}
+						>
+							<RadixCheckbox.Root
+								type="button"
+								className="flex h-[25px] w-[25px] appearance-none items-center justify-center rounded-[4px] bg-white outline-none shadow-[0_0_0_2px_black]"
+								id={props.id}
+								name={props.name}
+								value={props.value}
+								checked={control.value === props.value}
+								onCheckedChange={(state) =>
+									control.change(state.valueOf() ? props.value : '')
+								}
+								onBlur={control.blur}
+							>
+								<RadixCheckbox.Indicator>
+									<CheckIcon className="w-4 h-4" />
+								</RadixCheckbox.Indicator>
+							</RadixCheckbox.Root>
+							<label
+								htmlFor={props.id}
+								className="pl-[15px] text-[15px] leading-none"
+							>
+								{props.value}
+							</label>
+						</div>
+					)}
+				/>
 			))}
 		</div>
 	);

--- a/playground/app/routes/custom-inputs.tsx
+++ b/playground/app/routes/custom-inputs.tsx
@@ -8,7 +8,6 @@ import {
 	useInputControl,
 	getFormProps,
 	getSelectProps,
-	getCollectionProps,
 } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
@@ -417,16 +416,20 @@ function CheckboxGroup({
 	options: string[];
 }) {
 	const [field] = useField(name);
+	const initialValue =
+		typeof field.initialValue === 'string'
+			? [field.initialValue]
+			: field.initialValue ?? [];
 
 	return (
 		<div className="py-2 space-y-4">
-			{getCollectionProps(field, {
-				type: 'checkbox',
-				options,
-			}).map((props) => (
+			{options.map((option) => (
 				<Control
-					key={props.key}
-					options={props}
+					key={option}
+					meta={{
+						key: field.key,
+						initialValue: initialValue.includes(option) ? option : '',
+					}}
 					render={(control) => (
 						<div
 							className="flex items-center"
@@ -437,12 +440,12 @@ function CheckboxGroup({
 							<RadixCheckbox.Root
 								type="button"
 								className="flex h-[25px] w-[25px] appearance-none items-center justify-center rounded-[4px] bg-white outline-none shadow-[0_0_0_2px_black]"
-								id={props.id}
-								name={props.name}
-								value={props.value}
-								checked={control.value === props.value}
+								id={`${field.id}-${option}`}
+								name={field.name}
+								value={option}
+								checked={control.value === option}
 								onCheckedChange={(state) =>
-									control.change(state.valueOf() ? props.value : '')
+									control.change(state.valueOf() ? option : '')
 								}
 								onBlur={control.blur}
 							>
@@ -451,10 +454,10 @@ function CheckboxGroup({
 								</RadixCheckbox.Indicator>
 							</RadixCheckbox.Root>
 							<label
-								htmlFor={props.id}
+								htmlFor={`${field.id}-${option}`}
 								className="pl-[15px] text-[15px] leading-none"
 							>
-								{props.value}
+								{option}
 							</label>
 						</div>
 					)}

--- a/playground/app/routes/custom-inputs.tsx
+++ b/playground/app/routes/custom-inputs.tsx
@@ -3,17 +3,13 @@ import {
 	FormProvider,
 	useForm,
 	useField,
-	unstable_useControl as useControl,
 	useInputControl,
 	getFormProps,
-	getSelectProps,
-	getInputProps,
 } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import { Form, useActionData, useLoaderData } from '@remix-run/react';
-import { useRef } from 'react';
 import { z } from 'zod';
 import { Playground, Field } from '~/components';
 import { Listbox } from '@headlessui/react';
@@ -33,7 +29,6 @@ export async function loader({ request }: LoaderArgs) {
 	const url = new URL(request.url);
 
 	return {
-		manualSetup: url.searchParams.get('manualSetup') === 'yes',
 		noClientValidate: url.searchParams.get('noClientValidate') === 'yes',
 	};
 }
@@ -46,7 +41,7 @@ export async function action({ request }: ActionArgs) {
 }
 
 export default function Example() {
-	const { manualSetup, noClientValidate } = useLoaderData<typeof loader>();
+	const { noClientValidate } = useLoaderData<typeof loader>();
 	const lastResult = useActionData<typeof action>();
 	const [form, fields] = useForm({
 		id: 'example',
@@ -66,7 +61,6 @@ export default function Example() {
 							name={fields.color.name}
 							options={['red', 'green', 'blue']}
 							placeholder="Select a color"
-							manualSetup={manualSetup}
 						/>
 					</Field>
 					<Field label="Headless ListBox (Multiple)" meta={fields.languages}>
@@ -75,21 +69,18 @@ export default function Example() {
 							options={['English', 'Spanish', 'French']}
 							placeholder="Select languages"
 							multiple
-							manualSetup={manualSetup}
 						/>
 					</Field>
 					<Field label="Radix Checkbox (Single)" meta={fields.tos}>
 						<CustomCheckbox
 							label="I accept the terms of service"
 							name={fields.tos.name}
-							manualSetup={manualSetup}
 						/>
 					</Field>
 					<Field label="Radix Checkbox (Multiple)" meta={fields.options}>
 						<CustomMultipleCheckbox
 							name={fields.options.name}
 							options={['a', 'b', 'c', 'd']}
-							manualSetup={manualSetup}
 						/>
 					</Field>
 				</Playground>
@@ -107,18 +98,14 @@ function CustomSelect({
 	options,
 	placeholder,
 	multiple,
-	manualSetup,
 }: {
 	name: FieldName<string | string[]>;
 	placeholder: string;
 	options: string[];
 	multiple?: boolean;
-	manualSetup: boolean;
 }) {
 	const [field] = useField(name);
-	const buttonRef = useRef<HTMLButtonElement>(null);
-	// eslint-disable-next-line react-hooks/rules-of-hooks
-	const control = manualSetup ? useControl(field) : useInputControl(field);
+	const control = useInputControl(field);
 	const value =
 		typeof control.value === 'string' ? [control.value] : control.value ?? [];
 
@@ -128,36 +115,8 @@ function CustomSelect({
 			onChange={control.change}
 			multiple={multiple}
 		>
-			{manualSetup ? (
-				<>
-					{multiple ? (
-						<select
-							className="sr-only"
-							aria-hidden
-							tabIndex={-1}
-							{...getSelectProps(field)}
-							multiple
-						>
-							<option value="" />
-							{options.map((option) => (
-								<option key={option} value={option} />
-							))}
-						</select>
-					) : (
-						<input
-							className="sr-only"
-							aria-hidden
-							tabIndex={-1}
-							{...getInputProps(field, { type: 'text' })}
-						/>
-					)}
-				</>
-			) : null}
 			<div className="relative mt-1">
-				<Listbox.Button
-					className="relative w-full cursor-default rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 text-left shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm"
-					ref={buttonRef}
-				>
+				<Listbox.Button className="relative w-full cursor-default rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 text-left shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm">
 					<span className="block truncate">
 						{value.length === 0 ? placeholder : value.join(', ')}
 					</span>
@@ -214,15 +173,12 @@ function CustomSelect({
 function CustomCheckbox({
 	name,
 	label,
-	manualSetup,
 }: {
 	name: FieldName<boolean>;
 	label: string;
-	manualSetup: boolean;
 }) {
 	const [field] = useField(name);
-	// eslint-disable-next-line react-hooks/rules-of-hooks
-	const control = manualSetup ? useControl(field) : useInputControl(field);
+	const control = useInputControl(field);
 
 	return (
 		<div className="flex items-center py-2">
@@ -230,7 +186,6 @@ function CustomCheckbox({
 				type="button"
 				className="flex h-[25px] w-[25px] appearance-none items-center justify-center rounded-[4px] bg-white outline-none shadow-[0_0_0_2px_black]"
 				id={field.id}
-				name={manualSetup ? field.name : undefined}
 				checked={control.value === 'on'}
 				onCheckedChange={(state) => control.change(state.valueOf() ? 'on' : '')}
 				onBlur={control.blur}
@@ -249,15 +204,12 @@ function CustomCheckbox({
 function CustomMultipleCheckbox({
 	name,
 	options,
-	manualSetup,
 }: {
 	name: FieldName<string[]>;
 	options: string[];
-	manualSetup: boolean;
 }) {
 	const [field] = useField(name);
-	// eslint-disable-next-line react-hooks/rules-of-hooks
-	const control = manualSetup ? useControl(field) : useInputControl(field);
+	const control = useInputControl(field);
 	const value =
 		typeof control.value === 'string' ? [control.value] : control.value ?? [];
 
@@ -269,7 +221,6 @@ function CustomMultipleCheckbox({
 						type="button"
 						className="flex h-[25px] w-[25px] appearance-none items-center justify-center rounded-[4px] bg-white outline-none shadow-[0_0_0_2px_black]"
 						id={`${field.id}-${option}`}
-						name={manualSetup ? field.name : undefined}
 						value={option}
 						checked={value.includes(option)}
 						onCheckedChange={(state) =>

--- a/playground/app/routes/input-event.tsx
+++ b/playground/app/routes/input-event.tsx
@@ -1,7 +1,7 @@
 import {
 	getFormProps,
 	useForm,
-	unstable_useInputEvent as useInputEvent,
+	unstable_useControl as useControl,
 } from '@conform-to/react';
 import { type LoaderArgs } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
@@ -24,7 +24,7 @@ export default function Example() {
 			'base-input': defaultValue,
 		},
 	});
-	const control = useInputEvent();
+	const control = useControl(fields['base-input']);
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [logsByName, setLogsByName] = useState<Record<string, string[]>>({});
 	const log = (event: FormEvent<HTMLFormElement>) => {
@@ -83,7 +83,7 @@ export default function Example() {
 						ref={control.register}
 						name="base-input"
 						type="text"
-						defaultValue={fields['base-input'].initialValue ?? ''}
+						value={control.value}
 						onChange={(event) => control.change(event.target.value)}
 						onFocus={() => {
 							control.focus();

--- a/playground/app/routes/input-event.tsx
+++ b/playground/app/routes/input-event.tsx
@@ -1,4 +1,8 @@
-import { getFormProps, useForm, useInputControl } from '@conform-to/react';
+import {
+	getFormProps,
+	useForm,
+	unstable_useInputEvent as useInputEvent,
+} from '@conform-to/react';
 import { type LoaderArgs } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import { type FormEvent, useRef, useState } from 'react';
@@ -20,7 +24,7 @@ export default function Example() {
 			'base-input': defaultValue,
 		},
 	});
-	const control = useInputControl(fields['base-input']);
+	const control = useInputEvent();
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [logsByName, setLogsByName] = useState<Record<string, string[]>>({});
 	const log = (event: FormEvent<HTMLFormElement>) => {
@@ -57,7 +61,7 @@ export default function Example() {
 						className="p-2 flex-1"
 						name="native-input"
 						type="text"
-						value={control.value ?? ''}
+						defaultValue={fields['native-input'].initialValue ?? ''}
 						ref={inputRef}
 						onChange={(event) => control.change(event.target.value)}
 						onFocus={control.focus}
@@ -76,9 +80,10 @@ export default function Example() {
 				<div className="pt-4">
 					<div>Shadow input</div>
 					<input
+						ref={control.register}
 						name="base-input"
 						type="text"
-						defaultValue={defaultValue ?? ''}
+						defaultValue={fields['base-input'].initialValue ?? ''}
 						onChange={(event) => control.change(event.target.value)}
 						onFocus={() => {
 							control.focus();

--- a/tests/integrations/custom-inputs.spec.ts
+++ b/tests/integrations/custom-inputs.spec.ts
@@ -62,9 +62,9 @@ async function runTest(page: Page) {
 		status: 'success',
 		initialValue: {
 			color: 'blue',
-			languages: ['French', 'Spanish'],
+			languages: expect.arrayContaining(['French', 'Spanish']),
 			tos: 'on',
-			options: ['d', 'b'],
+			options: expect.arrayContaining(['d', 'b']),
 		},
 		state: {
 			validated: {
@@ -77,12 +77,22 @@ async function runTest(page: Page) {
 	});
 }
 
-test('Client Validation', async ({ page }) => {
+test('Client Validation: useInputControl', async ({ page }) => {
 	await page.goto('/custom-inputs');
 	await runTest(page);
 });
 
-test('Server Validation', async ({ page }) => {
+test('Server Validation: useInputControl', async ({ page }) => {
 	await page.goto('/custom-inputs?noClientValidate=yes');
+	await runTest(page);
+});
+
+test('Client Validation: useControl', async ({ page }) => {
+	await page.goto('/custom-inputs?manualSetup=yes');
+	await runTest(page);
+});
+
+test('Server Validation: useControl', async ({ page }) => {
+	await page.goto('/custom-inputs?manualSetup=yes&noClientValidate=yes');
 	await runTest(page);
 });

--- a/tests/integrations/custom-inputs.spec.ts
+++ b/tests/integrations/custom-inputs.spec.ts
@@ -77,22 +77,12 @@ async function runTest(page: Page) {
 	});
 }
 
-test('Client Validation: useInputControl', async ({ page }) => {
+test('Client Validation', async ({ page }) => {
 	await page.goto('/custom-inputs');
 	await runTest(page);
 });
 
-test('Server Validation: useInputControl', async ({ page }) => {
+test('Server Validation', async ({ page }) => {
 	await page.goto('/custom-inputs?noClientValidate=yes');
-	await runTest(page);
-});
-
-test('Client Validation: useControl', async ({ page }) => {
-	await page.goto('/custom-inputs?manualSetup=yes');
-	await runTest(page);
-});
-
-test('Server Validation: useControl', async ({ page }) => {
-	await page.goto('/custom-inputs?manualSetup=yes&noClientValidate=yes');
 	await runTest(page);
 });

--- a/tests/integrations/custom-inputs.spec.ts
+++ b/tests/integrations/custom-inputs.spec.ts
@@ -77,12 +77,22 @@ async function runTest(page: Page) {
 	});
 }
 
-test('Client Validation', async ({ page }) => {
+test('Client Validation: useInputControl', async ({ page }) => {
+	await page.goto('/custom-inputs?legacy=yes');
+	await runTest(page);
+});
+
+test('Server Validation: useInputControl', async ({ page }) => {
+	await page.goto('/custom-inputs?legacy=yes&noClientValidate=yes');
+	await runTest(page);
+});
+
+test('Client Validation: useControl', async ({ page }) => {
 	await page.goto('/custom-inputs');
 	await runTest(page);
 });
 
-test('Server Validation', async ({ page }) => {
+test('Server Validation: useControl', async ({ page }) => {
 	await page.goto('/custom-inputs?noClientValidate=yes');
 	await runTest(page);
 });


### PR DESCRIPTION
As reported on #306, #401, #443, the auto insert input feature on `useInputControl` is found to be problematic in several situations where you need to dynamically render the input. The current design is also not flexible in handling these cases. Although we can consider adding extra options to `useInputControl` for handling each cases, I believe it would be better stop supporting this and have developers deciding how they wanna render the hidden input themselves similar to the `useInputEvent` hook before v1.

As this would be a breaking change if we remove the feature directly from `useInputControl`, the react package will now export an additional `useControl` hook that works exactly the same as `useInputControl` except it will never insert an hidden input for you.

This is currently named `unstable_useControl` just so we can get some more feedbacks.
