### PR TITLE
chore: simplify types

### DIFF
--- a/docs/integration/ui-libraries.md
+++ b/docs/integration/ui-libraries.md
@@ -8,35 +8,35 @@ Conform supports all native inputs out of the box by attaching an **input** and 
 
 ```tsx
 function Example() {
-  const [form, fields] = useForm({
-    // Optional, Conform will generate a random id if not provided
-    id: 'example',
-  });
+	const [form, fields] = useForm({
+		// Optional, Conform will generate a random id if not provided
+		id: 'example',
+	});
 
-  return (
-    <form id={form.id}>
-      <div>
-        <label>Title</label>
-        <input type="text" name="title" />
-        <div>{fields.title.errors}</div>
-      </div>
-      <div>
-        <label>Description</label>
-        <textarea name="description" />
-        <div>{fields.description.errors}</div>
-      </div>
-      <div>
-        <label>Color</label>
-        <select name="color">
-          <option>Red</option>
-          <option>Green</option>
-          <option>Blue</option>
-        </select>
-        <div>{fields.color.errors}</div>
-      </div>
-      <button form={form.id}>Submit</button>
-    </form>
-  );
+	return (
+		<form id={form.id}>
+			<div>
+				<label>Title</label>
+				<input type="text" name="title" />
+				<div>{fields.title.errors}</div>
+			</div>
+			<div>
+				<label>Description</label>
+				<textarea name="description" />
+				<div>{fields.description.errors}</div>
+			</div>
+			<div>
+				<label>Color</label>
+				<select name="color">
+					<option>Red</option>
+					<option>Green</option>
+					<option>Blue</option>
+				</select>
+				<div>{fields.color.errors}</div>
+			</div>
+			<button form={form.id}>Submit</button>
+		</form>
+	);
 }
 ```
 
