### PR TITLE
docs: Correct "field." to "fields." and "validate" to "validates"

### DIFF
--- a/docs/api/react/getInputProps.md
+++ b/docs/api/react/getInputProps.md
@@ -60,14 +60,14 @@ function Example() {
         defaultValue={fields.task.initialValue}
         aria-invalid={!fields.task.valid || undefined}
         aria-describedby={!fields.task.valid ? fields.task.errorId : undefined}
-        required={field.task.required}
-        minLength={field.task.minLength}
-        maxLength={field.task.maxLength}
-        min={field.task.min}
-        max={field.task.max}
-        step={field.task.step}
-        pattern={field.task.pattern}
-        multiple={field.task.multiple}
+        required={fields.task.required}
+        minLength={fields.task.minLength}
+        maxLength={fields.task.maxLength}
+        min={fields.task.min}
+        max={fields.task.max}
+        step={fields.task.step}
+        pattern={fields.task.pattern}
+        multiple={fields.task.multiple}
       />
       {/* checkbox */}
       <input
@@ -82,7 +82,7 @@ function Example() {
         aria-describedby={
           !fields.completed.valid ? fields.completed.errorId : undefined
         }
-        required={field.completed.required}
+        required={fields.completed.required}
       />
     </form>
   );

--- a/docs/api/react/getSelectProps.md
+++ b/docs/api/react/getSelectProps.md
@@ -57,8 +57,8 @@ function Example() {
         aria-describedby={
           !fields.category.valid ? fields.category.errorId : undefined
         }
-        required={field.category.required}
-        multiple={field.category.multiple}
+        required={fields.category.required}
+        multiple={fields.category.multiple}
       />
     </form>
   );

--- a/docs/api/react/getTextareaProps.md
+++ b/docs/api/react/getTextareaProps.md
@@ -57,9 +57,9 @@ function Example() {
         aria-describedby={
           !fields.content.valid ? fields.content.errorId : undefined
         }
-        required={field.content.required}
-        minLength={field.content.minLength}
-        maxLength={field.content.maxLength}
+        required={fields.content.required}
+        minLength={fields.content.minLength}
+        maxLength={fields.content.maxLength}
       />
     </form>
   );

--- a/docs/api/react/useInputControl.md
+++ b/docs/api/react/useInputControl.md
@@ -18,7 +18,7 @@ function Example() {
 
   return (
     <Select
-      name={field.color.name}
+      name={fields.color.name}
       value={color.value}
       onChange={color.change}
       onFocus={color.focus}

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -85,7 +85,7 @@ export default function Signup() {
 
 Conform supports async validation in a slightly different way. Instead of sending a request to another endpoint, we will simply fallback to server validation when needed.
 
-Here is an example which validate if the email is unique.
+Here is an example which validates if the email is unique.
 
 ```tsx
 import { refine } from '@conform-to/zod';


### PR DESCRIPTION
This PR corrects some typo.

I have used since version 0, it became even more user-friendly with version 1. Thank you for your library.