### PR TITLE
fix: defaultValue

### DIFF
--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -129,7 +129,7 @@ export function getValue(target: unknown, name: string): unknown {
 	let pointer = target;
 
 	for (const path of getPaths(name)) {
-		if (typeof pointer === 'undefined' || pointer == null) {
+		if (typeof pointer === 'undefined') {
 			break;
 		}
 

--- a/playground/app/routes/recursive-list.tsx
+++ b/playground/app/routes/recursive-list.tsx
@@ -81,7 +81,7 @@ function CategoryField({ name }: { name: FieldName<Category> }) {
 						name: fields.subcategories.name,
 						defaultValue: {
 							name: '',
-							subcategories: [null],
+							subcategories: [{}],
 						},
 					})}
 				>


### PR DESCRIPTION
@edmundhung I would write a test for this, but it's pretty difficult for me to do, the fix here is as follows:

when serializing the form if a `getButtonProps` defaultValue has a value (key or direct value) that is `null` it should be preserved as its a value that is JSON Serializable and if a schema says it can be nullable, it should pass that check