### PR TITLE
Narrow the `type` prop returned from the `getInputProps` helper

### DIFF
--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -240,10 +240,10 @@ export function getFormControlProps<Schema>(
  * <input {...getInputProps(metadata, { type: 'radio', value: false })} />
  * ```
  */
-export function getInputProps<Schema>(
+export function getInputProps<Schema, Options extends InputOptions>(
 	metadata: FieldMetadata<Schema, any, any>,
-	options: InputOptions,
-): InputProps {
+	options: Options,
+): InputProps & Pick<Options, 'type'> {
 	const props: InputProps = {
 		...getFormControlProps(metadata, options),
 		type: options.type,


### PR DESCRIPTION
I updated the type annotations for the `getInputProps` helper function to better narrow the `type` prop that is returned.

<img width="940" alt="Screenshot 2024-04-12 at 10 27 44 PM" src="https://github.com/edmundhung/conform/assets/24993818/3abc3ad2-53fb-4605-a7b2-c3c2b862e946">

This is the same change that was recently made to the `getCollectionProps` helper function. 
- #561
- #562