@@ -50,11 +50,11 @@ To identify if the input is a native input, you can wrap it in a div with event 
 import { CustomInput } from 'your-ui-library';
 
 function Example() {
-  return (
-    <div onInput={console.log} onBlur={console.log}>
-      <CustomInput />
-    </div>
-  );
+	return (
+		<div onInput={console.log} onBlur={console.log}>
+			<CustomInput />
+		</div>
+	);
 }
 ```
 
@@ -71,83 +71,83 @@ Here is an example wrapping the [Select component from Radix UI](https://www.rad
 
 ```tsx
 import {
-  type FieldMetadata,
-  useForm,
-  useInputControl,
+	type FieldMetadata,
+	useForm,
+	useInputControl,
 } from '@conform-to/react';
 import * as Select from '@radix-ui/react-select';
 import {
-  CheckIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
+	CheckIcon,
+	ChevronDownIcon,
+	ChevronUpIcon,
 } from '@radix-ui/react-icons';
 
 type SelectFieldProps = {
-  // You can use the `FieldMetadata` type to define the `meta` prop
-  // And restrict the type of the field it accepts through its generics
-  meta: FieldMetadata<string>;
-  options: Array<string>;
+	// You can use the `FieldMetadata` type to define the `meta` prop
+	// And restrict the type of the field it accepts through its generics
+	meta: FieldMetadata<string>;
+	options: string[];
 };
 
 function SelectField({ meta, options }: SelectFieldProps) {
-  const control = useInputControl(meta);
+	const control = useInputControl(meta);
 
-  return (
-    <Select.Root
-      name={meta.name}
-      value={control.value}
-      onValueChange={(value) => {
-        control.change(value);
-      }}
-      onOpenChange={(open) => {
-        if (!open) {
-          control.blur();
-        }
-      }}
-    >
-      <Select.Trigger>
-        <Select.Value />
-        <Select.Icon>
-          <ChevronDownIcon />
-        </Select.Icon>
-      </Select.Trigger>
-      <Select.Portal>
-        <Select.Content>
-          <Select.ScrollUpButton>
-            <ChevronUpIcon />
-          </Select.ScrollUpButton>
-          <Select.Viewport>
-            {options.map((option) => (
-              <Select.Item key={option} value={option}>
-                <Select.ItemText>{option}</Select.ItemText>
-                <Select.ItemIndicator>
-                  <CheckIcon />
-                </Select.ItemIndicator>
-              </Select.Item>
-            ))}
-          </Select.Viewport>
-          <Select.ScrollDownButton>
-            <ChevronDownIcon />
-          </Select.ScrollDownButton>
-        </Select.Content>
-      </Select.Portal>
-    </Select.Root>
-  );
+	return (
+		<Select.Root
+			name={meta.name}
+			value={control.value}
+			onValueChange={(value) => {
+				control.change(value);
+			}}
+			onOpenChange={(open) => {
+				if (!open) {
+					control.blur();
+				}
+			}}
+		>
+			<Select.Trigger>
+				<Select.Value />
+				<Select.Icon>
+					<ChevronDownIcon />
+				</Select.Icon>
+			</Select.Trigger>
+			<Select.Portal>
+				<Select.Content>
+					<Select.ScrollUpButton>
+						<ChevronUpIcon />
+					</Select.ScrollUpButton>
+					<Select.Viewport>
+						{options.map((option) => (
+							<Select.Item key={option} value={option}>
+								<Select.ItemText>{option}</Select.ItemText>
+								<Select.ItemIndicator>
+									<CheckIcon />
+								</Select.ItemIndicator>
+							</Select.Item>
+						))}
+					</Select.Viewport>
+					<Select.ScrollDownButton>
+						<ChevronDownIcon />
+					</Select.ScrollDownButton>
+				</Select.Content>
+			</Select.Portal>
+		</Select.Root>
+	);
 }
 
 function Example() {
-  const [form, fields] = useForm();
+	const [form, fields] = useForm();
 
-  return (
-    <form id={form.id}>
-      <div>
-        <label>Currency</label>
-        <SelectField meta={fields.color} options={['red', 'green', 'blue']} />
-        <div>{fields.color.errors}</div>
-      </div>
-      <button>Submit</button>
-    </form>
-  );
+	return (
+		<form id={form.id}>
+			<div>
+				<label>Currency</label>
+				<SelectField meta={fields.color} options={['red', 'green', 'blue']} />
+				<div>{fields.color.errors}</div>
+			</div>
+			<button>Submit</button>
+		</form>
+	);
 }
 ```
 
@@ -157,63 +157,63 @@ You can also simplify the wrapper component by using the [useField](../api/react
 
 ```tsx
 import {
-  type FieldName,
-  FormProvider,
-  useForm,
-  useField,
-  useInputControl,
+	type FieldName,
+	FormProvider,
+	useForm,
+	useField,
+	useInputControl,
 } from '@conform-to/react';
 import * as Select from '@radix-ui/react-select';
 import {
-  CheckIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
+	CheckIcon,
+	ChevronDownIcon,
+	ChevronUpIcon,
 } from '@radix-ui/react-icons';
 
 type SelectFieldProps = {
-  // Instead of using the `FieldMetadata` type, we will use the `FieldName` type
-  // We can also restrict the type of the field it accepts through its generics
-  name: FieldName<string>;
-  options: Array<string>;
+	// Instead of using the `FieldMetadata` type, we will use the `FieldName` type
+	// We can also restrict the type of the field it accepts through its generics
+	name: FieldName<string>;
+	options: string[];
 };
 
 function Select({ name, options }: SelectFieldProps) {
-  const [meta] = useField(name);
-  const control = useInputControl(meta);
+	const [meta] = useField(name);
+	const control = useInputControl(meta);
 
-  return (
-    <Select.Root
-      name={meta.name}
-      value={control.value}
-      onValueChange={(value) => {
-        control.change(value);
-      }}
-      onOpenChange={(open) => {
-        if (!open) {
-          control.blur();
-        }
-      }}
-    >
-      {/* ... */}
-    </Select.Root>
-  );
+	return (
+		<Select.Root
+			name={meta.name}
+			value={control.value}
+			onValueChange={(value) => {
+				control.change(value);
+			}}
+			onOpenChange={(open) => {
+				if (!open) {
+					control.blur();
+				}
+			}}
+		>
+			{/* ... */}
+		</Select.Root>
+	);
 }
 
 function Example() {
-  const [form, fields] = useForm();
+	const [form, fields] = useForm();
 
-  return (
-    <FormProvider context={form.context}>
-      <form id={form.id}>
-        <div>
-          <label>Color</label>
-          <Select name={fields.color.name} options={['red', 'green', 'blue']} />
-          <div>{fields.color.errors}</div>
-        </div>
-        <button>Submit</button>
-      </form>
-    </FormProvider>
-  );
+	return (
+		<FormProvider context={form.context}>
+			<form id={form.id}>
+				<div>
+					<label>Color</label>
+					<Select name={fields.color.name} options={['red', 'green', 'blue']} />
+					<div>{fields.color.errors}</div>
+				</div>
+				<button>Submit</button>
+			</form>
+		</FormProvider>
+	);
 }
 ```
 

--- a/docs/ja/integration/ui-libraries.md
+++ b/docs/ja/integration/ui-libraries.md
@@ -8,35 +8,35 @@ Conform は、ドキュメントに直接 **input** と **focusout** イベン�
 
 ```tsx
 function Example() {
-  const [form, fields] = useForm({
-    // オプション。指定されていない場合は Conform がランダムなIDを生成します。
-    id: 'example',
-  });
+	const [form, fields] = useForm({
+		// オプション。指定されていない場合は Conform がランダムなIDを生成します。
+		id: 'example',
+	});
 
-  return (
-    <form id={form.id}>
-      <div>
-        <label>Title</label>
-        <input type="text" name="title" />
-        <div>{fields.title.errors}</div>
-      </div>
-      <div>
-        <label>Description</label>
-        <textarea name="description" />
-        <div>{fields.description.errors}</div>
-      </div>
-      <div>
-        <label>Color</label>
-        <select name="color">
-          <option>Red</option>
-          <option>Green</option>
-          <option>Blue</option>
-        </select>
-        <div>{fields.color.errors}</div>
-      </div>
-      <button form={form.id}>Submit</button>
-    </form>
-  );
+	return (
+		<form id={form.id}>
+			<div>
+				<label>Title</label>
+				<input type="text" name="title" />
+				<div>{fields.title.errors}</div>
+			</div>
+			<div>
+				<label>Description</label>
+				<textarea name="description" />
+				<div>{fields.description.errors}</div>
+			</div>
+			<div>
+				<label>Color</label>
+				<select name="color">
+					<option>Red</option>
+					<option>Green</option>
+					<option>Blue</option>
+				</select>
+				<div>{fields.color.errors}</div>
+			</div>
+			<button form={form.id}>Submit</button>
+		</form>
+	);
 }
 ```
 
@@ -50,11 +50,11 @@ Conform は[イベント移譲](#event-delegation)に依存してフォームを
 import { CustomInput } from 'your-ui-library';
 
 function Example() {
-  return (
-    <div onInput={console.log} onBlur={console.log}>
-      <CustomInput />
-    </div>
-  );
+	return (
+		<div onInput={console.log} onBlur={console.log}>
+			<CustomInput />
+		</div>
+	);
 }
 ```
 
