### PR TITLE
Consider using a variable-width font for docs

### DIFF
--- a/guide/app/layout.tsx
+++ b/guide/app/layout.tsx
@@ -108,7 +108,7 @@ export function Guide({
 			<header className="bg-zinc-900 xl:bg-transparent sticky top-0 max-h-screen z-10 flex flex-col">
 				<div className="py-2 xl:py-4">
 					<Link
-						className="inline-block py-4 text-[.25rem] leading-[.25rem] xl:text-[.35rem] xl:leading-[.40rem] whitespace-pre"
+						className="font-mono inline-block py-4 text-[.25rem] leading-[.25rem] xl:text-[.35rem] xl:leading-[.40rem] whitespace-pre"
 						title="Conform"
 						to="/"
 					>

--- a/guide/app/root.tsx
+++ b/guide/app/root.tsx
@@ -70,7 +70,7 @@ function Document({ children }: { children: React.ReactNode }) {
 					src="https://plausible.io/js/script.js"
 				/>
 			</head>
-			<body className="font-mono antialiased bg-zinc-900 text-zinc-50">
+			<body className="antialiased bg-zinc-900 text-zinc-50">
 				{children}
 				<ScrollRestoration />
 				<Scripts />


### PR DESCRIPTION
This PR switches most font in the documentation website from mono to variable-width font. I think variable-width paragraphs are generally easier to read, and with variable-width paragraphs, it's also easier to glance and see what part of the documentation site is code versus context.

This ultimately comes down to preference, and I defer to the library author. No hard feelings if this is closed! 