### PR TITLE
feat(conform-zod): add `disableAutoCoercion` option with `coerceFormValue` helper

### DIFF
--- a/.changeset/hot-geese-run.md
+++ b/.changeset/hot-geese-run.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/zod': minor
+---
+
+feat(conform-zod): add `disableAutoCoercion` option with `coerceFormValue` helper

--- a/docs/api/zod/coerceFormValue.md
+++ b/docs/api/zod/coerceFormValue.md
@@ -72,6 +72,23 @@ const schema = coerceFormValue(
   }),
   {
     defaultCoercion: {
+      // Trim the value for all string-based fields
+      // e.g. `z.string()`, `z.number()` or `z.boolean()`
+      string: (value) => {
+        if (typeof value !== 'string') {
+          return value;
+        }
+
+        const result = value.trim();
+
+        // Treat it as `undefined` if the value is empty
+        if (result === '') {
+          return undefined;
+        }
+
+        return result;
+      },
+
       // Override the default coercion with `z.number()`
       number: (value) => {
         // Pass the value as is if it's not a string
@@ -110,7 +127,7 @@ const schema = z.object({
 
 ### Define custom coercion
 
-You can define custom coercion for a specific schema by setting the `defineCoercion` option.
+You can customize coercion for a specific schema by setting the `customize` option.
 
 ```ts
 import {
@@ -132,7 +149,7 @@ const schema = coerceFormValue(
     metadata,
   }),
   {
-    defineCoercion(type) {
+    customize(type) {
       // Customize how the `metadata` field value is coerced
       if (type === metadata) {
         return (value) => {
@@ -145,6 +162,7 @@ const schema = coerceFormValue(
         };
       }
 
+      // Return `null` to keep the default behavior
       return null;
     },
   },

--- a/docs/api/zod/coerceFormValue.md
+++ b/docs/api/zod/coerceFormValue.md
@@ -12,7 +12,7 @@ The following rules will be applied by default:
 2. If the schema is `z.number()`, trim the value and cast it with the `Number` constructor
 3. If the schema is `z.boolean()`, treat the value as `true` if it equals to `on` (Browser default `value` of a checkbox / radio button)
 4. If the schema is `z.date()`, cast the value with the `Date` constructor
-5. If the schema is `z.bigint()`, cast the value with the `BigInt` constructor
+5. If the schema is `z.bigint()`, trim the value and cast it with the `BigInt` constructor
 
 ## Parameters
 

--- a/docs/api/zod/coerceFormValue.md
+++ b/docs/api/zod/coerceFormValue.md
@@ -1,0 +1,140 @@
+# unstable_coerceFormValue
+
+A helper that enhances the schema with extra preprocessing steps to strip empty value and coerce form value to the expected type.
+
+```tsx
+const enhancedSchema = coerceFormValue(schema, options);
+```
+
+The following rules will be applied by default:
+
+1. If the value is an empty string / file, pass `undefined` to the schema
+2. If the schema is `z.number()`, trim the value and cast it with the `Number` constructor
+3. If the schema is `z.boolean()`, treat the value as `true` if it equals to `on` (Browser default `value` of a checkbox / radio button)
+4. If the schema is `z.date()`, cast the value with the `Date` constructor
+5. If the schema is `z.bigint()`, cast the value with the `BigInt` constructor
+
+## Parameters
+
+### `schema`
+
+The zod schema to be enhanced.
+
+### `options.skipCoercion`
+
+Optional. You can use it to skip type coercion for a specific schema.
+
+## Example
+
+```tsx
+import { parseWithZod, unstable_coerceFormValue as coerceFormValue } from '@conform-to/zod';
+import { useForm } from '@conform-to/react';
+import { z } from 'zod';
+import { jsonSchema } from './jsonSchema';
+
+const schema = coerceFormValue(
+  z.object({
+    ref: z.string()
+    date: z.date(),
+    amount: z.number(),
+    confirm: z.boolean(),
+  }),
+);
+
+function Example() {
+  const [form, fields] = useForm({
+    onValidate({ formData }) {
+      return parseWithZod(formData, {
+        schema,
+        defaultTypeCoercion: false,
+      });
+    },
+  });
+
+  // ...
+}
+```
+
+## Tips
+
+### Override default behavior
+
+You can override the default coercion logic without disabling the type coercion by casting the value yourself inside `z.preprocess`.
+
+```ts
+const schema = coerceFormValue(
+  z.object({
+    // Override how the `amount` field value is coerced
+    amount: z.preprocess((value) => {
+      // If no value is provided, return `undefined`
+      if (!value) {
+        return undefined;
+      }
+
+      // Clear the formatting and cast the value to number
+      return Number(value.trim().replace(/,/g, ''));
+    }, z.number()),
+
+    // Keep the default behavior
+    number: z.number(),
+  }),
+);
+```
+
+### Default values
+
+`coerceFormValue` will always strip empty values to `undefined`. If you need a default value, use `.transform()` to define a fallback value that will be returned instead.
+
+```ts
+const schema = z.object({
+  foo: z.string().optional(), // string | undefined
+  bar: z
+    .string()
+    .optional()
+    .transform((value) => value ?? ''), // string
+  baz: z
+    .string()
+    .optional()
+    .transform((value) => value ?? null), // string | null
+});
+```
+
+### Disable default coercion
+
+You can always disable the default coercion for a specific schema by setting the `skipCoercion` option.
+
+```ts
+import { parseWithZod, unstable_coerceFormValue as coerceFormValue } from '@conform-to/zod';
+import { useForm } from '@conform-to/react';
+import { z } from 'zod';
+import { json } from './schema';
+
+const schema = coerceFormValue(
+  z.object({
+    ref: z.number()
+    date: z.date(),
+    amount: z.preprocess((value) => {
+      // Ignore non-string values
+      if (typeof value !== 'string') {
+        return value;
+      }
+
+      // If it is an empty string, return `undefined`
+      if (!value) {
+        return undefined;
+      }
+
+      // Clear the formatting and cast the value to number
+      return Number(value.trim().replace(/,/g, ''));
+    }, z.number())
+    confirm: z.boolean(),
+    meta: json,
+  }),
+  {
+    skipCoercion(type) {
+      // To skip coercion for all fields defined with z.number() or jsonSchema
+      return type instanceof z.ZodNumber || type === json;
+    }
+  },
+);
+```

--- a/docs/api/zod/coerceFormValue.md
+++ b/docs/api/zod/coerceFormValue.md
@@ -72,23 +72,6 @@ const schema = coerceFormValue(
   }),
   {
     defaultCoercion: {
-      // Trim the value for all string-based fields
-      // e.g. `z.string()`, `z.number()` or `z.boolean()`
-      string: (value) => {
-        if (typeof value !== 'string') {
-          return value;
-        }
-
-        const result = value.trim();
-
-        // Treat it as `undefined` if the value is empty
-        if (result === '') {
-          return undefined;
-        }
-
-        return result;
-      },
-
       // Override the default coercion with `z.number()`
       number: (value) => {
         // Pass the value as is if it's not a string
@@ -162,7 +145,6 @@ const schema = coerceFormValue(
         };
       }
 
-      // Return `null` to keep the default behavior
       return null;
     },
   },

--- a/docs/api/zod/coerceFormValue.md
+++ b/docs/api/zod/coerceFormValue.md
@@ -72,7 +72,7 @@ const schema = coerceFormValue(
   }),
   {
     defaultCoercion: {
-      // To trim the value for all string-based fields
+      // Trim the value for all string-based fields
       // e.g. `z.string()`, `z.number()` or `z.boolean()`
       string: (value) => {
         if (typeof value !== 'string') {
@@ -89,7 +89,7 @@ const schema = coerceFormValue(
         return result;
       },
 
-      // To override the default coercion with `z.number()`
+      // Override the default coercion with `z.number()`
       number: (value) => {
         // Pass the value as is if it's not a string
         if (typeof value !== 'string') {
@@ -100,7 +100,7 @@ const schema = coerceFormValue(
         return Number(value.trim().replace(/,/g, ''));
       },
 
-      // To disable coercion for `z.boolean()`
+      // Disable coercion for `z.boolean()`
       boolean: false,
     },
   },

--- a/docs/api/zod/parseWithZod.md
+++ b/docs/api/zod/parseWithZod.md
@@ -12,23 +12,25 @@ const submission = parseWithZod(payload, options);
 
 It could be either the **FormData** or **URLSearchParams** object depending on how the form is submitted.
 
-### `options`
-
-#### `schema`
+### `options.schema`
 
 Either a zod schema or a function that returns a zod schema.
 
-#### `async`
+### `options.async`
 
 Set it to **true** if you want to parse the form data with **safeParseAsync** method from the zod schema instead of **safeParse**.
 
-#### `errorMap`
+### `options.errorMap`
 
 A zod [error map](https://github.com/colinhacks/zod/blob/master/ERROR_HANDLING.md#contextual-error-map) to be used when parsing the form data.
 
-#### `formatError`
+### `options.formatError`
 
 A function that let you customize the error structure and include additional metadata as needed.
+
+### `options.disableAutoCoercion`
+
+Set it to **true** if you want to disable [automatic type coercion](#automatic-type-coercion) and manage how the form data is parsed yourself.
 
 ## Example
 
@@ -57,47 +59,40 @@ function Example() {
 
 ### Automatic type coercion
 
-Conform will strip empty value and coerce the form data to the expected type by introspecting the schema and inject an extra preprocessing step. The following rules will be applied:
+By default, `parseWithZod` will strip empty value and coerce form value to the correct type by introspecting the schema and inject extra preprocessing steps using the [coerceFormValue](./coerceFormValue) helper internally.
 
-1. If the value is an empty string / file, pass `undefined` to the schema
-2. If the schema is `z.string()`, pass the value as is
-3. If the schema is `z.number()`, trim the value and cast it with the `Number` constructor
-4. If the schema is `z.boolean()`, treat the value as `true` if it equals to `on`
-5. If the schema is `z.date()`, cast the value with the `Date` constructor
-6. If the schema is `z.bigint()`, cast the value with the `BigInt` constructor
-
-You can override this behavior by setting up your own `z.preprocess` step in the schema.
-
-> Note: There are several bug reports on Zod's repository regarding the behaviour of `z.preprocess` since v3.22, like https://github.com/colinhacks/zod/issues/2671 and https://github.com/colinhacks/zod/issues/2677. If you are experiencing any issues, please downgrade to v3.21.4.
+If you want to customize this behavior, you can disable automatic type coercion by setting `options.disableAutoCoercion` to `true` and manage it yourself.
 
 ```tsx
+import { parseWithZod } from '@conform-to/zod';
+import { useForm } from '@conform-to/react';
+import { z } from 'zod';
+
 const schema = z.object({
+  // Strip empty value and coerce the number yourself
   amount: z.preprocess((value) => {
-    // If no value is provided, return `undefined`
-    if (!value) {
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    if (value === '') {
       return undefined;
     }
 
-    // Clear the formatting and cast the value to number
     return Number(value.trim().replace(/,/g, ''));
   }, z.number()),
 });
-```
 
-### Default values
+function Example() {
+  const [form, fields] = useForm({
+    onValidate({ formData }) {
+      return parseWithZod(formData, {
+        schema,
+        disableAutoCoercion: true,
+      });
+    },
+  });
 
-Conform will always strip empty values to `undefined`. If you need a default value, please use `.transform()` to define a fallback value that will be returned instead.
-
-```tsx
-const schema = z.object({
-  foo: z.string().optional(), // string | undefined
-  bar: z
-    .string()
-    .optional()
-    .transform((value) => value ?? ''), // string
-  baz: z
-    .string()
-    .optional()
-    .transform((value) => value ?? null), // string | null
-});
+  // ...
+}
 ```

--- a/docs/ja/api/zod/coerceFormValue.md
+++ b/docs/ja/api/zod/coerceFormValue.md
@@ -72,6 +72,23 @@ const schema = coerceFormValue(
   }),
   {
     defaultCoercion: {
+      // Trim the value for all string-based fields
+      // e.g. `z.string()`, `z.number()` or `z.boolean()`
+      string: (value) => {
+        if (typeof value !== 'string') {
+          return value;
+        }
+
+        const result = value.trim();
+
+        // Treat it as `undefined` if the value is empty
+        if (result === '') {
+          return undefined;
+        }
+
+        return result;
+      },
+
       // Override the default coercion with `z.number()`
       number: (value) => {
         // Pass the value as is if it's not a string
@@ -110,7 +127,7 @@ const schema = z.object({
 
 ### Define custom coercion
 
-You can define custom coercion for a specific schema by setting the `defineCoercion` option.
+You can customize coercion for a specific schema by setting the `customize` option.
 
 ```ts
 import {
@@ -132,7 +149,7 @@ const schema = coerceFormValue(
     metadata,
   }),
   {
-    defineCoercion(type) {
+    customize(type) {
       // Customize how the `metadata` field value is coerced
       if (type === metadata) {
         return (value) => {
@@ -145,6 +162,7 @@ const schema = coerceFormValue(
         };
       }
 
+      // Return `null` to keep the default behavior
       return null;
     },
   },

--- a/docs/ja/api/zod/coerceFormValue.md
+++ b/docs/ja/api/zod/coerceFormValue.md
@@ -1,5 +1,7 @@
 # unstable_coerceFormValue
 
+> No translation available for this page. Here is the English version.
+
 A helper that enhances the schema with extra preprocessing steps to strip empty value and coerce form value to the expected type.
 
 ```ts

--- a/docs/ja/api/zod/coerceFormValue.md
+++ b/docs/ja/api/zod/coerceFormValue.md
@@ -72,23 +72,6 @@ const schema = coerceFormValue(
   }),
   {
     defaultCoercion: {
-      // Trim the value for all string-based fields
-      // e.g. `z.string()`, `z.number()` or `z.boolean()`
-      string: (value) => {
-        if (typeof value !== 'string') {
-          return value;
-        }
-
-        const result = value.trim();
-
-        // Treat it as `undefined` if the value is empty
-        if (result === '') {
-          return undefined;
-        }
-
-        return result;
-      },
-
       // Override the default coercion with `z.number()`
       number: (value) => {
         // Pass the value as is if it's not a string
@@ -162,7 +145,6 @@ const schema = coerceFormValue(
         };
       }
 
-      // Return `null` to keep the default behavior
       return null;
     },
   },

--- a/docs/ja/api/zod/coerceFormValue.md
+++ b/docs/ja/api/zod/coerceFormValue.md
@@ -72,7 +72,7 @@ const schema = coerceFormValue(
   }),
   {
     defaultCoercion: {
-      // To trim the value for all string-based fields
+      // Trim the value for all string-based fields
       // e.g. `z.string()`, `z.number()` or `z.boolean()`
       string: (value) => {
         if (typeof value !== 'string') {
@@ -89,7 +89,7 @@ const schema = coerceFormValue(
         return result;
       },
 
-      // To override the default coercion with `z.number()`
+      // Override the default coercion with `z.number()`
       number: (value) => {
         // Pass the value as is if it's not a string
         if (typeof value !== 'string') {
@@ -100,7 +100,7 @@ const schema = coerceFormValue(
         return Number(value.trim().replace(/,/g, ''));
       },
 
-      // To disable coercion for `z.boolean()`
+      // Disable coercion for `z.boolean()`
       boolean: false,
     },
   },

--- a/docs/ja/api/zod/parseWithZod.md
+++ b/docs/ja/api/zod/parseWithZod.md
@@ -82,21 +82,3 @@ const schema = z.object({
   }, z.number()),
 });
 ```
-
-### デフォルト値
-
-Conform は常に空の文字列を削除し、それらを「undefined」にします。 `.transform()` をスキーマに追加して、代わりに返されるデフォルト値を定義します。
-
-```tsx
-const schema = z.object({
-  foo: z.string().optional(), // string | undefined
-  bar: z
-    .string()
-    .optional()
-    .transform((value) => value ?? ''), // string
-  baz: z
-    .string()
-    .optional()
-    .transform((value) => value ?? null), // string | null
-});
-```

--- a/docs/ja/api/zod/parseWithZod.md
+++ b/docs/ja/api/zod/parseWithZod.md
@@ -12,23 +12,25 @@ const submission = parseWithZod(payload, options);
 
 フォームの送信方法に応じて、 **FormData** オブジェクトまたは **URLSearchParams** オブジェクトのいずれかになります。
 
-### `options`
-
-#### `schema`
+### `options.schema`
 
 Zod スキーマ、または Zod スキーマを返す関数のいずれかです。
 
-#### `async`
+### `options.async`
 
 **safeParse** の代わりに zod スキーマから **safeParseAsync** メソッドを使用してフォームデータを解析したい場合は、 **true** に設定してください。
 
-#### `errorMap`
+### `options.errorMap`
 
 フォームデータを解析する際に使用される zod の [エラーマップ](https://github.com/colinhacks/zod/blob/master/ERROR_HANDLING.md#contextual-error-map) です。
 
-#### `formatError`
+### `options.formatError`
 
 エラー構造をカスタマイズし、必要に応じて追加のメタデータを含めることができる関数です。
+
+### `options.disableAutoCoercion`
+
+スキーマの[自動強制](#自動型変換)変換を無効にし、フォームデータの解析方法を自分で管理したい場合は、**true** に設定します。
 
 ## 例
 
@@ -60,15 +62,12 @@ function Example() {
 Conform は空の値を除去し、スキーマを内省することでフォームデータを期待される型に強制し、追加の前処理ステップを注入します。以下のルールが適用されます:
 
 1. 値が空の文字列 / ファイルである場合、スキーマに `undefined` を渡します。
-2. スキーマが `z.string()` の場合、値をそのまま渡します。
-3. スキーマが `z.number()` の場合、値をトリムして `Number` コンストラクタでキャストします。
-4. スキーマが `z.boolean()` の場合、値が `on` に等しい場合には `true` として扱います。
-5. スキーマが `z.date()` の場合、値を `Date` コンストラクタでキャストします。
-6. スキーマが `z.bigint()` の場合、値を `BigInt` コンストラクタでキャストします。
+2. スキーマが `z.number()` の場合、値をトリムして `Number` コンストラクタでキャストします。
+3. スキーマが `z.boolean()` の場合、値が `on` に等しい場合には `true` として扱います。
+4. スキーマが `z.date()` の場合、値を `Date` コンストラクタでキャストします。
+5. スキーマが `z.bigint()` の場合、値を `BigInt` コンストラクタでキャストします。
 
 この挙動は、スキーマ内で独自の `z.preprocess` ステップを設定することで上書きすることができます。
-
-> 注意: v3.22 以降、 `z.preprocess` の挙動に関して Zod のリポジトリには複数のバグレポートがあります。例えば、 https://github.com/colinhacks/zod/issues/2671 および <br> https://github.com/colinhacks/zod/issues/2677 があります。問題を経験している場合は、v3.21.4 にダウングレードしてください。
 
 ```tsx
 const schema = z.object({

--- a/guide/app/layout.tsx
+++ b/guide/app/layout.tsx
@@ -61,11 +61,18 @@ const menus: { [code: string]: Menu[] } = {
 			],
 		},
 		{
-			title: 'Schema related',
+			title: 'Zod Schema',
 			links: [
 				{ title: 'parseWithZod', to: '/api/zod/parseWithZod' },
-				{ title: 'parseWithYup', to: '/api/yup/parseWithYup' },
+				{ title: 'coerceFormValue', to: '/api/zod/coerceFormValue' },
 				{ title: 'getZodConstraint', to: '/api/zod/getZodConstraint' },
+				{ title: 'conformZodMessage', to: '/api/zod/conformZodMessage' },
+			],
+		},
+		{
+			title: 'Yup Schema',
+			links: [
+				{ title: 'parseWithYup', to: '/api/yup/parseWithYup' },
 				{ title: 'getYupConstraint', to: '/api/yup/getYupConstraint' },
 			],
 		},
@@ -125,11 +132,18 @@ const menus: { [code: string]: Menu[] } = {
 			],
 		},
 		{
-			title: 'スキーマ関連',
+			title: 'Zod スキーマ',
 			links: [
 				{ title: 'parseWithZod', to: '/api/zod/parseWithZod' },
-				{ title: 'parseWithYup', to: '/api/yup/parseWithYup' },
+				{ title: 'coerceFormValue', to: '/api/zod/coerceFormValue' },
 				{ title: 'getZodConstraint', to: '/api/zod/getZodConstraint' },
+				{ title: 'conformZodMessage', to: '/api/zod/conformZodMessage' },
+			],
+		},
+		{
+			title: 'Yup スキーマ',
+			links: [
+				{ title: 'parseWithYup', to: '/api/yup/parseWithYup' },
 				{ title: 'getYupConstraint', to: '/api/yup/getYupConstraint' },
 			],
 		},

--- a/packages/conform-zod/coercion.ts
+++ b/packages/conform-zod/coercion.ts
@@ -360,17 +360,14 @@ export function enableTypeCoercion<Schema extends ZodTypeAny>(
  * import { parseWithZod, unstable_coerceFormValue as coerceFormValue } from '@conform-to/zod';
  * import { z } from 'zod';
  *
- * // To coerce the form value with default behaviour
+ * // Coerce the form value with default behaviour
  * const schema = coerceFormValue(
  *   z.object({
- *     ref: z.number()
- *     date: z.date(),
- *     amount: z.number(),
- *     confirm: z.boolean(),
+ *     // ...
  *   })
  * );
  *
- * // To coerce the form value with number type disabled
+ * // Coerce the form value with default coercion overrided
  * const schema = coerceFormValue(
  *   z.object({
  *     ref: z.number()
@@ -379,9 +376,36 @@ export function enableTypeCoercion<Schema extends ZodTypeAny>(
  *     confirm: z.boolean(),
  *   }),
  *   {
- *     coercionMap: {
- *       number: false,
- *     }
+ *     // Trim the value for all string-based fields
+ *     // e.g. `z.string()`, `z.number()` or `z.boolean()`
+ *     string: (value) => {
+ *       if (typeof value !== 'string') {
+ *          return value;
+ *       }
+ *
+ *       const result = value.trim();
+ *
+ *       // Treat it as `undefined` if the value is empty
+ *       if (result === '') {
+ *         return undefined;
+ *       }
+ *
+ *       return result;
+ *     },
+ *
+ *     // Override the default coercion with `z.number()`
+ *     number: (value) => {
+ *       // Pass the value as is if it's not a string
+ *       if (typeof value !== 'string') {
+ *         return value;
+ *       }
+ *
+ *       // Trim and remove commas before casting it to number
+ *       return Number(value.trim().replace(/,/g, ''));
+ *     },
+ *
+ *     // Disable coercion for `z.boolean()`
+ *     boolean: false,
  *   },
  * );
  * ```

--- a/packages/conform-zod/index.ts
+++ b/packages/conform-zod/index.ts
@@ -1,2 +1,3 @@
 export { getZodConstraint } from './constraint';
 export { parseWithZod, conformZodMessage } from './parse';
+export { coerceFormValue as unstable_coerceFormValue } from './coercion';

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -1136,7 +1136,7 @@ describe('conform-zod', () => {
 					required_error: 'required',
 					invalid_type_error: 'invalid',
 				}),
-				file: z.instanceof(File, { message: 'invalid' }),
+				file: z.instanceof(File, { message: 'message' }),
 			});
 
 			expect(
@@ -1152,21 +1152,22 @@ describe('conform-zod', () => {
 						},
 					}).safeParse({
 						title: '',
-						count: '',
-						amount: '',
-						date: '',
-						confirmed: '',
+						count: '123456',
+						amount: '9876543210',
+						date: '1970-01-01',
+						confirmed: 'on',
 						file: '',
 					}),
 				),
 			).toEqual({
 				success: false,
 				error: {
+					title: ['required'],
 					amount: ['invalid'],
 					count: ['invalid'],
 					date: ['invalid'],
 					confirmed: ['invalid'],
-					file: ['invalid'],
+					file: ['message'],
 				},
 			});
 
@@ -1188,31 +1189,6 @@ describe('conform-zod', () => {
 
 								return text;
 							},
-						},
-					}).safeParse({
-						title: ' ',
-						count: ' ',
-						amount: ' ',
-						date: ' ',
-						confirmed: ' ',
-						file: exampleFile,
-					}),
-				),
-			).toEqual({
-				success: false,
-				error: {
-					title: ['required'],
-					amount: ['required'],
-					count: ['required'],
-					date: ['required'],
-					confirmed: ['required'],
-				},
-			});
-
-			expect(
-				getResult(
-					coerceFormValue(schema, {
-						defaultCoercion: {
 							number(value) {
 								if (typeof value !== 'string') {
 									return value;
@@ -1231,9 +1207,9 @@ describe('conform-zod', () => {
 							},
 						},
 					}).safeParse({
-						title: 'example',
-						count: '123,456',
-						amount: '0',
+						title: ' example ',
+						count: ' 123,456 ',
+						amount: '9876543210',
 						date: '1970-01-01',
 						confirmed: 'true',
 						file: exampleFile,
@@ -1244,7 +1220,7 @@ describe('conform-zod', () => {
 				data: {
 					title: 'example',
 					count: 123456,
-					amount: 0n,
+					amount: 9876543210n,
 					date: new Date('1970-01-01'),
 					confirmed: true,
 					file: exampleFile,

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -1116,31 +1116,86 @@ describe('conform-zod', () => {
 			});
 		});
 
-		test('skipCoercion', () => {
-			const Payment = z.object({
-				date: z.date({ invalid_type_error: 'invalid' }),
-				confirmed: z.boolean({ invalid_type_error: 'invalid' }),
-			});
+		test('customize default coercion', () => {
+			const exampleFile = new File(['hello', 'world'], 'example.txt');
 			const schema = z.object({
 				title: z.string({ required_error: 'required' }),
-				count: z.number({ invalid_type_error: 'invalid' }),
-				amount: z.bigint({ required_error: 'required' }),
-				payment: Payment,
+				count: z.number({
+					required_error: 'required',
+					invalid_type_error: 'invalid',
+				}),
+				amount: z.bigint({
+					required_error: 'required',
+					invalid_type_error: 'invalid',
+				}),
+				date: z.date({
+					required_error: 'required',
+					invalid_type_error: 'invalid',
+				}),
+				confirmed: z.boolean({
+					required_error: 'required',
+					invalid_type_error: 'invalid',
+				}),
+				file: z.instanceof(File, { message: 'invalid' }),
 			});
 
 			expect(
 				getResult(
 					coerceFormValue(schema, {
-						skipCoercion: (type) =>
-							type instanceof z.ZodNumber || type === Payment,
+						defaultCoercion: {
+							string: false,
+							number: false,
+							bigint: false,
+							date: false,
+							boolean: false,
+							file: false,
+						},
 					}).safeParse({
 						title: '',
 						count: '',
 						amount: '',
-						payment: {
-							date: '',
-							confirmed: '',
+						date: '',
+						confirmed: '',
+						file: '',
+					}),
+				),
+			).toEqual({
+				success: false,
+				error: {
+					amount: ['invalid'],
+					count: ['invalid'],
+					date: ['invalid'],
+					confirmed: ['invalid'],
+					file: ['invalid'],
+				},
+			});
+
+			expect(
+				getResult(
+					coerceFormValue(schema, {
+						defaultCoercion: {
+							string(value) {
+								if (typeof value !== 'string') {
+									return value;
+								}
+
+								// Trim the text
+								const text = value.trim();
+
+								if (text === '') {
+									return undefined;
+								}
+
+								return text;
+							},
 						},
+					}).safeParse({
+						title: ' ',
+						count: ' ',
+						amount: ' ',
+						date: ' ',
+						confirmed: ' ',
+						file: exampleFile,
 					}),
 				),
 			).toEqual({
@@ -1148,9 +1203,106 @@ describe('conform-zod', () => {
 				error: {
 					title: ['required'],
 					amount: ['required'],
-					count: ['invalid'],
-					'payment.confirmed': ['invalid'],
-					'payment.date': ['invalid'],
+					count: ['required'],
+					date: ['required'],
+					confirmed: ['required'],
+				},
+			});
+
+			expect(
+				getResult(
+					coerceFormValue(schema, {
+						defaultCoercion: {
+							number(value) {
+								if (typeof value !== 'string') {
+									return value;
+								}
+
+								// Remove commas and space
+								return Number(value.trim().replace(/,/g, ''));
+							},
+							boolean(value) {
+								if (typeof value !== 'string') {
+									return value;
+								}
+
+								// Convert "true" to boolean instead of "on"
+								return value === 'true';
+							},
+						},
+					}).safeParse({
+						title: 'example',
+						count: '123,456',
+						amount: '0',
+						date: '1970-01-01',
+						confirmed: 'true',
+						file: exampleFile,
+					}),
+				),
+			).toEqual({
+				success: true,
+				data: {
+					title: 'example',
+					count: 123456,
+					amount: 0n,
+					date: new Date('1970-01-01'),
+					confirmed: true,
+					file: exampleFile,
+				},
+			});
+		});
+
+		test('define custom coercion', () => {
+			const Payment = z.object({
+				count: z.number({
+					required_error: 'required',
+					invalid_type_error: 'invalid',
+				}),
+				amount: z.bigint({
+					required_error: 'required',
+					invalid_type_error: 'invalid',
+				}),
+				date: z.date({
+					required_error: 'required',
+					invalid_type_error: 'invalid',
+				}),
+				confirmed: z.boolean({ invalid_type_error: 'invalid' }),
+			});
+			const schema = z.object({
+				title: z.string({ required_error: 'required' }),
+				payment: Payment,
+			});
+
+			expect(
+				getResult(
+					coerceFormValue(schema, {
+						defineCoercion(type) {
+							if (type === Payment) {
+								return (value) => {
+									if (typeof value !== 'string') {
+										return value;
+									}
+
+									return JSON.parse(value);
+								};
+							}
+
+							return null;
+						},
+					}).safeParse({
+						title: 'Test',
+						payment: JSON.stringify({
+							count: 123,
+							confirmed: true,
+							amount: '123456',
+						}),
+					}),
+				),
+			).toEqual({
+				success: false,
+				error: {
+					'payment.amount': ['invalid'],
+					'payment.date': ['required'],
 				},
 			});
 		});

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -2,14 +2,37 @@ import { beforeEach, vi, describe, test, expect } from 'vitest';
 import {
 	getZodConstraint,
 	parseWithZod,
+	unstable_coerceFormValue as coerceFormValue,
 	conformZodMessage,
 } from '@conform-to/zod';
-import { z } from 'zod';
+import { SafeParseReturnType, z } from 'zod';
 import { createFormData } from './helpers';
+import { formatPaths } from '@conform-to/dom';
 
 beforeEach(() => {
 	vi.unstubAllGlobals();
 });
+
+function getResult<Output>(
+	result: SafeParseReturnType<any, Output>,
+):
+	| { success: false; error: Record<string, string[]> }
+	| { success: true; data: Output } {
+	if (result.success) {
+		return { success: true, data: result.data };
+	}
+
+	const error: Record<string, string[]> = {};
+
+	for (const issue of result.error.issues) {
+		const name = formatPaths(issue.path);
+
+		error[name] ??= [];
+		error[name].push(issue.message);
+	}
+
+	return { success: false, error };
+}
 
 describe('conform-zod', () => {
 	test('getZodConstraint', () => {
@@ -286,309 +309,208 @@ describe('conform-zod', () => {
 		// });
 	});
 
-	describe('parseWithZod', () => {
+	describe('coerceFormValue', () => {
 		test('z.string', () => {
-			const schema = z.object({
-				test: z
-					.string({ required_error: 'required', invalid_type_error: 'invalid' })
-					.min(10, 'min')
-					.max(100, 'max')
-					.regex(/^[A-Z]{1-100}$/, 'regex')
-					.refine(() => false, 'refine'),
-			});
+			const schema = z
+				.string({ required_error: 'required', invalid_type_error: 'invalid' })
+				.min(10, 'min')
+				.max(100, 'max')
+				.regex(/^[A-Z]{1,100}$/, 'regex')
+				.refine((value) => value !== 'error', 'refine');
 			const file = new File([], '');
 
-			expect(parseWithZod(createFormData([]), { schema })).toEqual({
-				status: 'error',
-				payload: {},
-				error: { test: ['required'] },
-				reply: expect.any(Function),
+			expect(getResult(coerceFormValue(schema).safeParse(''))).toEqual({
+				success: false,
+				error: {
+					'': ['required'],
+				},
+			});
+			expect(getResult(coerceFormValue(schema).safeParse(file))).toEqual({
+				success: false,
+				error: {
+					'': ['invalid'],
+				},
+			});
+			expect(getResult(coerceFormValue(schema).safeParse('error'))).toEqual({
+				success: false,
+				error: {
+					'': ['min', 'regex', 'refine'],
+				},
 			});
 			expect(
-				parseWithZod(createFormData([['test', '']]), {
-					schema,
-				}),
+				getResult(coerceFormValue(schema).safeParse('ABCDEFGHIJ')),
 			).toEqual({
-				status: 'error',
-
-				payload: { test: '' },
-				error: { test: ['required'] },
-				reply: expect.any(Function),
-			});
-			expect(
-				parseWithZod(createFormData([['test', file]]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: file },
-				error: { test: ['invalid'] },
-				reply: expect.any(Function),
-			});
-			expect(
-				parseWithZod(createFormData([['test', 'xyz']]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: 'xyz' },
-				error: { test: ['min', 'regex', 'refine'] },
-				reply: expect.any(Function),
+				success: true,
+				data: 'ABCDEFGHIJ',
 			});
 		});
 
 		test('z.number', () => {
-			const schema = z.object({
-				test: z
-					.number({ required_error: 'required', invalid_type_error: 'invalid' })
-					.min(1, 'min')
-					.max(10, 'max')
-					.step(2, 'step'),
-			});
+			const schema = z
+				.number({ required_error: 'required', invalid_type_error: 'invalid' })
+				.min(1, 'min')
+				.max(10, 'max')
+				.step(2, 'step');
 			const file = new File([], '');
 
-			expect(parseWithZod(createFormData([]), { schema })).toEqual({
-				status: 'error',
-				payload: {},
-				error: { test: ['required'] },
-				reply: expect.any(Function),
+			expect(getResult(coerceFormValue(schema).safeParse(''))).toEqual({
+				success: false,
+				error: {
+					'': ['required'],
+				},
 			});
-			expect(
-				parseWithZod(createFormData([['test', '']]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: '' },
-				error: { test: ['required'] },
-				reply: expect.any(Function),
+			expect(getResult(coerceFormValue(schema).safeParse('abc'))).toEqual({
+				success: false,
+				error: {
+					'': ['invalid'],
+				},
 			});
-			expect(
-				parseWithZod(createFormData([['test', 'abc']]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: 'abc' },
-				error: { test: ['invalid'] },
-				reply: expect.any(Function),
+			expect(getResult(coerceFormValue(schema).safeParse(file))).toEqual({
+				success: false,
+				error: {
+					'': ['invalid'],
+				},
 			});
-			expect(
-				parseWithZod(createFormData([['test', file]]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: file },
-				error: { test: ['invalid'] },
-				reply: expect.any(Function),
+			expect(getResult(coerceFormValue(schema).safeParse('5'))).toEqual({
+				success: false,
+				error: {
+					'': ['step'],
+				},
 			});
-			expect(
-				parseWithZod(createFormData([['test', '5']]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: '5' },
-				error: { test: ['step'] },
-				reply: expect.any(Function),
+			expect(getResult(coerceFormValue(schema).safeParse(' '))).toEqual({
+				success: false,
+				error: {
+					'': ['invalid'],
+				},
 			});
-			expect(
-				parseWithZod(createFormData([['test', ' ']]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: ' ' },
-				error: { test: ['invalid'] },
-				reply: expect.any(Function),
+			expect(getResult(coerceFormValue(schema).safeParse('6'))).toEqual({
+				success: true,
+				data: 6,
 			});
 		});
 
 		test('z.bigint', () => {
-			const schema = z.object({
-				test: z
-					.bigint({ required_error: 'required', invalid_type_error: 'invalid' })
-					.min(1n, 'min')
-					.max(10n, 'max')
-					.multipleOf(2n, 'step'),
-			});
+			const schema = z
+				.bigint({ required_error: 'required', invalid_type_error: 'invalid' })
+				.min(1n, 'min')
+				.max(10n, 'max')
+				.multipleOf(2n, 'step');
 			const file = new File([], '');
 
-			expect(parseWithZod(createFormData([]), { schema })).toEqual({
-				status: 'error',
-				payload: {},
-				error: { test: ['required'] },
-				reply: expect.any(Function),
+			expect(getResult(coerceFormValue(schema).safeParse(''))).toEqual({
+				success: false,
+				error: {
+					'': ['required'],
+				},
 			});
-			expect(
-				parseWithZod(createFormData([['test', '']]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: '' },
-				error: { test: ['required'] },
-				reply: expect.any(Function),
+			expect(getResult(coerceFormValue(schema).safeParse('abc'))).toEqual({
+				success: false,
+				error: {
+					'': ['invalid'],
+				},
 			});
-			expect(
-				parseWithZod(createFormData([['test', 'abc']]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: 'abc' },
-				error: { test: ['invalid'] },
-				reply: expect.any(Function),
+			expect(getResult(coerceFormValue(schema).safeParse(file))).toEqual({
+				success: false,
+				error: {
+					'': ['invalid'],
+				},
 			});
-			expect(
-				parseWithZod(createFormData([['test', file]]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: file },
-				error: { test: ['invalid'] },
-				reply: expect.any(Function),
+			expect(getResult(coerceFormValue(schema).safeParse(' '))).toEqual({
+				success: false,
+				error: {
+					'': ['invalid'],
+				},
 			});
-			expect(
-				parseWithZod(createFormData([['test', '5']]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: '5' },
-				error: { test: ['step'] },
-				reply: expect.any(Function),
+			expect(getResult(coerceFormValue(schema).safeParse('5'))).toEqual({
+				success: false,
+				error: {
+					'': ['step'],
+				},
 			});
-			expect(
-				parseWithZod(createFormData([['test', ' ']]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: ' ' },
-				error: { test: ['invalid'] },
-				reply: expect.any(Function),
+			expect(getResult(coerceFormValue(schema).safeParse('4'))).toEqual({
+				success: true,
+				data: 4n,
 			});
 		});
 
 		test('z.date', () => {
-			const schema = z.object({
-				test: z
-					.date({
-						required_error: 'required',
-						invalid_type_error: 'invalid',
-					})
-					.min(new Date(1), 'min')
-					.max(new Date(10), 'max'),
-			});
+			const schema = z
+				.date({
+					required_error: 'required',
+					invalid_type_error: 'invalid',
+				})
+				.min(new Date(1), 'min')
+				.max(new Date(10), 'max');
 			const file = new File([], '');
 
-			expect(parseWithZod(createFormData([]), { schema })).toEqual({
-				status: 'error',
-				payload: {},
-				error: { test: ['required'] },
-				reply: expect.any(Function),
+			expect(getResult(coerceFormValue(schema).safeParse(''))).toEqual({
+				success: false,
+				error: {
+					'': ['required'],
+				},
+			});
+			expect(getResult(coerceFormValue(schema).safeParse('abc'))).toEqual({
+				success: false,
+				error: {
+					'': ['invalid'],
+				},
+			});
+			expect(getResult(coerceFormValue(schema).safeParse(file))).toEqual({
+				success: false,
+				error: {
+					'': ['invalid'],
+				},
+			});
+			expect(getResult(coerceFormValue(schema).safeParse(' '))).toEqual({
+				success: false,
+				error: {
+					'': ['invalid'],
+				},
 			});
 			expect(
-				parseWithZod(createFormData([['test', '']]), {
-					schema,
-				}),
+				getResult(coerceFormValue(schema).safeParse(new Date(0).toISOString())),
 			).toEqual({
-				status: 'error',
-				payload: { test: '' },
-				error: { test: ['required'] },
-				reply: expect.any(Function),
+				success: false,
+				error: {
+					'': ['min'],
+				},
 			});
 			expect(
-				parseWithZod(createFormData([['test', 'abc']]), {
-					schema,
-				}),
+				getResult(coerceFormValue(schema).safeParse(new Date(5).toISOString())),
 			).toEqual({
-				status: 'error',
-				payload: { test: 'abc' },
-				error: { test: ['invalid'] },
-				reply: expect.any(Function),
-			});
-			expect(
-				parseWithZod(createFormData([['test', file]]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: file },
-				error: { test: ['invalid'] },
-				reply: expect.any(Function),
-			});
-			expect(
-				parseWithZod(createFormData([['test', new Date(0).toISOString()]]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: new Date(0).toISOString() },
-				error: { test: ['min'] },
-				reply: expect.any(Function),
+				success: true,
+				data: new Date(5),
 			});
 		});
 
 		test('z.boolean', () => {
-			const schema = z.object({
-				test: z.boolean({
-					required_error: 'required',
-					invalid_type_error: 'invalid',
-				}),
+			const schema = z.boolean({
+				required_error: 'required',
+				invalid_type_error: 'invalid',
 			});
 			const file = new File([], '');
 
-			expect(parseWithZod(createFormData([]), { schema })).toEqual({
-				status: 'error',
-				payload: {},
-				error: { test: ['required'] },
-				reply: expect.any(Function),
-			});
-			expect(
-				parseWithZod(createFormData([['test', '']]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: '' },
-				error: { test: ['required'] },
-				reply: expect.any(Function),
-			});
-			expect(
-				parseWithZod(createFormData([['test', file]]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: file },
-				error: { test: ['invalid'] },
-				reply: expect.any(Function),
-			});
-			expect(
-				parseWithZod(createFormData([['test', 'abc']]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'error',
-				payload: { test: 'abc' },
-				error: { test: ['invalid'] },
-				reply: expect.any(Function),
-			});
-			expect(
-				parseWithZod(createFormData([['test', 'on']]), {
-					schema,
-				}),
-			).toEqual({
-				status: 'success',
-				payload: { test: 'on' },
-				value: {
-					test: true,
+			expect(getResult(coerceFormValue(schema).safeParse(''))).toEqual({
+				success: false,
+				error: {
+					'': ['required'],
 				},
-				reply: expect.any(Function),
+			});
+			expect(getResult(coerceFormValue(schema).safeParse(file))).toEqual({
+				success: false,
+				error: {
+					'': ['invalid'],
+				},
+			});
+			expect(getResult(coerceFormValue(schema).safeParse('true'))).toEqual({
+				success: false,
+				error: {
+					'': ['invalid'],
+				},
+			});
+			expect(getResult(coerceFormValue(schema).safeParse('on'))).toEqual({
+				success: true,
+				data: true,
 			});
 		});
 
@@ -598,9 +520,11 @@ describe('conform-zod', () => {
 					text: z.string({
 						required_error: 'required',
 					}),
-					flag: z.boolean({
-						required_error: 'required',
-					}),
+					flag: z
+						.boolean({
+							required_error: 'required',
+						})
+						.optional(),
 				}),
 				b: z
 					.object({
@@ -614,31 +538,51 @@ describe('conform-zod', () => {
 					.optional(),
 			});
 
-			expect(parseWithZod(createFormData([]), { schema })).toEqual({
-				status: 'error',
-				payload: {},
+			expect(getResult(coerceFormValue(schema).safeParse({}))).toEqual({
+				success: false,
 				error: {
 					'a.text': ['required'],
-					'a.flag': ['required'],
 				},
-				reply: expect.any(Function),
 			});
 			expect(
-				parseWithZod(createFormData([['b.text', '']]), { schema }),
+				getResult(
+					coerceFormValue(schema).safeParse({
+						b: {
+							text: '',
+						},
+					}),
+				),
 			).toEqual({
-				status: 'error',
-				payload: {
-					b: {
-						text: '',
-					},
-				},
+				success: false,
 				error: {
 					'a.text': ['required'],
-					'a.flag': ['required'],
 					'b.text': ['required'],
 					'b.flag': ['required'],
 				},
-				reply: expect.any(Function),
+			});
+			expect(
+				getResult(
+					coerceFormValue(schema).safeParse({
+						a: {
+							text: 'foo',
+						},
+						b: {
+							text: 'bar',
+							flag: 'on',
+						},
+					}),
+				),
+			).toEqual({
+				success: true,
+				data: {
+					a: {
+						text: 'foo',
+					},
+					b: {
+						text: 'bar',
+						flag: true,
+					},
+				},
 			});
 		});
 
@@ -649,254 +593,160 @@ describe('conform-zod', () => {
 					invalid_type_error: 'invalid',
 				}),
 			) =>
-				z.object({
-					test: z
-						.array(element, {
-							required_error: 'required',
-							invalid_type_error: 'invalid',
-						})
-						.min(1, 'min')
-						.max(1, 'max'),
-				});
+				z
+					.array(element, {
+						required_error: 'required',
+						invalid_type_error: 'invalid',
+					})
+					.min(1, 'min')
+					.max(1, 'max');
 
-			expect(
-				parseWithZod(createFormData([]), { schema: createSchema() }),
-			).toEqual({
-				status: 'error',
-				payload: {},
-				error: { test: ['min'] },
-				reply: expect.any(Function),
-			});
 			// Scenario: Multiple select (default option is empty string)
-			expect(
-				parseWithZod(createFormData([['test', '']]), {
-					schema: createSchema(),
-				}),
-			).toEqual({
-				status: 'error',
-				payload: {
-					test: '',
-				},
+			expect(getResult(coerceFormValue(createSchema()).safeParse(''))).toEqual({
+				success: false,
 				error: {
-					test: ['min'],
+					'': ['min'],
 				},
-				reply: expect.any(Function),
 			});
 			// Scenario: Checkbox group (Checked only one item)
-			expect(
-				parseWithZod(createFormData([['test', 'a']]), {
-					schema: createSchema(),
-				}),
-			).toEqual({
-				status: 'success',
-				payload: { test: 'a' },
-				value: { test: ['a'] },
-				reply: expect.any(Function),
-			});
+			expect(getResult(coerceFormValue(createSchema()).safeParse('a'))).toEqual(
+				{
+					success: true,
+					data: ['a'],
+				},
+			);
 			// Scenario: Checkbox group (Checked at least two items)
 			expect(
-				parseWithZod(
-					createFormData([
-						['test', 'a'],
-						['test', 'b'],
-					]),
-					{
-						schema: createSchema(),
-					},
-				),
+				getResult(coerceFormValue(createSchema()).safeParse(['a', 'b'])),
 			).toEqual({
-				status: 'error',
-				payload: { test: ['a', 'b'] },
+				success: false,
 				error: {
-					test: ['max'],
+					'': ['max'],
 				},
-				reply: expect.any(Function),
 			});
 			// Scenario: File upload (No file selected)
 			const emptyFile = new File([], '');
 			const textFile = new File(['helloword'], 'example.txt');
 
 			expect(
-				parseWithZod(createFormData([['test', emptyFile]]), {
-					schema: createSchema(z.instanceof(File)),
-				}),
+				getResult(
+					coerceFormValue(createSchema(z.instanceof(File))).safeParse(
+						emptyFile,
+					),
+				),
 			).toEqual({
-				status: 'error',
-				payload: { test: emptyFile },
+				success: false,
 				error: {
-					test: ['min'],
+					'': ['min'],
 				},
-				reply: expect.any(Function),
 			});
 			// Scenario: File upload (Only one file selected)
 			expect(
-				parseWithZod(createFormData([['test', textFile]]), {
-					schema: createSchema(z.instanceof(File)),
-				}),
+				getResult(
+					coerceFormValue(createSchema(z.instanceof(File))).safeParse(textFile),
+				),
 			).toEqual({
-				status: 'success',
-				payload: { test: textFile },
-				value: {
-					test: [textFile],
-				},
-				reply: expect.any(Function),
+				success: true,
+				data: [textFile],
 			});
 			// Scenario: File upload (At least two files selected)
 			expect(
-				parseWithZod(
-					createFormData([
-						['test', textFile],
-						['test', textFile],
+				getResult(
+					coerceFormValue(createSchema(z.instanceof(File))).safeParse([
+						textFile,
+						textFile,
 					]),
-					{
-						schema: createSchema(z.instanceof(File)),
-					},
 				),
 			).toEqual({
-				status: 'error',
-				payload: { test: [textFile, textFile] },
+				success: false,
 				error: {
-					test: ['max'],
+					'': ['max'],
 				},
-				reply: expect.any(Function),
 			});
 			// Scenario: Only one input with the specific name
 			expect(
-				parseWithZod(createFormData([['test[0]', '']]), {
-					schema: createSchema(),
-				}),
+				getResult(coerceFormValue(createSchema()).safeParse([''])),
 			).toEqual({
-				status: 'error',
-				payload: { test: [''] },
+				success: false,
 				error: {
-					'test[0]': ['required'],
+					'[0]': ['required'],
 				},
-				reply: expect.any(Function),
 			});
 			// Scenario: Group of inputs with the same name
 			expect(
-				parseWithZod(
-					createFormData([
-						['test', 'foo'],
-						['test', ''],
-					]),
-					{
-						schema: createSchema(),
-					},
-				),
+				getResult(coerceFormValue(createSchema()).safeParse(['a', ''])),
 			).toEqual({
-				status: 'error',
-				payload: { test: ['foo', ''] },
+				success: false,
 				error: {
-					test: ['max'],
-					'test[1]': ['required'],
+					'': ['max'],
+					'[1]': ['required'],
 				},
-				reply: expect.any(Function),
 			});
 		});
 
 		test('z.instanceof(file)', () => {
-			const schema = z.object({
-				test: z.instanceof(File, { message: 'message' }),
-			});
+			const schema = z.instanceof(File, { message: 'required' });
 			const emptyFile = new File([], '');
 			const txtFile = new File(['hello', 'world'], 'example.txt');
 
-			expect(parseWithZod(createFormData([]), { schema })).toEqual({
-				status: 'error',
-				payload: {},
-				error: { test: ['message'] },
-				reply: expect.any(Function),
-			});
-			expect(parseWithZod(createFormData([['test', '']]), { schema })).toEqual({
-				status: 'error',
-				payload: {
-					test: '',
+			expect(getResult(coerceFormValue(schema).safeParse(''))).toEqual({
+				success: false,
+				error: {
+					'': ['required'],
 				},
-				error: { test: ['message'] },
-				reply: expect.any(Function),
 			});
 			expect(
-				parseWithZod(createFormData([['test', 'helloworld']]), { schema }),
+				getResult(coerceFormValue(schema).safeParse('helloworld')),
 			).toEqual({
-				status: 'error',
-				payload: {
-					test: 'helloworld',
+				success: false,
+				error: {
+					'': ['required'],
 				},
-				error: { test: ['message'] },
-				reply: expect.any(Function),
 			});
-			expect(
-				parseWithZod(createFormData([['test', emptyFile]]), { schema }),
-			).toEqual({
-				status: 'error',
-				payload: {
-					test: emptyFile,
+			expect(getResult(coerceFormValue(schema).safeParse(emptyFile))).toEqual({
+				success: false,
+				error: {
+					'': ['required'],
 				},
-				error: { test: ['message'] },
-				reply: expect.any(Function),
 			});
-			expect(
-				parseWithZod(createFormData([['test', txtFile]]), { schema }),
-			).toEqual({
-				status: 'success',
-				payload: {
-					test: txtFile,
-				},
-				value: {
-					test: txtFile,
-				},
-				reply: expect.any(Function),
+			expect(getResult(coerceFormValue(schema).safeParse(txtFile))).toEqual({
+				success: true,
+				data: txtFile,
 			});
 		});
 
 		test('z.preprocess', () => {
-			const schemaWithNoPreprocess = z.object({
-				test: z.number({ invalid_type_error: 'invalid' }),
+			const schemaWithNoPreprocess = z.number({
+				invalid_type_error: 'invalid',
 			});
-			const schemaWithCustomPreprocess = z.object({
-				test: z.preprocess(
-					(value) => {
-						if (typeof value !== 'string') {
-							return value;
-						} else if (value === '') {
-							return undefined;
-						} else {
-							return value.replace(/,/g, '');
-						}
-					},
-					z.number({ invalid_type_error: 'invalid' }),
-				),
-			});
-			const formData = createFormData([['test', '1,234.5']]);
+			const schemaWithCustomPreprocess = z.preprocess(
+				(value) => {
+					if (typeof value !== 'string') {
+						return value;
+					} else if (value === '') {
+						return undefined;
+					} else {
+						return value.replace(/,/g, '');
+					}
+				},
+				z.number({ invalid_type_error: 'invalid' }),
+			);
 
 			expect(
-				parseWithZod(formData, {
-					schema: schemaWithNoPreprocess,
-				}),
+				getResult(coerceFormValue(schemaWithNoPreprocess).safeParse('1,234.5')),
 			).toEqual({
-				status: 'error',
-				payload: {
-					test: '1,234.5',
-				},
+				success: false,
 				error: {
-					test: ['invalid'],
+					'': ['invalid'],
 				},
-				reply: expect.any(Function),
 			});
 			expect(
-				parseWithZod(formData, {
-					schema: schemaWithCustomPreprocess,
-				}),
+				getResult(
+					coerceFormValue(schemaWithCustomPreprocess).safeParse('1,234.5'),
+				),
 			).toEqual({
-				status: 'success',
-				payload: {
-					test: '1,234.5',
-				},
-				value: {
-					test: 1234.5,
-				},
-				reply: expect.any(Function),
+				success: true,
+				data: 1234.5,
 			});
 		});
 
@@ -912,31 +762,9 @@ describe('conform-zod', () => {
 			});
 			const emptyFile = new File([], '');
 
-			expect(
-				parseWithZod(
-					createFormData([
-						['a', ''],
-						['b', ''],
-						['c', ''],
-						['d', ''],
-						['e', emptyFile],
-						['f', ''],
-						['g', ''],
-					]),
-					{ schema },
-				),
-			).toEqual({
-				status: 'success',
-				payload: {
-					a: '',
-					b: '',
-					c: '',
-					d: '',
-					e: emptyFile,
-					f: '',
-					g: '',
-				},
-				value: {
+			expect(getResult(coerceFormValue(schema).safeParse({}))).toEqual({
+				success: true,
+				data: {
 					a: undefined,
 					b: undefined,
 					c: undefined,
@@ -945,13 +773,38 @@ describe('conform-zod', () => {
 					f: [],
 					g: undefined,
 				},
-				reply: expect.any(Function),
+			});
+			expect(
+				getResult(
+					coerceFormValue(schema).safeParse({
+						a: '',
+						b: '',
+						c: '',
+						d: '',
+						e: emptyFile,
+						f: '',
+						g: '',
+					}),
+				),
+			).toEqual({
+				success: true,
+				data: {
+					a: undefined,
+					b: undefined,
+					c: undefined,
+					d: undefined,
+					e: undefined,
+					f: [],
+					g: undefined,
+				},
 			});
 
 			// To test if File is not defined in certain environment
 			vi.stubGlobal('File', undefined);
 
-			expect(() => parseWithZod(createFormData([]), { schema })).not.toThrow();
+			expect(() =>
+				getResult(coerceFormValue(schema).safeParse({})),
+			).not.toThrow();
 		});
 
 		test('z.default', () => {
@@ -970,28 +823,19 @@ describe('conform-zod', () => {
 			const emptyFile = new File([], '');
 
 			expect(
-				parseWithZod(
-					createFormData([
-						['a', ''],
-						['b', ''],
-						['c', ''],
-						['d', ''],
-						['e', emptyFile],
-						['f', ''],
-					]),
-					{ schema },
+				getResult(
+					coerceFormValue(schema).safeParse({
+						a: '',
+						b: '',
+						c: '',
+						d: '',
+						e: emptyFile,
+						f: '',
+					}),
 				),
 			).toEqual({
-				status: 'success',
-				payload: {
-					a: '',
-					b: '',
-					c: '',
-					d: '',
-					e: emptyFile,
-					f: '',
-				},
-				value: {
+				success: true,
+				data: {
 					a: 'text',
 					b: 123,
 					c: true,
@@ -1001,7 +845,6 @@ describe('conform-zod', () => {
 					g: null,
 					h: '',
 				},
-				reply: expect.any(Function),
 			});
 
 			const today = new Date();
@@ -1019,9 +862,8 @@ describe('conform-zod', () => {
 					.default(defaultFile),
 			});
 
-			expect(parseWithZod(createFormData([]), { schema: schema2 })).toEqual({
-				status: 'error',
-				payload: {},
+			expect(getResult(coerceFormValue(schema2).safeParse({}))).toEqual({
+				success: false,
 				error: {
 					a: ['invalid'],
 					b: ['invalid'],
@@ -1029,7 +871,6 @@ describe('conform-zod', () => {
 					d: ['invalid'],
 					e: ['invalid'],
 				},
-				reply: expect.any(Function),
 			});
 		});
 
@@ -1049,28 +890,19 @@ describe('conform-zod', () => {
 			const emptyFile = new File([], '');
 
 			expect(
-				parseWithZod(
-					createFormData([
-						['a', ''],
-						['b', ''],
-						['c', ''],
-						['d', ''],
-						['e', emptyFile],
-						['f', ''],
-					]),
-					{ schema },
+				getResult(
+					coerceFormValue(schema).safeParse({
+						a: '',
+						b: '',
+						c: '',
+						d: '',
+						e: emptyFile,
+						f: '',
+					}),
 				),
 			).toEqual({
-				status: 'success',
-				payload: {
-					a: '',
-					b: '',
-					c: '',
-					d: '',
-					e: emptyFile,
-					f: '',
-				},
-				value: {
+				success: true,
+				data: {
 					a: 'text',
 					b: 123,
 					c: true,
@@ -1078,32 +910,22 @@ describe('conform-zod', () => {
 					e: defaultFile,
 					f: ['foo', 'bar'],
 				},
-				reply: expect.any(Function),
 			});
+
 			expect(
-				parseWithZod(
-					createFormData([
-						['a', 'othertext'],
-						['b', '456'],
-						['c', 'on'],
-						['d', userDate.toISOString()],
-						['e', userFile],
-						['f', 'hello'],
-						['f', 'world'],
-					]),
-					{ schema },
+				getResult(
+					coerceFormValue(schema).safeParse({
+						a: 'othertext',
+						b: '456',
+						c: 'on',
+						d: userDate.toISOString(),
+						e: userFile,
+						f: ['hello', 'world'],
+					}),
 				),
 			).toEqual({
-				status: 'success',
-				payload: {
-					a: 'othertext',
-					b: '456',
-					c: 'on',
-					d: userDate.toISOString(),
-					e: userFile,
-					f: ['hello', 'world'],
-				},
-				value: {
+				success: true,
+				data: {
 					a: 'othertext',
 					b: 456,
 					c: true,
@@ -1111,7 +933,6 @@ describe('conform-zod', () => {
 					e: userFile,
 					f: ['hello', 'world'],
 				},
-				reply: expect.any(Function),
 			});
 		});
 
@@ -1131,59 +952,46 @@ describe('conform-zod', () => {
 			});
 
 			expect(
-				parseWithZod(
-					createFormData([
-						['category.name', ''],
-						['category.subcategories[0].name', ''],
-						['category.subcategories[0].subcategories[0].name', ''],
-						['category.subcategories[1].name', ''],
-						['node.name', ''],
-						['node.left.name', ''],
-						['node.left.left.name', ''],
-						['node.left.right.name', ''],
-						['node.right.name', ''],
-						['node.right.right.name', ''],
-					]),
-					{ schema },
-				),
-			).toEqual({
-				status: 'error',
-				payload: {
-					category: {
-						name: '',
-						subcategories: [
-							{
-								name: '',
-								subcategories: [
-									{
-										name: '',
-									},
-								],
-							},
-							{
-								name: '',
-							},
-						],
-					},
-					node: {
-						name: '',
-						left: {
+				getResult(
+					coerceFormValue(schema).safeParse({
+						category: {
+							name: '',
+							subcategories: [
+								{
+									name: '',
+									subcategories: [
+										{
+											name: '',
+										},
+									],
+								},
+								{
+									name: '',
+								},
+							],
+						},
+						node: {
 							name: '',
 							left: {
 								name: '',
+								left: {
+									name: '',
+								},
+								right: {
+									name: '',
+								},
 							},
 							right: {
 								name: '',
+								right: {
+									name: '',
+								},
 							},
 						},
-						right: {
-							name: '',
-							right: {
-								name: '',
-							},
-						},
-					},
-				},
+					}),
+				),
+			).toEqual({
+				success: false,
 				error: {
 					'category.name': ['required'],
 					'category.subcategories[0].name': ['required'],
@@ -1196,7 +1004,6 @@ describe('conform-zod', () => {
 					'node.right.name': ['required'],
 					'node.right.right.name': ['required'],
 				},
-				reply: expect.any(Function),
 			});
 		});
 
@@ -1213,44 +1020,32 @@ describe('conform-zod', () => {
 			]);
 
 			expect(
-				parseWithZod(
-					createFormData([
-						['type', 'a'],
-						['number', '1'],
-					]),
-					{ schema },
+				getResult(
+					coerceFormValue(schema).safeParse({
+						type: 'a',
+						number: '1',
+					}),
 				),
 			).toEqual({
-				status: 'success',
-				payload: {
-					type: 'a',
-					number: '1',
-				},
-				value: {
+				success: true,
+				data: {
 					type: 'a',
 					number: 1,
 				},
-				reply: expect.any(Function),
 			});
 			expect(
-				parseWithZod(
-					createFormData([
-						['type', 'b'],
-						['boolean', 'on'],
-					]),
-					{ schema },
+				getResult(
+					coerceFormValue(schema).safeParse({
+						type: 'b',
+						boolean: 'on',
+					}),
 				),
 			).toEqual({
-				status: 'success',
-				payload: {
-					type: 'b',
-					boolean: 'on',
-				},
-				value: {
+				success: true,
+				data: {
 					type: 'b',
 					boolean: true,
 				},
-				reply: expect.any(Function),
 			});
 		});
 
@@ -1261,79 +1056,102 @@ describe('conform-zod', () => {
 					b: z.number().brand(),
 					c: z.boolean().brand(),
 					d: z.date().brand(),
-					e: z.instanceof(File).brand(),
-					f: z.string().optional().brand(),
-					g: z.string().brand().optional(),
+					e: z.bigint().brand(),
+					f: z.instanceof(File).brand(),
+					g: z.string().optional().brand(),
+					h: z.string().brand().optional(),
 				})
 				.brand();
+			const defaultFile = new File(['hello', 'world'], 'example.txt');
+
 			expect(
-				parseWithZod(
-					createFormData([
-						['a', ''],
-						['b', ''],
-						['c', ''],
-						['d', ''],
-						['e', ''],
-						['f', ''],
-						['g', ''],
-					]),
-					{ schema },
+				getResult(
+					coerceFormValue(schema).safeParse({
+						a: '',
+						b: '',
+						c: '',
+						d: '',
+						e: '',
+						f: '',
+						g: '',
+						h: '',
+					}),
 				),
 			).toEqual({
-				status: 'error',
-				payload: {
-					a: '',
-					b: '',
-					c: '',
-					d: '',
-					e: '',
-					f: '',
-					g: '',
-				},
+				success: false,
 				error: {
 					a: ['Required'],
 					b: ['Required'],
 					c: ['Required'],
 					d: ['Required'],
-					e: ['Input not instance of File'],
+					e: ['Required'],
+					f: ['Input not instance of File'],
 				},
-				reply: expect.any(Function),
-			});
-			const coercionTypesSchema = z.object({
-				a: z.string().brand(),
-				b: z.number().brand(),
-				c: z.boolean().brand(),
-				d: z.date().brand(),
-				e: z.bigint().brand(),
 			});
 			expect(
-				parseWithZod(
-					createFormData([
-						['a', 'hello world'],
-						['b', '42'],
-						['c', 'on'],
-						['d', '1970-01-01'],
-						['e', '0x1fffffffffffff'],
-					]),
-					{ schema: coercionTypesSchema },
+				getResult(
+					coerceFormValue(schema).safeParse({
+						a: 'hello world',
+						b: '42',
+						c: 'on',
+						d: '1970-01-01',
+						e: '0x1fffffffffffff',
+						f: defaultFile,
+						g: '',
+						h: '',
+					}),
 				),
 			).toEqual({
-				status: 'success',
-				payload: {
-					a: 'hello world',
-					b: '42',
-					c: 'on',
-					d: '1970-01-01',
-					e: '0x1fffffffffffff',
-				},
-				value: {
+				success: true,
+				data: {
 					a: 'hello world',
 					b: 42,
 					c: true,
 					d: new Date('1970-01-01'),
 					e: BigInt('0x1fffffffffffff'),
+					f: defaultFile,
+					g: undefined,
+					h: undefined,
 				},
-				reply: expect.any(Function),
+			});
+		});
+
+		test('skipCoercion', () => {
+			const Payment = z.object({
+				date: z.date({ invalid_type_error: 'invalid' }),
+				confirmed: z.boolean({ invalid_type_error: 'invalid' }),
+			});
+			const schema = z.object({
+				title: z.string({ required_error: 'required' }),
+				count: z.number({ invalid_type_error: 'invalid' }),
+				amount: z.bigint({ required_error: 'required' }),
+				payment: Payment,
+			});
+
+			expect(
+				getResult(
+					coerceFormValue(schema, {
+						skipCoercion: (type) =>
+							type instanceof z.ZodNumber || type === Payment,
+					}).safeParse({
+						title: '',
+						count: '',
+						amount: '',
+						payment: {
+							date: '',
+							confirmed: '',
+						},
+					}),
+				),
+			).toEqual({
+				success: false,
+				error: {
+					title: ['required'],
+					amount: ['required'],
+					count: ['invalid'],
+					'payment.confirmed': ['invalid'],
+					'payment.date': ['invalid'],
+				},
 			});
 		});
 	});
@@ -1484,6 +1302,49 @@ describe('conform-zod', () => {
 			...submission,
 			status: 'success',
 			value: submission.payload,
+		});
+	});
+
+	test('parseWithZod with disableAutoCoercion', async () => {
+		const schema = z.object({
+			text: z.string(),
+			number: z.number({ invalid_type_error: 'invalid' }),
+			boolean: z.boolean({ invalid_type_error: 'invalid' }),
+			bigint: z.bigint({ invalid_type_error: 'invalid' }),
+			date: z.date({ invalid_type_error: 'invalid' }),
+			file: z.instanceof(File, { message: 'invalid' }),
+		});
+		const formData = createFormData([
+			['text', 'abc'],
+			['number', '1'],
+			['boolean', 'on'],
+			['bigint', '1'],
+			['date', '1970-01-01'],
+			['file', new File([], '')],
+		]);
+
+		expect(
+			parseWithZod(formData, {
+				schema,
+				disableAutoCoercion: true,
+			}),
+		).toEqual({
+			status: 'error',
+			payload: {
+				text: 'abc',
+				number: '1',
+				boolean: 'on',
+				bigint: '1',
+				date: '1970-01-01',
+				file: new File([], ''),
+			},
+			error: {
+				number: ['invalid'],
+				boolean: ['invalid'],
+				bigint: ['invalid'],
+				date: ['invalid'],
+			},
+			reply: expect.any(Function),
 		});
 	});
 });

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -1179,7 +1179,6 @@ describe('conform-zod', () => {
 								if (typeof value !== 'string') {
 									return value;
 								}
-
 								// Trim the text
 								const text = value.trim();
 
@@ -1189,6 +1188,31 @@ describe('conform-zod', () => {
 
 								return text;
 							},
+						},
+					}).safeParse({
+						title: ' ',
+						count: ' ',
+						amount: ' ',
+						date: ' ',
+						confirmed: ' ',
+						file: exampleFile,
+					}),
+				),
+			).toEqual({
+				success: false,
+				error: {
+					title: ['required'],
+					amount: ['required'],
+					count: ['required'],
+					date: ['required'],
+					confirmed: ['required'],
+				},
+			});
+
+			expect(
+				getResult(
+					coerceFormValue(schema, {
+						defaultCoercion: {
 							number(value) {
 								if (typeof value !== 'string') {
 									return value;
@@ -1218,7 +1242,7 @@ describe('conform-zod', () => {
 			).toEqual({
 				success: true,
 				data: {
-					title: 'example',
+					title: ' example ',
 					count: 123456,
 					amount: 9876543210n,
 					date: new Date('1970-01-01'),
@@ -1228,7 +1252,7 @@ describe('conform-zod', () => {
 			});
 		});
 
-		test('define custom coercion', () => {
+		test('customize coercion', () => {
 			const Payment = z.object({
 				count: z.number({
 					required_error: 'required',
@@ -1252,7 +1276,7 @@ describe('conform-zod', () => {
 			expect(
 				getResult(
 					coerceFormValue(schema, {
-						defineCoercion(type) {
+						customize(type) {
 							if (type === Payment) {
 								return (value) => {
 									if (typeof value !== 'string') {

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -863,13 +863,13 @@ describe('conform-zod', () => {
 			});
 
 			expect(getResult(coerceFormValue(schema2).safeParse({}))).toEqual({
-				success: false,
-				error: {
-					a: ['invalid'],
-					b: ['invalid'],
-					c: ['invalid'],
-					d: ['invalid'],
-					e: ['invalid'],
+				success: true,
+				data: {
+					a: '',
+					b: 0,
+					c: false,
+					d: defaultDate,
+					e: defaultFile,
 				},
 			});
 		});


### PR DESCRIPTION
This PR adds the ability to disable the default auto coercion behavior by setting the `disableAutoCoercion` option to `true` in `parseWithZod`.

```ts
function Example() {
  const [form, fields] = useForm({
    onValidate({ formData }) {
      return parseWithZod(formData, {
        schema,
        disableAutoCoercion: true,
      });
    },
  });

  // ...
}
```

You can then manage how the form value is parsed yourself, or use the new `coerceFormValue` helper to coerce form value, like this:

```ts
import { parseWithZod, unstable_coerceFormValue as coerceFormValue } from '@conform-to/zod';
import { z } from 'zod';

// Coerce the form value with default behaviour
const schema = coerceFormValue(
  z.object({
    // ...
  })
);

// Coerce the form value with default coercion overrided
const schema = coerceFormValue(
  z.object({
    ref: z.number()
    date: z.date(),
    amount: z.number(),
    confirm: z.boolean(),
  }),
  {
    // Trim the value for all string-based fields
    // e.g. `z.string()`, `z.number()` or `z.boolean()`
    string: (value) => {
      if (typeof value !== 'string') {
         return value;
      }

      const result = value.trim();

      // Treat it as `undefined` if the value is empty
      if (result === '') {
         return undefined;
      }

      return result;
    },

    // Override the default coercion with `z.number()`
    number: (value) => {
      // Pass the value as is if it's not a string
      if (typeof value !== 'string') {
        return value;
      }

      // Trim and remove commas before casting it to number
      return Number(value.trim().replace(/,/g, ''));
    },

    // Disable coercion for `z.boolean()`
    boolean: false,
  },
);
```

This helper is extracted from `parseWithZod` and shares the same coercion logic. It will be released with the `unstable_` prefix in `v1.3.0` and is expected to be marked stable soon. Lock your version to the patch version range (e.g. `~1.3.0`) if you want to use this feature without unexpected changes.
