### PR TITLE
Narrow the `type` prop returned from the `getCollectionProps` helper

### DIFF
--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -340,7 +340,7 @@ export function getTextareaProps<Schema>(
  * Derives the properties of a collection of checkboxes or radio buttons based on the field metadata,
  * including common form control attributes like `key`, `id`, `name`, `form`, `autoFocus`, `aria-invalid`, `aria-describedby` and `required`.
  *
- * @see https://conform.guide/api/react/getTextareaProps
+ * @see https://conform.guide/api/react/getCollectionProps
  * @example
  * ```tsx
  * <fieldset>

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -363,9 +363,7 @@ export function getCollectionProps<
 		| boolean
 		| undefined
 		| unknown,
->(
-	metadata: FieldMetadata<Schema, any, any>,
-	options: Pretty<
+	Options extends Pretty<
 		FormControlOptions & {
 			/**
 			 * The input type. Use `checkbox` for multiple selection or `radio` for single selection.
@@ -381,7 +379,12 @@ export function getCollectionProps<
 			value?: boolean;
 		}
 	>,
-): Array<InputProps & Pick<Required<InputProps>, 'type' | 'value'>> {
+>(
+	metadata: FieldMetadata<Schema, any, any>,
+	options: Options,
+): Array<
+	InputProps & { type: Options['type'] } & Pick<Required<InputProps>, 'value'>
+> {
 	return options.options.map((value) =>
 		simplify({
 			...getFormControlProps(metadata, options),

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -383,7 +383,7 @@ export function getCollectionProps<
 	metadata: FieldMetadata<Schema, any, any>,
 	options: Options,
 ): Array<
-	InputProps & { type: Options['type'] } & Pick<Required<InputProps>, 'value'>
+	InputProps & Pick<Options, 'type'> & Pick<Required<InputProps>, 'value'>
 > {
 	return options.options.map((value) =>
 		simplify({


### PR DESCRIPTION
I updated the type definitions for the `getCollectionProps` helper function to better narrow the `type` prop that is returned. This resolves #561.

<img width="549" alt="image" src="https://github.com/edmundhung/conform/assets/24993818/dfcf0f54-b6ca-4175-8be8-60f7195a0adb">

<img width="553" alt="image" src="https://github.com/edmundhung/conform/assets/24993818/2a36541f-83af-4401-8e93-0024274af34c">

I also corrected the URL to the docs in the `getCollectionProps` helper function's JSDoc comment.