### PR TITLE
chore: ensure readme is copied during build

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -39,7 +39,7 @@ node_modules/
 .DS_Store
 
 # Project files
-README
+README.md
 pnpm-lock.yaml
 
 # Build files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,14 +3,14 @@ on:
   push:
     branches: [main, next]
     paths-ignore:
-      - 'README'
+      - 'README.md'
       - 'docs/**'
       - 'examples/**'
       - 'guide/**'
   pull_request:
     branches: [main, next]
     paths-ignore:
-      - 'README'
+      - 'README.md'
       - 'docs/**'
       - 'examples/**'
       - 'guide/**'

--- a/.prettierignore
+++ b/.prettierignore
@@ -39,7 +39,7 @@ node_modules/
 .DS_Store
 
 # Project files
-README
+README.md
 pnpm-lock.yaml
 
 # Build files

--- a/packages/conform-dom/.gitignore
+++ b/packages/conform-dom/.gitignore
@@ -3,5 +3,5 @@ _virtual
 *.d.ts
 *.js
 *.mjs
-README
+README.md
 !rollup.config.js

--- a/packages/conform-dom/rollup.config.js
+++ b/packages/conform-dom/rollup.config.js
@@ -45,7 +45,7 @@ function configurePackage() {
 				extensions: ['.ts', '.tsx'],
 			}),
 			copy({
-				targets: [{ src: `../../README`, dest: sourceDir }],
+				targets: [{ src: `../../README.md`, dest: sourceDir }],
 			}),
 		],
 	};

--- a/packages/conform-react/.gitignore
+++ b/packages/conform-react/.gitignore
@@ -3,5 +3,5 @@ _virtual
 *.d.ts
 *.js
 *.mjs
-README
+README.md
 !rollup.config.js

--- a/packages/conform-react/rollup.config.js
+++ b/packages/conform-react/rollup.config.js
@@ -46,7 +46,7 @@ function configurePackage() {
 				extensions: ['.ts', '.tsx'],
 			}),
 			copy({
-				targets: [{ src: `../../README`, dest: sourceDir }],
+				targets: [{ src: `../../README.md`, dest: sourceDir }],
 			}),
 		],
 	};

--- a/packages/conform-valibot/.gitignore
+++ b/packages/conform-valibot/.gitignore
@@ -1,2 +1,2 @@
 dist
-README
+README.md

--- a/packages/conform-valibot/rollup.config.js
+++ b/packages/conform-valibot/rollup.config.js
@@ -45,7 +45,7 @@ function configurePackage() {
 				extensions: ['.ts', '.tsx'],
 			}),
 			copy({
-				targets: [{ src: `../../README`, dest: sourceDir }],
+				targets: [{ src: `../../README.md`, dest: sourceDir }],
 			}),
 		],
 	};

--- a/packages/conform-validitystate/.gitignore
+++ b/packages/conform-validitystate/.gitignore
@@ -3,5 +3,5 @@ _virtual
 *.d.ts
 *.js
 *.mjs
-README
+README.md
 !rollup.config.js

--- a/packages/conform-validitystate/rollup.config.js
+++ b/packages/conform-validitystate/rollup.config.js
@@ -45,7 +45,7 @@ function configurePackage() {
 				extensions: ['.ts', '.tsx'],
 			}),
 			copy({
-				targets: [{ src: `../../README`, dest: sourceDir }],
+				targets: [{ src: `../../README.md`, dest: sourceDir }],
 			}),
 		],
 	};

--- a/packages/conform-yup/.gitignore
+++ b/packages/conform-yup/.gitignore
@@ -3,5 +3,5 @@ _virtual
 *.d.ts
 *.js
 *.mjs
-README
+README.md
 !rollup.config.js

--- a/packages/conform-yup/rollup.config.js
+++ b/packages/conform-yup/rollup.config.js
@@ -45,7 +45,7 @@ function configurePackage() {
 				extensions: ['.ts', '.tsx'],
 			}),
 			copy({
-				targets: [{ src: `../../README`, dest: sourceDir }],
+				targets: [{ src: `../../README.md`, dest: sourceDir }],
 			}),
 		],
 	};

--- a/packages/conform-zod/.gitignore
+++ b/packages/conform-zod/.gitignore
@@ -3,5 +3,5 @@ _virtual
 *.d.ts
 *.js
 *.mjs
-README
+README.md
 !rollup.config.js

--- a/packages/conform-zod/rollup.config.js
+++ b/packages/conform-zod/rollup.config.js
@@ -45,7 +45,7 @@ function configurePackage() {
 				extensions: ['.ts', '.tsx'],
 			}),
 			copy({
-				targets: [{ src: `../../README`, dest: sourceDir }],
+				targets: [{ src: `../../README.md`, dest: sourceDir }],
 			}),
 		],
 	};


### PR DESCRIPTION
We were copying the `README` file over to each package before publishing it. But it fails silently when we renamed it to `README.md`. This should fix the issue 😓 