### PR TITLE
Replace `unknown` in submission payload

### DIFF
--- a/.changeset/gentle-humans-eat.md
+++ b/.changeset/gentle-humans-eat.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/dom': patch
+---
+
+Replace submission payload unknown types


### PR DESCRIPTION
Fix #628

This pull request replaces the `unknown` type in submission payloads. `unknown` is not compatible with Remix Single Fetch and new `defineLoader` or `defineAction` as it cannot be guaranteed that values of type `unknown` can be sent over the wire.

Removing `unknown` types addresses this issue. I've replaced it with what I think is correct but I don't know the ins and outs of this library so plz check.

Thanks!