### PR TITLE
Avoid type widening with enum-typed values in FormValue

### DIFF
--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -58,14 +58,9 @@ export type DefaultValue<Schema> = Schema extends
 	? { [Key in keyof Schema]?: DefaultValue<Schema[Key]> } | null | undefined
 	: string | null | undefined;
 
-export type FormValue<Schema> = Schema extends
-	| string
-	| number
-	| boolean
-	| Date
-	| bigint
-	| null
-	| undefined
+export type FormValue<Schema> = Schema extends string
+	? Schema | undefined
+	: Schema extends number | boolean | Date | bigint | null | undefined
 	? string | undefined
 	: Schema extends File
 	? File | undefined


### PR DESCRIPTION
The current generic type for `FormValue` is this:

```ts
export type FormValue<Schema> = Schema extends
	| string
	| number
	| boolean
	| Date
	| bigint
	| null
	| undefined
	? string | undefined
```

In this, if you have an enum or constant string type, then it will get widened into a `string` type. Turning `Date` and `null` types into string | undefined makes sense, but it is kind of just inconvenient to lose type information if you have an enum.

This tweaks the generic type so that if you have a type that `extends string`, then the `FormValue` generic uses that type instead of widening to string.