### PR TITLE
fix: where `undefined` value could not be correctly verified when `array` was defined in `nullish` or `optional` schema

### DIFF
--- a/.changeset/kind-coats-lie.md
+++ b/.changeset/kind-coats-lie.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/valibot': patch
+---
+
+fix: where `undefined` value could not be correctly verified when `array` was defined in `nullish` or `optional` schema

--- a/packages/conform-valibot/coercion.ts
+++ b/packages/conform-valibot/coercion.ts
@@ -215,13 +215,13 @@ function generateWrappedSchema<T extends GenericSchema | GenericSchemaAsync>(
 
 	// `expects` is required to generate error messages for `TupleSchema`, so it is passed to `UnkonwSchema` for coercion.
 	const unknown = { ...valibotUnknown(), expects: type.expects };
+	const default_ = 'default' in type ? type.default : undefined;
 	if (transformAction) {
 		const schema = type.async
 			? pipeAsync(unknown, transformAction, type)
 			: pipe(unknown, transformAction, type);
 
 		if (rewrap) {
-			const default_ = 'default' in type ? type.default : undefined;
 			return {
 				transformAction: undefined,
 				schema: type.reference(schema, default_),
@@ -239,6 +239,13 @@ function generateWrappedSchema<T extends GenericSchema | GenericSchemaAsync>(
 	const schema = wrappedSchema.async
 		? pipeAsync(unknown, transformActionForStripEmptyString, wrappedSchema)
 		: pipe(unknown, transformActionForStripEmptyString, wrappedSchema);
+
+	if (rewrap) {
+		return {
+			transformAction: undefined,
+			schema: type.reference(schema, default_),
+		};
+	}
 
 	return {
 		transformAction: undefined,

--- a/packages/conform-valibot/tests/coercion/schema/array.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/array.test.ts
@@ -1,4 +1,4 @@
-import { array, check, object, pipe, string } from 'valibot';
+import { array, check, nullish, number, object, pipe, string } from 'valibot';
 import { describe, expect, test } from 'vitest';
 import { parseWithValibot } from '../../../parse';
 import { createFormData } from '../../helpers/FormData';
@@ -57,6 +57,35 @@ describe('array', () => {
 		expect(outputWithPipe).toMatchObject({
 			status: 'success',
 			value: { select: ['1', '2', '3'] },
+		});
+	});
+
+	test('should pass array with nullish', () => {
+		const schema = object({
+			age: nullish(array(number())),
+		});
+
+		expect(parseWithValibot(new FormData(), { schema })).toMatchObject({
+			status: 'success',
+			value: {},
+		});
+
+		const output = parseWithValibot(createFormData('age', ''), { schema });
+
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { age: undefined },
+		});
+		expect(
+			parseWithValibot(createFormData('age', '20'), { schema }),
+		).toMatchObject({
+			status: 'success',
+			value: { age: [20] },
+		});
+		expect(
+			parseWithValibot(createFormData('age', 'non number'), { schema }),
+		).toMatchObject({
+			error: { 'age[0]': expect.anything() },
 		});
 	});
 });

--- a/packages/conform-valibot/tests/coercion/schema/nullish.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/nullish.test.ts
@@ -6,6 +6,12 @@ import { createFormData } from '../../helpers/FormData';
 describe('nullish', () => {
 	test('should pass also undefined', () => {
 		const schema = object({ name: nullish(string()), age: nullish(number()) });
+
+		expect(parseWithValibot(new FormData(), { schema })).toMatchObject({
+			status: 'success',
+			value: {},
+		});
+
 		const output = parseWithValibot(createFormData('age', ''), { schema });
 
 		expect(output).toMatchObject({

--- a/packages/conform-valibot/tests/coercion/schema/nullishAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/nullishAsync.test.ts
@@ -16,6 +16,12 @@ describe('nullishAsync', () => {
 			name: nullishAsync(string()),
 			age: nullishAsync(number()),
 		});
+
+		expect(await parseWithValibot(new FormData(), { schema })).toMatchObject({
+			status: 'success',
+			value: {},
+		});
+
 		const output = await parseWithValibot(createFormData('age', ''), {
 			schema,
 		});

--- a/packages/conform-valibot/tests/coercion/schema/optional.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/optional.test.ts
@@ -9,6 +9,12 @@ describe('optional', () => {
 			name: optional(string()),
 			age: optional(number()),
 		});
+
+		expect(parseWithValibot(new FormData(), { schema })).toMatchObject({
+			status: 'success',
+			value: {},
+		});
+
 		const output = parseWithValibot(createFormData('age', ''), { schema });
 
 		expect(output).toMatchObject({

--- a/packages/conform-valibot/tests/coercion/schema/optionalAsync.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/optionalAsync.test.ts
@@ -16,6 +16,12 @@ describe('optionalAsync', () => {
 			name: optionalAsync(string()),
 			age: optionalAsync(number()),
 		});
+
+		expect(await parseWithValibot(new FormData(), { schema })).toMatchObject({
+			status: 'success',
+			value: {},
+		});
+
 		const output = await parseWithValibot(createFormData('age', ''), {
 			schema,
 		});

--- a/packages/conform-valibot/tests/coercion/schema/union.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/union.test.ts
@@ -1,4 +1,13 @@
-import { check, number, object, pipe, undefined_, union } from 'valibot';
+import {
+	check,
+	date,
+	nullish,
+	number,
+	object,
+	pipe,
+	undefined_,
+	union,
+} from 'valibot';
 import { describe, expect, test } from 'vitest';
 import { parseWithValibot } from '../../../parse';
 import { createFormData } from '../../helpers/FormData';
@@ -57,6 +66,35 @@ describe('union', () => {
 			schema,
 		});
 		expect(errorOutput2).toMatchObject({
+			error: { age: expect.anything() },
+		});
+	});
+
+	test('should pass union with nullish', () => {
+		const schema = object({
+			age: nullish(union([number(), date()])),
+		});
+
+		expect(parseWithValibot(new FormData(), { schema })).toMatchObject({
+			status: 'success',
+			value: {},
+		});
+
+		const output = parseWithValibot(createFormData('age', ''), { schema });
+
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { age: undefined },
+		});
+		expect(
+			parseWithValibot(createFormData('age', '20'), { schema }),
+		).toMatchObject({
+			status: 'success',
+			value: { age: 20 },
+		});
+		expect(
+			parseWithValibot(createFormData('age', 'non number'), { schema }),
+		).toMatchObject({
 			error: { age: expect.anything() },
 		});
 	});


### PR DESCRIPTION
## Overview

Close #916 

## Details

The following validation should succeed:

```ts
import { object, nullish, array, number } from 'valibot';
import { parseWithValibot } from '@conform-to/valibot';

const schema = object({
  age: nullish(array(number())),
});

expect(parseWithValibot(new FormData(), { schema })).toMatchObject({
  status: 'success',
  value: {},
});
```

However, the above validation does not pass because `@conform-to/valitob` uses `transform` to convert empty strings as follows:

```ts
import * as v from 'valibot';

const Schema = v.object({
  ticketSpecs: v.pipe(
    // The `unknown` schema makes it seem as though the `ticketSpecs` value must have some value.
    v.unknown(),
    v.transform(v => typeof v !== 'string' ? v : (v === '' ? undefined : v)),
    v.nullish(
      v.array(
        v.number()
      ),
    []),
  )
});

const result = v.safeParse(Schema, {});
console.log(result);
// => `result.success` is not true
```

As the comment in the code says, the `unkown` schema validates on the assumption that a value exists. The correct schema transformation should be as follows:

```ts
import * as v from 'valibot';

const Schema = v.object({
  ticketSpecs: v.nullish(
    v.pipe(
      v.unknown(),
      v.transform(v => typeof v !== 'string' ? v : (v === '' ? undefined : v)),
      v.nullish(
        v.array(
          v.number()
        ),
      []),
    )
  )
});

const result = v.safeParse(Schema, {});
console.log(result);
// => `result.success` is true
```

