### PR TITLE
fix: validate only if the form element is mounted

### DIFF
--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -803,6 +803,7 @@ export function createFormContext<
 			!form ||
 			!isFieldElement(element) ||
 			element.form !== form ||
+			!element.form.isConnected ||
 			element.name === ''
 		) {
 			return null;


### PR DESCRIPTION
Fix #524.

When a dialog is closed, we might lose focus from the input and trigger validation while the form element is already unmounted. This makes sure form validation will only happens if the form element is still connected to the DOM.