### PR TITLE
feat(conform-zod): bigint coercion support

### DIFF
--- a/.changeset/hip-actors-wink.md
+++ b/.changeset/hip-actors-wink.md
@@ -2,4 +2,4 @@
 '@conform-to/zod': minor
 ---
 
-fix number and bigint coercion
+feat(conform-zod): bigint coercion support

--- a/.changeset/hip-actors-wink.md
+++ b/.changeset/hip-actors-wink.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/zod': minor
+---
+
+fix number and bigint coercion

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -405,6 +405,74 @@ describe('conform-zod', () => {
 			});
 		});
 
+		test('z.bigint', () => {
+			const schema = z.object({
+				test: z
+					.bigint({ required_error: 'required', invalid_type_error: 'invalid' })
+					.min(1n, 'min')
+					.max(10n, 'max')
+					.multipleOf(2n, 'step'),
+			});
+			const file = new File([], '');
+
+			expect(parseWithZod(createFormData([]), { schema })).toEqual({
+				status: 'error',
+				payload: {},
+				error: { test: ['required'] },
+				reply: expect.any(Function),
+			});
+			expect(
+				parseWithZod(createFormData([['test', '']]), {
+					schema,
+				}),
+			).toEqual({
+				status: 'error',
+				payload: { test: '' },
+				error: { test: ['required'] },
+				reply: expect.any(Function),
+			});
+			expect(
+				parseWithZod(createFormData([['test', 'abc']]), {
+					schema,
+				}),
+			).toEqual({
+				status: 'error',
+				payload: { test: 'abc' },
+				error: { test: ['invalid'] },
+				reply: expect.any(Function),
+			});
+			expect(
+				parseWithZod(createFormData([['test', file]]), {
+					schema,
+				}),
+			).toEqual({
+				status: 'error',
+				payload: { test: file },
+				error: { test: ['invalid'] },
+				reply: expect.any(Function),
+			});
+			expect(
+				parseWithZod(createFormData([['test', '5']]), {
+					schema,
+				}),
+			).toEqual({
+				status: 'error',
+				payload: { test: '5' },
+				error: { test: ['step'] },
+				reply: expect.any(Function),
+			});
+			expect(
+				parseWithZod(createFormData([['test', ' ']]), {
+					schema,
+				}),
+			).toEqual({
+				status: 'error',
+				payload: { test: ' ' },
+				error: { test: ['invalid'] },
+				reply: expect.any(Function),
+			});
+		});
+
 		test('z.date', () => {
 			const schema = z.object({
 				test: z


### PR DESCRIPTION
this change follows the same pattern as how booleans are coerced.

it also fixes issues with BigInt where if the value is not of a convertable value it doesn't break the app because BigInt/Symbol throw unlike the rest of the type constructors.