@@ -71,83 +71,83 @@ function Example() {
 
 ```tsx
 import {
-  type FieldMetadata,
-  useForm,
-  useInputControl,
+	type FieldMetadata,
+	useForm,
+	useInputControl,
 } from '@conform-to/react';
 import * as Select from '@radix-ui/react-select';
 import {
-  CheckIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
+	CheckIcon,
+	ChevronDownIcon,
+	ChevronUpIcon,
 } from '@radix-ui/react-icons';
 
 type SelectFieldProps = {
-  // `FieldMetadata` 型を使用して `meta` プロパティを定義し、
-  // そのジェネリクスを通じて受け入れるフィールドの型を制限することができます。
-  meta: FieldMetadata<string>;
-  options: Array<string>;
+	// `FieldMetadata` 型を使用して `meta` プロパティを定義し、
+	// そのジェネリクスを通じて受け入れるフィールドの型を制限することができます。
+	meta: FieldMetadata<string>;
+	options: string[];
 };
 
 function SelectField({ meta, options }: SelectFieldProps) {
-  const control = useInputControl(meta);
+	const control = useInputControl(meta);
 
-  return (
-    <Select.Root
-      name={meta.name}
-      value={control.value}
-      onValueChange={(value) => {
-        control.change(value);
-      }}
-      onOpenChange={(open) => {
-        if (!open) {
-          control.blur();
-        }
-      }}
-    >
-      <Select.Trigger>
-        <Select.Value />
-        <Select.Icon>
-          <ChevronDownIcon />
-        </Select.Icon>
-      </Select.Trigger>
-      <Select.Portal>
-        <Select.Content>
-          <Select.ScrollUpButton>
-            <ChevronUpIcon />
-          </Select.ScrollUpButton>
-          <Select.Viewport>
-            {options.map((option) => (
-              <Select.Item key={option} value={option}>
-                <Select.ItemText>{option}</Select.ItemText>
-                <Select.ItemIndicator>
-                  <CheckIcon />
-                </Select.ItemIndicator>
-              </Select.Item>
-            ))}
-          </Select.Viewport>
-          <Select.ScrollDownButton>
-            <ChevronDownIcon />
-          </Select.ScrollDownButton>
-        </Select.Content>
-      </Select.Portal>
-    </Select.Root>
-  );
+	return (
+		<Select.Root
+			name={meta.name}
+			value={control.value}
+			onValueChange={(value) => {
+				control.change(value);
+			}}
+			onOpenChange={(open) => {
+				if (!open) {
+					control.blur();
+				}
+			}}
+		>
+			<Select.Trigger>
+				<Select.Value />
+				<Select.Icon>
+					<ChevronDownIcon />
+				</Select.Icon>
+			</Select.Trigger>
+			<Select.Portal>
+				<Select.Content>
+					<Select.ScrollUpButton>
+						<ChevronUpIcon />
+					</Select.ScrollUpButton>
+					<Select.Viewport>
+						{options.map((option) => (
+							<Select.Item key={option} value={option}>
+								<Select.ItemText>{option}</Select.ItemText>
+								<Select.ItemIndicator>
+									<CheckIcon />
+								</Select.ItemIndicator>
+							</Select.Item>
+						))}
+					</Select.Viewport>
+					<Select.ScrollDownButton>
+						<ChevronDownIcon />
+					</Select.ScrollDownButton>
+				</Select.Content>
+			</Select.Portal>
+		</Select.Root>
+	);
 }
 
 function Example() {
-  const [form, fields] = useForm();
+	const [form, fields] = useForm();
 
-  return (
-    <form id={form.id}>
-      <div>
-        <label>Currency</label>
-        <SelectField meta={fields.color} options={['red', 'green', 'blue']} />
-        <div>{fields.color.errors}</div>
-      </div>
-      <button>Submit</button>
-    </form>
-  );
+	return (
+		<form id={form.id}>
+			<div>
+				<label>Currency</label>
+				<SelectField meta={fields.color} options={['red', 'green', 'blue']} />
+				<div>{fields.color.errors}</div>
+			</div>
+			<button>Submit</button>
+		</form>
+	);
 }
 ```
 
@@ -157,63 +157,63 @@ function Example() {
 
 ```tsx
 import {
-  type FieldName,
-  FormProvider,
-  useForm,
-  useField,
-  useInputControl,
+	type FieldName,
+	FormProvider,
+	useForm,
+	useField,
+	useInputControl,
 } from '@conform-to/react';
 import * as Select from '@radix-ui/react-select';
 import {
-  CheckIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
+	CheckIcon,
+	ChevronDownIcon,
+	ChevronUpIcon,
 } from '@radix-ui/react-icons';
 
 type SelectFieldProps = {
-  // `FieldMetadata` 型の代わりに `FieldName` 型を使用します。
-  // また、そのジェネリクスを通じて受け入れるフィールドの型を制限することもできます。
-  name: FieldName<string>;
-  options: Array<string>;
+	// `FieldMetadata` 型の代わりに `FieldName` 型を使用します。
+	// また、そのジェネリクスを通じて受け入れるフィールドの型を制限することもできます。
+	name: FieldName<string>;
+	options: string[];
 };
 
 function Select({ name, options }: SelectFieldProps) {
-  const [meta] = useField(name);
-  const control = useInputControl(meta);
+	const [meta] = useField(name);
+	const control = useInputControl(meta);
 
-  return (
-    <Select.Root
-      name={meta.name}
-      value={control.value}
-      onValueChange={(value) => {
-        control.change(value);
-      }}
-      onOpenChange={(open) => {
-        if (!open) {
-          control.blur();
-        }
-      }}
-    >
-      {/* ... */}
-    </Select.Root>
-  );
+	return (
+		<Select.Root
+			name={meta.name}
+			value={control.value}
+			onValueChange={(value) => {
+				control.change(value);
+			}}
+			onOpenChange={(open) => {
+				if (!open) {
+					control.blur();
+				}
+			}}
+		>
+			{/* ... */}
+		</Select.Root>
+	);
 }
 
 function Example() {
-  const [form, fields] = useForm();
+	const [form, fields] = useForm();
 
-  return (
-    <FormProvider context={form.context}>
-      <form id={form.id}>
-        <div>
-          <label>Color</label>
-          <Select name={fields.color.name} options={['red', 'green', 'blue']} />
-          <div>{fields.color.errors}</div>
-        </div>
-        <button>Submit</button>
-      </form>
-    </FormProvider>
-  );
+	return (
+		<FormProvider context={form.context}>
+			<form id={form.id}>
+				<div>
+					<label>Color</label>
+					<Select name={fields.color.name} options={['red', 'green', 'blue']} />
+					<div>{fields.color.errors}</div>
+				</div>
+				<button>Submit</button>
+			</form>
+		</FormProvider>
+	);
 }
 ```
 

--- a/examples/headless-ui/src/App.tsx
+++ b/examples/headless-ui/src/App.tsx
@@ -148,7 +148,7 @@ const people = [
 	{ id: 5, name: 'Katelyn Rohan' },
 ];
 
-function classNames(...classes: Array<string | boolean>): string {
+function classNames(...classes: (string | boolean)[]): string {
 	return classes.filter(Boolean).join(' ');
 }
 

--- a/examples/radix-ui/src/ui/RadioGroup.tsx
+++ b/examples/radix-ui/src/ui/RadioGroup.tsx
@@ -8,7 +8,7 @@ export function RadioGroup({
 	items,
 }: {
 	meta: FieldMetadata<string>;
-	items: Array<{ value: string; label: string }>;
+	items: { value: string; label: string }[];
 }) {
 	const radioGroupRef = useRef<ElementRef<typeof RadixRadioGroup.Root>>(null);
 	const control = useInputControl(meta);

--- a/examples/radix-ui/src/ui/Select.tsx
+++ b/examples/radix-ui/src/ui/Select.tsx
@@ -13,7 +13,7 @@ export const Select = ({
 	placeholder = '',
 }: {
 	meta: FieldMetadata<string>;
-	items: Array<{ name: string; value: string }>;
+	items: { name: string; value: string }[];
 	placeholder?: string;
 }) => {
 	const selectRef = useRef<ElementRef<typeof RadixSelect.Trigger>>(null);

--- a/examples/radix-ui/src/ui/ToggleGroup.tsx
+++ b/examples/radix-ui/src/ui/ToggleGroup.tsx
@@ -7,7 +7,7 @@ export function ToggleGroup({
 	items,
 }: {
 	meta: FieldMetadata<string>;
-	items: Array<{ label: string; value: string }>;
+	items: { label: string; value: string }[];
 }) {
 	const toggleGroupRef = useRef<ElementRef<typeof RadixToggleGroup.Root>>(null);
 	const control = useInputControl(meta);

--- a/examples/shadcn-ui/src/components/conform/CheckboxGroup.tsx
+++ b/examples/shadcn-ui/src/components/conform/CheckboxGroup.tsx
@@ -9,7 +9,7 @@ export function CheckboxGroupConform({
 	items,
 }: {
 	meta: FieldMetadata<string[]>;
-	items: Array<{ name: string; value: string }>;
+	items: { name: string; value: string }[];
 }) {
 	const initialValue =
 		typeof meta.initialValue === 'string'

--- a/examples/shadcn-ui/src/components/conform/RadioGroup.tsx
+++ b/examples/shadcn-ui/src/components/conform/RadioGroup.tsx
@@ -10,7 +10,7 @@ export function RadioGroupConform({
 	items,
 }: {
 	meta: FieldMetadata<string>;
-	items: Array<{ value: string; label: string }>;
+	items: { value: string; label: string }[];
 }) {
 	const radioGroupRef = useRef<ElementRef<typeof RadioGroup>>(null);
 	const control = useControl(meta);

--- a/examples/shadcn-ui/src/components/conform/Select.tsx
+++ b/examples/shadcn-ui/src/components/conform/Select.tsx
@@ -18,7 +18,7 @@ export const SelectConform = ({
 	...props
 }: {
 	meta: FieldMetadata<string>;
-	items: Array<{ name: string; value: string }>;
+	items: { name: string; value: string }[];
 	placeholder: string;
 } & ComponentProps<typeof Select>) => {
 	const selectRef = useRef<ElementRef<typeof SelectTrigger>>(null);

--- a/examples/shadcn-ui/src/components/conform/ToggleGroup.tsx
+++ b/examples/shadcn-ui/src/components/conform/ToggleGroup.tsx
@@ -10,7 +10,7 @@ export const ToggleGroupConform = ({
 	items,
 	...props
 }: {
-	items: Array<{ value: string; label: string }>;
+	items: { value: string; label: string }[];
 	meta: FieldMetadata<string>;
 } & Omit<ComponentProps<typeof ToggleGroup>, 'defaultValue'>) => {
 	const toggleGroupRef = useRef<ElementRef<typeof ToggleGroup>>(null);

--- a/guide/app/components.tsx
+++ b/guide/app/components.tsx
@@ -17,10 +17,7 @@ import { useEffect, useLayoutEffect, useRef } from 'react';
 
 export interface Menu {
 	title: string;
-	links: Array<{
-		title: string;
-		to: string;
-	}>;
+	links: { title: string; to: string }[];
 }
 
 const style = {

--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -53,8 +53,8 @@ export type DefaultValue<Schema> = Schema extends
 	? Schema | string | null | undefined
 	: Schema extends File
 	? null | undefined
-	: Schema extends Array<infer Item>
-	? Array<DefaultValue<Item>> | null | undefined
+	: Schema extends (infer Item)[]
+	? DefaultValue<Item>[] | null | undefined
 	: Schema extends Record<string, any>
 	? { [Key in keyof Schema]?: DefaultValue<Schema[Key]> } | null | undefined
 	: string | null | undefined;
@@ -71,9 +71,9 @@ export type FormValue<Schema> = Schema extends
 	: Schema extends File
 	? File | undefined
 	: Schema extends File[]
-	? File | Array<File> | undefined
-	: Schema extends Array<infer Item>
-	? string | Array<FormValue<Item>> | undefined
+	? File | File[] | undefined
+	: Schema extends (infer Item)[]
+	? string | FormValue<Item>[] | undefined
 	: Schema extends Record<string, any>
 	? { [Key in keyof Schema]?: FormValue<Schema[Key]> } | null | undefined
 	: unknown;
@@ -290,7 +290,7 @@ function createFormMeta<Schema, FormError, FormValue>(
 }
 
 function getDefaultKey(
-	defaultValue: Record<string, unknown> | Array<unknown>,
+	defaultValue: Record<string, unknown> | unknown[],
 	prefix?: string,
 ): Record<string, string> {
 	return Object.entries(flatten(defaultValue, { prefix })).reduce<
@@ -622,10 +622,10 @@ export function createFormContext<
 >(
 	options: FormOptions<Schema, FormError, FormValue>,
 ): FormContext<Schema, FormError, FormValue> {
-	let subscribers: Array<{
+	let subscribers: {
 		callback: () => void;
 		getSubject?: () => SubscriptionSubject | undefined;
-	}> = [];
+	}[] = [];
 	let latestOptions = options;
 	let meta = createFormMeta(options);
 	let state = createFormState(meta);

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -30,25 +30,23 @@ export function getFormData(
  * const paths = getPaths('todos[0].content'); // ['todos', 0, 'content']
  * ```
  */
-export function getPaths(name: string | undefined): Array<string | number> {
+export function getPaths(name: string | undefined): (string | number)[] {
 	if (!name) {
 		return [];
 	}
 
-	return name
-		.split(/\.|(\[\d*\])/)
-		.reduce<Array<string | number>>((result, segment) => {
-			if (typeof segment !== 'undefined' && segment !== '') {
-				if (segment.startsWith('[') && segment.endsWith(']')) {
-					const index = segment.slice(1, -1);
+	return name.split(/\.|(\[\d*\])/).reduce((result, segment) => {
+		if (typeof segment !== 'undefined' && segment !== '') {
+			if (segment.startsWith('[') && segment.endsWith(']')) {
+				const index = segment.slice(1, -1);
 
-					result.push(Number(index));
-				} else {
-					result.push(segment);
-				}
+				result.push(Number(index));
+			} else {
+				result.push(segment);
 			}
-			return result;
-		}, []);
+		}
+		return result;
+	}, [] as (string | number)[]);
 }
 
 /**
@@ -58,7 +56,7 @@ export function getPaths(name: string | undefined): Array<string | number> {
  * const name = formatPaths(['todos', 0, 'content']); // "todos[0].content"
  * ```
  */
-export function formatPaths(paths: Array<string | number>): string {
+export function formatPaths(paths: (string | number)[]): string {
 	return paths.reduce<string>((name, path) => {
 		if (typeof path === 'number') {
 			return `${name}[${Number.isNaN(path) ? '' : path}]`;
@@ -148,9 +146,7 @@ export function getValue(target: unknown, name: string): unknown {
 /**
  * Check if the value is a plain object
  */
-export function isPlainObject(
-	obj: unknown,
-): obj is Record<string | number | symbol, unknown> {
+export function isPlainObject(obj: unknown): obj is Record<keyof any, unknown> {
 	return (
 		!!obj &&
 		obj.constructor === Object &&
@@ -177,7 +173,7 @@ export function normalize<Type extends Record<string, unknown>>(
 	value: Type,
 	acceptFile?: boolean,
 ): Type | undefined;
-export function normalize<Type extends Array<unknown>>(
+export function normalize<Type extends unknown[]>(
 	value: Type,
 	acceptFile?: boolean,
 ): Type | undefined;
@@ -185,12 +181,10 @@ export function normalize(
 	value: unknown,
 	acceptFile?: boolean,
 ): unknown | undefined;
-export function normalize<
-	Type extends Record<string, unknown> | Array<unknown>,
->(
+export function normalize<Type extends Record<string, unknown> | unknown[]>(
 	value: Type,
 	acceptFile = true,
-): Record<string, unknown> | Array<unknown> | undefined {
+): Record<string, unknown> | unknown[] | undefined {
 	if (isPlainObject(value)) {
 		const obj = Object.keys(value)
 			.sort()
@@ -234,7 +228,7 @@ export function normalize<
  * Flatten a tree into a dictionary
  */
 export function flatten(
-	data: Record<string | number | symbol, unknown> | Array<unknown> | undefined,
+	data: Record<keyof any, unknown> | unknown[] | undefined,
 	options?: {
 		resolve?: (data: unknown) => unknown | null;
 		prefix?: string;
@@ -252,7 +246,7 @@ export function flatten(
 	}
 
 	function processObject(
-		obj: Record<string | number | symbol, unknown>,
+		obj: Record<keyof any, unknown>,
 		prefix: string,
 	): void {
 		setResult(obj, prefix);
@@ -270,7 +264,7 @@ export function flatten(
 		}
 	}
 
-	function processArray(array: Array<unknown>, prefix: string): void {
+	function processArray(array: unknown[], prefix: string): void {
 		setResult(array, prefix);
 
 		for (let i = 0; i < array.length; i++) {

--- a/packages/conform-dom/submission.ts
+++ b/packages/conform-dom/submission.ts
@@ -316,7 +316,7 @@ export type ResetIntent<Schema = any> = {
 		  }
 		| {
 				name: FieldName<Schema>;
-				index: Schema extends Array<unknown> ? number : never;
+				index: Schema extends unknown[] ? number : never;
 		  };
 };
 
@@ -331,15 +331,15 @@ export type UpdateIntent<Schema = unknown> = {
 		  }
 		| {
 				name: FieldName<Schema>;
-				index: Schema extends Array<unknown> ? number : never;
+				index: Schema extends unknown[] ? number : never;
 				value?: NonNullable<
-					DefaultValue<Schema extends Array<infer Item> ? Item : unknown>
+					DefaultValue<Schema extends (infer Item)[] ? Item : unknown>
 				>;
 				validated?: boolean;
 		  };
 };
 
-export type RemoveIntent<Schema extends Array<any> = any> = {
+export type RemoveIntent<Schema extends any[] = any> = {
 	type: 'remove';
 	payload: {
 		name: FieldName<Schema>;
@@ -347,18 +347,16 @@ export type RemoveIntent<Schema extends Array<any> = any> = {
 	};
 };
 
-export type InsertIntent<Schema extends Array<any> = any> = {
+export type InsertIntent<Schema extends any[] = any> = {
 	type: 'insert';
 	payload: {
 		name: FieldName<Schema>;
-		defaultValue?: Schema extends Array<infer Item>
-			? DefaultValue<Item>
-			: never;
+		defaultValue?: Schema extends (infer Item)[] ? DefaultValue<Item> : never;
 		index?: number;
 	};
 };
 
-export type ReorderIntent<Schema extends Array<any> = any> = {
+export type ReorderIntent<Schema extends any[] = any> = {
 	type: 'reorder';
 	payload: {
 		name: FieldName<Schema>;
@@ -371,9 +369,9 @@ export type Intent<Schema = unknown> =
 	| ValidateIntent<Schema>
 	| ResetIntent<Schema>
 	| UpdateIntent<Schema>
-	| ReorderIntent<Schema extends Array<any> ? Schema : any>
-	| RemoveIntent<Schema extends Array<any> ? Schema : any>
-	| InsertIntent<Schema extends Array<any> ? Schema : any>;
+	| ReorderIntent<Schema extends any[] ? Schema : any>
+	| RemoveIntent<Schema extends any[] ? Schema : any>
+	| InsertIntent<Schema extends any[] ? Schema : any>;
 
 export function getIntent(
 	serializedIntent: string | null | undefined,

--- a/packages/conform-react/context.tsx
+++ b/packages/conform-react/context.tsx
@@ -85,9 +85,9 @@ type SubfieldMetadata<
 	FormError,
 > = [Schema] extends [Primitive]
 	? {}
-	: [Schema] extends [Array<infer Item> | null | undefined]
+	: [Schema] extends [(infer Item)[] | null | undefined]
 	? {
-			getFieldList: () => Array<FieldMetadata<Item, FormSchema, FormError>>;
+			getFieldList: () => FieldMetadata<Item, FormSchema, FormError>[];
 	  }
 	: [Schema] extends [Record<string, any> | null | undefined]
 	? {

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -357,12 +357,7 @@ export function getTextareaProps<Schema>(
  * ```
  */
 export function getCollectionProps<
-	Schema extends
-		| Array<string | boolean>
-		| string
-		| boolean
-		| undefined
-		| unknown,
+	Schema extends (string | boolean)[] | string | boolean | undefined | unknown,
 	Options extends Pretty<
 		FormControlOptions & {
 			/**
@@ -382,9 +377,9 @@ export function getCollectionProps<
 >(
 	metadata: FieldMetadata<Schema, any, any>,
 	options: Options,
-): Array<
-	InputProps & Pick<Options, 'type'> & Pick<Required<InputProps>, 'value'>
-> {
+): (InputProps &
+	Pick<Options, 'type'> &
+	Pick<Required<InputProps>, 'value'>)[] {
 	return options.options.map((value) =>
 		simplify({
 			...getFormControlProps(metadata, options),

--- a/packages/conform-react/integrations.ts
+++ b/packages/conform-react/integrations.ts
@@ -14,7 +14,7 @@ export function getFormElement(formId: string): HTMLFormElement | null {
 export function getFieldElements(
 	form: HTMLFormElement | null,
 	name: string,
-): Array<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement> {
+): (HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement)[] {
 	const field = form?.elements.namedItem(name);
 	const elements = !field
 		? []
@@ -270,7 +270,7 @@ export function useInputEvent(): {
 }
 
 export function useInputValue<
-	Value extends string | string[] | Array<string | undefined>,
+	Value extends string | string[] | (string | undefined)[],
 >(options: { key?: Key | null | undefined; initialValue?: Value | undefined }) {
 	const initializeValue = ():
 		| (Value extends string ? Value : string | string[])
@@ -295,7 +295,7 @@ export function useInputValue<
 }
 
 export function useControl<
-	Value extends string | string[] | Array<string | undefined>,
+	Value extends string | string[] | (string | undefined)[],
 >(meta: { key?: Key | null | undefined; initialValue?: Value | undefined }) {
 	const [value, setValue] = useInputValue(meta);
 	const { register, change, focus, blur } = useInputEvent();
@@ -316,7 +316,7 @@ export function useControl<
 }
 
 export function useInputControl<
-	Value extends string | string[] | Array<string | undefined>,
+	Value extends string | string[] | (string | undefined)[],
 >(meta: {
 	key?: Key | null | undefined;
 	name: string;
@@ -378,7 +378,7 @@ export function useInputControl<
 }
 
 export function Control<
-	Value extends string | string[] | Array<string | undefined>,
+	Value extends string | string[] | (string | undefined)[],
 >(props: {
 	meta: { key?: Key | null | undefined; initialValue?: Value | undefined };
 	render: (control: ReturnType<typeof useControl<Value>>) => React.ReactNode;

--- a/packages/conform-zod/constraint.ts
+++ b/packages/conform-zod/constraint.ts
@@ -17,7 +17,7 @@ import {
 	ZodLazy,
 } from 'zod';
 
-const keys: Array<keyof Constraint> = [
+const keys: (keyof Constraint)[] = [
 	'required',
 	'minLength',
 	'maxLength',

--- a/packages/conform-zod/parse.ts
+++ b/packages/conform-zod/parse.ts
@@ -17,7 +17,7 @@ import { enableTypeCoercion } from './coercion';
 
 function getError<FormError>(
 	zodError: ZodError,
-	formatError: (issues: Array<ZodIssue>) => FormError,
+	formatError: (issues: ZodIssue[]) => FormError,
 ): Record<string, FormError | null> | null {
 	const result: Record<string, ZodIssue[] | null> = {};
 
@@ -69,7 +69,7 @@ export function parseWithZod<Schema extends ZodTypeAny, FormError>(
 		schema: Schema | ((intent: Intent | null) => Schema);
 		async?: false;
 		errorMap?: ZodErrorMap;
-		formatError: (issues: Array<ZodIssue>) => FormError;
+		formatError: (issues: ZodIssue[]) => FormError;
 	},
 ): Submission<input<Schema>, FormError, output<Schema>>;
 export function parseWithZod<Schema extends ZodTypeAny>(
@@ -86,7 +86,7 @@ export function parseWithZod<Schema extends ZodTypeAny, FormError>(
 		schema: Schema | ((intent: Intent | null) => Schema);
 		async: true;
 		errorMap?: ZodErrorMap;
-		formatError: (issues: Array<ZodIssue>) => FormError;
+		formatError: (issues: ZodIssue[]) => FormError;
 	},
 ): Promise<Submission<input<Schema>, FormError, output<Schema>>>;
 export function parseWithZod<Schema extends ZodTypeAny, FormError>(
@@ -95,7 +95,7 @@ export function parseWithZod<Schema extends ZodTypeAny, FormError>(
 		schema: Schema | ((intent: Intent | null) => Schema);
 		async?: boolean;
 		errorMap?: ZodErrorMap;
-		formatError?: (issues: Array<ZodIssue>) => FormError;
+		formatError?: (issues: ZodIssue[]) => FormError;
 	},
 ):
 	| Submission<input<Schema>, FormError | string[], output<Schema>>

--- a/playground/app/routes/custom-inputs.tsx
+++ b/playground/app/routes/custom-inputs.tsx
@@ -124,7 +124,7 @@ export default function Example() {
 	);
 }
 
-function classNames(...classes: Array<string | boolean>): string {
+function classNames(...classes: (string | boolean)[]): string {
 	return classes.filter(Boolean).join(' ');
 }
 

--- a/playground/app/routes/typing.tsx
+++ b/playground/app/routes/typing.tsx
@@ -21,13 +21,13 @@ interface Rule {
 
 interface Group {
 	type: 'group';
-	conditions: Array<Group | Rule>;
+	conditions: (Group | Rule)[];
 }
 
 type Schema =
 	| {
 			intent: 'foo';
-			tasks: Array<Task>;
+			tasks: Task[];
 			date: Date;
 	  }
 	| {
@@ -115,12 +115,12 @@ export default function Example() {
 	isFieldMetadataType0(tasks);
 	isFieldMetadataType1<Task[]>(tasks);
 	isFieldMetadataType1<Task[] | undefined>(tasks);
-	isFieldMetadataType1<Array<Task | undefined>>(tasks);
+	isFieldMetadataType1<(Task | undefined)[]>(tasks);
 
 	// @ts-expect-error
 	isFieldMetadataType1<Task>(tasks);
 	// @ts-expect-error
-	isFieldMetadataType1<Array<string>>(tasks);
+	isFieldMetadataType1<string[]>(tasks);
 
 	const date = fields.date;
 
@@ -169,17 +169,15 @@ export default function Example() {
 	isFieldMetadataType1<string>(filterFieldset.type);
 	isFieldMetadataType1<string | undefined>(filterFieldset.type);
 	isFieldMetadataType0(filterFieldset.conditions);
-	isFieldMetadataType1<Array<Rule | Group>>(filterFieldset.conditions);
-	isFieldMetadataType1<Array<Rule | Group> | undefined>(
-		filterFieldset.conditions,
-	);
+	isFieldMetadataType1<(Rule | Group)[]>(filterFieldset.conditions);
+	isFieldMetadataType1<(Rule | Group)[] | undefined>(filterFieldset.conditions);
 
 	// @ts-expect-error
 	isFieldMetadataType1<Rule | Group>(filterFieldset.conditions);
 	// @ts-expect-error
-	isFieldMetadataType1<Array<Rule>>(filterFieldset.conditions);
+	isFieldMetadataType1<Rule[]>(filterFieldset.conditions);
 	// @ts-expect-error
-	isFieldMetadataType1<Array<Group>>(filterFieldset.conditions);
+	isFieldMetadataType1<Group[]>(filterFieldset.conditions);
 
 	const conditionsList = filterFieldset.conditions.getFieldList();
 
@@ -201,10 +199,8 @@ export default function Example() {
 	isFieldMetadataType1<string>(ruleFieldset?.operator);
 	isFieldMetadataType1<string | undefined>(ruleFieldset?.operator);
 	isFieldMetadataType0(ruleFieldset?.conditions);
-	isFieldMetadataType1<Array<Group | Rule>>(ruleFieldset?.conditions);
-	isFieldMetadataType1<Array<Group | Rule | undefined>>(
-		ruleFieldset?.conditions,
-	);
+	isFieldMetadataType1<(Group | Rule)[]>(ruleFieldset?.conditions);
+	isFieldMetadataType1<(Group | Rule | undefined)[]>(ruleFieldset?.conditions);
 
 	const innerConditionsList = ruleFieldset?.conditions.getFieldList();
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -16,7 +16,7 @@ export function getPlayground(page: Page) {
 }
 
 export function createFormData(
-	entries: Array<[string, FormDataEntryValue]>,
+	entries: [string, FormDataEntryValue][],
 ): FormData {
 	const formData = new FormData();
 


### PR DESCRIPTION
simplifying types to resolved types.

1. `Array<T>` -> `T[]`
2. `Record<string | number | symbol, unknown>` -> `Record<keyof any, unknown>` as it resolves to the same thing