### PR TITLE
feat(conform-valibot): add support valibot

### DIFF
--- a/.changeset/honest-wolves-chew.md
+++ b/.changeset/honest-wolves-chew.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/valibot': minor
+---
+
+Added `@conform-to/valibot` package to perform validation with Valibot

--- a/.changeset/honest-wolves-chew.md
+++ b/.changeset/honest-wolves-chew.md
@@ -1,5 +1,5 @@
 ---
-'@conform-to/valibot': minor
+'@conform-to/valibot': major
 ---
 
 Added `@conform-to/valibot` package to perform validation with Valibot

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,5 +34,11 @@
     - [getYupConstraint](./api/yup/getYupConstraint.md)
   - @conform-to/zod
     - [parseWithZod](./api/zod/parseWithZod.md)
+    - [coerceFormValue](./api/zod/coerceFormValue.md)
     - [getZodConstraint](./api/zod/getZodConstraint.md)
     - [conformZodMessage](./api/zod/conformZodMessage.md)
+  - @conform-to/valibot
+    - [parseWithZod](./api/valibot/parseWithZod.md)
+    - [coerceFormValue](./api/valibot/coerceFormValue.md)
+    - [getZodConstraint](./api/valibot/getZodConstraint.md)
+    - [conformZodMessage](./api/valibot/conformZodMessage.md)

--- a/docs/api/valibot/coerceFormValue.md
+++ b/docs/api/valibot/coerceFormValue.md
@@ -9,10 +9,10 @@ const enhancedSchema = coerceFormValue(schema, options);
 The following rules will be applied by default:
 
 1. If the value is an empty string / file, pass `undefined` to the schema
-2. If the schema is `v.number()`, cast the value with the `Number` constructor
+2. If the schema is `v.number()`, trim the value and cast it with the `Number` constructor
 3. If the schema is `v.boolean()`, treat the value as `true` if it equals to `on` (Browser default `value` of a checkbox / radio button)
 4. If the schema is `v.date()`, cast the value with the `Date` constructor
-5. If the schema is `v.bigint()`, cast the value with the `BigInt` constructor
+5. If the schema is `v.bigint()`, trim the value and cast the value with the `BigInt` constructor
 
 ## Parameters
 
