### PR TITLE
Support validate intent to validate a full fieldset (all fields with a given prefix)

### DIFF
--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -332,6 +332,14 @@ function handleIntent<Error>(
 	switch (intent.type) {
 		case 'validate': {
 			if (intent.payload.name) {
+				if (intent.payload.recursive) {
+					const allNames = Object.keys(meta.error).concat(fields ?? []);
+					for (const name of allNames) {
+						if (isPrefix(name, intent.payload.name)) {
+							meta.validated[name] = true;
+						}
+					}
+				}
 				meta.validated[intent.payload.name] = true;
 			} else {
 				setFieldsValidated(meta, fields);

--- a/packages/conform-dom/submission.ts
+++ b/packages/conform-dom/submission.ts
@@ -304,6 +304,7 @@ export type ValidateIntent<Schema = any> = {
 	type: 'validate';
 	payload: {
 		name?: FieldName<Schema>;
+		recursive?: boolean;
 	};
 };
 


### PR DESCRIPTION
Proposed fix for #828

Here is a sandbox with the same example from above Issue, where this patch is applied, and a second button is added to the task fieldset that demonstrates the behaviour:
https://codesandbox.io/p/devbox/sad-tree-fdj7hj?workspaceId=ws_3qoruoNJ3FvmBgCfSAACYX