### PR TITLE
fix(conform-react): stop updating value of input buttons

### DIFF
--- a/.changeset/afraid-owls-repair.md
+++ b/.changeset/afraid-owls-repair.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/react': patch
+---
+
+fix(conform-react): stop updating value of input buttons

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -135,8 +135,13 @@ export function useForm<
 				const next = stateSnapshot.key[element.name];
 				const defaultValue = stateSnapshot.initialValue[element.name];
 
-				if (prev === 'managed') {
-					// Skip fields managed by useInputControl()
+				if (
+					prev === 'managed' ||
+					element.type === 'submit' ||
+					element.type === 'reset' ||
+					element.type === 'button'
+				) {
+					// Skip buttons and fields managed by useInputControl()
 					continue;
 				}
 

--- a/playground/app/routes/form-control.tsx
+++ b/playground/app/routes/form-control.tsx
@@ -128,6 +128,12 @@ export default function FormControl() {
 						>
 							Reset form
 						</button>
+						<input
+							type="submit"
+							className="rounded-md border p-2 hover:border-black"
+							name="example"
+							value="Submit"
+						/>
 					</div>
 				</Playground>
 			</Form>

--- a/tests/integrations/form-control.spec.ts
+++ b/tests/integrations/form-control.spec.ts
@@ -14,12 +14,16 @@ function getFieldset(form: Locator) {
 		clearMessage: form.locator('button:text("Clear message")'),
 		resetMessage: form.locator('button:text("Reset message")'),
 		resetForm: form.locator('button:text("Reset form")'),
+		inputButton: form.locator('input[type="submit"]'),
 	};
 }
 
 async function runValidationScenario(page: Page) {
 	const playground = getPlayground(page);
 	const fieldset = getFieldset(playground.container);
+
+	// Conform should not overwrite the value of any input buttons
+	await expect(fieldset.inputButton).toHaveValue('Submit');
 
 	await expect(playground.error).toHaveText(['', '', '']);
 


### PR DESCRIPTION
Just noticed that Conform is overwriting the value of input buttons while verifying whether #730 is resolved with v1.2.0. 😅 

This should stop it from changing the value with all kinds of buttons.