### PR TITLE
feat(conform-valibot): Add support auto type coercion with z.literal for boolean, number, and bigint

### DIFF
--- a/.changeset/tasty-planes-arrive.md
+++ b/.changeset/tasty-planes-arrive.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/valibot': minor
+---
+
+Add support auto type coercion with literal for boolean, number, and bigint

--- a/packages/conform-valibot/coercion.ts
+++ b/packages/conform-valibot/coercion.ts
@@ -318,9 +318,20 @@ function enableTypeCoercion<T extends GenericSchema | GenericSchemaAsync>(
 
 	switch (type.type) {
 		case 'string':
-		case 'literal':
 		case 'enum':
 		case 'undefined': {
+			return coerce(type, options.defaultCoercion.string);
+		}
+		case 'literal': {
+			// @ts-expect-error
+			switch (typeof type.literal) {
+				case 'number':
+					return coerce(type, options.defaultCoercion.number);
+				case 'boolean':
+					return coerce(type, options.defaultCoercion.boolean);
+				case 'bigint':
+					return coerce(type, options.defaultCoercion.bigint);
+			}
 			return coerce(type, options.defaultCoercion.string);
 		}
 		case 'number': {

--- a/packages/conform-valibot/tests/coercion/schema/literal.test.ts
+++ b/packages/conform-valibot/tests/coercion/schema/literal.test.ts
@@ -1,0 +1,64 @@
+import { object, literal } from 'valibot';
+import { describe, expect, test } from 'vitest';
+import { parseWithValibot } from '../../../parse';
+import { createFormData } from '../../helpers/FormData';
+
+describe('literal', () => {
+	test('should pass only literals', () => {
+		const schema = object({ name: literal('Jane') });
+
+		const output = parseWithValibot(createFormData('name', 'Jane'), { schema });
+
+		expect(output).toMatchObject({
+			status: 'success',
+			value: { name: 'Jane' },
+		});
+		expect(
+			parseWithValibot(createFormData('name', ''), { schema }),
+		).toMatchObject({
+			error: { name: expect.anything() },
+		});
+
+		const numberSchema = object({ age: literal(0) });
+		const numberOutput = parseWithValibot(createFormData('age', '0'), {
+			schema: numberSchema,
+		});
+		expect(numberOutput).toMatchObject({
+			status: 'success',
+			value: { age: 0 },
+		});
+		expect(
+			parseWithValibot(createFormData('age', '1'), { schema: numberSchema }),
+		).toMatchObject({
+			error: { age: expect.anything() },
+		});
+
+		const booleanSchema = object({ check: literal(true) });
+		const booleanOutput = parseWithValibot(createFormData('check', 'on'), {
+			schema: booleanSchema,
+		});
+		expect(booleanOutput).toMatchObject({
+			status: 'success',
+			value: { check: true },
+		});
+		expect(
+			parseWithValibot(createFormData('check', ''), { schema: booleanSchema }),
+		).toMatchObject({
+			error: { check: expect.anything() },
+		});
+
+		const bigintSchema = object({ big: literal(BigInt(0)) });
+		const bigintOutput = parseWithValibot(createFormData('big', '0'), {
+			schema: bigintSchema,
+		});
+		expect(bigintOutput).toMatchObject({
+			status: 'success',
+			value: { big: BigInt(0) },
+		});
+		expect(
+			parseWithValibot(createFormData('big', '1'), { schema: bigintSchema }),
+		).toMatchObject({
+			error: { big: expect.anything() },
+		});
+	});
+});


### PR DESCRIPTION
## Overview

https://github.com/edmundhung/conform/pull/930

Zod now supports numbers, booleans, and BigInt values ​​for literals, so we'll fix it so that valibot supports them as well.