### PR TITLE
Update intent-button.md, use `getInputProps`

### DIFF
--- a/docs/intent-button.md
+++ b/docs/intent-button.md
@@ -135,7 +135,7 @@ Be aware that both intents requires setting up the inputs with the **key** from 
 To manipulate a field list, you can use the **insert**, **remove** and **reorder** intents.
 
 ```tsx
-import { useForm } from '@conform-to/react';
+import { useForm, getInputProps } from '@conform-to/react';
 
 export default function Tasks() {
   const [form, fields] = useForm();
@@ -146,7 +146,7 @@ export default function Tasks() {
       <ul>
         {tasks.map((task, index) => (
           <li key={task.key}>
-            <input name={task.name} />
+            <input {...getInputProps(task, { type: "text"})} />
             <button
               {...form.reorder.getButtonProps({
                 name: fields.tasks.name,


### PR DESCRIPTION
I was about to open up a bug report because I couldn't get the `insert` intent to work correctly when setting a `defaultValue`, but then I realized it's because the input needs to use `getInputProps`. I had copied from the example here, so here's a simple PR to update the example to use `getInputProps`.

update: The complex structures page should probably receive some edits as well. https://conform.guide/complex-structures