### PR TITLE
chore: fix version script

### DIFF
--- a/.github/version.sh
+++ b/.github/version.sh
@@ -2,4 +2,4 @@
 VERSION=$(node -p "require('./packages/conform-dom/package.json').version")
 
 # Replace the version on the README
-sed -i '' "s/^Version [0-9]*\.[0-9]*\.[0-9]*/Version ${VERSION}/" README.md
+sed -i '' "s/^Version [0-9]*\.[0-9]*\.[0-9]*/Version ${VERSION}/" ./README.md


### PR DESCRIPTION
I am seeing `sed: can't read s/^Version [0-9]*\.[0-9]*\.[0-9]*/Version 1.2.1/: No such file or directory` on the [ci job](https://github.com/edmundhung/conform/actions/runs/10863466612/job/30147646591#step:7:49) but I can't reproduce it locally with my mac. This might be issue with how paths are resolved on different OS.