### PR TITLE
fix: Fixed to prevent unnecessary tests from being executed

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -44,7 +44,10 @@ function defineTests(packageName: string): TestProjectInlineConfiguration[] {
 				},
 				// This covers both .browser.test.ts/tsx and .test.ts/tsx files
 				include: [`packages/${packageName}/**/tests/**/*.test.{ts,tsx}`],
-				exclude: [`packages/${packageName}/**/tests/**/*.node.test.{ts,tsx}`],
+				exclude: [
+					`**/node_modules/**`,
+					`packages/${packageName}/**/tests/**/*.node.test.{ts,tsx}`,
+				],
 			},
 		},
 		{
@@ -54,6 +57,7 @@ function defineTests(packageName: string): TestProjectInlineConfiguration[] {
 				// This covers both .node.test.ts/tsx and .test.ts/tsx files
 				include: [`packages/${packageName}/**/tests/**/*.test.{ts,tsx}`],
 				exclude: [
+					`**/node_modules/**`,
 					`packages/${packageName}/**/tests/**/*.browser.test.{ts,tsx}`,
 				],
 			},


### PR DESCRIPTION
## Overview

Tests linked to node_modules were being run. Tests in files under node_modules do not need to be run, so they are excluded.

<img width="915" height="158" alt="image" src="https://github.com/user-attachments/assets/fef5e9c5-e899-44ac-ac68-ec3636f9a532" />
