### PR TITLE
feat: revalidate on blur only if changed

### DIFF
--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -112,6 +112,7 @@ export type Constraint = {
 };
 
 export type FormMeta<FormError> = {
+	isValueUpdated: boolean;
 	submissionStatus?: 'error' | 'success';
 	defaultValue: Record<string, unknown>;
 	initialValue: Record<string, unknown>;
@@ -122,7 +123,10 @@ export type FormMeta<FormError> = {
 	validated: Record<string, boolean>;
 };
 
-export type FormState<FormError> = FormMeta<FormError> & {
+export type FormState<FormError> = Omit<
+	FormMeta<FormError>,
+	'isValueUpdated'
+> & {
 	valid: Record<string, boolean>;
 	dirty: Record<string, boolean>;
 };
@@ -259,6 +263,7 @@ function createFormMeta<Schema, FormError, FormValue>(
 		: {};
 	const initialValue = lastResult?.initialValue ?? defaultValue;
 	const result: FormMeta<FormError> = {
+		isValueUpdated: false,
 		submissionStatus: lastResult?.status,
 		defaultValue,
 		initialValue,
@@ -829,7 +834,8 @@ export function createFormContext<
 		const validated = meta.validated[element.name];
 
 		return validated
-			? shouldRevalidate === eventName
+			? shouldRevalidate === eventName &&
+					(eventName === 'onInput' || meta.isValueUpdated)
 			: shouldValidate === eventName;
 	}
 
@@ -839,6 +845,7 @@ export function createFormContext<
 
 		updateFormMeta({
 			...meta,
+			isValueUpdated: true,
 			value: result.payload,
 		});
 	}
@@ -912,6 +919,7 @@ export function createFormContext<
 		}, {});
 		const update: FormMeta<FormError> = {
 			...meta,
+			isValueUpdated: false,
 			submissionStatus: result.status,
 			value: result.initialValue,
 			validated: {

--- a/playground/app/routes/_index.tsx
+++ b/playground/app/routes/_index.tsx
@@ -22,7 +22,13 @@ export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parseWithZod(formData, { schema });
 
-	return json(submission.reply());
+	return json(
+		submission.reply({
+			fieldErrors: {
+				name: ['Something went wrong'],
+			},
+		}),
+	);
 }
 
 export default function Example() {
@@ -30,6 +36,7 @@ export default function Example() {
 	const lastResult = useActionData<typeof action>();
 	const [form, fields] = useForm({
 		lastResult,
+		shouldValidate: 'onBlur',
 		onValidate: !noClientValidate
 			? ({ formData }) => parseWithZod(formData, { schema })
 			: undefined,

--- a/playground/app/routes/validation-flow.tsx
+++ b/playground/app/routes/validation-flow.tsx
@@ -44,6 +44,19 @@ export async function action({ request }: ActionArgs) {
 	const formData = await request.formData();
 	const submission = parseWithZod(formData, { schema });
 
+	if (
+		submission.status === 'success' &&
+		submission.value.email === 'test@email.registered'
+	) {
+		return json(
+			submission.reply({
+				fieldErrors: {
+					email: ['Email is already registered'],
+				},
+			}),
+		);
+	}
+
 	return json(submission.reply());
 }
 

--- a/tests/integrations/validation-flow.spec.ts
+++ b/tests/integrations/validation-flow.spec.ts
@@ -119,13 +119,13 @@ test('shouldValidate: onBlur', async ({ page }) => {
 		playground.container,
 	);
 
-	await email.type('Invalid email');
+	await email.fill('Invalid email');
 	await expect(playground.error).toHaveText(['', '', '']);
 
 	await playground.form.press('Tab');
 	await expect(playground.error).toHaveText(['Email is invalid', '', '']);
 
-	await password.type('1234');
+	await password.fill('1234');
 	await expect(playground.error).toHaveText(['Email is invalid', '', '']);
 
 	await playground.form.press('Tab');
@@ -135,7 +135,7 @@ test('shouldValidate: onBlur', async ({ page }) => {
 		'',
 	]);
 
-	await confirmPassword.type('5678');
+	await confirmPassword.fill('5678');
 	await expect(playground.error).toHaveText([
 		'Email is invalid',
 		'Password is too short',
@@ -150,7 +150,7 @@ test('shouldValidate: onBlur', async ({ page }) => {
 	]);
 
 	await email.clear();
-	await email.type('example@conform.guide');
+	await email.fill('test@email.registered');
 	await expect(playground.error).toHaveText([
 		'Email is invalid',
 		'Password is too short',
@@ -164,8 +164,7 @@ test('shouldValidate: onBlur', async ({ page }) => {
 		'Password does not match',
 	]);
 
-	await password.clear();
-	await password.type('secretpassword');
+	await password.fill('secretpassword');
 	await expect(playground.error).toHaveText([
 		'',
 		'Password is too short',
@@ -179,14 +178,32 @@ test('shouldValidate: onBlur', async ({ page }) => {
 		'Password does not match',
 	]);
 
-	await confirmPassword.clear();
-	await confirmPassword.type('secretpassword');
+	await confirmPassword.fill('secretpassword');
 	await expect(playground.error).toHaveText([
 		'',
 		'',
 		'Password does not match',
 	]);
 
+	await playground.form.press('Tab');
+	await expect(playground.error).toHaveText(['', '', '']);
+
+	await playground.submit.click();
+	await expect(playground.error).toHaveText([
+		'Email is already registered',
+		'',
+		'',
+	]);
+
+	await email.click();
+	await password.click();
+	await expect(playground.error).toHaveText([
+		'Email is already registered',
+		'',
+		'',
+	]);
+
+	await email.fill('example@conform.guide');
 	await playground.form.press('Tab');
 	await expect(playground.error).toHaveText(['', '', '']);
 });


### PR DESCRIPTION
This minimize the chance server error get cleared simply because of moving focus out of the inputs. However, if the users type / click on any intent buttons, the errors will still be cleared because of client validation.