### PR TITLE
feat(conform-zod): Add support auto type coercion with z.literal for boolean, number, and bigint

### DIFF
--- a/.changeset/smooth-shrimps-sell.md
+++ b/.changeset/smooth-shrimps-sell.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/zod': minor
+---
+
+Add support auto type coercion with z.literal for boolean, number, and bigint

--- a/packages/conform-zod/coercion.ts
+++ b/packages/conform-zod/coercion.ts
@@ -17,6 +17,7 @@ import {
 import type {
 	ZodDiscriminatedUnionOption,
 	ZodFirstPartySchemaTypes,
+	ZodLiteral,
 	ZodTypeAny,
 } from 'zod';
 
@@ -161,10 +162,22 @@ function selectDefaultCoercion(
 
 	if (
 		def.typeName === 'ZodString' ||
-		def.typeName === 'ZodLiteral' ||
 		def.typeName === 'ZodEnum' ||
 		def.typeName === 'ZodNativeEnum'
 	) {
+		return defaultCoercion.string;
+	} else if (def.typeName === 'ZodLiteral') {
+		const literalValue = (type as ZodLiteral<any>).value;
+
+		if (typeof literalValue === 'number') {
+			return defaultCoercion.number;
+		}
+		if (typeof literalValue === 'boolean') {
+			return defaultCoercion.boolean;
+		}
+		if (typeof literalValue === 'bigint') {
+			return defaultCoercion.bigint;
+		}
 		return defaultCoercion.string;
 	} else if (
 		def.typeName === 'ZodEffects' &&

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -1007,6 +1007,90 @@ describe('conform-zod', () => {
 			});
 		});
 
+		test('z.literal', () => {
+			const schema = z.object({
+				a: z.literal('a'),
+				b: z.literal(0),
+				c: z.literal(true),
+				d: z.literal(false).default(false),
+				e: z.literal(9007199254740991n),
+				f: z.union([z.literal('on'), z.literal(true)]),
+				g: z.union([z.literal(true), z.literal('on')]),
+				h: z.union([z.string(), z.literal(0)]),
+				i: z.union([z.literal(0), z.string()]),
+			});
+
+			expect(getResult(coerceFormValue(schema).safeParse({}))).toEqual({
+				success: false,
+				error: {
+					a: [`Invalid literal value, expected "a"`],
+					b: ['Invalid literal value, expected 0'],
+					c: ['Invalid literal value, expected true'],
+					e: [`Invalid literal value, expected "9007199254740991"`],
+					f: ['Invalid input'],
+					g: ['Invalid input'],
+					h: ['Invalid input'],
+					i: ['Invalid input'],
+				},
+			});
+
+			expect(
+				getResult(
+					coerceFormValue(schema).safeParse({
+						a: 'not a',
+						b: '1',
+						c: '',
+						d: 'on',
+						e: '0x1ffffffffffff0',
+						f: '',
+						g: '',
+						h: '1',
+						i: '1',
+					}),
+				),
+			).toEqual({
+				success: false,
+				error: {
+					a: [`Invalid literal value, expected "a"`],
+					b: ['Invalid literal value, expected 0'],
+					c: ['Invalid literal value, expected true'],
+					d: ['Invalid literal value, expected false'],
+					e: [`Invalid literal value, expected "9007199254740991"`],
+					f: ['Invalid input'],
+					g: ['Invalid input'],
+				},
+			});
+
+			expect(
+				getResult(
+					coerceFormValue(schema).safeParse({
+						a: 'a',
+						b: '0',
+						c: 'on',
+						d: undefined,
+						e: '9007199254740991',
+						f: 'on',
+						g: 'on',
+						h: '0',
+						i: '0',
+					}),
+				),
+			).toEqual({
+				success: true,
+				data: {
+					a: 'a',
+					b: 0,
+					c: true,
+					d: false,
+					e: 9007199254740991n,
+					f: 'on',
+					g: true,
+					h: '0',
+					i: 0,
+				},
+			});
+		});
+
 		test('z.discriminatedUnion', () => {
 			const schema = z.discriminatedUnion('type', [
 				z.object({

--- a/tests/conform-zod.spec.ts
+++ b/tests/conform-zod.spec.ts
@@ -54,6 +54,7 @@ describe('conform-zod', () => {
 					.max(new Date(), 'max')
 					.default(new Date()),
 				flag: z.boolean().optional(),
+				literalFlag: z.literal(true),
 				options: z
 					.array(z.enum(['a', 'b', 'c']).refine(() => false, 'refine'))
 					.min(3, 'min'),
@@ -98,6 +99,9 @@ describe('conform-zod', () => {
 			},
 			flag: {
 				required: false,
+			},
+			literalFlag: {
+				required: true,
 			},
 			options: {
 				required: true,


### PR DESCRIPTION
(partially) resolves #928 

This allows `z.literal` for number, boolean, and bigint types to coerce input to their respective values.

Previously, you had to write something like:
```ts
z.boolean().refine(v => v === true)
z.boolean().pipe(z.literal(true))
z.number().refine(v => v === 0)
z.number().pipe(z.literal(0))
```

Now, you can simply write:
```ts
z.literal(true)
z.literal(0)
```