### PR TITLE
chroe(guide): detect language based on hostname

### DIFF
--- a/guide/app/util.ts
+++ b/guide/app/util.ts
@@ -4,16 +4,15 @@ import type { AppLoadContext } from '@remix-run/cloudflare';
 interface Language {
 	code: string;
 	label: string;
-	branch: string;
 	docPath: string;
 	domain: string;
 	isDecodeUtf8: boolean;
 }
+
 export const allLanguages: Language[] = [
 	{
 		code: 'en',
 		label: 'en',
-		branch: 'main',
 		docPath: 'docs',
 		domain: 'conform.guide',
 		isDecodeUtf8: false,
@@ -21,7 +20,6 @@ export const allLanguages: Language[] = [
 	{
 		code: 'ja',
 		label: 'ja',
-		branch: 'ja',
 		docPath: 'docs/ja',
 		domain: 'ja.conform.guide',
 		isDecodeUtf8: true,
@@ -43,7 +41,7 @@ export function getMetadata(context: AppLoadContext) {
 		owner: 'edmundhung',
 		repo: 'conform',
 		ref: branch,
-		language: getLanguage(branch),
+		language: getLanguage(context.env.LANGUAGE),
 	};
 }
 
@@ -68,7 +66,14 @@ export const getDocPath = (context: AppLoadContext) => {
 	return docPath;
 };
 
-export function getLanguage(code: string): Language {
+export function getLanguageCode(url: string): string | undefined {
+	const { hostname } = new URL(url);
+	const language = allLanguages.find((lang) => lang.domain === hostname);
+
+	return language?.code;
+}
+
+export function getLanguage(code: string | undefined): Language {
 	const language = allLanguages.find((lang) => lang.code === code);
 	return language ?? allLanguages[0]; // default to English
 }

--- a/guide/remix.env.d.ts
+++ b/guide/remix.env.d.ts
@@ -4,6 +4,7 @@ import '@cloudflare/workers-types';
 
 interface Env {
 	ENVIRONMENT?: 'development';
+	LANGUAGE?: string;
 	GITHUB_ACCESS_TOKEN?: string;
 	CF_PAGES_BRANCH?: string;
 	CACHE: KVNamespace;

--- a/guide/server.ts
+++ b/guide/server.ts
@@ -1,6 +1,7 @@
 import { logDevReady } from '@remix-run/cloudflare';
 import { createPagesFunctionHandler } from '@remix-run/cloudflare-pages';
 import * as build from '@remix-run/dev/server-build';
+import { getLanguageCode } from '~/util';
 
 if (process.env.NODE_ENV === 'development') {
 	logDevReady(build);
@@ -11,6 +12,7 @@ export const onRequest = createPagesFunctionHandler({
 	getLoadContext: (context) => ({
 		env: {
 			CF_PAGES_BRANCH: 'main',
+			LANGUAGE: getLanguageCode(context.request.url),
 			...context.env,
 		},
 		waitUntil(promise: Promise<unknown>) {


### PR DESCRIPTION
This allows Remix to serve the docs based on the hostname and we can point the `ja` domain to the main branch as well.