### PR TITLE
chore: upgrade corepack in ci

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,7 +13,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Enable Corepack
-        run: corepack enable
+        run: |
+          npm i -g corepack@latest
+          corepack enable
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Enable Corepack
-        run: corepack enable
+        run: |
+          npm i -g corepack@latest
+          corepack enable
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Enable Corepack
-        run: corepack enable
+        run: |
+          npm i -g corepack@latest
+          corepack enable
       - name: Setup node
         uses: actions/setup-node@v4
         with:
@@ -62,7 +64,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Enable Corepack
-        run: corepack enable
+        run: |
+          npm i -g corepack@latest
+          corepack enable
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Enable Corepack
         run: |
-          npm i -g corepack@latest
+          npm i -g corepack@latest --force
           corepack enable
       - name: Setup node
         uses: actions/setup-node@v4


### PR DESCRIPTION
I made #859 but the ci failed apparently with this issue ( https://github.com/nodejs/corepack/issues/612 ).

I added `npm i -g corepack@latest` to avoid the error.