### PR TITLE
fix(conform-valibot): support nested fields with only checkboxes

### DIFF
--- a/.changeset/brave-timers-walk.md
+++ b/.changeset/brave-timers-walk.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/valibot': patch
+---
+
+fix: support nested fields with only checkboxes

--- a/.changeset/brave-timers-walk.md
+++ b/.changeset/brave-timers-walk.md
@@ -1,5 +1,5 @@
 ---
-'@conform-to/valibot': patch
+'@conform-to/valibot': minor
 ---
 
-fix: support nested fields with only checkboxes
+feat: support nested fields with only checkboxes

--- a/packages/conform-valibot/coercion.ts
+++ b/packages/conform-valibot/coercion.ts
@@ -29,6 +29,13 @@ type EnableTypeCoercionOptions = {
 	) => CoercionFunction | null;
 };
 
+const OBJECT_SCHEMA_TYPES: string[] = [
+	'object',
+	'loose_object',
+	'strict_object',
+	'object_with_rest',
+];
+
 /**
  * Reconstruct the provided schema with additional preprocessing steps
  * This coerce empty values to undefined and transform strings to the correct type
@@ -371,8 +378,29 @@ function enableTypeCoercion<T extends GenericSchema | GenericSchemaAsync>(
 				// @ts-expect-error
 				options: type.options.map(
 					// @ts-expect-error
-					(option) =>
-						enableTypeCoercion(option as GenericSchema, options).schema,
+					(option) => {
+						// In the case of `object` schema, `pipe` like the following cannot be defined. Therefore, `enableTypeCoercion` cannot be executed, so only object property conversion is performed.
+						// variant('type', [
+						//   pipe(unknown(), transform(v => v), object({ type: literal('a'), a: string() })),
+						//   object({ type: literal('b'), b: number() }),
+						// ]);
+						if (OBJECT_SCHEMA_TYPES.includes(option.type)) {
+							return {
+								...option,
+								entries: Object.fromEntries(
+									Object.entries(option.entries).map(([key, def]) => [
+										key,
+										enableTypeCoercion(def as GenericSchema, options).schema,
+									]),
+								),
+								rest:
+									'rest' in option
+										? enableTypeCoercion(option.rest, options).schema
+										: undefined,
+							};
+						}
+						return enableTypeCoercion(option as GenericSchema, options).schema;
+					},
 				),
 			};
 			return {
@@ -412,40 +440,44 @@ function enableTypeCoercion<T extends GenericSchema | GenericSchemaAsync>(
 		}
 		case 'loose_object':
 		case 'strict_object':
+		case 'object_with_rest':
 		case 'object': {
+			const childObjectSchemaKeys: string[] = [];
 			const objectSchema = {
 				...type,
 				entries: Object.fromEntries(
 					// @ts-expect-error
-					Object.entries(type.entries).map(([key, def]) => [
-						key,
-						enableTypeCoercion(def as GenericSchema, options).schema,
-					]),
+					Object.entries(type.entries).map(
+						// @ts-expect-error
+						([key, def]: [string, GenericSchema]) => {
+							if (OBJECT_SCHEMA_TYPES.includes(def.type)) {
+								childObjectSchemaKeys.push(key);
+							}
+							return [key, enableTypeCoercion(def, options).schema];
+						},
+					),
 				),
+				// `object_with_rest` schema requires conversion of `rest` property
+				rest:
+					'rest' in type
+						? // @ts-expect-error
+							enableTypeCoercion(type.rest, options).schema
+						: undefined,
 			};
-
 			return {
-				transformAction: undefined,
-				schema: objectSchema,
-			};
-		}
-		case 'object_with_rest': {
-			const objectWithRestSchema = {
-				...type,
-				entries: Object.fromEntries(
-					// @ts-expect-error
-					Object.entries(type.entries).map(([key, def]) => [
-						key,
-						enableTypeCoercion(def as GenericSchema, options).schema,
-					]),
-				),
-				// @ts-expect-error
-				rest: enableTypeCoercion(type.rest, options).schema,
-			};
+				schema: coerce(objectSchema, (value) => {
+					const ret: { [key: string]: unknown } = (value ?? {}) as {
+						[key: string]: unknown;
+					};
+					for (const key of childObjectSchemaKeys) {
+						if (!(key in ret)) {
+							ret[key] = {};
+						}
+					}
 
-			return {
+					return ret;
+				}).schema,
 				transformAction: undefined,
-				schema: objectWithRestSchema,
 			};
 		}
 	}

--- a/packages/conform-valibot/tests/coercion/schema/looseObject.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/looseObject.test.ts
@@ -41,6 +41,18 @@ describe('looseObject', () => {
 				key2: expect.anything(),
 			},
 		});
+
+		const schema2 = looseObject({
+			nest: schema1,
+		});
+		const input4 = new FormData();
+		const output5 = parseWithValibot(input4, { schema: schema2 });
+		expect(output5).toMatchObject({
+			error: {
+				'nest.key1': expect.anything(),
+				'nest.key2': expect.anything(),
+			},
+		});
 	});
 
 	test('should pass objects with pipe', () => {

--- a/packages/conform-valibot/tests/coercion/schema/looseObjectAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/looseObjectAsync.test.ts
@@ -48,6 +48,18 @@ describe('looseObjectAsync', () => {
 				key2: expect.anything(),
 			},
 		});
+
+		const schema2 = looseObjectAsync({
+			nest: schema1,
+		});
+		const input4 = new FormData();
+		const output5 = await parseWithValibot(input4, { schema: schema2 });
+		expect(output5).toMatchObject({
+			error: {
+				'nest.key1': expect.anything(),
+				'nest.key2': expect.anything(),
+			},
+		});
 	});
 
 	test('should pass objects with pipe', async () => {

--- a/packages/conform-valibot/tests/coercion/schema/object.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/object.test.ts
@@ -40,6 +40,18 @@ describe('object', () => {
 				key2: expect.anything(),
 			},
 		});
+
+		const schema2 = object({
+			nest: schema1,
+		});
+		const input4 = new FormData();
+		const output5 = parseWithValibot(input4, { schema: schema2 });
+		expect(output5).toMatchObject({
+			error: {
+				'nest.key1': expect.anything(),
+				'nest.key2': expect.anything(),
+			},
+		});
 	});
 
 	test('should pass objects with pipe', () => {

--- a/packages/conform-valibot/tests/coercion/schema/objectAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/objectAsync.test.ts
@@ -47,6 +47,18 @@ describe('objectAsync', () => {
 				key2: expect.anything(),
 			},
 		});
+
+		const schema2 = objectAsync({
+			nest: schema1,
+		});
+		const input4 = new FormData();
+		const output5 = await parseWithValibot(input4, { schema: schema2 });
+		expect(output5).toMatchObject({
+			error: {
+				'nest.key1': expect.anything(),
+				'nest.key2': expect.anything(),
+			},
+		});
 	});
 
 	test('should pass objects with pipe', async () => {

--- a/packages/conform-valibot/tests/coercion/schema/objectWithRest.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/objectWithRest.test.ts
@@ -30,6 +30,14 @@ describe('objectWithRest', () => {
 			status: 'success',
 			value: { obj: { key1: 'test', key2: 123, key3: undefined } },
 		});
+
+		const input2 = new FormData();
+		const output3 = parseWithValibot(input2, { schema: schema1 });
+		expect(output3).toMatchObject({
+			error: {
+				'obj.key1': expect.anything(),
+			},
+		});
 	});
 
 	test('should pass objects with pipe', () => {

--- a/packages/conform-valibot/tests/coercion/schema/objectWithRestAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/objectWithRestAsync.test.ts
@@ -30,6 +30,14 @@ describe('objectWithRestAsync', () => {
 			status: 'success',
 			value: { obj: { key1: 'test', key2: 123, key3: undefined } },
 		});
+
+		const input2 = new FormData();
+		const output3 = await parseWithValibot(input2, { schema: schema1 });
+		expect(output3).toMatchObject({
+			error: {
+				'obj.key1': expect.anything(),
+			},
+		});
 	});
 
 	test('should pass objects with pipe', async () => {

--- a/packages/conform-valibot/tests/coercion/schema/strictObject.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/strictObject.test.ts
@@ -39,6 +39,18 @@ describe('strictObject', () => {
 				key2: expect.anything(),
 			},
 		});
+
+		const schema2 = strictObject({
+			nest: schema1,
+		});
+		const input4 = new FormData();
+		const output5 = parseWithValibot(input4, { schema: schema2 });
+		expect(output5).toMatchObject({
+			error: {
+				'nest.key1': expect.anything(),
+				'nest.key2': expect.anything(),
+			},
+		});
 	});
 
 	test('should pass objects with pipe', () => {

--- a/packages/conform-valibot/tests/coercion/schema/strictObjectAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/strictObjectAsync.test.ts
@@ -46,6 +46,18 @@ describe('strictObjectAsync', () => {
 				key2: expect.anything(),
 			},
 		});
+
+		const schema2 = strictObjectAsync({
+			nest: schema1,
+		});
+		const input4 = new FormData();
+		const output5 = await parseWithValibot(input4, { schema: schema2 });
+		expect(output5).toMatchObject({
+			error: {
+				'nest.key1': expect.anything(),
+				'nest.key2': expect.anything(),
+			},
+		});
 	});
 
 	test('should pass objects with pipe', async () => {


### PR DESCRIPTION
## Overview

Valibot has also been modified to support validation of forms with nested checkboxes only, just like zod.
references: https://github.com/edmundhung/conform/pull/733

Zod has a `zodDiscriminatedUnion` schema, but valibot does not. Therefore, the same support as https://github.com/edmundhung/conform/pull/909 will not be performed.