### PR TITLE
chore: update tutorial regarding empty string default value support

### DIFF
--- a/docs/ja/tutorial.md
+++ b/docs/ja/tutorial.md
@@ -18,19 +18,13 @@ npm install @conform-to/react @conform-to/zod --save
 import { z } from 'zod';
 
 const schema = z.object({
-  // zodが必要なチェックを適切に実行するためには、前処理ステップが必要です。
-  // 空の入力の値は通常、空の文字列であるためです。
-  email: z.preprocess(
-    (value) => (value === '' ? undefined : value),
-    z.string({ required_error: 'Email is required' }).email('Email is invalid'),
-  ),
-  message: z.preprocess(
-    (value) => (value === '' ? undefined : value),
-    z
-      .string({ required_error: 'Message is required' })
-      .min(10, 'Message is too short')
-      .max(100, 'Message is too long'),
-  ),
+  email: z
+    .string({ required_error: 'Email is required' })
+    .email('Email is invalid'),
+  message: z
+    .string({ required_error: 'Message is required' })
+    .min(10, 'Message is too short')
+    .max(100, 'Message is too long'),
 });
 ```
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -18,19 +18,13 @@ First, let's define the schema. Here is a zod schema that we will use to validat
 import { z } from 'zod';
 
 const schema = z.object({
-  // The preprocess step is required for zod to perform the required check properly
-  // as the value of an empty input is usually an empty string
-  email: z.preprocess(
-    (value) => (value === '' ? undefined : value),
-    z.string({ required_error: 'Email is required' }).email('Email is invalid'),
-  ),
-  message: z.preprocess(
-    (value) => (value === '' ? undefined : value),
-    z
-      .string({ required_error: 'Message is required' })
-      .min(10, 'Message is too short')
-      .max(100, 'Message is too long'),
-  ),
+  email: z
+    .string({ required_error: 'Email is required' })
+    .email('Email is invalid'),
+  message: z
+    .string({ required_error: 'Message is required' })
+    .min(10, 'Message is too short')
+    .max(100, 'Message is too long'),
 });
 ```
 


### PR DESCRIPTION
After https://github.com/edmundhung/conform/pull/741 , Conform will always strip empty values to `undefined`.
It seems that we also need to remove preprocess() function and comments from tutorial.