### PR TITLE
fix(conform-react): Remove aria-invalid from form and fieldset

### DIFF
--- a/.changeset/spotty-mails-sleep.md
+++ b/.changeset/spotty-mails-sleep.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/react': patch
+---
+
+Removed aria-invalid from getFormProps and getFieldsetProps

--- a/docs/api/react/getFieldsetProps.md
+++ b/docs/api/react/getFieldsetProps.md
@@ -22,7 +22,7 @@ function Example() {
 
 ### `ariaAttributes`
 
-Decide whether to include `aria-invalid` and `aria-describedby` in the result props. Default to **true**.
+Decide whether to include `aria-describedby` in the result props. Default to **true**.
 
 ### `ariaInvalid`
 
@@ -46,7 +46,6 @@ function Example() {
       id={fields.address.id}
       name={fields.address.name}
       form={fields.address.formId}
-      aria-invalid={!form.valid || undefined}
       aria-describedby={!form.valid ? form.errorId : undefined}
     />
   );

--- a/docs/api/react/getFormProps.md
+++ b/docs/api/react/getFormProps.md
@@ -22,7 +22,7 @@ function Example() {
 
 ### `ariaAttributes`
 
-Decide whether to include `aria-invalid` and `aria-describedby` in the result props. Default to **true**.
+Decide whether to include `aria-describedby` in the result props. Default to **true**.
 
 ### `ariaInvalid`
 
@@ -46,7 +46,6 @@ function Example() {
       id={form.id}
       onSubmit={form.onSubmit}
       noValidate={form.noValidate}
-      aria-invalid={!form.valid || undefined}
       aria-describedby={!form.valid ? form.errorId : undefined}
     />
   );

--- a/docs/ja/api/react/getFieldsetProps.md
+++ b/docs/ja/api/react/getFieldsetProps.md
@@ -22,7 +22,7 @@ function Example() {
 
 ### `ariaAttributes`
 
-結果のプロパティに `aria-invalid` と `aria-describedby` を含めるかどうかを決定します。デフォルトは **true** です。
+結果のプロパティに `aria-describedby` を含めるかどうかを決定します。デフォルトは **true** です。
 
 ### `ariaInvalid`
 
@@ -46,7 +46,6 @@ function Example() {
       id={fields.address.id}
       name={fields.address.name}
       form={fields.address.formId}
-      aria-invalid={!form.valid || undefined}
       aria-describedby={!form.valid ? form.errorId : undefined}
     />
   );

--- a/docs/ja/api/react/getFormProps.md
+++ b/docs/ja/api/react/getFormProps.md
@@ -22,7 +22,7 @@ function Example() {
 
 ### `ariaAttributes`
 
-結果のプロパティに `aria-invalid` と `aria-describedby` を含めるかどうかを決定します。デフォルトは **true** です。
+結果のプロパティに `aria-describedby` を含めるかどうかを決定します。デフォルトは **true** です。
 
 ### `ariaInvalid`
 
@@ -46,7 +46,6 @@ function Example() {
       id={form.id}
       onSubmit={form.onSubmit}
       noValidate={form.noValidate}
-      aria-invalid={!form.valid || undefined}
       aria-describedby={!form.valid ? form.errorId : undefined}
     />
   );

--- a/docs/ja/tutorial.md
+++ b/docs/ja/tutorial.md
@@ -145,7 +145,6 @@ export default function ContactUs() {
   return (
     <Form
       method="POST"
-      aria-invalid={result?.formErrors ? true : undefined}
       aria-describedby={result?.formErrors ? 'contact-error' : undefined}
     >
       <div id="contact-error">{result?.formErrors}</div>
@@ -279,7 +278,6 @@ export default function ContactUs() {
       method="post"
       {/* 追加で必要な属性は `id` 属性のみです。*/}
       id={form.id}
-      aria-invalid={form.errors ? true : undefined}
       aria-describedby={form.errors ? form.errorId : undefined}
     >
       <div id={form.errorId}>{form.errors}</div>
@@ -402,7 +400,6 @@ export default function ContactUs() {
       id={form.id}
       {/* クライアント検証には `onSubmit` ハンドラが必要です。 */}
       onSubmit={form.onSubmit}
-      aria-invalid={form.errors ? true : undefined}
       aria-describedby={form.errors ? form.errorId : undefined}
     >
       {/* ... */}

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -145,7 +145,6 @@ export default function ContactUs() {
   return (
     <Form
       method="POST"
-      aria-invalid={result?.formErrors ? true : undefined}
       aria-describedby={result?.formErrors ? 'contact-error' : undefined}
     >
       <div id="contact-error">{result?.formErrors}</div>
@@ -280,7 +279,6 @@ export default function ContactUs() {
 			method="post"
       {/* The only additional attribute you need is the `id` attribute */}
 			id={form.id}
-			aria-invalid={form.errors ? true : undefined}
 			aria-describedby={form.errors ? form.errorId : undefined}
 		>
 			<div id={form.errorId}>{form.errors}</div>
@@ -403,7 +401,6 @@ export default function ContactUs() {
 			id={form.id}
       {/* The `onSubmit` handler is required for client validation */}
       onSubmit={form.onSubmit}
-			aria-invalid={form.errors ? true : undefined}
 			aria-describedby={form.errors ? form.errorId : undefined}
     >
       {/* ... */}

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -17,7 +17,7 @@ type FormControlOptions =
 			 */
 			ariaAttributes?: true;
 			/**
-			 * Decide whether the aria-invalid attributes should be based on `meta.errors` or `meta.allErrors`.
+			 * Decide whether the `aria-invalid` and `aria-describedby` attributes should be based on `meta.errors` or `meta.allErrors`.
 			 * @default 'errors'
 			 */
 			ariaInvalid?: 'errors' | 'allErrors';
@@ -139,6 +139,7 @@ function simplify<Props>(props: Props): Props {
 export function getAriaAttributes(
 	metadata: Metadata<any, any, any>,
 	options: FormControlOptions = {},
+	field: boolean = false,
 ): {
 	'aria-invalid'?: boolean;
 	'aria-describedby'?: string;
@@ -157,7 +158,7 @@ export function getAriaAttributes(
 	const ariaDescribedBy = options.ariaDescribedBy;
 
 	return simplify({
-		'aria-invalid': invalid || undefined,
+		'aria-invalid': (field && invalid) || undefined,
 		'aria-describedby': invalid
 			? `${metadata.errorId} ${ariaDescribedBy ?? ''}`.trim()
 			: ariaDescribedBy,
@@ -166,7 +167,7 @@ export function getAriaAttributes(
 
 /**
  * Derives the properties of a form element based on the form metadata,
- * including `id`, `onSubmit`, `noValidate`, `aria-invalid` and `aria-describedby`.
+ * including `id`, `onSubmit`, `noValidate`, and `aria-describedby`.
  *
  * @example
  * ```tsx
@@ -187,7 +188,7 @@ export function getFormProps<Schema extends Record<string, any>, FormError>(
 
 /**
  * Derives the properties of a fieldset element based on the field metadata,
- * including `id`, `name`, `form`, `aria-invalid` and `aria-describedby`.
+ * including `id`, `name`, `form`, and `aria-describedby`.
  *
  * @example
  * ```tsx
@@ -196,12 +197,16 @@ export function getFormProps<Schema extends Record<string, any>, FormError>(
  */
 export function getFieldsetProps<
 	Schema extends Record<string, any> | undefined | unknown,
->(metadata: FieldMetadata<Schema, any, any>, options?: FormControlOptions) {
+>(
+	metadata: FieldMetadata<Schema, any, any>,
+	options?: FormControlOptions,
+	field: boolean = false,
+) {
 	return simplify({
 		id: metadata.id,
 		name: metadata.name,
 		form: metadata.formId,
-		...getAriaAttributes(metadata, options),
+		...getAriaAttributes(metadata, options, field),
 	});
 }
 
@@ -216,7 +221,7 @@ export function getFormControlProps<Schema>(
 	return simplify({
 		key: undefined,
 		required: metadata.required || undefined,
-		...getFieldsetProps(metadata, options),
+		...getFieldsetProps(metadata, options, true),
 	});
 }
 

--- a/tests/conform-react.spec.ts
+++ b/tests/conform-react.spec.ts
@@ -297,7 +297,6 @@ describe('conform-react', () => {
 			}),
 		).toEqual({
 			...props,
-			'aria-invalid': true,
 			'aria-describedby': 'test-error',
 		});
 		expect(
@@ -316,7 +315,6 @@ describe('conform-react', () => {
 			),
 		).toEqual({
 			...props,
-			'aria-invalid': true,
 			'aria-describedby': 'test-error something',
 		});
 		expect(

--- a/tests/integrations/input-attributes.spec.ts
+++ b/tests/integrations/input-attributes.spec.ts
@@ -220,7 +220,7 @@ test('setup aria-invalid correctly', async ({ page }) => {
 	);
 
 	await playground.submit.click();
-	await expect(playground.form).toHaveAttribute('aria-invalid', 'true');
+	await expect(playground.form).not.toHaveAttribute('aria-invalid', 'true');
 	await expect(fieldset.title).toHaveAttribute('aria-invalid', 'true');
 	await expect(fieldset.description).toHaveAttribute('aria-invalid', 'true');
 	await expect(fieldset.images).toHaveAttribute('aria-invalid', 'true');


### PR DESCRIPTION
Removes aria-invalid from getFormProps and getFieldsetProps. This change matches [the applicable roles for aria-invalid](https://w3c.github.io/aria/#aria-invalid).

Note: I do not know Japanese so I'm not sure if the changes to the Japanese docs are grammatically correct

Fixes #955 