### PR TITLE
fix(conform-zod): coercion for composed discriminated unions

### DIFF
--- a/.changeset/wise-dragons-develop.md
+++ b/.changeset/wise-dragons-develop.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/zod': patch
+---
+
+fix(conform-zod): coercion for composed discriminated unions

--- a/packages/conform-zod/v4/tests/coercion/schema/discriminatedUnion.test.ts
+++ b/packages/conform-zod/v4/tests/coercion/schema/discriminatedUnion.test.ts
@@ -7,6 +7,7 @@ import {
 	literal,
 	number,
 	boolean,
+	extend,
 } from 'zod/v4-mini';
 import { getResult } from '../../../../tests/helpers/zod';
 
@@ -123,6 +124,114 @@ describe('coercion', () => {
 				success: false,
 				error: {
 					'nest.type': ['Invalid input'],
+				},
+			});
+		});
+
+		test('should pass composed discriminatedUnion', () => {
+			const base = z.object({
+				status: z.literal('failed'),
+				message: z.string(),
+			});
+			const schema = z.discriminatedUnion('status', [
+				z.object({ status: z.literal('success'), data: z.string() }),
+				z.discriminatedUnion('code', [
+					base.extend({ code: z.literal(400) }),
+					base.extend({ code: z.literal(401) }),
+					base.extend({ code: z.literal(500) }),
+				]),
+			]);
+
+			const baseWithMini = object({
+				status: literal('failed'),
+				message: z.string(),
+			});
+			const schemaWithMini = discriminatedUnion('status', [
+				object({ status: literal('success'), data: z.string() }),
+				discriminatedUnion('code', [
+					extend(baseWithMini, { code: literal(400) }),
+					extend(baseWithMini, { code: literal(401) }),
+					extend(baseWithMini, { code: literal(500) }),
+				]),
+			]);
+
+			expect(
+				getResult(
+					coerceFormValue(schema).safeParse({
+						status: 'success',
+						data: 'test',
+					}),
+				),
+			).toEqual({
+				success: true,
+				data: {
+					status: 'success',
+					data: 'test',
+				},
+			});
+			expect(
+				getResult(
+					coerceFormValue(schema).safeParse({
+						status: 'failed',
+						message: 'error',
+						code: 400,
+					}),
+				),
+			).toEqual({
+				success: true,
+				data: {
+					status: 'failed',
+					message: 'error',
+					code: 400,
+				},
+			});
+			expect(
+				getResult(coerceFormValue(schema).safeParse({ status: 'none' })),
+			).toEqual({
+				success: false,
+				error: {
+					status: ['Invalid input'],
+				},
+			});
+
+			expect(
+				getResult(
+					coerceFormValue(schemaWithMini).safeParse({
+						status: 'success',
+						data: 'test',
+					}),
+				),
+			).toEqual({
+				success: true,
+				data: {
+					status: 'success',
+					data: 'test',
+				},
+			});
+			expect(
+				getResult(
+					coerceFormValue(schemaWithMini).safeParse({
+						status: 'failed',
+						message: 'error',
+						code: 400,
+					}),
+				),
+			).toEqual({
+				success: true,
+				data: {
+					status: 'failed',
+					message: 'error',
+					code: 400,
+				},
+			});
+			expect(
+				getResult(
+					coerceFormValue(schemaWithMini).safeParse({ status: 'none' }),
+				),
+			).toEqual({
+				success: false,
+				error: {
+					status: ['Invalid input'],
 				},
 			});
 		});


### PR DESCRIPTION
## Overview

Close #968

Fixed a bug where a schema combining `discriminatedUnion` could not be validated correctly.

Zod v4 allows you to define a schema combining `discriminatedUnion`.
https://zod.dev/v4?id=upgraded-zdiscriminatedunion