### PR TITLE
docs: Fix typo in parseWithYup.md

### DIFF
--- a/docs/api/yup/parseWithYup.md
+++ b/docs/api/yup/parseWithYup.md
@@ -27,7 +27,7 @@ Set it to **true** if you want to parse the form data with **validate** method f
 ```tsx
 import { parseWithYup } from '@conform-to/zod';
 import { useForm } from '@conform-to/react';
-import * as yup from 'zod';
+import * as yup from 'yup';
 
 const schema = yup.object({
   email: yup.string().email(),

--- a/docs/api/yup/parseWithYup.md
+++ b/docs/api/yup/parseWithYup.md
@@ -25,7 +25,7 @@ Set it to **true** if you want to parse the form data with **validate** method f
 ## Example
 
 ```tsx
-import { parseWithYup } from '@conform-to/zod';
+import { parseWithYup } from '@conform-to/yup';
 import { useForm } from '@conform-to/react';
 import * as yup from 'yup';
 

--- a/docs/ja/api/yup/parseWithYup.md
+++ b/docs/ja/api/yup/parseWithYup.md
@@ -25,7 +25,7 @@ Yup スキーマ、または Yup スキーマを返す関数のいずれかで�
 ## 例
 
 ```tsx
-import { parseWithYup } from '@conform-to/zod';
+import { parseWithYup } from '@conform-to/yup';
 import { useForm } from '@conform-to/react';
 import * as yup from 'yup';
 

--- a/docs/ja/api/yup/parseWithYup.md
+++ b/docs/ja/api/yup/parseWithYup.md
@@ -27,7 +27,7 @@ Yup スキーマ、または Yup スキーマを返す関数のいずれかで�
 ```tsx
 import { parseWithYup } from '@conform-to/zod';
 import { useForm } from '@conform-to/react';
-import * as yup from 'zod';
+import * as yup from 'yup';
 
 const schema = yup.object({
   email: yup.string().email(),


### PR DESCRIPTION
The module name of the import destination was incorrect, so I fixed it.