### PR TITLE
fix(conform-react): stops managing all inputs by default

### DIFF
--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -214,6 +214,8 @@ export function getFormControlProps<Schema>(
 	options?: FormControlOptions,
 ): FormControlProps {
 	return simplify({
+		// let Conform updates the field value for us
+		'data-conform': '',
 		required: metadata.required || undefined,
 		...getFieldsetProps(metadata, options),
 	});

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -179,7 +179,8 @@ export function useForm<
 						'checked' in element &&
 						(element.type === 'checkbox' || element.type === 'radio')
 					) {
-						element.checked = get(defaultValue) === element.value;
+						element.checked =
+							getAll(defaultValue)?.includes(element.value) ?? false;
 					} else {
 						element.value = get(defaultValue) ?? '';
 					}

--- a/tests/conform-react.spec.ts
+++ b/tests/conform-react.spec.ts
@@ -35,7 +35,10 @@ function getProps(metadata: FieldMetadata<any>) {
 describe('conform-react', () => {
 	test('getInputProps', () => {
 		const metadata = createFieldMetadata();
-		const props = getProps(metadata);
+		const props = {
+			'data-conform': '',
+			...getProps(metadata),
+		};
 
 		expect(
 			getInputProps(
@@ -159,7 +162,10 @@ describe('conform-react', () => {
 
 	test('getTextareaProps', () => {
 		const metadata = createFieldMetadata();
-		const props = getProps(metadata);
+		const props = {
+			'data-conform': '',
+			...getProps(metadata),
+		};
 
 		expect(getTextareaProps(metadata)).toEqual(props);
 		expect(
@@ -229,7 +235,10 @@ describe('conform-react', () => {
 
 	test('getSelectProps', () => {
 		const metadata = createFieldMetadata();
-		const props = getProps(metadata);
+		const props = {
+			'data-conform': '',
+			...getProps(metadata),
+		};
 
 		expect(getSelectProps(metadata)).toEqual(props);
 		expect(


### PR DESCRIPTION
Fix #729

Related Issues:
- #770
- #771
- #774

This stops Conform from managing all inputs, except those that are configured with `getInputProps`, `getSelectProps` and `getTextareaProps`. You can customize the behavior by setting `shouldManagerInput` on the `useForm` hook, e.g.

```tsx
function Example() {
  const [form, fields] = useForm({
    shouldManageInput(element) {
       // To manage all inputs except the csrf-token input
       return element.name !== 'csrf-token';
    }
  });

  // ...
}
```

If we decide to go with this solution, we can also deprecate `shouldDirtyConsider` later as it could be derived based on the result of `shouldManageInput`.

Todos: 
- [ ] Regression tests
- [ ] Docs update