@@ -72,22 +72,6 @@ const schema = coerceFormValue(
   }),
   {
     defaultCoercion: {
-      // Override the default coercion with `string()`
-      string: (value) => {
-        if (typeof value !== 'string') {
-          return value;
-        }
-
-        const result = value.trim();
-
-        // Treat it as `undefined` if the value is empty
-        if (result === '') {
-          return undefined;
-        }
-
-        return result;
-      },
-
       // Override the default coercion with `number()`
       number: (value) => {
         // Pass the value as is if it's not a string

--- a/docs/api/valibot/coerceFormValue.md
+++ b/docs/api/valibot/coerceFormValue.md
@@ -24,7 +24,7 @@ The valibot schema to be enhanced.
 
 Optional. Set it if you want to [override the default behavior](#override-default-behavior).
 
-### `options.defineCoercion`
+### `options.customize`
 
 Optional. Use it to [define custom coercion](#define-custom-coercion) for a specific schema.
 
@@ -104,7 +104,7 @@ const schema = object({
 
 ### Define custom coercion
 
-You can define custom coercion for a specific schema by setting the `defineCoercion` option.
+You can customize coercion for a specific schema by setting the `customize` option.
 
 ```ts
 import {
@@ -126,7 +126,7 @@ const schema = coerceFormValue(
     metadata,
   }),
   {
-    defineCoercion(schema) {
+    customize(schema) {
       // Customize how the `metadata` field value is coerced
       if (schema === metadata) {
         return (value) => {

--- a/docs/api/valibot/coerceFormValue.md
+++ b/docs/api/valibot/coerceFormValue.md
@@ -1,0 +1,163 @@
+# unstable_coerceFormValue
+
+A helper that enhances the schema with extra preprocessing steps to strip empty value and coerce form value to the expected type.
+
+```ts
+const enhancedSchema = coerceFormValue(schema, options);
+```
+
+The following rules will be applied by default:
+
+1. If the value is an empty string / file, pass `undefined` to the schema
+2. If the schema is `v.number()`, cast the value with the `Number` constructor
+3. If the schema is `v.boolean()`, treat the value as `true` if it equals to `on` (Browser default `value` of a checkbox / radio button)
+4. If the schema is `v.date()`, cast the value with the `Date` constructor
+5. If the schema is `v.bigint()`, cast the value with the `BigInt` constructor
+
+## Parameters
+
+### `schema`
+
+The valibot schema to be enhanced.
+
+### `options.defaultCoercion`
+
+Optional. Set it if you want to [override the default behavior](#override-default-behavior).
+
+### `options.defineCoercion`
+
+Optional. Use it to [define custom coercion](#define-custom-coercion) for a specific schema.
+
+## Example
+
+```ts
+import { parseWithValibot, unstable_coerceFormValue as coerceFormValue } from '@conform-to/valibot';
+import { useForm } from '@conform-to/react';
+import { object, string, date, number, boolean } from 'valibot';
+import { jsonSchema } from './jsonSchema';
+
+const schema = coerceFormValue(
+  object({
+    ref: string()
+    date: date(),
+    amount: number(),
+    confirm: boolean(),
+  }),
+);
+
+function Example() {
+  const [form, fields] = useForm({
+    onValidate({ formData }) {
+      return parseWithValibot(formData, {
+        schema,
+        defaultTypeCoercion: false,
+      });
+    },
+  });
+
+  // ...
+}
+```
+
+## Tips
+
+### Override default behavior
+
+You can override the default coercion by specifying the `defaultCoercion` mapping in the options.
+
+```ts
+const schema = coerceFormValue(
+  object({
+    // ...
+  }),
+  {
+    defaultCoercion: {
+      // Override the default coercion with `string()`
+      string: (value) => {
+        if (typeof value !== 'string') {
+          return value;
+        }
+
+        const result = value.trim();
+
+        // Treat it as `undefined` if the value is empty
+        if (result === '') {
+          return undefined;
+        }
+
+        return result;
+      },
+
+      // Override the default coercion with `number()`
+      number: (value) => {
+        // Pass the value as is if it's not a string
+        if (typeof value !== 'string') {
+          return value;
+        }
+
+        // Trim and remove commas before casting it to number
+        return Number(value.trim().replace(/,/g, ''));
+      },
+
+      // Disable coercion for `boolean()`
+      boolean: false,
+    },
+  },
+);
+```
+
+### Default values
+
+`coerceFormValue` will always strip empty values to `undefined`. If you need a default value, use `optional()` to define a fallback value that will be returned instead.
+
+```ts
+const schema = object({
+  foo: optional(string()), // string | undefined
+  bar: optional(string(), ''), // string
+  baz: optional(nullable(optional()), null), // string | null
+});
+```
+
+### Define custom coercion
+
+You can define custom coercion for a specific schema by setting the `defineCoercion` option.
+
+```ts
+import {
+  parseWithValibot,
+  unstable_coerceFormValue as coerceFormValue,
+} from '@conform-to/valibot';
+import { useForm } from '@conform-to/react';
+import { object, string, number, boolean } from 'valibot';
+import { json } from './schema';
+
+const metadata = object({
+  number: number(),
+  confirmed: boolean(),
+});
+
+const schema = coerceFormValue(
+  object({
+    ref: string(),
+    metadata,
+  }),
+  {
+    defineCoercion(schema) {
+      // Customize how the `metadata` field value is coerced
+      if (schema === metadata) {
+        return (value) => {
+          if (typeof value !== 'string') {
+            return value;
+          }
+
+          // Parse the value as JSON
+          return JSON.parse(value);
+        };
+      }
+
+      // Return `null` to keep the default behavior
+      return null;
+    },
+  },
+);
+```

--- a/docs/api/valibot/conformValibotMessage.md
+++ b/docs/api/valibot/conformValibotMessage.md
@@ -1,0 +1,113 @@
+# conformValibotMessage
+
+A set of custom messages to control the validation behavior. This is useful if you need async validation for one of the fields.
+
+## Options
+
+### `conformValibotMessage.VALIDATION_SKIPPED`
+
+This message is used to indicate that the validation is skipped and Conform should use the previous result instead.
+
+### `conformValibotMessage.VALIDATION_UNDEFINED`
+
+This message is used to indicate that the validation is not defined and Conform should fallback to server validation.
+
+## Example
+
+You can skip an validation to use the previous result. On client validation, you can indicate the validation is not defined to fallback to server validation.
+
+```tsx
+import type { Intent } from '@conform-to/react';
+import { useForm } from '@conform-to/react';
+import { parseWithValibot, conformValibotMessage } from 'conform-to-valibot';
+import {
+  check,
+  forward,
+  forwardAsync,
+  object,
+  partialCheck,
+  partialCheckAsync,
+  pipe,
+  pipeAsync,
+  string,
+} from 'valibot';
+
+function createBaseSchema(intent: Intent | null) {
+  return object({
+    email: pipe(
+      string('Email is required'),
+      // When not validating email, leave the email error as it is.
+      check(
+        () =>
+          intent === null ||
+          (intent.type === 'validate' && intent.payload.name === 'email'),
+        conformValibotMessage.VALIDATION_SKIPPED,
+      ),
+    ),
+    password: string('Password is required'),
+  });
+}
+
+function createServerSchema(
+  intent: Intent | null,
+  options: { isEmailUnique: (email: string) => Promise<boolean> },
+) {
+  return pipeAsync(
+    createBaseSchema(intent),
+    forwardAsync(
+      partialCheckAsync(
+        [['email']],
+        async ({ email }) => options.isEmailUnique(email),
+        'Email is already used',
+      ),
+      ['email'],
+    ),
+  );
+}
+
+function createClientSchema(intent: Intent | null) {
+  return pipe(
+    createBaseSchema(intent),
+    forward(
+      // If email is specified, fallback to server validation to check its uniqueness.
+      partialCheck(
+        [['email']],
+        () => false,
+        conformValibotMessage.VALIDATION_UNDEFINED,
+      ),
+      ['email'],
+    ),
+  );
+}
+
+export async function action({ request }) {
+  const formData = await request.formData();
+  const submission = await parseWithValibot(formData, {
+    schema: (intent) =>
+      createServerSchema(intent, {
+        isEmailUnique: async (email) => {
+          // Query your database to check if the email is unique
+        },
+      }),
+  });
+
+  // Send the submission back to the client if the status is not successful
+  if (submission.status !== 'success') {
+    return submission.reply();
+  }
+
+  // ...
+}
+
+function ExampleForm() {
+  const [form, { email, password }] = useForm({
+    onValidate({ formData }) {
+      return parseWithValibot(formData, {
+        schema: (intent) => createClientSchema(intent),
+      });
+    },
+  });
+
+  // ...
+}
+```

--- a/docs/api/valibot/getValibodConstraint.md
+++ b/docs/api/valibot/getValibodConstraint.md
@@ -1,0 +1,34 @@
+# getValibotConstraint
+
+A helper that returns an object containing the validation attributes for each field by introspecting the valibot schema.
+
+```tsx
+const constraint = getValibotConstraint(schema);
+```
+
+## Parameters
+
+### `schema`
+
+The valibot schema to be introspected.
+
+## Example
+
+```tsx
+import { getValibotConstraint } from '@conform-to/valibot';
+import { useForm } from '@conform-to/react';
+import { object, pipe, string, minLength, optional } from 'valibot';
+
+const schema = object({
+  title: pipe(string(), minLength(5), maxLength(20)),
+  description: optional(pipe(string(), minLength(100), maxLength(1000))),
+});
+
+function Example() {
+  const [form, fields] = useForm({
+    constraint: getValibotConstraint(schema),
+  });
+
+  // ...
+}
+```

--- a/docs/api/valibot/parseWithValibot.md
+++ b/docs/api/valibot/parseWithValibot.md
@@ -1,0 +1,94 @@
+# parseWithValibot
+
+A helper that returns an overview of the submission by parsing the form data with the provided valibot schema.
+
+```tsx
+const submission = parseWithValibot(payload, options);
+```
+
+## Parameters
+
+### `payload`
+
+It could be either the **FormData** or **URLSearchParams** object depending on how the form is submitted.
+
+### `options.schema`
+
+Either a valibot schema or a function that returns a valibot schema.
+
+### `options.info`
+
+A valibot [parse configuration](<https://github.com/fabian-hiller/valibot/blob/main/website/src/routes/guides/(main-concepts)/parse-data/index.mdx#configuration>) and [select language](<https://github.com/fabian-hiller/valibot/blob/main/website/src/routes/guides/(advanced)/internationalization/index.mdx#select-language>) to be used when parsing the form data.
+
+### `options.disableAutoCoercion`
+
+Set it to **true** if you want to disable [automatic type coercion](#automatic-type-coercion) and manage how the form data is parsed yourself.
+
+## Example
+
+```tsx
+import { parseWithValibot } from '@conform-to/valibot';
+import { useForm } from '@conform-to/react';
+import { pipe, string, email } from 'valibot';
+
+const schema = object({
+  email: pipe(string(), email()),
+  password: string(),
+});
+
+function Example() {
+  const [form, fields] = useForm({
+    onValidate({ formData }) {
+      return parseWithValibot(formData, { schema });
+    },
+  });
+
+  // ...
+}
+```
+
+## Tips
+
+### Automatic type coercion
+
+By default, `parseWithValibot` will strip empty value and coerce form value to the correct type by introspecting the schema and inject extra preprocessing steps using the [coerceFormValue](./coerceFormValue) helper internally.
+
+If you want to customize this behavior, you can disable automatic type coercion by setting `options.disableAutoCoercion` to `true` and manage it yourself.
+
+```tsx
+import { parseWithValibot } from '@conform-to/valibot';
+import { useForm } from '@conform-to/react';
+import { pipe, object, transform, unknown, number } from 'valibot';
+
+const schema = object({
+  // Strip empty value and coerce the number yourself
+  amount: pipe(
+    unknown(),
+    transform((value) => {
+      if (typeof value !== 'string') {
+        return value;
+      }
+
+      if (value === '') {
+        return undefined;
+      }
+
+      return Number(value.trim().replace(/,/g, ''));
+    }),
+    number(),
+  ),
+});
+
+function Example() {
+  const [form, fields] = useForm({
+    onValidate({ formData }) {
+      return parseWithValibot(formData, {
+        schema,
+        disableAutoCoercion: true,
+      });
+    },
+  });
+
+  // ...
+}
+```

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -34,5 +34,11 @@
     - [getYupConstraint](./api/yup/getYupConstraint.md)
   - @conform-to/zod
     - [parseWithZod](./api/zod/parseWithZod.md)
+    - [coerceFormValue](./api/zod/coerceFormValue.md)
     - [getZodConstraint](./api/zod/getZodConstraint.md)
     - [conformZodMessage](./api/zod/conformZodMessage.md)
+  - @conform-to/valibot
+    - [parseWithZod](./api/valibot/parseWithZod.md)
+    - [coerceFormValue](./api/valibot/coerceFormValue.md)
+    - [getZodConstraint](./api/valibot/getZodConstraint.md)
+    - [conformZodMessage](./api/valibot/conformZodMessage.md)

--- a/docs/ja/api/valibot/coerceFormValue.md
+++ b/docs/ja/api/valibot/coerceFormValue.md
@@ -12,7 +12,7 @@ const enhancedSchema = coerceFormValue(schema, options);
 2. スキーマが `v.number()` の場合、値をトリムして `Number` コンストラクタでキャストします
 3. スキーマが `v.boolean()` の場合、値が `on`（ブラウザのチェックボックス/ラジオボタンのデフォルト `value`）と等しい場合、`true` として扱います
 4. スキーマが `v.date()` の場合、値を `Date` コンストラクタでキャストします
-5. スキーマが `v.bigint()` の場合、値を `BigInt` コンストラクタでキャストします
+5. スキーマが `v.bigint()` の場合、値をトリムして `BigInt` コンストラクタでキャストします
 
 ## パラメータ
 
@@ -72,22 +72,6 @@ const schema = coerceFormValue(
   }),
   {
     defaultCoercion: {
-      // `string()` のデフォルト変換をオーバーライドする
-      string: (value) => {
-        if (typeof value !== 'string') {
-          return value;
-        }
-
-        const result = value.trim();
-
-        // 値が空の場合は `undefined` として扱う
-        if (result === '') {
-          return undefined;
-        }
-
-        return result;
-      },
-
       // `number()` のデフォルト変換をオーバーライドする
       number: (value) => {
         // 文字列でない場合はそのまま値を渡す

--- a/docs/ja/api/valibot/coerceFormValue.md
+++ b/docs/ja/api/valibot/coerceFormValue.md
@@ -1,0 +1,163 @@
+# unstable_coerceFormValue
+
+空の値を取り除き、フォーム値を期待される型に変換するための追加の前処理ステップでスキーマを強化するヘルパー関数です。
+
+```ts
+const enhancedSchema = coerceFormValue(schema, options);
+```
+
+デフォルトでは、以下のルールが適用されます：
+
+1. 値が空の文字列/ファイルの場合、スキーマに `undefined` を渡します
+2. スキーマが `v.number()` の場合、値をトリムして `Number` コンストラクタでキャストします
+3. スキーマが `v.boolean()` の場合、値が `on`（ブラウザのチェックボックス/ラジオボタンのデフォルト `value`）と等しい場合、`true` として扱います
+4. スキーマが `v.date()` の場合、値を `Date` コンストラクタでキャストします
+5. スキーマが `v.bigint()` の場合、値を `BigInt` コンストラクタでキャストします
+
+## パラメータ
+
+### `schema`
+
+拡張するvalibotスキーマ。
+
+### `options.defaultCoercion`
+
+[デフォルトの動作をオーバーライド](#デフォルトの動作をオーバーライドする)したい場合に設定します。
+
+### `options.defineCoercion`
+
+特定のスキーマに対して[カスタム変換を定義](#カスタム変換を定義する)するために使用します。
+
+## 例
+
+```ts
+import { parseWithValibot, unstable_coerceFormValue as coerceFormValue } from '@conform-to/valibot';
+import { useForm } from '@conform-to/react';
+import { object, string, date, number, boolean } from 'valibot';
+import { jsonSchema } from './jsonSchema';
+
+const schema = coerceFormValue(
+  object({
+    ref: string()
+    date: date(),
+    amount: number(),
+    confirm: boolean(),
+  }),
+);
+
+function Example() {
+  const [form, fields] = useForm({
+    onValidate({ formData }) {
+      return parseWithValibot(formData, {
+        schema,
+        defaultTypeCoercion: false,
+      });
+    },
+  });
+
+  // ...
+}
+```
+
+## ヒント
+
+### デフォルトの動作をオーバーライドする
+
+オプションで `defaultCoercion` マッピングを指定することで、デフォルトの変換をオーバーライドできます。
+
+```ts
+const schema = coerceFormValue(
+  object({
+    // ...
+  }),
+  {
+    defaultCoercion: {
+      // `string()` のデフォルト変換をオーバーライドする
+      string: (value) => {
+        if (typeof value !== 'string') {
+          return value;
+        }
+
+        const result = value.trim();
+
+        // 値が空の場合は `undefined` として扱う
+        if (result === '') {
+          return undefined;
+        }
+
+        return result;
+      },
+
+      // `number()` のデフォルト変換をオーバーライドする
+      number: (value) => {
+        // 文字列でない場合はそのまま値を渡す
+        if (typeof value !== 'string') {
+          return value;
+        }
+
+        // 数値にキャストする前に、トリムしてカンマを削除する
+        return Number(value.trim().replace(/,/g, ''));
+      },
+
+      // `boolean()` の変換を無効にする
+      boolean: false,
+    },
+  },
+);
+```
+
+### デフォルト値
+
+`coerceFormValue` は常に空の値を `undefined` に変換します。デフォルト値が必要な場合は、`optional()` を使用して代わりに返されるフォールバック値を定義します。
+
+```ts
+const schema = object({
+  foo: optional(string()), // string | undefined
+  bar: optional(string(), ''), // string
+  baz: optional(nullable(optional()), null), // string | null
+});
+```
+
+### カスタム変換を定義する
+
+`defineCoercion` オプションを設定することで、特定のスキーマに対してカスタム変換を定義できます。
+
+```ts
+import {
+  parseWithValibot,
+  unstable_coerceFormValue as coerceFormValue,
+} from '@conform-to/valibot';
+import { useForm } from '@conform-to/react';
+import { object, string, number, boolean } from 'valibot';
+import { json } from './schema';
+
+const metadata = object({
+  number: number(),
+  confirmed: boolean(),
+});
+
+const schema = coerceFormValue(
+  object({
+    ref: string(),
+    metadata,
+  }),
+  {
+    defineCoercion(schema) {
+      // `metadata` フィールドの値がどのように変換されるかをカスタマイズする
+      if (schema === metadata) {
+        return (value) => {
+          if (typeof value !== 'string') {
+            return value;
+          }
+
+          // 値をJSONとしてパースする
+          return JSON.parse(value);
+        };
+      }
+
+      // デフォルトの動作を維持するために `null` を返す
+      return null;
+    },
+  },
+);
+```

--- a/docs/ja/api/valibot/coerceFormValue.md
+++ b/docs/ja/api/valibot/coerceFormValue.md
@@ -24,9 +24,9 @@ const enhancedSchema = coerceFormValue(schema, options);
 
 [デフォルトの動作をオーバーライド](#デフォルトの動作をオーバーライドする)したい場合に設定します。
 
-### `options.defineCoercion`
+### `options.customize`
 
-特定のスキーマに対して[カスタム変換を定義](#カスタム変換を定義する)するために使用します。
+特定のスキーマに対して[カスタム変換を定義する](#カスタム変換を定義する)するために使用します。
 
 ## 例
 
@@ -104,7 +104,7 @@ const schema = object({
 
 ### カスタム変換を定義する
 
-`defineCoercion` オプションを設定することで、特定のスキーマに対してカスタム変換を定義できます。
+`customize` オプションを設定することで、特定のスキーマに対してカスタム変換を定義できます。
 
 ```ts
 import {
@@ -126,7 +126,7 @@ const schema = coerceFormValue(
     metadata,
   }),
   {
-    defineCoercion(schema) {
+    customize(schema) {
       // `metadata` フィールドの値がどのように変換されるかをカスタマイズする
       if (schema === metadata) {
         return (value) => {

--- a/docs/ja/api/valibot/conformValibotMessage.md
+++ b/docs/ja/api/valibot/conformValibotMessage.md
@@ -1,0 +1,113 @@
+# conformValibotMessage
+
+検証動作を制御するためのカスタムメッセージのセットです。これは、フィールドの一つに対して非同期検証が必要な場合に便利です。
+
+## Options
+
+### `conformValibotMessage.VALIDATION_SKIPPED`
+
+このメッセージは、検証がスキップされ、 Conform が前回の結果を代わりに使用すべきであることを示すために使用されます。
+
+### `conformValibotMessage.VALIDATION_UNDEFINED`
+
+このメッセージは、検証が定義されていないことを示し、 Conform がサーバー検証にフォールバックすべきであることを示すために使用されます。
+
+## Example
+
+検証をスキップして、以前の結果を使用できます。クライアント検証では、検証が定義されていないことを示すことで、サーバー検証にフォールバックできます。
+
+```tsx
+import type { Intent } from '@conform-to/react';
+import { useForm } from '@conform-to/react';
+import { parseWithValibot, conformValibotMessage } from 'conform-to-valibot';
+import {
+  check,
+  forward,
+  forwardAsync,
+  object,
+  partialCheck,
+  partialCheckAsync,
+  pipe,
+  pipeAsync,
+  string,
+} from 'valibot';
+
+function createBaseSchema(intent: Intent | null) {
+  return object({
+    email: pipe(
+      string('Email is required'),
+      // メールアドレスを検証しない場合は、メールエラーをそのままにしておきます。
+      check(
+        () =>
+          intent === null ||
+          (intent.type === 'validate' && intent.payload.name === 'email'),
+        conformValibotMessage.VALIDATION_SKIPPED,
+      ),
+    ),
+    password: string('Password is required'),
+  });
+}
+
+function createServerSchema(
+  intent: Intent | null,
+  options: { isEmailUnique: (email: string) => Promise<boolean> },
+) {
+  return pipeAsync(
+    createBaseSchema(intent),
+    forwardAsync(
+      partialCheckAsync(
+        [['email']],
+        async ({ email }) => options.isEmailUnique(email),
+        'Email is already used',
+      ),
+      ['email'],
+    ),
+  );
+}
+
+function createClientSchema(intent: Intent | null) {
+  return pipe(
+    createBaseSchema(intent),
+    forward(
+      // メールアドレスが指定されている場合は、その一意性をチェックするためにサーバー検証にフォールバックします。
+      partialCheck(
+        [['email']],
+        () => false,
+        conformValibotMessage.VALIDATION_UNDEFINED,
+      ),
+      ['email'],
+    ),
+  );
+}
+
+export async function action({ request }) {
+  const formData = await request.formData();
+  const submission = await parseWithValibot(formData, {
+    schema: (intent) =>
+      createServerSchema(intent, {
+        isEmailUnique: async (email) => {
+          // データベースを参照して、メールアドレスが一意であるかどうかを確認します
+        },
+      }),
+  });
+
+  // ステータスが成功でない場合は、送信内容をクライアントに送り返します
+  if (submission.status !== 'success') {
+    return submission.reply();
+  }
+
+  // ...
+}
+
+function ExampleForm() {
+  const [form, { email, password }] = useForm({
+    onValidate({ formData }) {
+      return parseWithValibot(formData, {
+        schema: (intent) => createClientSchema(intent),
+      });
+    },
+  });
+
+  // ...
+}
+```

--- a/docs/ja/api/valibot/getValibodConstraint.md
+++ b/docs/ja/api/valibot/getValibodConstraint.md
@@ -1,0 +1,34 @@
+# getValibotConstraint
+
+Valibot スキーマを内省することにより、各フィールドの検証属性を含むオブジェクトを返すヘルパーです。
+
+```tsx
+const constraint = getValibotConstraint(schema);
+```
+
+## Parameters
+
+### `schema`
+
+イントロスペクトされる valibot スキーマ。
+
+## Example
+
+```tsx
+import { getValibotConstraint } from '@conform-to/valibot';
+import { useForm } from '@conform-to/react';
+import { object, pipe, string, minLength, optional } from 'valibot';
+
+const schema = object({
+  title: pipe(string(), minLength(5), maxLength(20)),
+  description: optional(pipe(string(), minLength(100), maxLength(1000))),
+});
+
+function Example() {
+  const [form, fields] = useForm({
+    constraint: getValibotConstraint(schema),
+  });
+
+  // ...
+}
+```

--- a/docs/ja/api/valibot/parseWithValibot.md
+++ b/docs/ja/api/valibot/parseWithValibot.md
@@ -1,0 +1,94 @@
+# parseWithValibot
+
+提供された valibot スキーマを使用してフォームデータを解析し、送信内容の概要を返すヘルパーです。
+
+```tsx
+const submission = parseWithValibot(payload, options);
+```
+
+## パラメータ
+
+### `payload`
+
+フォームの送信方法に応じて、 **FormData** オブジェクトまたは **URLSearchParams** オブジェクトのいずれかになります。
+
+### `options.schema`
+
+Valibot スキーマ、または Valibot スキーマを返す関数のいずれかです。
+
+### `options.info`
+
+フォームデータの解析時に使用される Valibot の[解析設定](<https://github.com/fabian-hiller/valibot/blob/main/website/src/routes/guides/(main-concepts)/parse-data/index.mdx#configuration>)および[言語の選択](<https://github.com/fabian-hiller/valibot/blob/main/website/src/routes/guides/(advanced)/internationalization/index.mdx#select-language>) を指定します。
+
+### `options.disableAutoCoercion`
+
+[自動強制変換](#自動強制変換)を無効にして、フォームデータの解析方法を自分で管理する場合は、**true** に設定します。
+
+## 例
+
+```tsx
+import { parseWithValibot } from '@conform-to/valibot';
+import { useForm } from '@conform-to/react';
+import { pipe, string, email, object } from 'valibot';
+
+const schema = object({
+  email: pipe(string(), email()),
+  password: string(),
+});
+
+function Example() {
+  const [form, fields] = useForm({
+    onValidate({ formData }) {
+      return parseWithValibot(formData, { schema });
+    },
+  });
+
+  // ...
+}
+```
+
+## ヒント
+
+### 自動強制変換
+
+デフォルトでは、`parseWithValibot` は空の値を削除し、スキーマをイントロスペクトしてフォームの値を正しい型に強制し、内部的に [coerceFormValue](./coerceFormValue) ヘルパーを使用して追加の前処理ステップを挿入します。
+
+この動作をカスタマイズする場合は、`options.disableAutoCoercion` を `true` に設定して自動強制変換を無効にし、自分で管理できます。
+
+```tsx
+import { parseWithValibot } from '@conform-to/valibot';
+import { useForm } from '@conform-to/react';
+import { pipe, object, transform, unknown, number } from 'valibot';
+
+const schema = object({
+  // 空の値を削除し、自分で数値を強制します
+  amount: pipe(
+    unknown(),
+    transform((value) => {
+      if (typeof value !== 'string') {
+        return value;
+      }
+
+      if (value === '') {
+        return undefined;
+      }
+
+      return Number(value.trim().replace(/,/g, ''));
+    }),
+    number(),
+  ),
+});
+
+function Example() {
+  const [form, fields] = useForm({
+    onValidate({ formData }) {
+      return parseWithValibot(formData, {
+        schema,
+        disableAutoCoercion: true,
+      });
+    },
+  });
+
+  // ...
+}
+```

--- a/guide/app/layout.tsx
+++ b/guide/app/layout.tsx
@@ -70,6 +70,21 @@ const menus: { [code: string]: Menu[] } = {
 			],
 		},
 		{
+			title: 'Valibot Schema',
+			links: [
+				{ title: 'parseWithValibot', to: '/api/valibot/parseWithValibot' },
+				{ title: 'coerceFormValue', to: '/api/valibot/coerceFormValue' },
+				{
+					title: 'getValibotConstraint',
+					to: '/api/valibot/getValibotConstraint',
+				},
+				{
+					title: 'conformValibotMessage',
+					to: '/api/valibot/conformValibotMessage',
+				},
+			],
+		},
+		{
 			title: 'Yup Schema',
 			links: [
 				{ title: 'parseWithYup', to: '/api/yup/parseWithYup' },
@@ -138,6 +153,21 @@ const menus: { [code: string]: Menu[] } = {
 				{ title: 'coerceFormValue', to: '/api/zod/coerceFormValue' },
 				{ title: 'getZodConstraint', to: '/api/zod/getZodConstraint' },
 				{ title: 'conformZodMessage', to: '/api/zod/conformZodMessage' },
+			],
+		},
+		{
+			title: 'Valibot スキーマ',
+			links: [
+				{ title: 'parseWithValibot', to: '/api/valibot/parseWithValibot' },
+				{ title: 'coerceFormValue', to: '/api/valibot/coerceFormValue' },
+				{
+					title: 'getValibotConstraint',
+					to: '/api/valibot/getValibotConstraint',
+				},
+				{
+					title: 'conformValibotMessage',
+					to: '/api/valibot/conformValibotMessage',
+				},
 			],
 		},
 		{

--- a/packages/conform-valibot/.gitignore
+++ b/packages/conform-valibot/.gitignore
@@ -1,0 +1,2 @@
+dist
+README

--- a/packages/conform-valibot/.npmignore
+++ b/packages/conform-valibot/.npmignore
@@ -1,0 +1,9 @@
+# ignore all .ts, .tsx files except .d.ts
+*.ts
+*.tsx
+!*.d.ts
+
+# config / build result
+rollup.config.js
+tsconfig.json
+**/*.tsbuildinfo

--- a/packages/conform-valibot/coercion.ts
+++ b/packages/conform-valibot/coercion.ts
@@ -92,7 +92,7 @@ function coerceNumber(value: unknown) {
 		return value;
 	}
 
-	return value.trim() === '' ? undefined : Number(value);
+	return value === '' ? undefined : Number(value);
 }
 
 /**
@@ -133,7 +133,7 @@ function coerceBigInt(value: unknown) {
 		return value;
 	}
 
-	if (value.trim() === '') {
+	if (value === '') {
 		return undefined;
 	}
 

--- a/packages/conform-valibot/coercion.ts
+++ b/packages/conform-valibot/coercion.ts
@@ -206,15 +206,15 @@ function generateWrappedSchema<T extends GenericSchema | GenericSchemaAsync>(
 		options,
 	);
 
+	// `expects` is required to generate error messages for `TupleSchema`, so it is passed to `UnkonwSchema` for coercion.
+	const unknown = { ...valibotUnknown(), expects: type.expects };
 	if (transformAction) {
-		// `expects` is required to generate error messages for `TupleSchema`, so it is passed to `UnkonwSchema` for coercion.
-		const unknown = { ...valibotUnknown(), expects: type.expects };
 		const schema = type.async
 			? pipeAsync(unknown, transformAction, type)
 			: pipe(unknown, transformAction, type);
 
-		const default_ = 'default' in type ? type.default : undefined;
 		if (rewrap) {
+			const default_ = 'default' in type ? type.default : undefined;
 			return {
 				transformAction: undefined,
 				schema: type.reference(schema, default_),
@@ -228,10 +228,14 @@ function generateWrappedSchema<T extends GenericSchema | GenericSchemaAsync>(
 		...type,
 		wrapped: wrapSchema,
 	};
+	const transformActionForStripEmptyString = vTransform(stripEmptyString);
+	const schema = wrappedSchema.async
+		? pipeAsync(unknown, transformActionForStripEmptyString, wrappedSchema)
+		: pipe(unknown, transformActionForStripEmptyString, wrappedSchema);
 
 	return {
 		transformAction: undefined,
-		schema: wrappedSchema,
+		schema,
 	};
 }
 

--- a/packages/conform-valibot/coercion.ts
+++ b/packages/conform-valibot/coercion.ts
@@ -24,7 +24,7 @@ export type DefaultCoercionType =
 
 type EnableTypeCoercionOptions = {
 	defaultCoercion: Record<DefaultCoercionType, CoercionFunction>;
-	defineCoercion: (
+	customize: (
 		type: GenericSchema | GenericSchemaAsync,
 	) => CoercionFunction | null;
 };
@@ -280,10 +280,10 @@ function enableTypeCoercion<T extends GenericSchema | GenericSchemaAsync>(
 		return { transformAction, schema };
 	}
 
-	const defineCoercionFn = options.defineCoercion(type);
+	const customizeFn = options.customize(type);
 
-	if (defineCoercionFn) {
-		return coerce(type, defineCoercionFn);
+	if (customizeFn) {
+		return coerce(type, customizeFn);
 	}
 
 	switch (type.type) {
@@ -479,7 +479,7 @@ function enableTypeCoercion<T extends GenericSchema | GenericSchemaAsync>(
  *     defaultCoercion: {
  *       number: false,
  *     },
- *     defineCoercion: (schema) => {
+ *     customize: (schema) => {
  *       if (schema.type === 'string') {
  *         return (value) => value.trim();
  *       }
@@ -495,7 +495,7 @@ export function coerceFormValue<T extends GenericSchema | GenericSchemaAsync>(
 		defaultCoercion?: {
 			[key in DefaultCoercionType]?: CoercionFunction | boolean;
 		};
-		defineCoercion?: (
+		customize?: (
 			type: GenericSchema | GenericSchemaAsync,
 		) => CoercionFunction | null;
 	},
@@ -527,7 +527,7 @@ export function coerceFormValue<T extends GenericSchema | GenericSchemaAsync>(
 				getCoercion(options?.defaultCoercion?.bigint, coerceBigInt),
 			),
 		},
-		defineCoercion: options?.defineCoercion ?? (() => null),
+		customize: options?.customize ?? (() => null),
 	}).schema;
 }
 

--- a/packages/conform-valibot/coercion.ts
+++ b/packages/conform-valibot/coercion.ts
@@ -432,7 +432,7 @@ function enableTypeCoercion<T extends GenericSchema | GenericSchemaAsync>(
 		}
 	}
 
-	return coerce(type, options.defaultCoercion.string);
+	return coerce(type, (value) => value);
 }
 
 /**

--- a/packages/conform-valibot/coercion.ts
+++ b/packages/conform-valibot/coercion.ts
@@ -1,0 +1,370 @@
+import {
+	type BaseIssue,
+	type GenericSchema,
+	type GenericSchemaAsync,
+	type PipeItem,
+	type SchemaWithPipe,
+	type SchemaWithPipeAsync,
+	type TransformAction,
+	pipe,
+	pipeAsync,
+	transform as vTransform,
+	unknown as valibotUnknown,
+} from 'valibot';
+
+/**
+ * Helpers for coercing string value
+ * Modify the value only if it's a string, otherwise return the value as-is
+ */
+export function coerceString(
+	value: unknown,
+	transform?: (text: string) => unknown,
+) {
+	if (typeof value !== 'string') {
+		return value;
+	}
+
+	if (value === '') {
+		return undefined;
+	}
+
+	if (typeof transform !== 'function') {
+		return value;
+	}
+
+	try {
+		return transform(value);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Reconstruct the provided schema with additional preprocessing steps
+ * This coerce empty values to undefined and transform strings to the correct type
+ * @param type The schema to be coerced
+ * @param transform The transformation function
+ * @returns The transform action and the coerced schema
+ */
+function coerce<T extends GenericSchema | GenericSchemaAsync>(
+	type: T,
+	transform?: (text: string) => unknown,
+) {
+	// `expects` is required to generate error messages for `TupleSchema`, so it is passed to `UnkonwSchema` for coercion.
+	const unknown = { ...valibotUnknown(), expects: type.expects };
+	const transformAction = vTransform((output: unknown) =>
+		type.type === 'blob' || type.type === 'file'
+			? coerceFile(output)
+			: coerceString(output, transform),
+	);
+	const schema = type.async
+		? pipeAsync(unknown, transformAction, type)
+		: pipe(unknown, transformAction, type);
+
+	return { transformAction, schema };
+}
+
+/**
+ * Helpers for coercing array value
+ * Modify the value only if it's an array, otherwise return the value as-is
+ */
+function coerceArray<T extends GenericSchema | GenericSchemaAsync>(type: T) {
+	// `expects` is required to generate error messages for `TupleSchema`, so it is passed to `UnkonwSchema` for coercion.
+	const unknown = { ...valibotUnknown(), expects: type.expects };
+	const transformFunction = (output: unknown): unknown => {
+		if (Array.isArray(output)) {
+			return output;
+		}
+
+		if (
+			typeof output === 'undefined' ||
+			typeof coerceFile(coerceString(output)) === 'undefined'
+		) {
+			return [];
+		}
+
+		return [output];
+	};
+
+	if (type.async) {
+		return pipeAsync(unknown, vTransform(transformFunction), type);
+	}
+
+	return pipe(unknown, vTransform(transformFunction), type);
+}
+
+/**
+ * Helpers for coercing file
+ * Modify the value only if it's a file, otherwise return the value as-is
+ */
+function coerceFile(file: unknown) {
+	if (
+		typeof File !== 'undefined' &&
+		file instanceof File &&
+		file.name === '' &&
+		file.size === 0
+	) {
+		return undefined;
+	}
+
+	return file;
+}
+
+/**
+ * Generate a wrapped schema with coercion
+ * @param type The schema to be coerced
+ * @param rewrap Whether the result schema should be rewrapped with the `type` schema.
+ *   See <https://github.com/chimame/conform-to-valibot/issues/53> for cases that need rewrapping.
+ * @returns The coerced schema
+ */
+function generateWrappedSchema<T extends GenericSchema | GenericSchemaAsync>(
+	type: T,
+	rewrap = false,
+) {
+	const { transformAction, schema: wrapSchema } = enableTypeCoercion(
+		// @ts-expect-error
+		type.wrapped,
+	);
+
+	if (transformAction) {
+		// `expects` is required to generate error messages for `TupleSchema`, so it is passed to `UnkonwSchema` for coercion.
+		const unknown = { ...valibotUnknown(), expects: type.expects };
+		const schema = type.async
+			? pipeAsync(unknown, transformAction, type)
+			: pipe(unknown, transformAction, type);
+
+		const default_ = 'default' in type ? type.default : undefined;
+		if (rewrap) {
+			return {
+				transformAction: undefined,
+				schema: type.reference(schema, default_),
+			};
+		}
+
+		return { transformAction, schema };
+	}
+
+	const wrappedSchema = {
+		...type,
+		wrapped: wrapSchema,
+	};
+
+	return {
+		transformAction: undefined,
+		schema: wrappedSchema,
+	};
+}
+
+/**
+ * Reconstruct the provided schema with additional preprocessing steps
+ * This coerce empty values to undefined and transform strings to the correct type
+ */
+export function enableTypeCoercion<
+	T extends GenericSchema | GenericSchemaAsync,
+>(
+	type: T,
+): {
+	transformAction: TransformAction<unknown, unknown> | undefined;
+	// If we use just `T` for type of `schema`, `enabltTypeCoercion<GenericSchema<string, string>>` will return
+	// `GenericSchema<string, string>`. However, we want it to return `GenericSchema<unknown, string>`.
+	schema: T extends GenericSchema<unknown, infer Output, infer Issue>
+		? GenericSchema<unknown, Output, Issue>
+		: T extends GenericSchemaAsync<unknown, infer OutputAsync, infer IssueAsync>
+			? GenericSchemaAsync<unknown, OutputAsync, IssueAsync>
+			: never;
+};
+export function enableTypeCoercion<
+	T extends GenericSchema | GenericSchemaAsync,
+>(
+	type:
+		| T
+		| (T extends GenericSchema
+				? SchemaWithPipe<
+						[T, ...PipeItem<unknown, unknown, BaseIssue<unknown>>[]]
+					>
+				: SchemaWithPipeAsync<
+						[T, ...PipeItem<unknown, unknown, BaseIssue<unknown>>[]]
+					>),
+): {
+	transformAction: TransformAction<unknown, unknown> | undefined;
+	schema: GenericSchema | GenericSchemaAsync;
+} {
+	if ('pipe' in type) {
+		const { transformAction, schema: coercedSchema } = enableTypeCoercion(
+			type.pipe[0],
+		);
+		const schema = type.async
+			? pipeAsync(coercedSchema, ...type.pipe.slice(1))
+			: // @ts-expect-error `coercedSchema` must be sync here but TypeScript can't infer that.
+				pipe(coercedSchema, ...type.pipe.slice(1));
+
+		return { transformAction, schema };
+	}
+
+	switch (type.type) {
+		case 'string':
+		case 'literal':
+		case 'enum':
+		case 'undefined': {
+			return coerce(type);
+		}
+		case 'number': {
+			return coerce(type, Number);
+		}
+		case 'boolean': {
+			return coerce(type, (text) => (text === 'on' ? true : text));
+		}
+		case 'date': {
+			return coerce(type, (timestamp) => {
+				const date = new Date(timestamp);
+				if (Number.isNaN(date.getTime())) {
+					return timestamp;
+				}
+
+				return date;
+			});
+		}
+		case 'bigint': {
+			return coerce(type, BigInt);
+		}
+		case 'file':
+		case 'blob': {
+			return coerce(type);
+		}
+		case 'array': {
+			const arraySchema = {
+				...type,
+				// @ts-expect-error
+				item: enableTypeCoercion(type.item).schema,
+			};
+			return {
+				transformAction: undefined,
+				schema: coerceArray(arraySchema),
+			};
+		}
+		case 'exact_optional': {
+			// @ts-expect-error
+			const { schema: wrapSchema } = enableTypeCoercion(type.wrapped);
+
+			const exactOptionalSchema = {
+				...type,
+				wrapped: wrapSchema,
+			};
+
+			return {
+				transformAction: undefined,
+				schema: exactOptionalSchema,
+			};
+		}
+		case 'nullish':
+		case 'optional': {
+			return generateWrappedSchema(type, true);
+		}
+		case 'undefinedable':
+		case 'nullable':
+		case 'non_optional':
+		case 'non_nullish':
+		case 'non_nullable': {
+			return generateWrappedSchema(type);
+		}
+		case 'union':
+		case 'intersect': {
+			const unionSchema = {
+				...type,
+				// @ts-expect-error
+				options: type.options.map(
+					// @ts-expect-error
+					(option) => enableTypeCoercion(option as GenericSchema).schema,
+				),
+			};
+			return {
+				transformAction: undefined,
+				schema: unionSchema,
+			};
+		}
+		case 'variant': {
+			const variantSchema = {
+				...type,
+				// @ts-expect-error
+				options: type.options.map(
+					// @ts-expect-error
+					(option) => enableTypeCoercion(option as GenericSchema).schema,
+				),
+			};
+			return {
+				transformAction: undefined,
+				schema: variantSchema,
+			};
+		}
+		case 'tuple': {
+			const tupleSchema = {
+				...type,
+				// @ts-expect-error
+				items: type.items.map(
+					// @ts-expect-error
+					(option) => enableTypeCoercion(option).schema,
+				),
+			};
+			return {
+				transformAction: undefined,
+				schema: tupleSchema,
+			};
+		}
+		case 'tuple_with_rest': {
+			const tupleWithRestSchema = {
+				...type,
+				// @ts-expect-error
+				items: type.items.map(
+					// @ts-expect-error
+					(option) => enableTypeCoercion(option).schema,
+				),
+				// @ts-expect-error
+				rest: enableTypeCoercion(type.rest).schema,
+			};
+			return {
+				transformAction: undefined,
+				schema: tupleWithRestSchema,
+			};
+		}
+		case 'loose_object':
+		case 'strict_object':
+		case 'object': {
+			const objectSchema = {
+				...type,
+				entries: Object.fromEntries(
+					// @ts-expect-error
+					Object.entries(type.entries).map(([key, def]) => [
+						key,
+						enableTypeCoercion(def as GenericSchema).schema,
+					]),
+				),
+			};
+
+			return {
+				transformAction: undefined,
+				schema: objectSchema,
+			};
+		}
+		case 'object_with_rest': {
+			const objectWithRestSchema = {
+				...type,
+				entries: Object.fromEntries(
+					// @ts-expect-error
+					Object.entries(type.entries).map(([key, def]) => [
+						key,
+						enableTypeCoercion(def as GenericSchema).schema,
+					]),
+				),
+				// @ts-expect-error
+				rest: enableTypeCoercion(type.rest).schema,
+			};
+
+			return {
+				transformAction: undefined,
+				schema: objectWithRestSchema,
+			};
+		}
+	}
+
+	return coerce(type);
+}

--- a/packages/conform-valibot/coercion.ts
+++ b/packages/conform-valibot/coercion.ts
@@ -499,7 +499,7 @@ export function coerceFormValue<T extends GenericSchema | GenericSchemaAsync>(
 			type: GenericSchema | GenericSchemaAsync,
 		) => CoercionFunction | null;
 	},
-): ReturnType<typeof enableTypeCoercion> {
+): T extends GenericSchema ? GenericSchema : GenericSchemaAsync {
 	return enableTypeCoercion(type, {
 		defaultCoercion: {
 			string: compose(
@@ -528,7 +528,7 @@ export function coerceFormValue<T extends GenericSchema | GenericSchemaAsync>(
 			),
 		},
 		defineCoercion: options?.defineCoercion ?? (() => null),
-	});
+	}).schema;
 }
 
 /**

--- a/packages/conform-valibot/constraint.ts
+++ b/packages/conform-valibot/constraint.ts
@@ -1,0 +1,172 @@
+import type { Constraint } from '@conform-to/dom';
+import type { GenericSchema, GenericSchemaAsync } from 'valibot';
+
+const keys: Array<keyof Constraint> = [
+	'required',
+	'minLength',
+	'maxLength',
+	'min',
+	'max',
+	'step',
+	'multiple',
+	'pattern',
+];
+
+export function getValibotConstraint<
+	T extends GenericSchema | GenericSchemaAsync,
+>(schema: T): Record<string, Constraint> {
+	function updateConstraint(
+		schema: T,
+
+		data: Record<string, Constraint>,
+		name = '',
+	): void {
+		if (name !== '' && !data[name]) {
+			data[name] = { required: true };
+		}
+		const constraint = name !== '' ? (data[name] as Constraint) : {};
+
+		if (schema.type === 'object') {
+			// @ts-expect-error
+			for (const key in schema.entries) {
+				updateConstraint(
+					// @ts-expect-error
+					schema.entries[key],
+					data,
+					name ? `${name}.${key}` : key,
+				);
+			}
+		} else if (schema.type === 'intersect') {
+			// @ts-expect-error
+			for (const option of schema.options) {
+				const result: Record<string, Constraint> = {};
+				updateConstraint(option, result, name);
+
+				Object.assign(data, result);
+			}
+		} else if (schema.type === 'union' || schema.type === 'variant') {
+			Object.assign(
+				data,
+				// @ts-expect-error
+				schema.options
+					// @ts-expect-error
+					.map((option) => {
+						const result: Record<string, Constraint> = {};
+
+						updateConstraint(option, result, name);
+
+						return result;
+					})
+					// @ts-expect-error
+					.reduce((prev, next) => {
+						const list = new Set([...Object.keys(prev), ...Object.keys(next)]);
+						const result: Record<string, Constraint> = {};
+
+						for (const name of list) {
+							const prevConstraint = prev[name];
+							const nextConstraint = next[name];
+
+							if (prevConstraint && nextConstraint) {
+								const constraint: Constraint = {};
+
+								result[name] = constraint;
+
+								for (const key of keys) {
+									if (
+										typeof prevConstraint[key] !== 'undefined' &&
+										typeof nextConstraint[key] !== 'undefined' &&
+										prevConstraint[key] === nextConstraint[key]
+									) {
+										constraint[key] = prevConstraint[key];
+									}
+								}
+							} else {
+								result[name] = {
+									...prevConstraint,
+									...nextConstraint,
+									required: false,
+								};
+							}
+						}
+
+						return result;
+					}),
+			);
+		} else if (name === '') {
+			// All the cases below are not allowed on root
+			throw new Error('Unsupported schema');
+		} else if (schema.type === 'array') {
+			constraint.multiple = true;
+			// @ts-expect-error
+			updateConstraint(schema.item, data, `${name}[]`);
+		} else if (schema.type === 'string') {
+			// @ts-expect-error
+			const minLength = schema.pipe?.find(
+				// @ts-expect-error
+				(v) => 'type' in v && v.type === 'min_length',
+			);
+			if (minLength && 'requirement' in minLength) {
+				constraint.minLength = minLength.requirement as number;
+			}
+			// @ts-expect-error
+			const maxLength = schema.pipe?.find(
+				// @ts-expect-error
+				(v) => 'type' in v && v.type === 'max_length',
+			);
+			if (maxLength && 'requirement' in maxLength) {
+				constraint.maxLength = maxLength.requirement as number;
+			}
+		} else if (schema.type === 'optional') {
+			constraint.required = false;
+			// @ts-expect-error
+			updateConstraint(schema.wrapped, data, name);
+		} else if (schema.type === 'nullish') {
+			constraint.required = false;
+			// @ts-expect-error
+			updateConstraint(schema.wrapped, data, name);
+		} else if (schema.type === 'number') {
+			// @ts-expect-error
+			const minValue = schema.pipe?.find(
+				// @ts-expect-error
+				(v) => 'type' in v && v.type === 'min_value',
+			);
+			if (minValue && 'requirement' in minValue) {
+				constraint.min = minValue.requirement as number;
+			}
+			// @ts-expect-error
+			const maxValue = schema.pipe?.find(
+				// @ts-expect-error
+				(v) => 'type' in v && v.type === 'max_value',
+			);
+			if (maxValue && 'requirement' in maxValue) {
+				constraint.max = maxValue.requirement as number;
+			}
+		} else if (schema.type === 'enum') {
+			// @ts-expect-error
+			constraint.pattern = Object.entries(schema.enum)
+				.map(([, option]) =>
+					// To escape unsafe characters on regex
+					typeof option === 'string'
+						? option
+								.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
+								.replace(/-/g, '\\x2d')
+						: option,
+				)
+				.join('|');
+		} else if (schema.type === 'tuple') {
+			// @ts-expect-error
+			for (let i = 0; i < schema.items.length; i++) {
+				// @ts-expect-error
+				updateConstraint(schema.items[i], data, `${name}[${i}]`);
+			}
+		} else {
+			// FIXME: If you are interested in this, feel free to create a PR
+		}
+	}
+
+	const result: Record<string, Constraint> = {};
+
+	updateConstraint(schema, result);
+
+	return result;
+}

--- a/packages/conform-valibot/constraint.ts
+++ b/packages/conform-valibot/constraint.ts
@@ -26,14 +26,19 @@ export function getValibotConstraint<
 		}
 		const constraint = name !== '' ? (data[name] as Constraint) : {};
 
-		if (schema.type === 'object') {
+		if (
+			schema.type === 'object' ||
+			schema.type === 'object_with_rest' ||
+			schema.type === 'strict_object' ||
+			schema.type === 'loose_object'
+		) {
 			// @ts-expect-error
 			for (const key in schema.entries) {
 				updateConstraint(
 					// @ts-expect-error
 					schema.entries[key],
 					data,
-					name ? `${name}.${key}` : key,
+					name !== '' ? `${name}.${key}` : key,
 				);
 			}
 		} else if (schema.type === 'intersect') {
@@ -116,15 +121,15 @@ export function getValibotConstraint<
 			if (maxLength && 'requirement' in maxLength) {
 				constraint.maxLength = maxLength.requirement as number;
 			}
-		} else if (schema.type === 'optional') {
+		} else if (
+			schema.type === 'optional' ||
+			schema.type === 'nullish' ||
+			schema.type === 'exact_optional'
+		) {
 			constraint.required = false;
 			// @ts-expect-error
 			updateConstraint(schema.wrapped, data, name);
-		} else if (schema.type === 'nullish') {
-			constraint.required = false;
-			// @ts-expect-error
-			updateConstraint(schema.wrapped, data, name);
-		} else if (schema.type === 'number') {
+		} else if (schema.type === 'number' || schema.type === 'bigint') {
 			// @ts-expect-error
 			const minValue = schema.pipe?.find(
 				// @ts-expect-error
@@ -153,7 +158,7 @@ export function getValibotConstraint<
 						: option,
 				)
 				.join('|');
-		} else if (schema.type === 'tuple') {
+		} else if (schema.type === 'tuple' || schema.type === 'tuple_with_rest') {
 			// @ts-expect-error
 			for (let i = 0; i < schema.items.length; i++) {
 				// @ts-expect-error

--- a/packages/conform-valibot/index.ts
+++ b/packages/conform-valibot/index.ts
@@ -1,0 +1,2 @@
+export { getValibotConstraint } from './constraint';
+export { conformValibotMessage, parseWithValibot } from './parse';

--- a/packages/conform-valibot/index.ts
+++ b/packages/conform-valibot/index.ts
@@ -1,2 +1,6 @@
 export { getValibotConstraint } from './constraint';
 export { conformValibotMessage, parseWithValibot } from './parse';
+export {
+	coerceFormValue as unstable_coerceFormValue,
+	type CoercionFunction,
+} from './coercion';

--- a/packages/conform-valibot/package.json
+++ b/packages/conform-valibot/package.json
@@ -1,0 +1,66 @@
+{
+	"name": "@conform-to/valibot",
+	"description": "Conform helpers for integrating with Valibot",
+	"homepage": "https://conform.guide",
+	"license": "MIT",
+	"version": "1.2.2",
+	"main": "./dist/index.js",
+	"module": "./dist/index.mjs",
+	"types": "./dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"module": "./dist/index.mjs",
+			"import": "./dist/index.mjs",
+			"require": "./dist/index.js",
+			"default": "./dist/index.mjs"
+		}
+	},
+	"scripts": {
+		"build:js": "rollup -c",
+		"build:ts": "tsc --project ./tsconfig.build.json",
+		"build": "pnpm run \"/^build:.*/\"",
+		"dev:js": "pnpm run build:js --watch",
+		"dev:ts": "pnpm run build:ts --watch",
+		"dev": "pnpm run \"/^dev:.*/\"",
+		"test": "vitest",
+		"prepare": "pnpm run build"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/edmundhung/conform",
+		"directory": "packages/conform-zod"
+	},
+	"bugs": {
+		"url": "https://github.com/edmundhung/conform/issues"
+	},
+	"dependencies": {
+		"@conform-to/dom": "workspace:*"
+	},
+	"peerDependencies": {
+		"valibot": ">= 0.32.0"
+	},
+	"devDependencies": {
+		"@babel/core": "^7.17.8",
+		"@babel/preset-env": "^7.20.2",
+		"@babel/preset-typescript": "^7.20.2",
+		"@rollup/plugin-babel": "^5.3.1",
+		"@rollup/plugin-node-resolve": "^13.3.0",
+		"rollup-plugin-copy": "^3.4.0",
+		"rollup": "^2.79.1",
+		"valibot": "^1.0.0-rc.3"
+	},
+	"keywords": [
+		"constraint-validation",
+		"form",
+		"form-validation",
+		"html",
+		"progressive-enhancement",
+		"validation",
+		"valibot"
+	],
+	"sideEffects": false
+}

--- a/packages/conform-valibot/package.json
+++ b/packages/conform-valibot/package.json
@@ -3,7 +3,7 @@
 	"description": "Conform helpers for integrating with Valibot",
 	"homepage": "https://conform.guide",
 	"license": "MIT",
-	"version": "1.2.2",
+	"version": "0.0.0",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",

--- a/packages/conform-valibot/package.json
+++ b/packages/conform-valibot/package.json
@@ -51,7 +51,7 @@
 		"@rollup/plugin-node-resolve": "^13.3.0",
 		"rollup-plugin-copy": "^3.4.0",
 		"rollup": "^2.79.1",
-		"valibot": "^1.0.0-rc.3"
+		"valibot": "^1.0.0"
 	},
 	"keywords": [
 		"constraint-validation",

--- a/packages/conform-valibot/package.json
+++ b/packages/conform-valibot/package.json
@@ -38,7 +38,7 @@
 		"url": "https://github.com/edmundhung/conform/issues"
 	},
 	"dependencies": {
-		"@conform-to/dom": "workspace:*"
+		"@conform-to/dom": "workspace:^"
 	},
 	"peerDependencies": {
 		"valibot": ">= 0.32.0"

--- a/packages/conform-valibot/package.json
+++ b/packages/conform-valibot/package.json
@@ -32,7 +32,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/edmundhung/conform",
-		"directory": "packages/conform-zod"
+		"directory": "packages/conform-valibot"
 	},
 	"bugs": {
 		"url": "https://github.com/edmundhung/conform/issues"
@@ -41,7 +41,7 @@
 		"@conform-to/dom": "workspace:*"
 	},
 	"peerDependencies": {
-		"valibot": ">= 0.32.0"
+		"valibot": ">= 1.0.0-rc.3"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.17.8",

--- a/packages/conform-valibot/package.json
+++ b/packages/conform-valibot/package.json
@@ -41,7 +41,7 @@
 		"@conform-to/dom": "workspace:*"
 	},
 	"peerDependencies": {
-		"valibot": ">= 1.0.0-rc.3"
+		"valibot": ">= 0.32.0"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.17.8",

--- a/packages/conform-valibot/parse.ts
+++ b/packages/conform-valibot/parse.ts
@@ -66,7 +66,7 @@ export function parseWithValibot<
 					: config.schema;
 			const schema = config.disableAutoCoercion
 				? baseSchema
-				: coerceFormValue(baseSchema).schema;
+				: coerceFormValue(baseSchema);
 
 			const resolveResult = (
 				result: SafeParseResult<Schema>,

--- a/packages/conform-valibot/parse.ts
+++ b/packages/conform-valibot/parse.ts
@@ -14,7 +14,7 @@ import {
 	safeParse,
 	safeParseAsync,
 } from 'valibot';
-import { enableTypeCoercion } from './coercion';
+import { coerceFormValue } from './coercion';
 
 export const conformValibotMessage = {
 	VALIDATION_SKIPPED: '__skipped__',
@@ -27,6 +27,7 @@ export function parseWithValibot<Schema extends GenericSchema>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: Intent | null) => Schema);
+		disableAutoCoercion?: boolean;
 		info?: Pick<
 			Config<BaseIssue<unknown>>,
 			'abortEarly' | 'abortPipeEarly' | 'lang'
@@ -37,6 +38,7 @@ export function parseWithValibot<Schema extends GenericSchemaAsync>(
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: Intent | null) => Schema);
+		disableAutoCoercion?: boolean;
 		info?: Pick<
 			Config<BaseIssue<unknown>>,
 			'abortEarly' | 'abortPipeEarly' | 'lang'
@@ -49,6 +51,7 @@ export function parseWithValibot<
 	payload: FormData | URLSearchParams,
 	config: {
 		schema: Schema | ((intent: Intent | null) => Schema);
+		disableAutoCoercion?: boolean;
 		info?: Pick<
 			Config<BaseIssue<unknown>>,
 			'abortEarly' | 'abortPipeEarly' | 'lang'
@@ -57,11 +60,13 @@ export function parseWithValibot<
 ): Submission<InferOutput<Schema>> | Promise<Submission<InferOutput<Schema>>> {
 	return baseParse<InferOutput<Schema>, string[]>(payload, {
 		resolve(payload, intent) {
-			const originalSchema =
+			const baseSchema =
 				typeof config.schema === 'function'
 					? config.schema(intent)
 					: config.schema;
-			const { schema } = enableTypeCoercion(originalSchema);
+			const schema = config.disableAutoCoercion
+				? baseSchema
+				: coerceFormValue(baseSchema).schema;
 
 			const resolveResult = (
 				result: SafeParseResult<Schema>,

--- a/packages/conform-valibot/parse.ts
+++ b/packages/conform-valibot/parse.ts
@@ -1,0 +1,106 @@
+import {
+	type Intent,
+	type Submission,
+	parse as baseParse,
+	formatPaths,
+} from '@conform-to/dom';
+import {
+	type BaseIssue,
+	type Config,
+	type GenericSchema,
+	type GenericSchemaAsync,
+	type InferOutput,
+	type SafeParseResult,
+	safeParse,
+	safeParseAsync,
+} from 'valibot';
+import { enableTypeCoercion } from './coercion';
+
+export const conformValibotMessage = {
+	VALIDATION_SKIPPED: '__skipped__',
+	VALIDATION_UNDEFINED: '__undefined__',
+};
+
+type ErrorType = Record<string, string[] | null> | null;
+
+export function parseWithValibot<Schema extends GenericSchema>(
+	payload: FormData | URLSearchParams,
+	config: {
+		schema: Schema | ((intent: Intent | null) => Schema);
+		info?: Pick<
+			Config<BaseIssue<unknown>>,
+			'abortEarly' | 'abortPipeEarly' | 'lang'
+		>;
+	},
+): Submission<InferOutput<Schema>>;
+export function parseWithValibot<Schema extends GenericSchemaAsync>(
+	payload: FormData | URLSearchParams,
+	config: {
+		schema: Schema | ((intent: Intent | null) => Schema);
+		info?: Pick<
+			Config<BaseIssue<unknown>>,
+			'abortEarly' | 'abortPipeEarly' | 'lang'
+		>;
+	},
+): Promise<Submission<InferOutput<Schema>>>;
+export function parseWithValibot<
+	Schema extends GenericSchema | GenericSchemaAsync,
+>(
+	payload: FormData | URLSearchParams,
+	config: {
+		schema: Schema | ((intent: Intent | null) => Schema);
+		info?: Pick<
+			Config<BaseIssue<unknown>>,
+			'abortEarly' | 'abortPipeEarly' | 'lang'
+		>;
+	},
+): Submission<InferOutput<Schema>> | Promise<Submission<InferOutput<Schema>>> {
+	return baseParse<InferOutput<Schema>, string[]>(payload, {
+		resolve(payload, intent) {
+			const originalSchema =
+				typeof config.schema === 'function'
+					? config.schema(intent)
+					: config.schema;
+			const { schema } = enableTypeCoercion(originalSchema);
+
+			const resolveResult = (
+				result: SafeParseResult<Schema>,
+			): { value: InferOutput<Schema> } | { error: ErrorType } => {
+				if (result.success) {
+					return {
+						value: result.output,
+					};
+				}
+
+				return {
+					error: result.issues.reduce<ErrorType>((result, e) => {
+						if (
+							result === null ||
+							e.message === conformValibotMessage.VALIDATION_UNDEFINED
+						) {
+							return null;
+						}
+
+						const name = formatPaths(
+							e.path?.map((d) => d.key as string | number) ?? [],
+						);
+
+						result[name] =
+							result[name] === null ||
+							e.message === conformValibotMessage.VALIDATION_SKIPPED
+								? null
+								: [...(result[name] ?? []), e.message];
+
+						return result;
+					}, {}),
+				};
+			};
+
+			if (schema.async === true) {
+				return safeParseAsync(schema, payload, config.info).then(resolveResult);
+			}
+
+			return resolveResult(safeParse(schema, payload, config.info));
+		},
+	});
+}

--- a/packages/conform-valibot/rollup.config.js
+++ b/packages/conform-valibot/rollup.config.js
@@ -1,0 +1,97 @@
+import path from 'node:path';
+import babel from '@rollup/plugin-babel';
+import nodeResolve from '@rollup/plugin-node-resolve';
+import copy from 'rollup-plugin-copy';
+
+/** @returns {import("rollup").RollupOptions[]} */
+function configurePackage() {
+	let sourceDir = '.';
+	let outputDir = './dist';
+
+	/** @type {import("rollup").RollupOptions} */
+	let ESM = {
+		external(id) {
+			return !id.startsWith('.') && !path.isAbsolute(id);
+		},
+		input: `${sourceDir}/index.ts`,
+		output: {
+			dir: outputDir,
+			format: 'esm',
+			preserveModules: true,
+			entryFileNames: '[name].mjs',
+		},
+		plugins: [
+			babel({
+				babelrc: false,
+				configFile: false,
+				presets: [
+					[
+						'@babel/preset-env',
+						{
+							targets: {
+								node: '16',
+								esmodules: true,
+							},
+						},
+					],
+					'@babel/preset-typescript',
+				],
+				plugins: [],
+				babelHelpers: 'bundled',
+				exclude: /node_modules/,
+				extensions: ['.ts', '.tsx'],
+			}),
+			nodeResolve({
+				extensions: ['.ts', '.tsx'],
+			}),
+			copy({
+				targets: [{ src: `../../README`, dest: sourceDir }],
+			}),
+		],
+	};
+
+	/** @type {import("rollup").RollupOptions} */
+	let CJS = {
+		external(id) {
+			return !id.startsWith('.') && !path.isAbsolute(id);
+		},
+		input: `${sourceDir}/index.ts`,
+		output: {
+			dir: outputDir,
+			format: 'cjs',
+			preserveModules: true,
+			exports: 'auto',
+		},
+		plugins: [
+			babel({
+				babelrc: false,
+				configFile: false,
+				presets: [
+					[
+						'@babel/preset-env',
+						{
+							targets: {
+								node: '16',
+								esmodules: true,
+							},
+						},
+					],
+					'@babel/preset-typescript',
+				],
+				plugins: [],
+				babelHelpers: 'bundled',
+				exclude: /node_modules/,
+				extensions: ['.ts', '.tsx'],
+			}),
+			nodeResolve({
+				extensions: ['.ts', '.tsx'],
+			}),
+		],
+	};
+
+	return [ESM, CJS];
+}
+
+export default function rollup() {
+	return configurePackage();
+}

--- a/packages/conform-valibot/tests/coercion.test.ts
+++ b/packages/conform-valibot/tests/coercion.test.ts
@@ -23,7 +23,7 @@ describe('coerceFormValue', () => {
 			bigNumber: bigint(),
 		});
 
-		const { schema: coercedSchema } = coerceFormValue(schema);
+		const coercedSchema = coerceFormValue(schema);
 		const result = safeParse(coercedSchema as GenericSchema, {
 			text: 'hello',
 			num: '123',
@@ -54,7 +54,7 @@ describe('coerceFormValue', () => {
 					bigNumber: bigint(),
 				});
 
-				const { schema: coercedSchemaWithoutNumber } = coerceFormValue(schema, {
+				const coercedSchemaWithoutNumber = coerceFormValue(schema, {
 					defaultCoercion: {
 						number: false,
 						boolean: false,
@@ -63,7 +63,7 @@ describe('coerceFormValue', () => {
 					},
 				});
 
-				const result = safeParse(coercedSchemaWithoutNumber as GenericSchema, {
+				const result = safeParse(coercedSchemaWithoutNumber, {
 					text: 'hello',
 					num: '123',
 					flag: 'on',
@@ -121,7 +121,7 @@ describe('coerceFormValue', () => {
 					return data + BigInt(1);
 				};
 
-				const { schema: coercedSchema } = coerceFormValue(schema, {
+				const coercedSchema = coerceFormValue(schema, {
 					defaultCoercion: {
 						string: customStringCoercion,
 						number: customNumberCoercion,
@@ -130,7 +130,7 @@ describe('coerceFormValue', () => {
 					},
 				});
 
-				const result = safeParse(coercedSchema as GenericSchema, {
+				const result = safeParse(coercedSchema, {
 					text: 'hello',
 					num: '10',
 					flag: 'on',
@@ -206,11 +206,11 @@ describe('coerceFormValue', () => {
 					return null;
 				};
 
-				const { schema: coercedSchema } = coerceFormValue(schema, {
+				const coercedSchema = coerceFormValue(schema, {
 					defineCoercion,
 				});
 
-				const result = safeParse(coercedSchema as GenericSchema, {
+				const result = safeParse(coercedSchema, {
 					text: '  hello  ',
 					num: '123',
 					timestamp: '2023-01-01',

--- a/packages/conform-valibot/tests/coercion.test.ts
+++ b/packages/conform-valibot/tests/coercion.test.ts
@@ -150,8 +150,8 @@ describe('coerceFormValue', () => {
 			});
 		});
 
-		describe('defineCoercion', () => {
-			test('defineCoercion for specific schema types', () => {
+		describe('customize', () => {
+			test('customize for specific schema types', () => {
 				const meta = object({
 					text: string(),
 					num: number(),
@@ -165,7 +165,7 @@ describe('coerceFormValue', () => {
 					meta,
 				});
 
-				const defineCoercion = (
+				const customize = (
 					schema: GenericSchema | GenericSchemaAsync,
 				): CoercionFunction | null => {
 					if (schema.type === 'string') {
@@ -207,7 +207,7 @@ describe('coerceFormValue', () => {
 				};
 
 				const coercedSchema = coerceFormValue(schema, {
-					defineCoercion,
+					customize,
 				});
 
 				const result = safeParse(coercedSchema, {

--- a/packages/conform-valibot/tests/coercion.test.ts
+++ b/packages/conform-valibot/tests/coercion.test.ts
@@ -94,14 +94,14 @@ describe('coerceFormValue', () => {
 					if (typeof value !== 'string') {
 						return value;
 					}
-					return value === '' ? undefined : value.toUpperCase();
+					return value === '' ? value : value.toUpperCase();
 				};
 
 				const customNumberCoercion: CoercionFunction = (value) => {
 					if (typeof value !== 'string') {
 						return value;
 					}
-					return value.trim() === '' ? undefined : Number(value) * 2;
+					return value.trim() === '' ? value : Number(value) * 2;
 				};
 
 				const customDateCoercion: CoercionFunction = (value) => {

--- a/packages/conform-valibot/tests/coercion.test.ts
+++ b/packages/conform-valibot/tests/coercion.test.ts
@@ -1,0 +1,216 @@
+import {
+	type GenericSchema,
+	type GenericSchemaAsync,
+	bigint,
+	boolean,
+	date,
+	number,
+	object,
+	string,
+	safeParse,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { coerceFormValue, type CoercionFunction } from '../coercion';
+import { getResult } from './helpers/valibot';
+
+describe('coerceFormValue', () => {
+	test('default behavior without options', () => {
+		const schema = object({
+			text: string(),
+			num: number(),
+			flag: boolean(),
+			timestamp: date(),
+			bigNumber: bigint(),
+		});
+
+		const { schema: coercedSchema } = coerceFormValue(schema);
+		const result = safeParse(coercedSchema as GenericSchema, {
+			text: 'hello',
+			num: '123',
+			flag: 'on',
+			timestamp: '2023-01-01',
+			bigNumber: '9007199254740991',
+		});
+		expect(getResult(result)).toEqual({
+			success: true,
+			data: {
+				text: 'hello',
+				num: 123,
+				flag: true,
+				timestamp: new Date('2023-01-01'),
+				bigNumber: BigInt('9007199254740991'),
+			},
+		});
+	});
+
+	describe('behavior with options', () => {
+		describe('defaultCoercion', () => {
+			test('disable specific type coercion', () => {
+				const schema = object({
+					text: string(),
+					num: number(),
+					flag: boolean(),
+					timestamp: date(),
+					bigNumber: bigint(),
+				});
+
+				const { schema: coercedSchemaWithoutNumber } = coerceFormValue(schema, {
+					defaultCoercion: {
+						number: false,
+						boolean: false,
+						date: false,
+						bigint: false,
+					},
+				});
+
+				const result = safeParse(coercedSchemaWithoutNumber as GenericSchema, {
+					text: 'hello',
+					num: '123',
+					flag: 'on',
+					timestamp: '2023-01-01',
+					bigNumber: '9007199254740991',
+				});
+				expect(getResult(result)).toEqual({
+					success: false,
+					error: {
+						num: [expect.anything()],
+						flag: [expect.anything()],
+						timestamp: [expect.anything()],
+						bigNumber: [expect.anything()],
+					},
+				});
+			});
+
+			test('custom coercion functions', () => {
+				const schema = object({
+					text: string(),
+					num: number(),
+					flag: boolean(),
+					timestamp: date(),
+					bigNumber: bigint(),
+				});
+
+				const customStringCoercion: CoercionFunction = (value) => {
+					if (typeof value !== 'string') {
+						return value;
+					}
+					return value === '' ? undefined : value.toUpperCase();
+				};
+
+				const customNumberCoercion: CoercionFunction = (value) => {
+					if (typeof value !== 'string') {
+						return value;
+					}
+					return value.trim() === '' ? undefined : Number(value) * 2;
+				};
+
+				const customDateCoercion: CoercionFunction = (value) => {
+					if (typeof value !== 'string') {
+						return value;
+					}
+					const date = new Date(value);
+					date.setDate(date.getDate() + 1);
+					return date;
+				};
+
+				const customBigIntCoercion: CoercionFunction = (value) => {
+					if (typeof value !== 'string') {
+						return value;
+					}
+					const data = BigInt(value);
+					return data + BigInt(1);
+				};
+
+				const { schema: coercedSchema } = coerceFormValue(schema, {
+					defaultCoercion: {
+						string: customStringCoercion,
+						number: customNumberCoercion,
+						date: customDateCoercion,
+						bigint: customBigIntCoercion,
+					},
+				});
+
+				const result = safeParse(coercedSchema as GenericSchema, {
+					text: 'hello',
+					num: '10',
+					flag: 'on',
+					timestamp: '2023-01-01',
+					bigNumber: '9007199254740991',
+				});
+				expect(getResult(result)).toEqual({
+					success: true,
+					data: {
+						text: 'HELLO',
+						num: 20,
+						flag: true,
+						timestamp: new Date('2023-01-02'),
+						bigNumber: BigInt('9007199254740992'),
+					},
+				});
+			});
+		});
+
+		describe('defineCoercion', () => {
+			test('defineCoercion for specific schema types', () => {
+				const schema = object({
+					text: string(),
+					num: number(),
+					timestamp: date(),
+					yes: boolean(),
+					no: boolean(),
+				});
+
+				const defineCoercion = (
+					type: GenericSchema | GenericSchemaAsync,
+				): CoercionFunction | null => {
+					if (type.type === 'string') {
+						return (value) => {
+							if (typeof value === 'string') {
+								return value.trim() === '' ? undefined : value.trim();
+							}
+							return value;
+						};
+					}
+
+					if (type.type === 'boolean') {
+						return (value) => {
+							if (typeof value === 'string') {
+								if (value === 'yes') {
+									return true;
+								}
+								if (value === 'no') {
+									return false;
+								}
+							}
+							return value;
+						};
+					}
+
+					return null;
+				};
+
+				const { schema: coercedSchema } = coerceFormValue(schema, {
+					defineCoercion,
+				});
+
+				const result = safeParse(coercedSchema as GenericSchema, {
+					text: '  hello  ',
+					num: '123',
+					timestamp: '2023-01-01',
+					yes: 'yes',
+					no: 'no',
+				});
+				expect(getResult(result)).toEqual({
+					success: true,
+					data: {
+						text: 'hello',
+						num: 123,
+						timestamp: new Date('2023-01-01'),
+						yes: true,
+						no: false,
+					},
+				});
+			});
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion.test.ts
+++ b/packages/conform-valibot/tests/coercion.test.ts
@@ -8,6 +8,7 @@ import {
 	object,
 	string,
 	safeParse,
+	optional,
 } from 'valibot';
 import { describe, expect, test } from 'vitest';
 import { coerceFormValue, type CoercionFunction } from '../coercion';
@@ -158,6 +159,7 @@ describe('coerceFormValue', () => {
 				});
 				const schema = object({
 					text: string(),
+					optionalText: optional(string()),
 					num: number(),
 					timestamp: date(),
 					yes: boolean(),
@@ -212,6 +214,7 @@ describe('coerceFormValue', () => {
 
 				const result = safeParse(coercedSchema, {
 					text: '  hello  ',
+					optionalText: ' ',
 					num: '123',
 					timestamp: '2023-01-01',
 					yes: 'yes',
@@ -222,6 +225,7 @@ describe('coerceFormValue', () => {
 					success: true,
 					data: {
 						text: 'hello',
+						optionalText: undefined,
 						num: 123,
 						timestamp: new Date('2023-01-01'),
 						yes: true,

--- a/packages/conform-valibot/tests/coercion.test.ts
+++ b/packages/conform-valibot/tests/coercion.test.ts
@@ -152,18 +152,23 @@ describe('coerceFormValue', () => {
 
 		describe('defineCoercion', () => {
 			test('defineCoercion for specific schema types', () => {
+				const meta = object({
+					text: string(),
+					num: number(),
+				});
 				const schema = object({
 					text: string(),
 					num: number(),
 					timestamp: date(),
 					yes: boolean(),
 					no: boolean(),
+					meta,
 				});
 
 				const defineCoercion = (
-					type: GenericSchema | GenericSchemaAsync,
+					schema: GenericSchema | GenericSchemaAsync,
 				): CoercionFunction | null => {
-					if (type.type === 'string') {
+					if (schema.type === 'string') {
 						return (value) => {
 							if (typeof value === 'string') {
 								return value.trim() === '' ? undefined : value.trim();
@@ -172,7 +177,7 @@ describe('coerceFormValue', () => {
 						};
 					}
 
-					if (type.type === 'boolean') {
+					if (schema.type === 'boolean') {
 						return (value) => {
 							if (typeof value === 'string') {
 								if (value === 'yes') {
@@ -181,6 +186,18 @@ describe('coerceFormValue', () => {
 								if (value === 'no') {
 									return false;
 								}
+							}
+							return value;
+						};
+					}
+
+					if (schema === meta) {
+						return (value) => {
+							if (value === undefined) {
+								return {
+									text: 'text',
+									num: 0,
+								};
 							}
 							return value;
 						};
@@ -199,6 +216,7 @@ describe('coerceFormValue', () => {
 					timestamp: '2023-01-01',
 					yes: 'yes',
 					no: 'no',
+					meta: undefined,
 				});
 				expect(getResult(result)).toEqual({
 					success: true,
@@ -208,6 +226,10 @@ describe('coerceFormValue', () => {
 						timestamp: new Date('2023-01-01'),
 						yes: true,
 						no: false,
+						meta: {
+							text: 'text',
+							num: 0,
+						},
 					},
 				});
 			});

--- a/packages/conform-valibot/tests/coercion/schema/any.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/any.test.ts
@@ -1,0 +1,23 @@
+import { any, object } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('any', () => {
+	test('should pass any values', () => {
+		const schema = object({ item: any() });
+		const input1 = createFormData('item', 'hello');
+		const output1 = parseWithValibot(input1, { schema });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { item: 'hello' },
+		});
+		const input2 = createFormData('item', '1');
+		input2.append('item', '2');
+		const output2 = parseWithValibot(input2, { schema });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { item: ['1', '2'] },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/array.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/array.test.ts
@@ -1,0 +1,62 @@
+import { array, check, object, pipe, string } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('array', () => {
+	test('should pass only arrays', () => {
+		const schema = object({ select: array(string()) });
+		const formData = createFormData('select', '1');
+		const outputForNonArray = parseWithValibot(formData, { schema });
+
+		expect(outputForNonArray).toMatchObject({
+			status: 'success',
+			value: { select: ['1'] },
+		});
+
+		formData.append('select', '2');
+		formData.append('select', '3');
+		const outputForArray = parseWithValibot(formData, { schema });
+
+		expect(outputForArray).toMatchObject({
+			status: 'success',
+			value: { select: ['1', '2', '3'] },
+		});
+
+		const schema2 = object({ nest: array(object({ name: string() })) });
+		const formData2 = createFormData('nest[].name', 'test name');
+		const output2 = parseWithValibot(formData2, { schema: schema2 });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { nest: [{ name: 'test name' }] },
+		});
+
+		const errorFormData = createFormData('nest[].name', '');
+		const errorOutput = parseWithValibot(errorFormData, { schema: schema2 });
+		expect(errorOutput).toMatchObject({
+			error: {
+				'nest[0].name': expect.anything(),
+			},
+		});
+	});
+
+	test('should pass arrays with pipe', () => {
+		const schema = object({
+			select: pipe(
+				array(string()),
+				check((value) => value.length === 3, 'error in number of arrays'),
+			),
+		});
+		const formData = createFormData('select', '1');
+		formData.append('select', '2');
+		formData.append('select', '3');
+
+		const outputWithPipe = parseWithValibot(formData, {
+			schema,
+		});
+		expect(outputWithPipe).toMatchObject({
+			status: 'success',
+			value: { select: ['1', '2', '3'] },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/bigint.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/bigint.test.ts
@@ -1,0 +1,23 @@
+import { bigint, object } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('bigint', () => {
+	test('should pass only bigint', () => {
+		const schema = object({ id: bigint() });
+		const output = parseWithValibot(createFormData('id', '20'), { schema });
+
+		expect(output).toMatchObject({ status: 'success', value: { id: 20n } });
+		expect(
+			parseWithValibot(createFormData('id', ''), { schema }),
+		).toMatchObject({
+			error: { id: expect.anything() },
+		});
+		expect(
+			parseWithValibot(createFormData('id', 'non bigint'), { schema }),
+		).toMatchObject({
+			error: { id: expect.anything() },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/blob.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/blob.test.ts
@@ -1,0 +1,48 @@
+import { blob, mimeType, object, pipe } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('blob', () => {
+	test('should pass only blob', () => {
+		const schema = object({ file: blob() });
+
+		const output = parseWithValibot(createFormData('file', new Blob(['foo'])), {
+			schema,
+		});
+
+		expect(output).toMatchObject({
+			status: 'success',
+		});
+		expect(
+			parseWithValibot(createFormData('name', ''), { schema }),
+		).toMatchObject({
+			error: { file: expect.anything() },
+		});
+	});
+
+	test('should pass blob with pipe', () => {
+		const schema = object({
+			file: pipe(blob(), mimeType(['image/jpeg', 'image/png'])),
+		});
+
+		const output = parseWithValibot(
+			createFormData('file', new Blob(['foo'], { type: 'image/jpeg' })),
+			{ schema },
+		);
+
+		expect(output).toMatchObject({
+			status: 'success',
+		});
+		expect(
+			parseWithValibot(
+				createFormData('file', new Blob(['foo'], { type: 'image/gif' })),
+				{ schema },
+			),
+		).toMatchObject({
+			error: {
+				file: expect.anything(),
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/boolean.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/boolean.test.ts
@@ -1,0 +1,23 @@
+import { boolean, object } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('boolean', () => {
+	test('should pass only booleans', () => {
+		const schema = object({ check: boolean() });
+		const input1 = createFormData('check', 'on');
+		const output1 = parseWithValibot(input1, { schema });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { check: true },
+		});
+		expect(
+			parseWithValibot(createFormData('check', ''), { schema }),
+		).toMatchObject({
+			error: {
+				check: expect.anything(),
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/date.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/date.test.ts
@@ -1,0 +1,25 @@
+import { date, object } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('date', () => {
+	test('should pass only dates', () => {
+		const schema = object({ birthday: date() });
+		const output = parseWithValibot(createFormData('birthday', '2023-11-19'), {
+			schema,
+		});
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { birthday: new Date('2023-11-19') },
+		});
+
+		expect(
+			parseWithValibot(createFormData('birthday', 'non date'), { schema }),
+		).toMatchObject({
+			error: {
+				birthday: expect.anything(),
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/enum.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/enum.test.ts
@@ -1,0 +1,37 @@
+import { enum_, object } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+enum Direction {
+	Left = 'left',
+	Right = 'right',
+}
+
+describe('enum_', () => {
+	test('should pass only enum values', () => {
+		const schema = object({ item: enum_(Direction) });
+
+		const formData1 = createFormData('item', Direction.Left);
+		const output1 = parseWithValibot(formData1, { schema });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { item: Direction.Left },
+		});
+
+		const formData2 = createFormData('item', Direction.Right);
+		const output2 = parseWithValibot(formData2, { schema });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { item: Direction.Right },
+		});
+
+		const formData3 = createFormData('item', 'value_3');
+		const output3 = parseWithValibot(formData3, { schema });
+		expect(output3).toMatchObject({
+			error: {
+				item: expect.anything(),
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/exactOptional.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/exactOptional.test.ts
@@ -1,0 +1,27 @@
+import { exactOptional, number, object, string } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('exactOptional', () => {
+	test('should pass only exactOptional', () => {
+		const schema = object({ name: string(), age: exactOptional(number()) });
+		const formData1 = createFormData('name', 'Jane');
+		expect(parseWithValibot(formData1, { schema })).toMatchObject({
+			status: 'success',
+			value: { name: 'Jane' },
+		});
+
+		formData1.append('age', '20');
+		expect(parseWithValibot(formData1, { schema })).toMatchObject({
+			status: 'success',
+			value: { name: 'Jane', age: 20 },
+		});
+
+		const formData2 = createFormData('name', 'Jane');
+		formData2.append('age', 'abc');
+		expect(parseWithValibot(formData2, { schema })).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/exactOptionalAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/exactOptionalAsync.test.ts
@@ -1,0 +1,30 @@
+import { exactOptionalAsync, number, objectAsync, string } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('exactOptionalAsync', () => {
+	test('should pass only exactOptional', async () => {
+		const schema = objectAsync({
+			name: string(),
+			age: exactOptionalAsync(number()),
+		});
+		const formData1 = createFormData('name', 'Jane');
+		expect(await parseWithValibot(formData1, { schema })).toMatchObject({
+			status: 'success',
+			value: { name: 'Jane' },
+		});
+
+		formData1.append('age', '20');
+		expect(await parseWithValibot(formData1, { schema })).toMatchObject({
+			status: 'success',
+			value: { name: 'Jane', age: 20 },
+		});
+
+		const formData2 = createFormData('name', 'Jane');
+		formData2.append('age', 'abc');
+		expect(await parseWithValibot(formData2, { schema })).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/file.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/file.test.ts
@@ -1,0 +1,57 @@
+import { file, mimeType, object, pipe } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('file', () => {
+	test('should pass only file', () => {
+		const schema = object({ file: file() });
+
+		const output = parseWithValibot(
+			createFormData('file', new File(['foo'], 'foo.pn')),
+			{
+				schema,
+			},
+		);
+
+		expect(output).toMatchObject({
+			status: 'success',
+		});
+		expect(
+			parseWithValibot(createFormData('name', ''), { schema }),
+		).toMatchObject({
+			error: { file: expect.anything() },
+		});
+	});
+
+	test('should pass file with pipe', () => {
+		const schema = object({
+			file: pipe(file(), mimeType(['image/jpeg', 'image/png'])),
+		});
+
+		const output = parseWithValibot(
+			createFormData(
+				'file',
+				new File(['foo'], 'foo.jpeg', { type: 'image/jpeg' }),
+			),
+			{ schema },
+		);
+
+		expect(output).toMatchObject({
+			status: 'success',
+		});
+		expect(
+			parseWithValibot(
+				createFormData(
+					'file',
+					new File(['foo'], 'foo.gif', { type: 'image/gif' }),
+				),
+				{ schema },
+			),
+		).toMatchObject({
+			error: {
+				file: expect.anything(),
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/intersect.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/intersect.test.ts
@@ -1,0 +1,92 @@
+import { check, intersect, literal, object, pipe, string } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('intersect', () => {
+	test('should pass only intersect values', () => {
+		const schema1 = object({
+			intersect: intersect([string(), literal('test')]),
+		});
+		const input1 = createFormData('intersect', 'test');
+		const output1 = parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { intersect: 'test' },
+		});
+
+		const errorInput1 = createFormData('intersect', 'foo');
+		const errorOutput1 = parseWithValibot(errorInput1, { schema: schema1 });
+		expect(errorOutput1).toMatchObject({
+			error: {
+				intersect: expect.anything(),
+			},
+		});
+		const errorInput2 = createFormData('intersect', '');
+		const errorOutput2 = parseWithValibot(errorInput2, { schema: schema1 });
+		expect(errorOutput2).toMatchObject({
+			error: {
+				intersect: expect.anything(),
+			},
+		});
+
+		const schema2 = intersect([
+			object({ foo: string() }),
+			object({ bar: string() }),
+		]);
+		const input2 = createFormData('foo', 'test');
+		input2.append('bar', 'test');
+		const output2 = parseWithValibot(input2, { schema: schema2 });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { foo: 'test', bar: 'test' },
+		});
+		const errorInput3 = createFormData('foo', 'test');
+		const errorOutput3 = parseWithValibot(errorInput3, { schema: schema2 });
+		expect(errorOutput3).toMatchObject({
+			error: { bar: expect.anything() },
+		});
+		const errorInput4 = createFormData('bar', 'test');
+		const errorOutput4 = parseWithValibot(errorInput4, { schema: schema2 });
+		expect(errorOutput4).toMatchObject({
+			error: { foo: expect.anything() },
+		});
+	});
+
+	test('should pass only intersect values with pipe', () => {
+		const schema = object({
+			intersect: pipe(
+				intersect([string()]),
+				check((value) => value === 'test', 'intersect must be equal to test'),
+			),
+		});
+		const input1 = createFormData('intersect', 'test');
+		const output1 = parseWithValibot(input1, { schema });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { intersect: 'test' },
+		});
+
+		const errorInput1 = createFormData('intersect', 'foo');
+		const errorOutput1 = parseWithValibot(errorInput1, { schema });
+		expect(errorOutput1).toMatchObject({
+			error: {
+				intersect: expect.anything(),
+			},
+		});
+	});
+
+	test('should throw only first issue', () => {
+		const schema = object({
+			intersect: intersect([string(), literal('test')]),
+		});
+		const errorInput = createFormData('intersect', '');
+		const info = { abortEarly: true };
+		const errorOutput = parseWithValibot(errorInput, { schema, info });
+		expect(errorOutput).toMatchObject({
+			error: {
+				intersect: expect.anything(),
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/intersectAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/intersectAsync.test.ts
@@ -1,0 +1,110 @@
+import {
+	checkAsync,
+	intersectAsync,
+	literal,
+	objectAsync,
+	pipeAsync,
+	string,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('intersectAsync', () => {
+	test('should pass only intersect values', async () => {
+		const schema1 = objectAsync({
+			intersect: intersectAsync([string(), literal('test')]),
+		});
+		const input1 = createFormData('intersect', 'test');
+		const output1 = await parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { intersect: 'test' },
+		});
+
+		const errorInput1 = createFormData('intersect', 'foo');
+		const errorOutput1 = await parseWithValibot(errorInput1, {
+			schema: schema1,
+		});
+		expect(errorOutput1).toMatchObject({
+			error: {
+				intersect: expect.anything(),
+			},
+		});
+		const errorInput2 = createFormData('intersect', '');
+		const errorOutput2 = await parseWithValibot(errorInput2, {
+			schema: schema1,
+		});
+		expect(errorOutput2).toMatchObject({
+			error: {
+				intersect: expect.anything(),
+			},
+		});
+
+		const schema2 = intersectAsync([
+			objectAsync({ foo: string() }),
+			objectAsync({ bar: string() }),
+		]);
+		const input2 = createFormData('foo', 'test');
+		input2.append('bar', 'test');
+		const output2 = await parseWithValibot(input2, { schema: schema2 });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { foo: 'test', bar: 'test' },
+		});
+		const errorInput3 = createFormData('foo', 'test');
+		const errorOutput3 = await parseWithValibot(errorInput3, {
+			schema: schema2,
+		});
+		expect(errorOutput3).toMatchObject({
+			error: { bar: expect.anything() },
+		});
+		const errorInput4 = createFormData('bar', 'test');
+		const errorOutput4 = await parseWithValibot(errorInput4, {
+			schema: schema2,
+		});
+		expect(errorOutput4).toMatchObject({
+			error: { foo: expect.anything() },
+		});
+	});
+
+	test('should pass only intersect values with pipe', async () => {
+		const schema = objectAsync({
+			intersect: pipeAsync(
+				intersectAsync([string()]),
+				checkAsync(
+					async (value) => value === 'test',
+					'intersect must be equal to test',
+				),
+			),
+		});
+		const input1 = createFormData('intersect', 'test');
+		const output1 = await parseWithValibot(input1, { schema });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { intersect: 'test' },
+		});
+
+		const errorInput1 = createFormData('intersect', 'foo');
+		const errorOutput1 = await parseWithValibot(errorInput1, { schema });
+		expect(errorOutput1).toMatchObject({
+			error: {
+				intersect: expect.anything(),
+			},
+		});
+	});
+
+	test('should throw only first issue', async () => {
+		const schema = objectAsync({
+			intersect: intersectAsync([string(), literal('test')]),
+		});
+		const errorInput = createFormData('intersect', '');
+		const info = { abortEarly: true };
+		const errorOutput = await parseWithValibot(errorInput, { schema, info });
+		expect(errorOutput).toMatchObject({
+			error: {
+				intersect: expect.anything(),
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/looseObject.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/looseObject.test.ts
@@ -1,0 +1,74 @@
+import { check, forward, looseObject, number, pipe, string } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('looseObject', () => {
+	test('should pass only loose objects', () => {
+		const schema1 = looseObject({ key1: string(), key2: number() });
+		const input1 = createFormData('key1', 'test');
+		input1.append('key2', '123');
+		const output1 = parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { key1: 'test', key2: 123 },
+		});
+
+		input1.append('key3', '');
+		const output2 = parseWithValibot(input1, { schema: schema1 });
+		expect(output2.status).toBe('success');
+		// @ts-expect-error
+		expect(output2.value).toStrictEqual({
+			key1: 'test',
+			key2: 123,
+			key3: '',
+		});
+
+		const input2 = createFormData('key1', '');
+		input2.append('key2', '123');
+		const output3 = parseWithValibot(input2, { schema: schema1 });
+		expect(output3).toMatchObject({
+			error: {
+				key1: expect.anything(),
+			},
+		});
+
+		const input3 = createFormData('key1', 'string');
+		input3.set('key2', 'non number');
+		const output4 = parseWithValibot(input3, { schema: schema1 });
+		expect(output4).toMatchObject({
+			error: {
+				key2: expect.anything(),
+			},
+		});
+	});
+
+	test('should pass objects with pipe', () => {
+		const schema = pipe(
+			looseObject({
+				key: string(),
+			}),
+			forward(
+				check(({ key }) => key !== 'error name', 'key is error'),
+				['key'],
+			),
+		);
+
+		const output = parseWithValibot(createFormData('key', 'valid'), {
+			schema,
+		});
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { key: 'valid' },
+		});
+
+		const errorOutput = parseWithValibot(createFormData('key', 'error name'), {
+			schema,
+		});
+		expect(errorOutput).toMatchObject({
+			error: {
+				key: expect.anything(),
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/looseObjectAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/looseObjectAsync.test.ts
@@ -1,0 +1,84 @@
+import {
+	checkAsync,
+	forwardAsync,
+	looseObjectAsync,
+	number,
+	pipeAsync,
+	string,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('looseObjectAsync', () => {
+	test('should pass only loose objects', async () => {
+		const schema1 = looseObjectAsync({ key1: string(), key2: number() });
+		const input1 = createFormData('key1', 'test');
+		input1.append('key2', '123');
+		const output1 = await parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { key1: 'test', key2: 123 },
+		});
+
+		input1.append('key3', '');
+		const output2 = await parseWithValibot(input1, { schema: schema1 });
+		expect(output2.status).toBe('success');
+		// @ts-expect-error
+		expect(output2.value).toStrictEqual({
+			key1: 'test',
+			key2: 123,
+			key3: '',
+		});
+
+		const input2 = createFormData('key1', '');
+		input2.append('key2', '123');
+		const output3 = await parseWithValibot(input2, { schema: schema1 });
+		expect(output3).toMatchObject({
+			error: {
+				key1: expect.anything(),
+			},
+		});
+
+		const input3 = createFormData('key1', 'string');
+		input3.set('key2', 'non number');
+		const output4 = await parseWithValibot(input3, { schema: schema1 });
+		expect(output4).toMatchObject({
+			error: {
+				key2: expect.anything(),
+			},
+		});
+	});
+
+	test('should pass objects with pipe', async () => {
+		const schema = pipeAsync(
+			looseObjectAsync({
+				key: string(),
+			}),
+			forwardAsync(
+				checkAsync(async ({ key }) => key !== 'error name', 'key is error'),
+				['key'],
+			),
+		);
+
+		const output = await parseWithValibot(createFormData('key', 'valid'), {
+			schema,
+		});
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { key: 'valid' },
+		});
+
+		const errorOutput = await parseWithValibot(
+			createFormData('key', 'error name'),
+			{
+				schema,
+			},
+		);
+		expect(errorOutput).toMatchObject({
+			error: {
+				key: expect.anything(),
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/nonNullish.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/nonNullish.test.ts
@@ -1,0 +1,93 @@
+import {
+	check,
+	nonNullish,
+	number,
+	object,
+	optional,
+	pipe,
+	undefined_,
+	union,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('nonOptional', () => {
+	test('should not pass undefined', () => {
+		const schema1 = object({
+			item: nonNullish(optional(number())),
+		});
+		const input1 = createFormData('item', '1');
+		const output1 = parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({ status: 'success', value: { item: 1 } });
+		expect(
+			parseWithValibot(createFormData('item', 'non Number'), {
+				schema: schema1,
+			}),
+		).toMatchObject({
+			error: { item: expect.anything() },
+		});
+		expect(
+			parseWithValibot(createFormData('item2', 'non Param'), {
+				schema: schema1,
+			}),
+		).toMatchObject({
+			error: {
+				item: expect.anything(),
+			},
+		});
+
+		const schema2 = object({
+			item: nonNullish(union([number(), undefined_()])),
+		});
+		const output2 = parseWithValibot(input1, { schema: schema2 });
+		expect(output2).toMatchObject({ status: 'success', value: { item: 1 } });
+		expect(
+			parseWithValibot(createFormData('item', 'non Number'), {
+				schema: schema2,
+			}),
+		).toMatchObject({
+			error: {
+				item: expect.anything(),
+			},
+		});
+		expect(
+			parseWithValibot(createFormData('item2', 'non Param'), {
+				schema: schema2,
+			}),
+		).toMatchObject({
+			error: {
+				item: expect.anything(),
+			},
+		});
+	});
+
+	test('should pass nonNullish with pipe', () => {
+		const schema = object({
+			age: pipe(
+				nonNullish(optional(number())),
+				check((value) => value > 0, 'age must be greater than 0'),
+			),
+		});
+
+		const output1 = parseWithValibot(createFormData('age', ''), { schema });
+		expect(output1).toMatchObject({
+			error: {
+				age: expect.anything(),
+			},
+		});
+
+		const output2 = parseWithValibot(createFormData('age', '20'), { schema });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { age: 20 },
+		});
+
+		const errorOutput = parseWithValibot(createFormData('age', '0'), {
+			schema,
+		});
+		expect(errorOutput).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/nonNullishAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/nonNullishAsync.test.ts
@@ -1,0 +1,97 @@
+import {
+	checkAsync,
+	nonNullishAsync,
+	number,
+	objectAsync,
+	optionalAsync,
+	pipeAsync,
+	undefined_,
+	unionAsync,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('nonOptionalAsync', () => {
+	test('should not pass undefined', async () => {
+		const schema1 = objectAsync({
+			item: nonNullishAsync(optionalAsync(number())),
+		});
+		const input1 = createFormData('item', '1');
+		const output1 = await parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({ status: 'success', value: { item: 1 } });
+		expect(
+			await parseWithValibot(createFormData('item', 'non Number'), {
+				schema: schema1,
+			}),
+		).toMatchObject({
+			error: { item: expect.anything() },
+		});
+		expect(
+			await parseWithValibot(createFormData('item2', 'non Param'), {
+				schema: schema1,
+			}),
+		).toMatchObject({
+			error: {
+				item: expect.anything(),
+			},
+		});
+
+		const schema2 = objectAsync({
+			item: nonNullishAsync(unionAsync([number(), undefined_()])),
+		});
+		const output2 = await parseWithValibot(input1, { schema: schema2 });
+		expect(output2).toMatchObject({ status: 'success', value: { item: 1 } });
+		expect(
+			await parseWithValibot(createFormData('item', 'non Number'), {
+				schema: schema2,
+			}),
+		).toMatchObject({
+			error: {
+				item: expect.anything(),
+			},
+		});
+		expect(
+			await parseWithValibot(createFormData('item2', 'non Param'), {
+				schema: schema2,
+			}),
+		).toMatchObject({
+			error: {
+				item: expect.anything(),
+			},
+		});
+	});
+
+	test('should pass nonNullish with pipe', async () => {
+		const schema = objectAsync({
+			age: pipeAsync(
+				nonNullishAsync(optionalAsync(number())),
+				checkAsync((value) => value > 0, 'age must be greater than 0'),
+			),
+		});
+
+		const output1 = await parseWithValibot(createFormData('age', ''), {
+			schema,
+		});
+		expect(output1).toMatchObject({
+			error: {
+				age: expect.anything(),
+			},
+		});
+
+		const output2 = await parseWithValibot(createFormData('age', '20'), {
+			schema,
+		});
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { age: 20 },
+		});
+
+		const errorOutput = await parseWithValibot(createFormData('age', '0'), {
+			schema,
+		});
+		expect(errorOutput).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/nonOptional.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/nonOptional.test.ts
@@ -1,0 +1,88 @@
+import {
+	check,
+	nonOptional,
+	number,
+	object,
+	optional,
+	pipe,
+	undefined_,
+	union,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('nonOptional', () => {
+	test('should not pass undefined', () => {
+		const schema1 = object({
+			item: nonOptional(optional(number())),
+		});
+		const input1 = createFormData('item', '1');
+		const output1 = parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({ status: 'success', value: { item: 1 } });
+		expect(
+			parseWithValibot(createFormData('item', 'non Number'), {
+				schema: schema1,
+			}),
+		).toMatchObject({
+			error: { item: expect.anything() },
+		});
+		expect(
+			parseWithValibot(createFormData('item2', 'non Param'), {
+				schema: schema1,
+			}),
+		).toMatchObject({
+			error: {
+				item: expect.anything(),
+			},
+		});
+
+		const schema2 = object({
+			item: nonOptional(union([number(), undefined_()])),
+		});
+		const output2 = parseWithValibot(input1, { schema: schema2 });
+		expect(output2).toMatchObject({ status: 'success', value: { item: 1 } });
+		expect(
+			parseWithValibot(createFormData('item', 'non Number'), {
+				schema: schema2,
+			}),
+		).toMatchObject({
+			error: {
+				item: expect.anything(),
+			},
+		});
+		expect(
+			parseWithValibot(createFormData('item2', 'non Param'), {
+				schema: schema2,
+			}),
+		).toMatchObject({
+			error: {
+				item: expect.anything(),
+			},
+		});
+	});
+
+	test('should pass nonOptional with pipe', () => {
+		const schema = object({
+			age: pipe(
+				nonOptional(optional(number())),
+				check((value) => value > 0, 'age must be greater than 0'),
+			),
+		});
+
+		const output1 = parseWithValibot(createFormData('age', '1'), { schema });
+		expect(output1).toMatchObject({ status: 'success', value: { age: 1 } });
+
+		const output2 = parseWithValibot(createFormData('age', '0'), { schema });
+		expect(output2).toMatchObject({
+			error: { age: expect.anything() },
+		});
+
+		const output3 = parseWithValibot(createFormData('age', ''), { schema });
+		expect(output3).toMatchObject({
+			error: {
+				age: expect.anything(),
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/nonOptionalAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/nonOptionalAsync.test.ts
@@ -1,0 +1,94 @@
+import {
+	checkAsync,
+	nonOptionalAsync,
+	number,
+	objectAsync,
+	optionalAsync,
+	pipeAsync,
+	undefined_,
+	unionAsync,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('nonOptionalAsync', () => {
+	test('should not pass undefined', async () => {
+		const schema1 = objectAsync({
+			item: nonOptionalAsync(optionalAsync(number())),
+		});
+		const input1 = createFormData('item', '1');
+		const output1 = await parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({ status: 'success', value: { item: 1 } });
+		expect(
+			await parseWithValibot(createFormData('item', 'non Number'), {
+				schema: schema1,
+			}),
+		).toMatchObject({
+			error: { item: expect.anything() },
+		});
+		expect(
+			await parseWithValibot(createFormData('item2', 'non Param'), {
+				schema: schema1,
+			}),
+		).toMatchObject({
+			error: {
+				item: expect.anything(),
+			},
+		});
+
+		const schema2 = objectAsync({
+			item: nonOptionalAsync(unionAsync([number(), undefined_()])),
+		});
+		const output2 = await parseWithValibot(input1, { schema: schema2 });
+		expect(output2).toMatchObject({ status: 'success', value: { item: 1 } });
+		expect(
+			await parseWithValibot(createFormData('item', 'non Number'), {
+				schema: schema2,
+			}),
+		).toMatchObject({
+			error: {
+				item: expect.anything(),
+			},
+		});
+		expect(
+			await parseWithValibot(createFormData('item2', 'non Param'), {
+				schema: schema2,
+			}),
+		).toMatchObject({
+			error: {
+				item: expect.anything(),
+			},
+		});
+	});
+
+	test('should pass nonOptional with pipe', async () => {
+		const schema = objectAsync({
+			age: pipeAsync(
+				nonOptionalAsync(optionalAsync(number())),
+				checkAsync(async (value) => value > 0, 'age must be greater than 0'),
+			),
+		});
+
+		const output1 = await parseWithValibot(createFormData('age', '1'), {
+			schema,
+		});
+		expect(output1).toMatchObject({ status: 'success', value: { age: 1 } });
+
+		const output2 = await parseWithValibot(createFormData('age', '0'), {
+			schema,
+		});
+		expect(output2).toMatchObject({
+			error: { age: expect.anything() },
+		});
+
+		const output3 = await parseWithValibot(createFormData('age', ''), {
+			schema,
+		});
+		expect(output3).toMatchObject({
+			error: {
+				age: expect.anything(),
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/nullable.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/nullable.test.ts
@@ -1,0 +1,83 @@
+import {
+	check,
+	nullable,
+	number,
+	object,
+	optional,
+	pipe,
+	string,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('nullable', () => {
+	test('should pass also undefined', () => {
+		const schema = object({ age: nullable(number()) });
+		const output = parseWithValibot(createFormData('age', '20'), { schema });
+
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { age: 20 },
+		});
+		expect(
+			parseWithValibot(createFormData('age', 'non number'), { schema }),
+		).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+
+	test('should pass nullable with pipe', () => {
+		const schema = object({
+			age: pipe(
+				nullable(number()),
+				check(
+					(value) => value == null || value > 0,
+					'age must be greater than 0',
+				),
+			),
+		});
+
+		const output2 = parseWithValibot(createFormData('age', '20'), { schema });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { age: 20 },
+		});
+
+		const errorOutput = parseWithValibot(createFormData('age', '0'), {
+			schema,
+		});
+		expect(errorOutput).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+
+	test('should use default if required', () => {
+		const default_ = 'default';
+
+		const schema1 = object({
+			name: optional(nullable(string(), default_), null),
+		});
+		const output1 = parseWithValibot(createFormData('name', ''), {
+			schema: schema1,
+		});
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { name: 'default' },
+		});
+
+		const schema2 = object({
+			name: optional(
+				nullable(string(), () => default_),
+				null,
+			),
+		});
+		const output2 = parseWithValibot(createFormData('name', ''), {
+			schema: schema2,
+		});
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { name: 'default' },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/nullableAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/nullableAsync.test.ts
@@ -1,0 +1,87 @@
+import {
+	checkAsync,
+	nullableAsync,
+	number,
+	objectAsync,
+	optionalAsync,
+	pipeAsync,
+	string,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('nullableAsync', () => {
+	test('should pass also undefined', async () => {
+		const schema = objectAsync({ age: nullableAsync(number()) });
+		const output = await parseWithValibot(createFormData('age', '20'), {
+			schema,
+		});
+
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { age: 20 },
+		});
+		expect(
+			await parseWithValibot(createFormData('age', 'non number'), { schema }),
+		).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+
+	test('should pass nullable with pipe', async () => {
+		const schema = objectAsync({
+			age: pipeAsync(
+				nullableAsync(number()),
+				checkAsync(
+					async (value) => value == null || value > 0,
+					'age must be greater than 0',
+				),
+			),
+		});
+
+		const output2 = await parseWithValibot(createFormData('age', '20'), {
+			schema,
+		});
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { age: 20 },
+		});
+
+		const errorOutput = await parseWithValibot(createFormData('age', '0'), {
+			schema,
+		});
+		expect(errorOutput).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+
+	test('should use default if required', async () => {
+		const default_ = 'default';
+
+		const schema1 = objectAsync({
+			name: optionalAsync(nullableAsync(string(), default_), null),
+		});
+		const output1 = await parseWithValibot(createFormData('name', ''), {
+			schema: schema1,
+		});
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { name: 'default' },
+		});
+
+		const schema2 = objectAsync({
+			name: optionalAsync(
+				nullableAsync(string(), () => default_),
+				null,
+			),
+		});
+		const output2 = await parseWithValibot(createFormData('name', ''), {
+			schema: schema2,
+		});
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { name: 'default' },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/nullish.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/nullish.test.ts
@@ -1,0 +1,89 @@
+import { check, nullish, number, object, pipe, string } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('nullish', () => {
+	test('should pass also undefined', () => {
+		const schema = object({ name: nullish(string()), age: nullish(number()) });
+		const output = parseWithValibot(createFormData('age', ''), { schema });
+
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { age: undefined },
+		});
+		expect(
+			parseWithValibot(createFormData('age', '20'), { schema }),
+		).toMatchObject({
+			status: 'success',
+			value: { age: 20 },
+		});
+		expect(
+			parseWithValibot(createFormData('age', 'non number'), { schema }),
+		).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+
+	test('should pass nullish with pipe', () => {
+		const schema = object({
+			age: pipe(
+				nullish(number()),
+				check(
+					(value) => value == null || value > 0,
+					'age must be greater than 0',
+				),
+			),
+		});
+
+		const output1 = parseWithValibot(createFormData('age', ''), { schema });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { age: undefined },
+		});
+
+		const output2 = parseWithValibot(createFormData('age', '20'), { schema });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { age: 20 },
+		});
+
+		const errorOutput = parseWithValibot(createFormData('age', '0'), {
+			schema,
+		});
+		expect(errorOutput).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+
+	test('should use default if required', () => {
+		const default_ = 'default';
+
+		const schema1 = object({ name: nullish(string(), default_) });
+		const output1 = parseWithValibot(createFormData('name', ''), {
+			schema: schema1,
+		});
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { name: 'default' },
+		});
+
+		const schema2 = object({ name: nullish(string(), () => default_) });
+		const output2 = parseWithValibot(createFormData('name', ''), {
+			schema: schema2,
+		});
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { name: 'default' },
+		});
+
+		const schema3 = object({ name: nullish(string(), () => default_) });
+		const output3 = parseWithValibot(createFormData('age', '30'), {
+			schema: schema3,
+		});
+		expect(output3).toMatchObject({
+			status: 'success',
+			value: { name: 'default' },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/nullishAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/nullishAsync.test.ts
@@ -1,0 +1,109 @@
+import {
+	checkAsync,
+	nullishAsync,
+	number,
+	objectAsync,
+	pipeAsync,
+	string,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('nullishAsync', () => {
+	test('should pass also undefined', async () => {
+		const schema = objectAsync({
+			name: nullishAsync(string()),
+			age: nullishAsync(number()),
+		});
+		const output = await parseWithValibot(createFormData('age', ''), {
+			schema,
+		});
+
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { age: undefined },
+		});
+		expect(
+			await parseWithValibot(createFormData('age', '20'), { schema }),
+		).toMatchObject({
+			status: 'success',
+			value: { age: 20 },
+		});
+		expect(
+			await parseWithValibot(createFormData('age', 'non number'), { schema }),
+		).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+
+	test('should pass nullish with pipe', async () => {
+		const schema = objectAsync({
+			age: pipeAsync(
+				nullishAsync(number()),
+				checkAsync(
+					async (value) => value == null || value > 0,
+					'age must be greater than 0',
+				),
+			),
+		});
+
+		const output1 = await parseWithValibot(createFormData('age', ''), {
+			schema,
+		});
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { age: undefined },
+		});
+
+		const output2 = await parseWithValibot(createFormData('age', '20'), {
+			schema,
+		});
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { age: 20 },
+		});
+
+		const errorOutput = await parseWithValibot(createFormData('age', '0'), {
+			schema,
+		});
+		expect(errorOutput).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+
+	test('should use default if required', async () => {
+		const default_ = 'default';
+
+		const schema1 = objectAsync({ name: nullishAsync(string(), default_) });
+		const output1 = await parseWithValibot(createFormData('name', ''), {
+			schema: schema1,
+		});
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { name: 'default' },
+		});
+
+		const schema2 = objectAsync({
+			name: nullishAsync(string(), () => default_),
+		});
+		const output2 = await parseWithValibot(createFormData('name', ''), {
+			schema: schema2,
+		});
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { name: 'default' },
+		});
+
+		const schema3 = objectAsync({
+			name: nullishAsync(string(), () => default_),
+		});
+		const output3 = await parseWithValibot(createFormData('age', '30'), {
+			schema: schema3,
+		});
+		expect(output3).toMatchObject({
+			status: 'success',
+			value: { name: 'default' },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/number.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/number.test.ts
@@ -1,0 +1,23 @@
+import { number, object } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('number', () => {
+	test('should pass only numbers', () => {
+		const schema = object({ age: number() });
+		const output = parseWithValibot(createFormData('age', '20'), { schema });
+
+		expect(output).toMatchObject({ status: 'success', value: { age: 20 } });
+		expect(
+			parseWithValibot(createFormData('age', ''), { schema }),
+		).toMatchObject({
+			error: { age: expect.anything() },
+		});
+		expect(
+			parseWithValibot(createFormData('age', 'non number'), { schema }),
+		).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/object.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/object.test.ts
@@ -1,0 +1,96 @@
+import { check, forward, number, object, pipe, string } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('object', () => {
+	test('should pass only objects', () => {
+		const schema1 = object({ key1: string(), key2: number() });
+		const input1 = createFormData('key1', 'test');
+		input1.append('key2', '123');
+		const output1 = parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { key1: 'test', key2: 123 },
+		});
+
+		input1.append('key3', '');
+		const output2 = parseWithValibot(input1, { schema: schema1 });
+		expect(output2.status).toBe('success');
+		// @ts-expect-error
+		expect(output2.value).toStrictEqual({
+			key1: 'test',
+			key2: 123,
+		});
+
+		const input2 = createFormData('key1', '');
+		input2.append('key2', '123');
+		const output3 = parseWithValibot(input2, { schema: schema1 });
+		expect(output3).toMatchObject({
+			error: {
+				key1: expect.anything(),
+			},
+		});
+
+		const input3 = createFormData('key1', 'string');
+		input3.set('key2', 'non number');
+		const output4 = parseWithValibot(input3, { schema: schema1 });
+		expect(output4).toMatchObject({
+			error: {
+				key2: expect.anything(),
+			},
+		});
+	});
+
+	test('should pass objects with pipe', () => {
+		const schema = pipe(
+			object({
+				key: string(),
+			}),
+			forward(
+				check(({ key }) => key !== 'error name', 'key is error'),
+				['key'],
+			),
+		);
+
+		const output = parseWithValibot(createFormData('key', 'valid'), {
+			schema,
+		});
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { key: 'valid' },
+		});
+
+		const errorOutput = parseWithValibot(createFormData('key', 'error name'), {
+			schema,
+		});
+		expect(errorOutput).toMatchObject({
+			error: {
+				key: expect.anything(),
+			},
+		});
+	});
+
+	test('should fail with check on object', () => {
+		const schema = pipe(
+			object({
+				key1: string(),
+				key2: string(),
+			}),
+			check(({ key1, key2 }) => key1 === key2, 'keys must match'),
+		);
+
+		const input = createFormData('key1', 'foo');
+		input.append('key2', 'bar');
+
+		const errorOutput = parseWithValibot(input, {
+			schema,
+		});
+
+		expect(errorOutput).toMatchObject({
+			error: {
+				'': ['keys must match'],
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/objectAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/objectAsync.test.ts
@@ -1,0 +1,106 @@
+import {
+	checkAsync,
+	forwardAsync,
+	number,
+	objectAsync,
+	pipeAsync,
+	string,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('objectAsync', () => {
+	test('should pass only objects', async () => {
+		const schema1 = objectAsync({ key1: string(), key2: number() });
+		const input1 = createFormData('key1', 'test');
+		input1.append('key2', '123');
+		const output1 = await parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { key1: 'test', key2: 123 },
+		});
+
+		input1.append('key3', '');
+		const output2 = await parseWithValibot(input1, { schema: schema1 });
+		expect(output2.status).toBe('success');
+		// @ts-expect-error
+		expect(output2.value).toStrictEqual({
+			key1: 'test',
+			key2: 123,
+		});
+
+		const input2 = createFormData('key1', '');
+		input2.append('key2', '123');
+		const output3 = await parseWithValibot(input2, { schema: schema1 });
+		expect(output3).toMatchObject({
+			error: {
+				key1: expect.anything(),
+			},
+		});
+
+		const input3 = createFormData('key1', 'string');
+		input3.set('key2', 'non number');
+		const output4 = await parseWithValibot(input3, { schema: schema1 });
+		expect(output4).toMatchObject({
+			error: {
+				key2: expect.anything(),
+			},
+		});
+	});
+
+	test('should pass objects with pipe', async () => {
+		const schema = pipeAsync(
+			objectAsync({
+				key: string(),
+			}),
+			forwardAsync(
+				checkAsync(async ({ key }) => key !== 'error name', 'key is error'),
+				['key'],
+			),
+		);
+
+		const output = await parseWithValibot(createFormData('key', 'valid'), {
+			schema,
+		});
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { key: 'valid' },
+		});
+
+		const errorOutput = await parseWithValibot(
+			createFormData('key', 'error name'),
+			{
+				schema,
+			},
+		);
+		expect(errorOutput).toMatchObject({
+			error: {
+				key: expect.anything(),
+			},
+		});
+	});
+
+	test('should fail with check on object', async () => {
+		const schema = pipeAsync(
+			objectAsync({
+				key1: string(),
+				key2: string(),
+			}),
+			checkAsync(({ key1, key2 }) => key1 === key2, 'keys must match'),
+		);
+
+		const input = createFormData('key1', 'foo');
+		input.append('key2', 'bar');
+
+		const errorOutput = await parseWithValibot(input, {
+			schema,
+		});
+
+		expect(errorOutput).toMatchObject({
+			error: {
+				'': ['keys must match'],
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/objectWithRest.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/objectWithRest.test.ts
@@ -1,0 +1,66 @@
+import {
+	check,
+	number,
+	object,
+	objectWithRest,
+	optional,
+	pipe,
+	string,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('objectWithRest', () => {
+	test('should pass only objects', () => {
+		const schema1 = object({
+			obj: objectWithRest({ key1: string() }, optional(number())),
+		});
+		const input1 = createFormData('obj.key1', 'test');
+		input1.append('obj.key2', '123');
+		const output1 = parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { obj: { key1: 'test', key2: 123 } },
+		});
+
+		input1.append('obj.key3', '');
+		const output2 = parseWithValibot(input1, { schema: schema1 });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { obj: { key1: 'test', key2: 123, key3: undefined } },
+		});
+	});
+
+	test('should pass objects with pipe', () => {
+		const schema = object({
+			obj: pipe(
+				objectWithRest({ key1: string() }, optional(number())),
+				// eslint-disable-next-line no-prototype-builtins
+				check((v) => v.hasOwnProperty('key2'), 'key2 is required'),
+			),
+		});
+
+		const input = createFormData('obj.key1', 'has key2');
+		input.append('obj.key2', '123');
+		const output = parseWithValibot(input, {
+			schema,
+		});
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { obj: { key1: 'has key2', key2: 123 } },
+		});
+
+		const errorOutput = parseWithValibot(
+			createFormData('obj.key1', 'not has key2'),
+			{
+				schema,
+			},
+		);
+		expect(errorOutput).toMatchObject({
+			error: {
+				obj: expect.anything(),
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/objectWithRestAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/objectWithRestAsync.test.ts
@@ -1,0 +1,66 @@
+import {
+	check,
+	number,
+	objectAsync,
+	objectWithRestAsync,
+	optional,
+	pipeAsync,
+	string,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('objectWithRestAsync', () => {
+	test('should pass only objects', async () => {
+		const schema1 = objectAsync({
+			obj: objectWithRestAsync({ key1: string() }, optional(number())),
+		});
+		const input1 = createFormData('obj.key1', 'test');
+		input1.append('obj.key2', '123');
+		const output1 = await parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { obj: { key1: 'test', key2: 123 } },
+		});
+
+		input1.append('obj.key3', '');
+		const output2 = await parseWithValibot(input1, { schema: schema1 });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { obj: { key1: 'test', key2: 123, key3: undefined } },
+		});
+	});
+
+	test('should pass objects with pipe', async () => {
+		const schema = objectAsync({
+			obj: pipeAsync(
+				objectWithRestAsync({ key1: string() }, optional(number())),
+				// eslint-disable-next-line no-prototype-builtins
+				check((v) => v.hasOwnProperty('key2'), 'key2 is required'),
+			),
+		});
+
+		const input = createFormData('obj.key1', 'has key2');
+		input.append('obj.key2', '123');
+		const output = await parseWithValibot(input, {
+			schema,
+		});
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { obj: { key1: 'has key2', key2: 123 } },
+		});
+
+		const errorOutput = await parseWithValibot(
+			createFormData('obj.key1', 'not has key2'),
+			{
+				schema,
+			},
+		);
+		expect(errorOutput).toMatchObject({
+			error: {
+				obj: expect.anything(),
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/optional.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/optional.test.ts
@@ -1,0 +1,92 @@
+import { check, number, object, optional, pipe, string } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('optional', () => {
+	test('should pass also undefined', () => {
+		const schema = object({
+			name: optional(string()),
+			age: optional(number()),
+		});
+		const output = parseWithValibot(createFormData('age', ''), { schema });
+
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { age: undefined },
+		});
+		expect(
+			parseWithValibot(createFormData('age', '20'), { schema }),
+		).toMatchObject({
+			status: 'success',
+			value: { age: 20 },
+		});
+		expect(
+			parseWithValibot(createFormData('age', 'non number'), { schema }),
+		).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+
+	test('should pass optional with pipe', () => {
+		const schema = object({
+			age: pipe(
+				optional(number()),
+				check(
+					(value) => value == null || value > 0,
+					'age must be greater than 0',
+				),
+			),
+		});
+
+		const output1 = parseWithValibot(createFormData('age', ''), { schema });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { age: undefined },
+		});
+
+		const output2 = parseWithValibot(createFormData('age', '20'), { schema });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { age: 20 },
+		});
+
+		const errorOutput = parseWithValibot(createFormData('age', '0'), {
+			schema,
+		});
+		expect(errorOutput).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+
+	test('should use default if required', () => {
+		const default_ = 'default';
+
+		const schema1 = object({ name: optional(string(), default_) });
+		const output1 = parseWithValibot(createFormData('name', ''), {
+			schema: schema1,
+		});
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { name: 'default' },
+		});
+
+		const schema2 = object({ name: optional(string(), () => default_) });
+		const output2 = parseWithValibot(createFormData('name', ''), {
+			schema: schema2,
+		});
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { name: 'default' },
+		});
+
+		const schema3 = object({ name: optional(string(), () => default_) });
+		const output3 = parseWithValibot(createFormData('age', '30'), {
+			schema: schema3,
+		});
+		expect(output3).toMatchObject({
+			status: 'success',
+			value: { name: 'default' },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/optionalAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/optionalAsync.test.ts
@@ -1,0 +1,109 @@
+import {
+	checkAsync,
+	number,
+	objectAsync,
+	optionalAsync,
+	pipeAsync,
+	string,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('optionalAsync', () => {
+	test('should pass also undefined', async () => {
+		const schema = objectAsync({
+			name: optionalAsync(string()),
+			age: optionalAsync(number()),
+		});
+		const output = await parseWithValibot(createFormData('age', ''), {
+			schema,
+		});
+
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { age: undefined },
+		});
+		expect(
+			await parseWithValibot(createFormData('age', '20'), { schema }),
+		).toMatchObject({
+			status: 'success',
+			value: { age: 20 },
+		});
+		expect(
+			await parseWithValibot(createFormData('age', 'non number'), { schema }),
+		).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+
+	test('should pass optional with pipe', async () => {
+		const schema = objectAsync({
+			age: pipeAsync(
+				optionalAsync(number()),
+				checkAsync(
+					async (value) => value == null || value > 0,
+					'age must be greater than 0',
+				),
+			),
+		});
+
+		const output1 = await parseWithValibot(createFormData('age', ''), {
+			schema,
+		});
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { age: undefined },
+		});
+
+		const output2 = await parseWithValibot(createFormData('age', '20'), {
+			schema,
+		});
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { age: 20 },
+		});
+
+		const errorOutput = await parseWithValibot(createFormData('age', '0'), {
+			schema,
+		});
+		expect(errorOutput).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+
+	test('should use default if required', async () => {
+		const default_ = 'default';
+
+		const schema1 = objectAsync({ name: optionalAsync(string(), default_) });
+		const output1 = await parseWithValibot(createFormData('name', ''), {
+			schema: schema1,
+		});
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { name: 'default' },
+		});
+
+		const schema2 = objectAsync({
+			name: optionalAsync(string(), () => default_),
+		});
+		const output2 = await parseWithValibot(createFormData('name', ''), {
+			schema: schema2,
+		});
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { name: 'default' },
+		});
+
+		const schema3 = objectAsync({
+			name: optionalAsync(string(), () => default_),
+		});
+		const output3 = await parseWithValibot(createFormData('age', '30'), {
+			schema: schema3,
+		});
+		expect(output3).toMatchObject({
+			status: 'success',
+			value: { name: 'default' },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/picklist.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/picklist.test.ts
@@ -1,0 +1,32 @@
+import { object, picklist } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('picklist', () => {
+	test('should pass only picklist values', () => {
+		const schema = object({ list: picklist(['value_1', 'value_2']) });
+
+		const formData1 = createFormData('list', 'value_1');
+		const output1 = parseWithValibot(formData1, { schema });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { list: 'value_1' },
+		});
+
+		const formData2 = createFormData('list', 'value_2');
+		const output2 = parseWithValibot(formData2, { schema });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { list: 'value_2' },
+		});
+
+		const formData3 = createFormData('list', 'value_3');
+		const output3 = parseWithValibot(formData3, { schema });
+		expect(output3).toMatchObject({
+			error: {
+				list: expect.anything(),
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/strictObject.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/strictObject.test.ts
@@ -1,0 +1,72 @@
+import { check, forward, number, pipe, strictObject, string } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('strictObject', () => {
+	test('should pass only strict objects', () => {
+		const schema1 = strictObject({ key1: string(), key2: number() });
+		const input1 = createFormData('key1', 'test');
+		input1.append('key2', '123');
+		const output1 = parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { key1: 'test', key2: 123 },
+		});
+
+		input1.append('key3', '');
+		const output2 = parseWithValibot(input1, { schema: schema1 });
+		expect(output2).toMatchObject({
+			error: {
+				key3: expect.anything(),
+			},
+		});
+
+		const input2 = createFormData('key1', '');
+		input2.append('key2', '123');
+		const output3 = parseWithValibot(input2, { schema: schema1 });
+		expect(output3).toMatchObject({
+			error: {
+				key1: expect.anything(),
+			},
+		});
+
+		const input3 = createFormData('key1', 'string');
+		input3.set('key2', 'non number');
+		const output4 = parseWithValibot(input3, { schema: schema1 });
+		expect(output4).toMatchObject({
+			error: {
+				key2: expect.anything(),
+			},
+		});
+	});
+
+	test('should pass objects with pipe', () => {
+		const schema = pipe(
+			strictObject({
+				key: string(),
+			}),
+			forward(
+				check(({ key }) => key !== 'error name', 'key is error'),
+				['key'],
+			),
+		);
+
+		const output = parseWithValibot(createFormData('key', 'valid'), {
+			schema,
+		});
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { key: 'valid' },
+		});
+
+		const errorOutput = parseWithValibot(createFormData('key', 'error name'), {
+			schema,
+		});
+		expect(errorOutput).toMatchObject({
+			error: {
+				key: expect.anything(),
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/strictObjectAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/strictObjectAsync.test.ts
@@ -1,0 +1,82 @@
+import {
+	checkAsync,
+	forwardAsync,
+	number,
+	pipeAsync,
+	strictObjectAsync,
+	string,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('strictObjectAsync', () => {
+	test('should pass only strict objects', async () => {
+		const schema1 = strictObjectAsync({ key1: string(), key2: number() });
+		const input1 = createFormData('key1', 'test');
+		input1.append('key2', '123');
+		const output1 = await parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { key1: 'test', key2: 123 },
+		});
+
+		input1.append('key3', '');
+		const output2 = await parseWithValibot(input1, { schema: schema1 });
+		expect(output2).toMatchObject({
+			error: {
+				key3: expect.anything(),
+			},
+		});
+
+		const input2 = createFormData('key1', '');
+		input2.append('key2', '123');
+		const output3 = await parseWithValibot(input2, { schema: schema1 });
+		expect(output3).toMatchObject({
+			error: {
+				key1: expect.anything(),
+			},
+		});
+
+		const input3 = createFormData('key1', 'string');
+		input3.set('key2', 'non number');
+		const output4 = await parseWithValibot(input3, { schema: schema1 });
+		expect(output4).toMatchObject({
+			error: {
+				key2: expect.anything(),
+			},
+		});
+	});
+
+	test('should pass objects with pipe', async () => {
+		const schema = pipeAsync(
+			strictObjectAsync({
+				key: string(),
+			}),
+			forwardAsync(
+				checkAsync(async ({ key }) => key !== 'error name', 'key is error'),
+				['key'],
+			),
+		);
+
+		const output = await parseWithValibot(createFormData('key', 'valid'), {
+			schema,
+		});
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { key: 'valid' },
+		});
+
+		const errorOutput = await parseWithValibot(
+			createFormData('key', 'error name'),
+			{
+				schema,
+			},
+		);
+		expect(errorOutput).toMatchObject({
+			error: {
+				key: expect.anything(),
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/string.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/string.test.ts
@@ -1,0 +1,22 @@
+import { object, string } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('string', () => {
+	test('should pass only strings', () => {
+		const schema = object({ name: string() });
+
+		const output = parseWithValibot(createFormData('name', 'Jane'), { schema });
+
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { name: 'Jane' },
+		});
+		expect(
+			parseWithValibot(createFormData('name', ''), { schema }),
+		).toMatchObject({
+			error: { name: expect.anything() },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/tuple.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/tuple.test.ts
@@ -1,0 +1,59 @@
+import { check, number, object, pipe, string, tuple } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('tuple', () => {
+	test('should pass only tuples', () => {
+		const schema1 = object({ tuple: tuple([number(), string()]) });
+		const input1 = createFormData('tuple', '1');
+		input1.append('tuple', 'test');
+		const output1 = parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { tuple: [1, 'test'] },
+		});
+		const input2 = createFormData('tuple', '1');
+		input2.append('tuple', 'test');
+		input2.append('tuple', '');
+		const output2 = parseWithValibot(input2, { schema: schema1 });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { tuple: [1, 'test'] },
+		});
+
+		const errorInput1 = createFormData('tuple', '1');
+		expect(parseWithValibot(errorInput1, { schema: schema1 })).toMatchObject({
+			error: { tuple: expect.anything() },
+		});
+		const errorInput2 = createFormData('tuple', '123');
+		expect(parseWithValibot(errorInput2, { schema: schema1 })).toMatchObject({
+			error: { tuple: expect.anything() },
+		});
+	});
+
+	test('should pass only tuples with pipe', () => {
+		const schema = object({
+			tuple: pipe(
+				tuple([number(), string()]),
+				check(([num]) => num > 0, 'num is not greater than 0'),
+			),
+		});
+
+		const input = createFormData('tuple', '1');
+		input.append('tuple', 'test');
+		const output = parseWithValibot(input, {
+			schema,
+		});
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { tuple: [1, 'test'] },
+		});
+
+		const errorInput = createFormData('tuple', '0');
+		errorInput.append('tuple', 'test');
+		expect(parseWithValibot(errorInput, { schema })).toMatchObject({
+			error: { tuple: expect.anything() },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/tupleAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/tupleAsync.test.ts
@@ -1,0 +1,70 @@
+import {
+	checkAsync,
+	number,
+	objectAsync,
+	pipeAsync,
+	string,
+	tupleAsync,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('tupleAsync', () => {
+	test('should pass only tuples', async () => {
+		const schema1 = objectAsync({ tuple: tupleAsync([number(), string()]) });
+		const input1 = createFormData('tuple', '1');
+		input1.append('tuple', 'test');
+		const output1 = await parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { tuple: [1, 'test'] },
+		});
+		const input2 = createFormData('tuple', '1');
+		input2.append('tuple', 'test');
+		input2.append('tuple', '');
+		const output2 = await parseWithValibot(input2, { schema: schema1 });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { tuple: [1, 'test'] },
+		});
+
+		const errorInput1 = createFormData('tuple', '1');
+		expect(
+			await parseWithValibot(errorInput1, { schema: schema1 }),
+		).toMatchObject({
+			error: { tuple: expect.anything() },
+		});
+		const errorInput2 = createFormData('tuple', '123');
+		expect(
+			await parseWithValibot(errorInput2, { schema: schema1 }),
+		).toMatchObject({
+			error: { tuple: expect.anything() },
+		});
+	});
+
+	test('should pass only tuples with pipe', async () => {
+		const schema = objectAsync({
+			tuple: pipeAsync(
+				tupleAsync([number(), string()]),
+				checkAsync(async ([num]) => num > 0, 'num is not greater than 0'),
+			),
+		});
+
+		const input = createFormData('tuple', '1');
+		input.append('tuple', 'test');
+		const output = await parseWithValibot(input, {
+			schema,
+		});
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { tuple: [1, 'test'] },
+		});
+
+		const errorInput = createFormData('tuple', '0');
+		errorInput.append('tuple', 'test');
+		expect(await parseWithValibot(errorInput, { schema })).toMatchObject({
+			error: { tuple: expect.anything() },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/tupleWithRest.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/tupleWithRest.test.ts
@@ -1,0 +1,64 @@
+import {
+	check,
+	number,
+	object,
+	optional,
+	pipe,
+	string,
+	tupleWithRest,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('tupleWithRest', () => {
+	test('should pass only tuples', () => {
+		const schema1 = object({
+			tuple: tupleWithRest([string()], optional(number())),
+		});
+		const input2 = createFormData('tuple[]', 'test');
+		const output2 = parseWithValibot(input2, { schema: schema1 });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { tuple: ['test'] },
+		});
+		const input3 = createFormData('tuple', 'test');
+		input3.append('tuple', '');
+		const output3 = parseWithValibot(input3, { schema: schema1 });
+		expect(output3).toMatchObject({
+			status: 'success',
+			value: { tuple: ['test', undefined] },
+		});
+		const input4 = createFormData('tuple', 'test');
+		input4.append('tuple', '1');
+		input4.append('tuple', '2');
+		const output4 = parseWithValibot(input4, { schema: schema1 });
+		expect(output4).toMatchObject({
+			status: 'success',
+			value: { tuple: ['test', 1, 2] },
+		});
+	});
+
+	test('should pass tuples with pipe', () => {
+		const schema = object({
+			tuple: pipe(
+				tupleWithRest([string()], optional(number())),
+				check((v) => v.length > 2, 'tuple must have more than 1 element'),
+			),
+		});
+		const input = createFormData('tuple', 'test');
+		input.append('tuple', '1');
+		input.append('tuple', '2');
+		const output = parseWithValibot(input, { schema });
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { tuple: ['test', 1, 2] },
+		});
+
+		const errorInput = createFormData('tuple', 'test');
+		errorInput.append('tuple', '1');
+		expect(parseWithValibot(errorInput, { schema })).toMatchObject({
+			error: { tuple: expect.anything() },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/tupleWithRestAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/tupleWithRestAsync.test.ts
@@ -1,0 +1,67 @@
+import {
+	checkAsync,
+	number,
+	objectAsync,
+	optionalAsync,
+	pipeAsync,
+	string,
+	tupleWithRestAsync,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('tupleWithRestAsync', () => {
+	test('should pass only tuples', async () => {
+		const schema1 = objectAsync({
+			tuple: tupleWithRestAsync([string()], optionalAsync(number())),
+		});
+		const input2 = createFormData('tuple[]', 'test');
+		const output2 = await parseWithValibot(input2, { schema: schema1 });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { tuple: ['test'] },
+		});
+		const input3 = createFormData('tuple', 'test');
+		input3.append('tuple', '');
+		const output3 = await parseWithValibot(input3, { schema: schema1 });
+		expect(output3).toMatchObject({
+			status: 'success',
+			value: { tuple: ['test', undefined] },
+		});
+		const input4 = createFormData('tuple', 'test');
+		input4.append('tuple', '1');
+		input4.append('tuple', '2');
+		const output4 = await parseWithValibot(input4, { schema: schema1 });
+		expect(output4).toMatchObject({
+			status: 'success',
+			value: { tuple: ['test', 1, 2] },
+		});
+	});
+
+	test('should pass tuples with pipe', async () => {
+		const schema = objectAsync({
+			tuple: pipeAsync(
+				tupleWithRestAsync([string()], optionalAsync(number())),
+				checkAsync(
+					async (v) => v.length > 2,
+					'tuple must have more than 1 element',
+				),
+			),
+		});
+		const input = createFormData('tuple', 'test');
+		input.append('tuple', '1');
+		input.append('tuple', '2');
+		const output = await parseWithValibot(input, { schema });
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { tuple: ['test', 1, 2] },
+		});
+
+		const errorInput = createFormData('tuple', 'test');
+		errorInput.append('tuple', '1');
+		expect(await parseWithValibot(errorInput, { schema })).toMatchObject({
+			error: { tuple: expect.anything() },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/undefined.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/undefined.test.ts
@@ -1,0 +1,26 @@
+import { object, string, undefined_ } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('undefined', () => {
+	test('should pass only undefined', () => {
+		const schema = object({ name: string(), age: undefined_() });
+		const formData1 = createFormData('name', 'Jane');
+		formData1.append('age', '');
+		expect(parseWithValibot(formData1, { schema })).toMatchObject({
+			status: 'success',
+			value: { name: 'Jane', age: undefined },
+		});
+
+		const formData2 = createFormData('name', 'Jane');
+		expect(parseWithValibot(formData2, { schema })).toMatchObject({
+			error: { age: expect.anything() },
+		});
+
+		formData2.append('age', '20');
+		expect(parseWithValibot(formData2, { schema })).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/undefinedable.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/undefinedable.test.ts
@@ -1,0 +1,27 @@
+import { number, object, string, undefinedable } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('undefinedable', () => {
+	test('should pass only undefinedable', () => {
+		const schema = object({ name: string(), age: undefinedable(number()) });
+		const formData1 = createFormData('name', 'Jane');
+		formData1.append('age', '');
+		expect(parseWithValibot(formData1, { schema })).toMatchObject({
+			status: 'success',
+			value: { name: 'Jane', age: undefined },
+		});
+
+		const formData2 = createFormData('name', 'Jane');
+		expect(parseWithValibot(formData2, { schema })).toMatchObject({
+			error: { age: expect.anything() },
+		});
+
+		formData2.append('age', '20');
+		expect(parseWithValibot(formData2, { schema })).toMatchObject({
+			status: 'success',
+			value: { name: 'Jane', age: 20 },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/undefinedableAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/undefinedableAsync.test.ts
@@ -1,0 +1,30 @@
+import { number, objectAsync, string, undefinedableAsync } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('undefinedableAsync', () => {
+	test('should pass only undefinedable', async () => {
+		const schema = objectAsync({
+			name: string(),
+			age: undefinedableAsync(number()),
+		});
+		const formData1 = createFormData('name', 'Jane');
+		formData1.append('age', '');
+		expect(await parseWithValibot(formData1, { schema })).toMatchObject({
+			status: 'success',
+			value: { name: 'Jane', age: undefined },
+		});
+
+		const formData2 = createFormData('name', 'Jane');
+		expect(await parseWithValibot(formData2, { schema })).toMatchObject({
+			error: { age: expect.anything() },
+		});
+
+		formData2.append('age', '20');
+		expect(await parseWithValibot(formData2, { schema })).toMatchObject({
+			status: 'success',
+			value: { name: 'Jane', age: 20 },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/union.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/union.test.ts
@@ -1,0 +1,63 @@
+import { check, number, object, pipe, undefined_, union } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('union', () => {
+	test('should pass only union values', () => {
+		const schema = object({ age: union([number(), undefined_()]) });
+		const output1 = parseWithValibot(createFormData('age', '30'), { schema });
+		expect(output1).toMatchObject({ status: 'success', value: { age: 30 } });
+
+		const output2 = parseWithValibot(createFormData('age', ''), { schema });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { age: undefined },
+		});
+
+		expect(
+			parseWithValibot(createFormData('age', 'non number'), { schema }),
+		).toMatchObject({
+			error: {
+				age: expect.anything(),
+			},
+		});
+	});
+
+	test('should pass only union values with pipe', () => {
+		const schema = object({
+			age: pipe(
+				union([number(), undefined_()]),
+				check(
+					(value) => value == null || value > 0,
+					'age must be greater than 0',
+				),
+			),
+		});
+
+		const output1 = parseWithValibot(createFormData('age', '30'), { schema });
+		expect(output1).toMatchObject({ status: 'success', value: { age: 30 } });
+
+		const output2 = parseWithValibot(createFormData('age', ''), { schema });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { age: undefined },
+		});
+
+		const errorOutput1 = parseWithValibot(createFormData('age', 'non number'), {
+			schema,
+		});
+		expect(errorOutput1).toMatchObject({
+			error: {
+				age: expect.anything(),
+			},
+		});
+
+		const errorOutput2 = parseWithValibot(createFormData('age', '0'), {
+			schema,
+		});
+		expect(errorOutput2).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/variant.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/variant.test.ts
@@ -1,0 +1,112 @@
+import {
+	check,
+	forward,
+	literal,
+	number,
+	object,
+	pipe,
+	string,
+	variant,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('variant', () => {
+	test('should pass only variant values', () => {
+		const schema1 = variant('type', [
+			object({ type: literal('a'), a: string() }),
+			object({ type: literal('b'), b: number() }),
+		]);
+		const input1 = createFormData('type', 'a');
+		input1.append('a', 'hello');
+		const output1 = parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { type: 'a', a: 'hello' },
+		});
+		const input2 = createFormData('type', 'b');
+		input2.append('b', '123');
+		const output2 = parseWithValibot(input2, { schema: schema1 });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { type: 'b', b: 123 },
+		});
+
+		const schema2 = variant('type', [
+			schema1,
+			object({ type: literal('c'), foo: literal('foo') }),
+			object({ type: literal('c'), bar: literal('bar') }),
+		]);
+		const input3 = createFormData('type', 'b');
+		input3.append('b', '123');
+		const output3 = parseWithValibot(input3, { schema: schema2 });
+		expect(output3).toMatchObject({
+			status: 'success',
+			value: { type: 'b', b: 123 },
+		});
+		const input4 = createFormData('type', 'c');
+		input4.append('foo', 'foo');
+		const output4 = parseWithValibot(input4, { schema: schema2 });
+		expect(output4).toMatchObject({
+			status: 'success',
+			value: { type: 'c', foo: 'foo' },
+		});
+		const input5 = createFormData('type', 'c');
+		input5.append('bar', 'bar');
+		const output5 = parseWithValibot(input5, { schema: schema2 });
+		expect(output5).toMatchObject({
+			status: 'success',
+			value: { type: 'c', bar: 'bar' },
+		});
+
+		const errorInput1 = createFormData('type', 'x');
+		expect(parseWithValibot(errorInput1, { schema: schema2 })).toMatchObject({
+			error: { type: expect.anything() },
+		});
+		const errorInput2 = createFormData('type2', 'a');
+		expect(parseWithValibot(errorInput2, { schema: schema2 })).toMatchObject({
+			error: {
+				type: expect.anything(),
+			},
+		});
+	});
+
+	test('should pass only variant values with pipe', () => {
+		const schema = pipe(
+			variant('type', [
+				object({ type: literal('a'), a: string() }),
+				object({ type: literal('b'), b: number() }),
+			]),
+			forward(
+				check(
+					({ type, ...other }) =>
+						type === 'a' || (type === 'b' && 'b' in other && other.b !== 0),
+					'b must be non-zero',
+				),
+				['b'],
+			),
+		);
+		const input1 = createFormData('type', 'a');
+		input1.append('a', 'hello');
+		const output1 = parseWithValibot(input1, { schema });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { type: 'a', a: 'hello' },
+		});
+		const input2 = createFormData('type', 'b');
+		input2.append('b', '123');
+		const output2 = parseWithValibot(input2, { schema });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { type: 'b', b: 123 },
+		});
+
+		const errorInput1 = createFormData('type', 'b');
+		errorInput1.append('b', '0');
+		const errorOutput1 = parseWithValibot(errorInput1, { schema });
+		expect(errorOutput1).toMatchObject({
+			error: { b: expect.anything() },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/variantAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/variantAsync.test.ts
@@ -1,0 +1,116 @@
+import {
+	checkAsync,
+	forwardAsync,
+	literal,
+	number,
+	object,
+	pipeAsync,
+	string,
+	variantAsync,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('variantAsync', () => {
+	test('should pass only variant values', async () => {
+		const schema1 = variantAsync('type', [
+			object({ type: literal('a'), a: string() }),
+			object({ type: literal('b'), b: number() }),
+		]);
+		const input1 = createFormData('type', 'a');
+		input1.append('a', 'hello');
+		const output1 = await parseWithValibot(input1, { schema: schema1 });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { type: 'a', a: 'hello' },
+		});
+		const input2 = createFormData('type', 'b');
+		input2.append('b', '123');
+		const output2 = await parseWithValibot(input2, { schema: schema1 });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { type: 'b', b: 123 },
+		});
+
+		const schema2 = variantAsync('type', [
+			schema1,
+			object({ type: literal('c'), foo: literal('foo') }),
+			object({ type: literal('c'), bar: literal('bar') }),
+		]);
+		const input3 = createFormData('type', 'b');
+		input3.append('b', '123');
+		const output3 = await parseWithValibot(input3, { schema: schema2 });
+		expect(output3).toMatchObject({
+			status: 'success',
+			value: { type: 'b', b: 123 },
+		});
+		const input4 = createFormData('type', 'c');
+		input4.append('foo', 'foo');
+		const output4 = await parseWithValibot(input4, { schema: schema2 });
+		expect(output4).toMatchObject({
+			status: 'success',
+			value: { type: 'c', foo: 'foo' },
+		});
+		const input5 = createFormData('type', 'c');
+		input5.append('bar', 'bar');
+		const output5 = await parseWithValibot(input5, { schema: schema2 });
+		expect(output5).toMatchObject({
+			status: 'success',
+			value: { type: 'c', bar: 'bar' },
+		});
+
+		const errorInput1 = createFormData('type', 'x');
+		expect(
+			await parseWithValibot(errorInput1, { schema: schema2 }),
+		).toMatchObject({
+			error: { type: expect.anything() },
+		});
+		const errorInput2 = createFormData('type2', 'a');
+		expect(
+			await parseWithValibot(errorInput2, { schema: schema2 }),
+		).toMatchObject({
+			error: {
+				type: expect.anything(),
+			},
+		});
+	});
+
+	test('should pass only variant values with pipe', async () => {
+		const schema = pipeAsync(
+			variantAsync('type', [
+				object({ type: literal('a'), a: string() }),
+				object({ type: literal('b'), b: number() }),
+			]),
+			forwardAsync(
+				checkAsync(
+					async ({ type, ...other }) =>
+						type === 'a' || (type === 'b' && 'b' in other && other.b !== 0),
+					'b must be non-zero',
+				),
+				['b'],
+			),
+		);
+		const input1 = createFormData('type', 'a');
+		input1.append('a', 'hello');
+		const output1 = await parseWithValibot(input1, { schema });
+		expect(output1).toMatchObject({
+			status: 'success',
+			value: { type: 'a', a: 'hello' },
+		});
+		const input2 = createFormData('type', 'b');
+		input2.append('b', '123');
+		const output2 = await parseWithValibot(input2, { schema });
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { type: 'b', b: 123 },
+		});
+
+		const errorInput1 = createFormData('type', 'b');
+		errorInput1.append('b', '0');
+		const errorOutput1 = await parseWithValibot(errorInput1, { schema });
+		expect(errorOutput1).toMatchObject({
+			error: { b: expect.anything() },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/wrap.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/wrap.test.ts
@@ -1,0 +1,85 @@
+import {
+	check,
+	isoDate,
+	nullable,
+	number,
+	object,
+	optional,
+	pipe,
+	string,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('wrap', () => {
+	test('should pass also undefined', () => {
+		const schema = object({ name: optional(nullable(string()), null) });
+		const output = parseWithValibot(createFormData('name', ''), { schema });
+		expect(output).toMatchObject({ status: 'success', value: { name: null } });
+	});
+
+	test('should pass with nested pipe object', () => {
+		const schema = object({
+			key1: string(),
+			key2: optional(
+				pipe(
+					object({
+						date: optional(pipe(string(), isoDate())),
+					}),
+					check((input) => input?.date !== '2000-01-01', 'Bad date'),
+				),
+			),
+		});
+
+		const input = createFormData('key1', 'valid');
+		input.append('key2.date', '');
+
+		const output = parseWithValibot(input, {
+			schema,
+		});
+
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { key1: 'valid', key2: {} },
+		});
+	});
+
+	test('should pass with directly nested pipe object', () => {
+		const schema = pipe(
+			pipe(
+				object({
+					key: number(),
+				}),
+				check(({ key }) => key > 0, 'key is not positive'),
+			),
+			check(({ key }) => key % 2 === 0, 'key is not even'),
+		);
+
+		const output = parseWithValibot(createFormData('key', '2'), {
+			schema,
+		});
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { key: 2 },
+		});
+
+		const errorOutput1 = parseWithValibot(createFormData('key', '-2'), {
+			schema,
+		});
+		expect(errorOutput1).toMatchObject({
+			error: {
+				'': ['key is not positive'],
+			},
+		});
+
+		const errorOutput2 = parseWithValibot(createFormData('key', '1'), {
+			schema,
+		});
+		expect(errorOutput2).toMatchObject({
+			error: {
+				'': ['key is not even'],
+			},
+		});
+	});
+});

--- a/packages/conform-valibot/tests/coercion/schema/wrap.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/wrap.test.ts
@@ -1,12 +1,14 @@
 import {
 	check,
 	isoDate,
+	literal,
 	nullable,
 	number,
 	object,
 	optional,
 	pipe,
 	string,
+	union,
 } from 'valibot';
 import { describe, expect, test } from 'vitest';
 import { parseWithValibot } from '../../../parse';
@@ -79,6 +81,39 @@ describe('wrap', () => {
 		expect(errorOutput2).toMatchObject({
 			error: {
 				'': ['key is not even'],
+			},
+		});
+	});
+
+	test('should pass wrapped union', () => {
+		const schema = object({
+			union: optional(union([number(), literal('test')])),
+		});
+
+		const output1 = parseWithValibot(createFormData('union', '30'), { schema });
+		expect(output1).toMatchObject({ status: 'success', value: { union: 30 } });
+
+		const output2 = parseWithValibot(createFormData('union', 'test'), {
+			schema,
+		});
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { union: 'test' },
+		});
+
+		const output3 = parseWithValibot(createFormData('union', ''), { schema });
+		expect(output3).toMatchObject({
+			status: 'success',
+			value: { union: undefined },
+		});
+
+		const errorOutput = parseWithValibot(
+			createFormData('union', 'non number'),
+			{ schema },
+		);
+		expect(errorOutput).toMatchObject({
+			error: {
+				union: expect.anything(),
 			},
 		});
 	});

--- a/packages/conform-valibot/tests/coercion/schema/wrapAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/wrapAsync.test.ts
@@ -1,6 +1,7 @@
 import {
 	checkAsync,
 	isoDate,
+	literal,
 	nullableAsync,
 	number,
 	object,
@@ -8,6 +9,7 @@ import {
 	optionalAsync,
 	pipeAsync,
 	string,
+	unionAsync,
 } from 'valibot';
 import { describe, expect, test } from 'vitest';
 import { parseWithValibot } from '../../../parse';
@@ -102,6 +104,43 @@ describe('wrapAsync', () => {
 		expect(output).toMatchObject({
 			status: 'success',
 			value: { key: 'valid' },
+		});
+	});
+
+	test('should pass wrapped async union', async () => {
+		const schema = objectAsync({
+			union: optionalAsync(unionAsync([number(), literal('test')])),
+		});
+
+		const output1 = await parseWithValibot(createFormData('union', '30'), {
+			schema,
+		});
+		expect(output1).toMatchObject({ status: 'success', value: { union: 30 } });
+
+		const output2 = await parseWithValibot(createFormData('union', 'test'), {
+			schema,
+		});
+		expect(output2).toMatchObject({
+			status: 'success',
+			value: { union: 'test' },
+		});
+
+		const output3 = await parseWithValibot(createFormData('union', ''), {
+			schema,
+		});
+		expect(output3).toMatchObject({
+			status: 'success',
+			value: { union: undefined },
+		});
+
+		const errorOutput = await parseWithValibot(
+			createFormData('union', 'non number'),
+			{ schema },
+		);
+		expect(errorOutput).toMatchObject({
+			error: {
+				union: expect.anything(),
+			},
 		});
 	});
 });

--- a/packages/conform-valibot/tests/coercion/schema/wrapAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/wrapAsync.test.ts
@@ -1,0 +1,107 @@
+import {
+	checkAsync,
+	isoDate,
+	nullableAsync,
+	number,
+	object,
+	objectAsync,
+	optionalAsync,
+	pipeAsync,
+	string,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('wrapAsync', () => {
+	test('should pass also undefined', async () => {
+		const schema = objectAsync({
+			name: optionalAsync(nullableAsync(string()), null),
+		});
+		const output = await parseWithValibot(createFormData('name', ''), {
+			schema,
+		});
+		expect(output).toMatchObject({ status: 'success', value: { name: null } });
+	});
+
+	test('should pass with nested pipe object', async () => {
+		const schema = objectAsync({
+			key1: string(),
+			key2: optionalAsync(
+				pipeAsync(
+					objectAsync({
+						date: optionalAsync(pipeAsync(string(), isoDate())),
+					}),
+					checkAsync((input) => input?.date !== '2000-01-01', 'Bad date'),
+				),
+			),
+		});
+
+		const input = createFormData('key1', 'valid');
+		input.append('key2.date', '');
+
+		const output = await parseWithValibot(input, {
+			schema,
+		});
+
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { key1: 'valid', key2: {} },
+		});
+	});
+
+	test('should pass with directly nested pipe object', async () => {
+		const schema = pipeAsync(
+			pipeAsync(
+				objectAsync({
+					key: number(),
+				}),
+				checkAsync(({ key }) => key > 0, 'key is not positive'),
+			),
+			checkAsync(({ key }) => key % 2 === 0, 'key is not even'),
+		);
+
+		const output = await parseWithValibot(createFormData('key', '2'), {
+			schema,
+		});
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { key: 2 },
+		});
+
+		const errorOutput1 = await parseWithValibot(createFormData('key', '-2'), {
+			schema,
+		});
+		expect(errorOutput1).toMatchObject({
+			error: {
+				'': ['key is not positive'],
+			},
+		});
+
+		const errorOutput2 = await parseWithValibot(createFormData('key', '1'), {
+			schema,
+		});
+		expect(errorOutput2).toMatchObject({
+			error: {
+				'': ['key is not even'],
+			},
+		});
+	});
+
+	test('should pass sync object with async pipe', async () => {
+		const schema = pipeAsync(
+			object({
+				key: string(),
+			}),
+			checkAsync(async ({ key }) => key !== 'error name', 'key is error'),
+		);
+
+		const output = await parseWithValibot(createFormData('key', 'valid'), {
+			schema,
+		});
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { key: 'valid' },
+		});
+	});
+});

--- a/packages/conform-valibot/tests/constraint.test.ts
+++ b/packages/conform-valibot/tests/constraint.test.ts
@@ -1,0 +1,319 @@
+import {
+	array,
+	boolean,
+	check,
+	date,
+	enum_,
+	instance,
+	intersect,
+	literal,
+	maxLength,
+	maxValue,
+	minLength,
+	minValue,
+	nullish,
+	number,
+	object,
+	optional,
+	pipe,
+	string,
+	tuple,
+	union,
+	variant,
+} from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { getValibotConstraint } from '../constraint';
+
+enum TestEnum {
+	a = 'a',
+	b = 'b',
+	c = 'c',
+}
+
+describe('constraint', () => {
+	test('getValibotConstraint', () => {
+		const schema = pipe(
+			object({
+				text: pipe(
+					string('required'),
+					minLength(10, 'min'),
+					maxLength(100, 'max'),
+					check(() => false, 'refine'),
+				),
+				number: pipe(
+					number('required'),
+					minValue(1, 'min'),
+					maxValue(10, 'max'),
+					check((v) => v % 2 === 0, 'step'),
+				),
+				timestamp: optional(
+					pipe(
+						date(),
+						minValue(new Date(1), 'min'),
+						maxValue(new Date(), 'max'),
+					),
+					new Date(),
+				),
+				flag: optional(boolean()),
+				options: pipe(array(enum_(TestEnum)), minLength(3, 'min')),
+				nested: pipe(
+					object({
+						key: pipe(
+							string(),
+							check(() => false, 'refine'),
+						),
+					}),
+					check(() => false, 'refine'),
+				),
+				list: pipe(
+					array(
+						object({
+							key: pipe(
+								string('required'),
+								check(() => false, 'refine'),
+							),
+						}),
+					),
+					maxLength(0, 'max'),
+				),
+				files: pipe(
+					array(instance(Date, 'Invalid file')),
+					minLength(1, 'required'),
+				),
+				tuple: tuple([
+					pipe(string(), minLength(3, 'min')),
+					optional(pipe(number(), maxValue(100, 'max'))),
+				]),
+				nullishString: nullish(string()),
+			}),
+			check(() => false, 'refine'),
+		);
+		const constraint = {
+			text: {
+				required: true,
+				minLength: 10,
+				maxLength: 100,
+			},
+			number: {
+				required: true,
+				min: 1,
+				max: 10,
+			},
+			timestamp: {
+				required: false,
+			},
+			flag: {
+				required: false,
+			},
+			options: {
+				required: true,
+				multiple: true,
+			},
+			'options[]': {
+				required: true,
+				pattern: 'a|b|c',
+			},
+			files: {
+				required: true,
+				multiple: true,
+			},
+			'files[]': {
+				required: true,
+			},
+			nested: {
+				required: true,
+			},
+			'nested.key': {
+				required: true,
+			},
+			list: {
+				required: true,
+				multiple: true,
+			},
+			'list[]': {
+				required: true,
+			},
+			'list[].key': {
+				required: true,
+			},
+			tuple: {
+				required: true,
+			},
+			'tuple[0]': {
+				required: true,
+				minLength: 3,
+			},
+			'tuple[1]': {
+				required: false,
+				max: 100,
+			},
+			nullishString: {
+				required: false,
+			},
+		};
+
+		expect(getValibotConstraint(schema)).toEqual(constraint);
+
+		// Non-object schemas will throw an error
+		expect(() => getValibotConstraint(string())).toThrow();
+		expect(() => getValibotConstraint(array(string()))).toThrow();
+
+		// Intersection is supported
+		expect(
+			getValibotConstraint(
+				intersect([
+					schema,
+					object({ text: optional(string()), something: string() }),
+				]),
+			),
+		).toEqual({
+			...constraint,
+			text: { required: false },
+			something: { required: true },
+		});
+
+		// Union is supported
+		expect(
+			getValibotConstraint(
+				intersect([
+					union([
+						object({
+							type: literal('a'),
+							foo: pipe(string(), minLength(1, 'min')),
+							baz: pipe(string(), minLength(1, 'min')),
+						}),
+						object({
+							type: literal('b'),
+							bar: pipe(string(), minLength(1, 'min')),
+							baz: pipe(string(), minLength(1, 'min')),
+						}),
+					]),
+					object({
+						qux: pipe(string(), minLength(1, 'min')),
+					}),
+				]),
+			),
+		).toEqual({
+			type: { required: true },
+			foo: { required: false, minLength: 1 },
+			bar: { required: false, minLength: 1 },
+			baz: { required: true, minLength: 1 },
+			qux: { required: true, minLength: 1 },
+		});
+
+		// Discriminated union is also supported
+		expect(
+			getValibotConstraint(
+				intersect([
+					variant('type', [
+						object({
+							type: literal('a'),
+							foo: pipe(string(), minLength(1, 'min')),
+							baz: pipe(string(), minLength(1, 'min')),
+						}),
+						object({
+							type: literal('b'),
+							bar: pipe(string(), minLength(1, 'min')),
+							baz: pipe(string(), minLength(1, 'min')),
+						}),
+					]),
+					object({
+						qux: pipe(string(), minLength(1, 'min')),
+					}),
+				]),
+			),
+		).toEqual({
+			type: { required: true },
+			foo: { required: false, minLength: 1 },
+			bar: { required: false, minLength: 1 },
+			baz: { required: true, minLength: 1 },
+			qux: { required: true, minLength: 1 },
+		});
+
+		// // Recursive schema should be supported too
+		// const baseCategorySchema = z.object({
+		// 	name: z.string(),
+		//   });
+
+		// type Category = z.infer<typeof baseCategorySchema> & {
+		// 	subcategories: Category[];
+		// };
+
+		// const categorySchema: z.ZodType<Category> = baseCategorySchema.extend({
+		// 	subcategories: z.lazy(() => categorySchema.array()),
+		// });
+
+		// expect(
+		// 	getZodConstraint(categorySchema),
+		// ).toEqual({
+		// 	name: {
+		// 		required: true,
+		// 	},
+		// 	subcategories: {
+		// 		required: true,
+		// 		multiple: true,
+		// 	},
+
+		// 	'subcategories[].name': {
+		// 		required: true,
+		// 	},
+		// 	'subcategories[].subcategories': {
+		// 		required: true,
+		// 		multiple: true,
+		// 	},
+
+		// 	'subcategories[].subcategories[].name': {
+		// 		required: true,
+		// 	},
+		// 	'subcategories[].subcategories[].subcategories': {
+		// 		required: true,
+		// 		multiple: true,
+		// 	},
+		// });
+
+		// type Condition = { type: 'filter' } | { type: 'group', conditions: Condition[] }
+
+		// const ConditionSchema: z.ZodType<Condition> = z.discriminatedUnion('type', [
+		// 	z.object({
+		// 		type: z.literal('filter')
+		// 	}),
+		// 	z.object({
+		// 		type: z.literal('group'),
+		// 		conditions: z.lazy(() => ConditionSchema.array()),
+		// 	}),
+		// ]);
+
+		// const FilterSchema = z.object({
+		// 	type: z.literal('group'),
+		// 	conditions: ConditionSchema.array(),
+		// })
+
+		// expect(
+		// 	getZodConstraint(FilterSchema),
+		// ).toEqual({
+		// 	type: {
+		// 		required: true,
+		// 	},
+		// 	conditions: {
+		// 		required: true,
+		// 		multiple: true,
+		// 	},
+
+		// 	'conditions[].type': {
+		// 		required: true,
+		// 	},
+		// 	'conditions[].conditions': {
+		// 		required: true,
+		// 		multiple: true,
+		// 	},
+
+		// 	'conditions[].conditions[].type': {
+		// 		required: true,
+		// 	},
+		// 	'conditions[].conditions[].conditions': {
+		// 		required: true,
+		// 		multiple: true,
+		// 	},
+		// });
+	});
+});

--- a/packages/conform-valibot/tests/helpers/FormData.ts
+++ b/packages/conform-valibot/tests/helpers/FormData.ts
@@ -1,0 +1,5 @@
+export function createFormData(key: string, value: string | Blob) {
+	const formData = new FormData();
+	formData.append(key, value);
+	return formData;
+}

--- a/packages/conform-valibot/tests/helpers/valibot.ts
+++ b/packages/conform-valibot/tests/helpers/valibot.ts
@@ -1,0 +1,29 @@
+import type {
+	GenericSchema,
+	GenericSchemaAsync,
+	SafeParseResult,
+} from 'valibot';
+import { formatPaths } from '@conform-to/dom';
+
+export function getResult<Output>(
+	result: SafeParseResult<GenericSchema | GenericSchemaAsync>,
+):
+	| { success: false; error: Record<string, string[]> }
+	| { success: true; data: Output } {
+	if (result.success) {
+		return { success: true, data: result.output as Output };
+	}
+
+	const error: Record<string, string[]> = {};
+
+	for (const issue of result.issues) {
+		const name = formatPaths(
+			issue.path?.map((d) => d.key as string | number) ?? [],
+		);
+
+		error[name] ??= [];
+		error[name].push(issue.message);
+	}
+
+	return { success: false, error };
+}

--- a/packages/conform-valibot/tests/parse.test.ts
+++ b/packages/conform-valibot/tests/parse.test.ts
@@ -1,9 +1,73 @@
-import { check, object, pipe, string } from 'valibot';
+import {
+	check,
+	number,
+	object,
+	optional,
+	pipe,
+	string,
+	transform,
+	unknown,
+} from 'valibot';
 import { describe, expect, test } from 'vitest';
 import { conformValibotMessage, parseWithValibot } from '../parse';
 import { createFormData } from './helpers/FormData';
 
 describe('parseWithValibot', () => {
+	describe('config', () => {
+		describe('disableAutoCoercion', () => {
+			test('should validate without automatic schema conversion when disableAutoCoercion is true', () => {
+				const schema1 = object({
+					name: string(),
+					age: number(),
+				});
+				const input = createFormData('age', '26');
+				input.append('name', '');
+				const output1 = parseWithValibot(input, {
+					schema: schema1,
+					disableAutoCoercion: true,
+				});
+				expect(output1).toMatchObject({
+					error: {
+						age: expect.anything(),
+					},
+				});
+
+				const schema2 = object({
+					name: string(),
+					age: pipe(
+						unknown(),
+						transform((v) => Number(v)),
+						number(),
+					),
+				});
+				const output2 = parseWithValibot(input, {
+					schema: schema2,
+					disableAutoCoercion: true,
+				});
+				expect(output2).toMatchObject({
+					status: 'success',
+					value: { name: '', age: 26 },
+				});
+			});
+		});
+
+		test('should validate with automatic schema conversion when disableAutoCoercion is false', () => {
+			const schema = object({
+				name: optional(string()),
+				age: number(),
+			});
+			const input = createFormData('age', '26');
+			input.append('name', '');
+			const output = parseWithValibot(input, {
+				schema,
+			});
+			expect(output).toMatchObject({
+				status: 'success',
+				value: { name: undefined, age: 26 },
+			});
+		});
+	});
+
 	test('should return null for an error field when its error message is skipped', () => {
 		const schema = object({
 			key: pipe(

--- a/packages/conform-valibot/tests/parse.test.ts
+++ b/packages/conform-valibot/tests/parse.test.ts
@@ -1,0 +1,38 @@
+import { check, object, pipe, string } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { conformValibotMessage, parseWithValibot } from '../parse';
+import { createFormData } from './helpers/FormData';
+
+describe('parseWithValibot', () => {
+	test('should return null for an error field when its error message is skipped', () => {
+		const schema = object({
+			key: pipe(
+				string(),
+				check(
+					(input) => input === 'valid',
+					conformValibotMessage.VALIDATION_SKIPPED,
+				),
+			),
+		});
+		const output = parseWithValibot(createFormData('key', 'invalid'), {
+			schema,
+		});
+		expect(output).toMatchObject({ error: { key: null } });
+	});
+
+	test('should return null for the error when any error message is undefined', () => {
+		const schema = object({
+			key: pipe(
+				string(),
+				check(
+					(input) => input === 'valid',
+					conformValibotMessage.VALIDATION_UNDEFINED,
+				),
+			),
+		});
+		const output = parseWithValibot(createFormData('key', 'invalid'), {
+			schema,
+		});
+		expect(output).toMatchObject({ error: null });
+	});
+});

--- a/packages/conform-valibot/tsconfig.build.json
+++ b/packages/conform-valibot/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"outDir": "./dist"
+	},
+	"exclude": ["./tests/**", "dist"]
+}

--- a/packages/conform-valibot/tsconfig.json
+++ b/packages/conform-valibot/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"target": "ES2022",
+		"module": "ES2022",
+		"moduleResolution": "Bundler",
+		"allowSyntheticDefaultImports": true,
+		"noUncheckedIndexedAccess": true,
+		"strict": true,
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		"composite": true,
+		"skipLibCheck": true
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -676,7 +676,7 @@ importers:
   packages/conform-valibot:
     dependencies:
       '@conform-to/dom':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../conform-dom
     devDependencies:
       '@babel/core':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,7 +586,7 @@ importers:
         version: 12.4.0
       '@remix-run/dev':
         specifier: ^2.5.1
-        version: 2.9.1(@remix-run/react@2.9.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5))(@remix-run/serve@2.9.1(typescript@5.4.5))(@types/node@20.11.20)(terser@5.26.0)(typescript@5.4.5)(vite@5.1.4(@types/node@20.11.20)(terser@5.26.0))(wrangler@3.53.1(@cloudflare/workers-types@4.20240502.0))
+        version: 2.9.1(@remix-run/react@2.9.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5))(@remix-run/serve@2.9.1(typescript@5.4.5))(@types/node@20.11.20)(terser@5.26.0)(typescript@5.4.5)(vite@5.1.4(@types/node@20.11.20)(terser@5.26.0))(wrangler@3.53.1)
       '@tailwindcss/forms':
         specifier: ^0.5.7
         version: 0.5.7(tailwindcss@3.4.3)
@@ -672,6 +672,37 @@ importers:
       rollup-plugin-copy:
         specifier: ^3.4.0
         version: 3.5.0
+
+  packages/conform-valibot:
+    dependencies:
+      '@conform-to/dom':
+        specifier: workspace:*
+        version: link:../conform-dom
+    devDependencies:
+      '@babel/core':
+        specifier: ^7.17.8
+        version: 7.23.5
+      '@babel/preset-env':
+        specifier: ^7.20.2
+        version: 7.23.5(@babel/core@7.23.5)
+      '@babel/preset-typescript':
+        specifier: ^7.20.2
+        version: 7.23.3(@babel/core@7.23.5)
+      '@rollup/plugin-babel':
+        specifier: ^5.3.1
+        version: 5.3.1(@babel/core@7.23.5)(@types/babel__core@7.20.5)(rollup@2.79.1)
+      '@rollup/plugin-node-resolve':
+        specifier: ^13.3.0
+        version: 13.3.0(rollup@2.79.1)
+      rollup:
+        specifier: ^2.79.1
+        version: 2.79.1
+      rollup-plugin-copy:
+        specifier: ^3.4.0
+        version: 3.5.0
+      valibot:
+        specifier: ^1.0.0-rc.3
+        version: 1.0.0-rc.3(typescript@5.4.5)
 
   packages/conform-validitystate:
     devDependencies:
@@ -815,7 +846,7 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.9.1
-        version: 2.9.1(@remix-run/react@2.9.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5))(@remix-run/serve@2.9.1(typescript@5.4.5))(@types/node@20.11.20)(terser@5.26.0)(typescript@5.4.5)(vite@5.1.4(@types/node@20.11.20)(terser@5.26.0))(wrangler@3.53.1(@cloudflare/workers-types@4.20240502.0))
+        version: 2.9.1(@remix-run/react@2.9.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5))(@remix-run/serve@2.9.1(typescript@5.4.5))(@types/node@20.11.20)(terser@5.26.0)(typescript@5.4.5)(vite@5.1.4(@types/node@20.11.20)(terser@5.26.0))(wrangler@3.53.1)
       '@tailwindcss/forms':
         specifier: ^0.5.2
         version: 0.5.7(tailwindcss@3.4.3)
@@ -11007,6 +11038,14 @@ packages:
     resolution: {integrity: sha512-FGtKtv3xIpR6BYhvgH8MI/y78oT7d8Au3ww4QIxymrCtZEh5b8gCw2siywE+puhEmuWKDtmfrvF5UlB298ut3w==}
     engines: {node: '>=10.12.0'}
 
+  valibot@1.0.0-rc.3:
+    resolution: {integrity: sha512-LT0REa7Iqx4QGcaHLiTiTkcmJqJ9QdpOy89HALFFBJgejTS64GQFRIbDF7e4f6pauQbo/myfKGmWXCLhMeM6+g==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
@@ -11542,7 +11581,7 @@ snapshots:
       '@babel/traverse': 7.23.5
       '@babel/types': 7.23.5
       convert-source-map: 2.0.0
-      debug: 4.3.4
+      debug: 4.4.0
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -11605,7 +11644,7 @@ snapshots:
       '@babel/core': 7.23.5
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4
+      debug: 4.4.0
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -12379,7 +12418,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.5
       '@babel/types': 7.23.5
-      debug: 4.3.4
+      debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -14298,11 +14337,11 @@ snapshots:
   '@npmcli/fs@1.1.1':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.5.4
+      semver: 7.6.2
 
   '@npmcli/fs@3.1.0':
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.2
 
   '@npmcli/git@4.1.0':
     dependencies:
@@ -14312,7 +14351,7 @@ snapshots:
       proc-log: 3.0.0
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.5.4
+      semver: 7.6.2
       which: 3.0.1
     transitivePeerDependencies:
       - bluebird
@@ -14334,7 +14373,7 @@ snapshots:
       json-parse-even-better-errors: 3.0.1
       normalize-package-data: 5.0.0
       proc-log: 3.0.0
-      semver: 7.5.4
+      semver: 7.6.2
     transitivePeerDependencies:
       - bluebird
 
@@ -15089,7 +15128,7 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@remix-run/dev@2.9.1(@remix-run/react@2.9.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5))(@remix-run/serve@2.9.1(typescript@5.4.5))(@types/node@20.11.20)(terser@5.26.0)(typescript@5.4.5)(vite@5.1.4(@types/node@20.11.20)(terser@5.26.0))(wrangler@3.53.1(@cloudflare/workers-types@4.20240502.0))':
+  '@remix-run/dev@2.9.1(@remix-run/react@2.9.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5))(@remix-run/serve@2.9.1(typescript@5.4.5))(@types/node@20.11.20)(terser@5.26.0)(typescript@5.4.5)(vite@5.1.4(@types/node@20.11.20)(terser@5.26.0))(wrangler@3.53.1)':
     dependencies:
       '@babel/core': 7.23.5
       '@babel/generator': 7.23.5
@@ -15174,7 +15213,7 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.29.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.29.0)(eslint@8.57.0)
       eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.57.0)
@@ -15930,7 +15969,7 @@ snapshots:
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare-lite: 1.4.0
-      semver: 7.5.4
+      semver: 7.6.2
       tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
       typescript: 4.9.5
@@ -16020,7 +16059,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
-      debug: 4.3.4
+      debug: 4.4.0
       eslint: 8.57.0
       tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
@@ -16050,7 +16089,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.2
@@ -16407,13 +16446,13 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
   agent-base@7.1.0:
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -17020,7 +17059,7 @@ snapshots:
 
   capnp-ts@0.7.0:
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
@@ -18094,8 +18133,8 @@ snapshots:
       '@typescript-eslint/parser': 6.20.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.33.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
@@ -18148,12 +18187,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.29.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.29.0)(eslint@8.57.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.29.0)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
@@ -18165,13 +18204,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0)(eslint@8.57.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -18187,7 +18226,7 @@ snapshots:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
@@ -18199,14 +18238,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.29.0)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.29.0)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18221,34 +18260,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.20.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.11.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 7.11.0(eslint@8.57.0)(typescript@5.4.5)
-      eslint: 8.57.0
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
@@ -18294,7 +18323,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.0(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -18304,7 +18333,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -18315,7 +18344,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.14.2
     optionalDependencies:
-      '@typescript-eslint/parser': 6.20.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 7.11.0(eslint@8.57.0)(typescript@5.4.5)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -18358,7 +18387,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -19023,7 +19052,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.3
       data-uri-to-buffer: 6.0.1
-      debug: 4.3.4
+      debug: 4.4.0
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -19325,14 +19354,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.0:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19364,14 +19393,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -19722,7 +19751,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.0
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -20853,7 +20882,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.0
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -21135,7 +21164,7 @@ snapshots:
     dependencies:
       hosted-git-info: 6.1.1
       is-core-module: 2.13.1
-      semver: 7.5.4
+      semver: 7.6.2
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -21376,7 +21405,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.4.0
       get-uri: 6.0.2
       http-proxy-agent: 7.0.0
       https-proxy-agent: 7.0.2
@@ -22984,7 +23013,7 @@ snapshots:
   socks-proxy-agent@8.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.4.0
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -23058,7 +23087,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.0
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -23069,7 +23098,7 @@ snapshots:
 
   spdy@4.0.2:
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.0
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -23868,6 +23897,10 @@ snapshots:
       convert-source-map: 1.9.0
       source-map: 0.7.4
 
+  valibot@1.0.0-rc.3(typescript@5.4.5):
+    optionalDependencies:
+      typescript: 5.4.5
+
   validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.2.0
@@ -23896,7 +23929,7 @@ snapshots:
   vite-node@0.28.5(@types/node@20.11.20)(terser@5.26.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4
+      debug: 4.4.0
       mlly: 1.4.2
       pathe: 1.1.2
       picocolors: 1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -701,8 +701,8 @@ importers:
         specifier: ^3.4.0
         version: 3.5.0
       valibot:
-        specifier: ^1.0.0-rc.3
-        version: 1.0.0-rc.3(typescript@5.4.5)
+        specifier: ^1.0.0
+        version: 1.0.0(typescript@5.4.5)
 
   packages/conform-validitystate:
     devDependencies:
@@ -11038,8 +11038,8 @@ packages:
     resolution: {integrity: sha512-FGtKtv3xIpR6BYhvgH8MI/y78oT7d8Au3ww4QIxymrCtZEh5b8gCw2siywE+puhEmuWKDtmfrvF5UlB298ut3w==}
     engines: {node: '>=10.12.0'}
 
-  valibot@1.0.0-rc.3:
-    resolution: {integrity: sha512-LT0REa7Iqx4QGcaHLiTiTkcmJqJ9QdpOy89HALFFBJgejTS64GQFRIbDF7e4f6pauQbo/myfKGmWXCLhMeM6+g==}
+  valibot@1.0.0:
+    resolution: {integrity: sha512-1Hc0ihzWxBar6NGeZv7fPLY0QuxFMyxwYR2sF1Blu7Wq7EnremwY2W02tit2ij2VJT8HcSkHAQqmFfl77f73Yw==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -23897,7 +23897,7 @@ snapshots:
       convert-source-map: 1.9.0
       source-map: 0.7.4
 
-  valibot@1.0.0-rc.3(typescript@5.4.5):
+  valibot@1.0.0(typescript@5.4.5):
     optionalDependencies:
       typescript: 5.4.5
 

--- a/vitest.workspace.mts
+++ b/vitest.workspace.mts
@@ -22,4 +22,5 @@ export default defineWorkspace([
 			environment: 'node',
 		},
 	},
+	'packages/conform-valibot',
 ]);


### PR DESCRIPTION
## Overview

Add a package that supports valibot based on [`conform-to-valibot`](https://github.com/chimame/conform-to-valibot).

`@conform-to/valibot` extends the schema so that FormData can validate the valibot schema defined by the user.

```ts
import { object, string } from "valibot";

const schema = object({
  name: string()
})

// Convert to a schema for FormData validation
const validationSchema = coerceFormValue(schema)
// object({
//   name: pipe(
//     unknown(),
//     transform(value => value === '' ? undefined : value),
//     string()
//   )
// })
```

There is a low level API being added to `@conform-to/zod`. `@conform-to/valibot` also adds the same API. https://github.com/edmundhung/conform/pull/871

## Changes
- Create based on the package structure of `@conform-to/zod`
  - Test files placed in `packages/conform-valibot/tests/`
  - Changed build files to output to `packages/conform-valibot/dist/`
- Add `coerceFormValue` low-level API to convert the valibot schema to validate FormData.
  - Add `disableAutoCoercion` option to `parseWithValibot` API to disable schema conversion by `coerceFormValue`

## TODO

The following additional steps are required.

- [x] Create documentation
- [x] Add a documentation link to the sidebar menu on the Conform website
- [x] Create the `coerceFormValue` API
- [x] Add a valibot schema supported by `getValibotConstraint` (e.g. `objectWithRest`)
