### PR TITLE
fix: revert auto field value update

### DIFF
--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -1,7 +1,7 @@
 import type { FormMetadata, FieldMetadata, Metadata, Pretty } from './context';
 
 type FormControlProps = {
-	key?: string;
+	key: string | undefined;
 	id: string;
 	name: string;
 	form: string;
@@ -214,6 +214,7 @@ export function getFormControlProps<Schema>(
 	options?: FormControlOptions,
 ): FormControlProps {
 	return simplify({
+		key: metadata.key,
 		required: metadata.required || undefined,
 		...getFieldsetProps(metadata, options),
 	});

--- a/packages/conform-react/hooks.ts
+++ b/packages/conform-react/hooks.ts
@@ -91,81 +91,10 @@ export function useForm<
 		context.onUpdate({ ...formConfig, formId });
 	});
 
-	const subjectRef = useSubjectRef({
-		key: {
-			// Subscribe to all key changes so it will re-render and
-			// update the field value as soon as the DOM is updated
-			prefix: [''],
-		},
-	});
+	const subjectRef = useSubjectRef();
 	const stateSnapshot = useFormState(context, subjectRef);
 	const noValidate = useNoValidate(options.defaultNoValidate);
 	const form = getFormMetadata(context, subjectRef, stateSnapshot, noValidate);
-
-	useEffect(() => {
-		const formElement = document.forms.namedItem(formId);
-
-		if (!formElement) {
-			return;
-		}
-
-		const getAll = (value: unknown) => {
-			if (typeof value === 'string') {
-				return [value];
-			}
-
-			if (
-				Array.isArray(value) &&
-				value.every((item) => typeof item === 'string')
-			) {
-				return value;
-			}
-
-			return undefined;
-		};
-		const get = (value: unknown) => getAll(value)?.[0];
-
-		for (const element of formElement.elements) {
-			if (
-				element instanceof HTMLInputElement ||
-				element instanceof HTMLTextAreaElement ||
-				element instanceof HTMLSelectElement
-			) {
-				const prev = element.dataset.conform;
-				const next = stateSnapshot.key[element.name];
-				const defaultValue = stateSnapshot.initialValue[element.name];
-
-				if (
-					prev === 'managed' ||
-					element.type === 'submit' ||
-					element.type === 'reset' ||
-					element.type === 'button'
-				) {
-					// Skip buttons and fields managed by useInputControl()
-					continue;
-				}
-
-				if (typeof prev === 'undefined' || prev !== next) {
-					element.dataset.conform = next;
-
-					if ('options' in element) {
-						const value = getAll(defaultValue) ?? [];
-
-						for (const option of element.options) {
-							option.selected = value.includes(option.value);
-						}
-					} else if (
-						'checked' in element &&
-						(element.type === 'checkbox' || element.type === 'radio')
-					) {
-						element.checked = get(defaultValue) === element.value;
-					} else {
-						element.value = get(defaultValue) ?? '';
-					}
-				}
-			}
-		}
-	}, [formId, stateSnapshot]);
 
 	return [form, form.getFieldset()];
 }

--- a/packages/conform-react/integrations.ts
+++ b/packages/conform-react/integrations.ts
@@ -71,7 +71,7 @@ export function createDummySelect(
 
 	select.name = name;
 	select.multiple = true;
-	select.dataset.conform = 'managed';
+	select.dataset.conform = 'true';
 
 	// To make sure the input is hidden but still focusable
 	select.setAttribute('aria-hidden', 'true');
@@ -98,7 +98,7 @@ export function createDummySelect(
 export function isDummySelect(
 	element: HTMLElement,
 ): element is HTMLSelectElement {
-	return element.dataset.conform === 'managed';
+	return element.dataset.conform === 'true';
 }
 
 export function updateFieldValue(
@@ -306,8 +306,26 @@ export function useControl<
 		change(value);
 	};
 
+	const refCallback: RefCallback<
+		HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | undefined
+	> = (element) => {
+		register(element);
+
+		if (!element) {
+			return;
+		}
+
+		const prevKey = element.dataset.conform;
+		const nextKey = `${meta.key ?? ''}`;
+
+		if (prevKey !== nextKey) {
+			element.dataset.conform = nextKey;
+			updateFieldValue(element, value ?? '');
+		}
+	};
+
 	return {
-		register,
+		register: refCallback,
 		value,
 		change: handleChange,
 		focus,

--- a/playground/app/routes/form-control.tsx
+++ b/playground/app/routes/form-control.tsx
@@ -128,12 +128,6 @@ export default function FormControl() {
 						>
 							Reset form
 						</button>
-						<input
-							type="submit"
-							className="rounded-md border p-2 hover:border-black"
-							name="example"
-							value="Submit"
-						/>
 					</div>
 				</Playground>
 			</Form>

--- a/tests/integrations/form-control.spec.ts
+++ b/tests/integrations/form-control.spec.ts
@@ -14,16 +14,12 @@ function getFieldset(form: Locator) {
 		clearMessage: form.locator('button:text("Clear message")'),
 		resetMessage: form.locator('button:text("Reset message")'),
 		resetForm: form.locator('button:text("Reset form")'),
-		inputButton: form.locator('input[type="submit"]'),
 	};
 }
 
 async function runValidationScenario(page: Page) {
 	const playground = getPlayground(page);
 	const fieldset = getFieldset(playground.container);
-
-	// Conform should not overwrite the value of any input buttons
-	await expect(fieldset.inputButton).toHaveValue('Submit');
 
 	await expect(playground.error).toHaveText(['', '', '']);
 


### PR DESCRIPTION
Revert #729 and #766

These changes have caused several issues over the past few days. While I appreciate what they accomplished, I’ve realized the current solution isn't robust enough to handle all potential use cases. To minimize the impact on everyone, I believe it's best to revert these changes for now.

Related Issues:

- https://github.com/edmundhung/conform/issues/770
- https://github.com/edmundhung/conform/issues/771
- https://github.com/edmundhung/conform/issues/774
- https://github.com/edmundhung/conform/issues/777

