### PR TITLE
Remove usage of `instanceof` for Zod schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ node_modules/
 /test-results/
 /playwright-report/
 /playwright/.cache/
+
+# DS Store
+.DS_Store
+**/.DS_Store


### PR DESCRIPTION
I got a weird bug report on Twitter here: https://twitter.com/Varkoffs/status/1783118133848400070

It seems to be due to a weirdness in Remix, where both the ESM and CommonJS versions of Zod are loaded and used during server initialization. Somehow a schema declared in a Remix page (using ESM) was getting passed into a `parseWithZod` call that was using CJS internally to do `instanceof` checks. Because each copy of Zod has separate class definitions, the `instanceof` checks fail. 

This is by no means an issue with conform, but one possible solution is for conform to avoid `instanceof`. There are other scenarios where both builds of a package can be loaded simultaneously. Some are described by isaacs (founder of npm) here: https://github.com/isaacs/tshy?tab=readme-ov-file#dual-package-hazards 

The tldr is that its best to avoid `instanceof` when possible, especially for libraries that are referencing classes from their dependencies. 

This PR technically relies on "internal" `_def` APIs but these haven't changed in a long time and you can consider them stable. (Zod 4 will break this, but that's an issue for another day.) Apologies for some of the hackiness/casting but I didn't see a way to avoid it.