### PR TITLE
fix: `FormValue` should never be `null`

### DIFF
--- a/.changeset/chilled-dingos-sniff.md
+++ b/.changeset/chilled-dingos-sniff.md
@@ -1,0 +1,5 @@
+---
+"@conform-to/dom": patch
+---
+
+fix: FormValue should never be null

--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -80,7 +80,6 @@ export type FormValue<Schema> = Schema extends
 				: Schema extends Record<string, any>
 					?
 							| { [Key in keyof Schema]?: FormValue<Schema[Key]> }
-							| null
 							| undefined
 					: unknown;
 


### PR DESCRIPTION
It looks like I made a mistake in #508 when I widened `FormValue` to include `null` in some cases.  I'm reasonably confident a field's `initialValue` will never be `null`.

I noticed this when I created a component that takes `name: FieldName<string | object>`. You can see the strange behaviour here:

[TypeScript Playground](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbzgVwM4FMBix0BsAmcAvnAGZQQhwBEAAgMYQB2p0IAtDBAPRToCG9GNQDcAKDGMmqeAG0Q-AJ4AjdAGUYUYEwDmAXTgBeFBmx58AHhlbdAPgAU1VhGoBKcQpXrN2nQDptYBhgflwANVDkdBE4bm44a184AB8UJnx0Um10fAkpGTh5JVUNGx0AeShy5QArdCEDYzQsHAIrH10UuAha+pgHJwgXdzFPEo6Kqt6hAKYgkPDI6Nj4xM7UnrqhLqZkXFwu5HTM7NygA)

You can see what happened when I ran `git blame` here:

<details>

![image](https://github.com/user-attachments/assets/40893c88-bad9-4be0-928c-ac47099a582c)

</details>

Since this is a one-line change, I'm just submitting it through the GitHub UI to confirm the tests will pass.