### PR TITLE
fix: wrap form control in flush sync

### DIFF
--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -176,6 +176,11 @@ export type FormOptions<Schema, FormError = string[], FormValue = Schema> = {
 		submitter: HTMLInputElement | HTMLButtonElement | null;
 		formData: FormData;
 	}) => Submission<Schema, FormError, FormValue>;
+
+	/**
+	 * To schedule when an intent should be dispatched.
+	 */
+	onSchedule?: (callback: () => void) => void;
 };
 
 export type SubscriptionSubject = {
@@ -966,11 +971,10 @@ export function createFormContext<
 	}
 
 	function createFormControl<Type extends Intent['type']>(type: Type) {
+		const schedule =
+			latestOptions.onSchedule ?? ((callback: () => void) => callback());
 		const control = (payload: any = {}) =>
-			dispatch({
-				type,
-				payload,
-			});
+			schedule(() => dispatch({ type, payload }));
 
 		return Object.assign(control, {
 			getButtonProps(payload: any = {}) {

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -1,5 +1,6 @@
 import { type FormId, type FieldName } from '@conform-to/dom';
 import { useEffect, useId, useState, useLayoutEffect } from 'react';
+import { flushSync } from 'react-dom';
 import {
 	type FormMetadata,
 	type FieldMetadata,
@@ -49,7 +50,7 @@ export function useForm<
 	FormError = string[],
 >(
 	options: Pretty<
-		Omit<FormOptions<Schema, FormError, FormValue>, 'formId'> & {
+		Omit<FormOptions<Schema, FormError, FormValue>, 'formId' | 'onSchedule'> & {
 			/**
 			 * The form id. If not provided, a random id will be generated.
 			 */
@@ -70,7 +71,11 @@ export function useForm<
 	const { id, ...formConfig } = options;
 	const formId = useFormId<Schema, FormError>(id);
 	const [context] = useState(() =>
-		createFormContext({ ...formConfig, formId }),
+		createFormContext({
+			...formConfig,
+			onSchedule: (callback: () => void) => flushSync(callback),
+			formId,
+		}),
 	);
 
 	useSafeLayoutEffect(() => {

--- a/packages/conform-react/package.json
+++ b/packages/conform-react/package.json
@@ -33,11 +33,13 @@
 		"@conform-to/dom": "1.0.2"
 	},
 	"devDependencies": {
-		"@types/react": "^18.2.43",
+		"@types/react": "^18.2.64",
+		"@types/react-dom": "^18.2.20",
 		"react": "^18.2.0"
 	},
 	"peerDependencies": {
-		"react": ">=18"
+		"react": ">=18",
+		"react-dom": ">=18"
 	},
 	"keywords": [
 		"constraint-validation",

--- a/playground/app/components.tsx
+++ b/playground/app/components.tsx
@@ -5,7 +5,7 @@ interface PlaygroundProps {
 	title: string;
 	description?: ReactNode;
 	form?: string;
-	result?: Record<string, unknown>;
+	result?: Record<string, unknown> | null | undefined;
 	formAction?: string;
 	formMethod?: string;
 	formEncType?: string;

--- a/playground/app/routes/form-control.tsx
+++ b/playground/app/routes/form-control.tsx
@@ -48,7 +48,7 @@ export default function FormControl() {
 		<FormProvider context={form.context}>
 			<Form method="post" {...getFormProps(form)}>
 				<FormStateInput formId={form.id} />
-				<Playground title="Form Control" result={lastResult}>
+				<Playground title="Form Control" result={form.value}>
 					<Field label="Name" meta={fields.name}>
 						<input {...getInputProps(fields.name, { type: 'text' })} />
 					</Field>
@@ -114,6 +114,21 @@ export default function FormControl() {
 							{...form.reset.getButtonProps()}
 						>
 							Reset form
+						</button>
+						<button
+							className="rounded-md border p-2 hover:border-black"
+							type="button"
+							onClick={() => {
+								form.update({
+									name: fields.message.name,
+									value: 'Hello World',
+								});
+								form.reset({
+									name: fields.number.name,
+								});
+							}}
+						>
+							Reset number with message updated
 						</button>
 					</div>
 				</Playground>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -633,10 +633,16 @@ importers:
       '@conform-to/dom':
         specifier: 1.0.2
         version: link:../conform-dom
+      react-dom:
+        specifier: '>=18'
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@types/react':
-        specifier: ^18.2.43
-        version: 18.2.43
+        specifier: ^18.2.64
+        version: 18.2.64
+      '@types/react-dom':
+        specifier: ^18.2.20
+        version: 18.2.20
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -10563,6 +10569,15 @@ packages:
     dependencies:
       '@types/react': 18.2.58
 
+  /@types/react-dom@18.2.20:
+    resolution:
+      {
+        integrity: sha512-HXN/biJY8nv20Cn9ZbCFq3liERd4CozVZmKbaiZ9KiKTrWqsP7eoGDO6OOGvJQwoVFuiXaiJ7nBBjiFFbRmQMQ==,
+      }
+    dependencies:
+      '@types/react': 18.2.64
+    dev: true
+
   /@types/react-syntax-highlighter@15.5.11:
     resolution:
       {
@@ -10578,7 +10593,7 @@ packages:
         integrity: sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==,
       }
     dependencies:
-      '@types/react': 18.2.58
+      '@types/react': 18.2.64
     dev: false
 
   /@types/react@18.2.42:
@@ -10616,6 +10631,16 @@ packages:
     resolution:
       {
         integrity: sha512-TaGvMNhxvG2Q0K0aYxiKfNDS5m5ZsoIBBbtfUorxdH4NGSXIlYvZxLJI+9Dd3KjeB3780bciLyAb7ylO8pLhPw==,
+      }
+    dependencies:
+      '@types/prop-types': 15.7.11
+      '@types/scheduler': 0.16.8
+      csstype: 3.1.3
+
+  /@types/react@18.2.64:
+    resolution:
+      {
+        integrity: sha512-MlmPvHgjj2p3vZaxbQgFUQFvD8QiZwACfGqEdDSWou5yISWxDQ4/74nCAwsUiX7UFLKZz3BbVSPj+YxeoGGCfg==,
       }
     dependencies:
       '@types/prop-types': 15.7.11


### PR DESCRIPTION
Fix #400.

This ensures all form intent applies to the latest form data in case multiple intents are dispatched in one single callback. Note: This only works with client validation in place in which an update can be triggered synchronously. 