### PR TITLE
chore: sync @conform-to/valibot package version

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,7 @@
 		[
 			"@conform-to/dom",
 			"@conform-to/react",
+			"@conform-to/valibot",
 			"@conform-to/yup",
 			"@conform-to/zod"
 		]

--- a/.changeset/thirty-eyes-sell.md
+++ b/.changeset/thirty-eyes-sell.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/valibot': minor
+---
+
+chore: sync @conform-to/valibot package version with the rest of the packages


### PR DESCRIPTION
As discussed in https://github.com/edmundhung/conform/pull/911#issuecomment-2831917866, this should trigger changesets to bump the `@conform-to/valibot` package version to `1.5.0` and sync it with the rest of the packages going forward.