### PR TITLE
Fix `getFieldset` with interfaces and nullable schemas

### DIFF
--- a/packages/conform-react/context.tsx
+++ b/packages/conform-react/context.tsx
@@ -83,11 +83,11 @@ type SubfieldMetadata<
 	FormSchema extends Record<string, any>,
 	FormError,
 	CombinedSchema = Combine<Schema>,
-> = Exclude<Schema, undefined> extends Array<infer Item>
+> = NonNullable<Schema> extends Array<infer Item>
 	? {
 			getFieldList: () => Array<FieldMetadata<Item, FormSchema, FormError>>;
 	  }
-	: Exclude<Schema, undefined> extends Record<string, unknown>
+	: NonNullable<Schema> extends object
 	? {
 			getFieldset: () => Required<{
 				[Key in keyof CombinedSchema]: FieldMetadata<


### PR DESCRIPTION
This should fix #499, specifically the types failing to reveal `getFieldset` in these two scenarios:

- Your `FieldSchema` is an interface, not a type.
- Your `defaultValue` is nullable.

I'm filing this as a draft, as I have no idea what kinds of tests to write for this.

Known existing issues this PR doesn't try to fix:

- `getFieldset` is incorrectly available on other object types, e.g. `Date`.