### PR TITLE
docs: add Ja translation in `ui-libraries.md`

### DIFF
--- a/docs/ja/integration/ui-libraries.md
+++ b/docs/ja/integration/ui-libraries.md
@@ -1,45 +1,47 @@
-# UI ライブラリとのインテグレーション
+# UI ライブラリとの統合
 
-In this guide, we'll walk through how to integrate Conform with custom input components.
+このガイドではConformとカスタムされた入力コンポーネントの統合方法を解説します。
 
-## Concept
+## コンセプト
 
-Conform supports native inputs out of the box by listening for form events like `input`, `focusout`, and `reset` on the document. This means simple custom components that wrap native elements (e.g. a styled `<input>`) typically work without extra setup.
+Conformは`input`、`focusout`や`reset`といったフォームイベントを利用した要素以外でのネイティブ入力をサポートしています。
+これにより標準の要素（例：スタイリングされた`<input>`タグなど）をラップしたカスタムコンポーネントが特別な設定なしに機能するようにしています。
 
-However, more complex inputs like `<Select />`, `<DatePicker />`, or custom file uploaders often involve additional layers of abstraction. These layers interfere with how the browser emits native form events, making it harder for Conform to track user interactions.
+しかしながら`<Select />`や`<DatePicker />`、あるいはカスタムファイルアップローダーのようなより複雑な入力コンポーネントには抽象化レイヤーが含まれていることがあります。
 
-To solve this, we provide the [`useControl`](../api/react/useControl.md) hook. It lets you manually connect a hidden base input to a custom UI component and dispatch native events in response to user interaction.
+これらのレイヤーはブラウザが発火するネイティブなフォームイベントに干渉し、Conformがユーザーのインタラクティブな入力を追跡するのを難しくします。
 
-## Emulating Native Inputs
+この問題を解決するために、Conformでは[`useControl`](../api/react/future/useControl.md)フックを提供しています.
+これにより、hiddenに設定された標準の入力とカスタムされたUIコンポーネントを接続し、ユーザーの操作に反応してネイティブなイベントを発火させることができます。
 
-There are multiple ways to wire up a base input with `useControl`:
+## ネイティブ入力のエミュレーション
 
-- In some cases, you may be able to **re-use an input rendered by the UI library**. This can help with progressive enhancement — for instance, when a user clicks on a styled label that toggles a real hidden checkbox using standard HTML behavior. The form still submits correctly even if JavaScript hasn't loaded.
+`useControl`と標準の入力を組み合わせる方法は複数あります。
 
-- But not all custom inputs enable this. Some UI libraries render hidden inputs and update their value via JavaScript after interacting with entirely separate elements. These setups won't work before JavaScript loads and may trigger their event handler in an unexpected order — for example, calling `onChange` before updating the input's value.
+- いくつかの場合において、**UIライブラリによって描画された入力コンポーネントの再利用**が可能です。 これはプログレッシブエンハンスメントの助けになります。例えば、ユーザーがスタイリングされたラベルをクリックした際に標準のHTMLの挙動を通してhiddenに設定されたチェックボックスの実体を切り替えます。JavaScriptがロードされていなかったとしてもフォームは正しく値を送信できます。
 
-- Because `useControl` itself requires JavaScript, the benefits of re-using library-provided inputs are marginal. We recommend **rendering your own base input** unless you're confident it helps with progressive enhancement and behaves as expected.
+- とはいえ全ての入力においてこれができるわけではありません。いくつかのUIライブラリは見えない入力コンポーネントを描画し、完全に分離されたユーザー入力に対してJavaScriptを通じて値を更新します。これらの設定はJavaScriptがロードされるまで機能せず、予期せぬ順番でロードされることでイベントハンドラーが発火することがあります。例えば入力された値の更新前に`onChange`イベントが呼び出されることがあります。
 
-The `useControl` hook gives you a control object that manages the input value and provides methods to trigger form events. Here are the main steps to integrate it:
+- `useControl`自体がJavaScriptは必要とするため、ライブラリが提供する入力コンポーネントの再利用することの利点は大きくありません。もしあなたがプログレッシブエンハンスメントや期待される振る舞いについて自信がない場合、**UIライブラリ用に別の標準入力コンポーネントを描画すること**を推奨します。
 
-1. **Register a base input**
+`useControl` フックは入力された値を管理しフォームイベントを発火させるcontrolオブジェクトを提供します。統合するための手順は次の通りです。
 
-   - Render a hidden native input element (e.g. `<input hidden />`) and register it with `control.register()`.
-   - This serves as the authoritative source of the value and emits native form events.
+1. **標準入力の登録**
 
-2. **Emit form events**
+  - hiddenに設定された入力要素（例：`<input hidden/>`）を描画し、`control.register()`を利用し登録してください。
+  - これにより信頼できる入力値とネイティブフォームイベントを扱えます。
 
-   - Use `control.change()` and `control.blur()` in your custom component's `onChange` and `onBlur` handlers.
+2. **イベント発火**
+  - `control.change()`と`control.blur()`をカスタムコンポーネントの`onChange`と`onBlur`ハンドラーにそれぞれ渡して使うことができます。
 
-3. **Make it controlled**
+3. **制御された状態にする**
 
-   - Use `control.value`, `control.options`, `control.checked`, or `control.files` to sync the custom component with the current state.
+  - `control.value`、`control.options`、`control.checked`あるいは`control.files`を使い、カスタムコンポーネントと現在の状態を同期できます。
 
-4. **Delegate focus (optional)**
+4. （オプション）フォーカスを委譲する
+  - 標準入力がhiddenに設定されている場合、`useControl`の`onFocus`コールバックを利用して、アクセシビリティ向けにフォーカスをカスタム入力に委譲できます。
 
-   - If your base input is hidden, use the `onFocus` callback in `useControl` to forward focus to the custom input for accessibility.
-
-### Example
+### 実装例
 
 ```tsx
 import { useControl } from '@conform-to/react/future';
@@ -62,24 +64,24 @@ function MyInput({ name, defaultValue }) {
 }
 ```
 
-### Input Type Differences
+### input typeの違い
 
-Input types contribute to form data in different ways when it comes to form submission. Here's a quick reference:
+入力タイプはフォームデータ
 
-- **Text Inputs**: Straightforward. When empty, the value is an empty string.
-- **Checkboxes / Radios**:
+フォームの送信時、各入力タイプは異なる形でフォームデータに反映されます。以下はその簡単なまとめです。
 
-  - Default value is `'on'` unless `value` is specified.
-  - If checked, the value is submitted; if unchecked, it's omitted.
+- **テキスト入力**: 簡単です。値が空の場合、空文字列が渡されます。
+- **チェックボックス / ラジオ**：
+  - `value`が指定されていない場合、初期値は`'on'`になります.
+  - チェックされた場合、値が送信され、チェックが外れた場合値が除外されます。
+- **セレクト（単一）**：値が選ばれた選択肢が`value`になっているとき、最初の選択肢が初期値になります。
+- **セレクト（複数）**：選択された複数の値を配列として表現します。何も選択されていない場合、値が存在しません。
+- **ファイル入力**：1つかそれ以上の`File`オブジェクトが値として返ります。何も選択されていない場合、フィールドが削除されます。
+- **その他入力**：テキスト入力と同じ振る舞いをします。該当の`type`がコンテキストを追加することがありますが、送信される値には影響しません。
 
-- **Select (single)**: Value is the selected option's `value`. Defaults to the first option.
-- **Select (multiple)**: Represents an array of selected values. If none selected, no entry in `FormData`.
-- **File Inputs**: Yields one or more `File` objects. If empty, `FormData` omits the field.
-- **Other inputs**: Behave like text inputs. Their `type` adds context but doesn't affect how data is submitted.
+## 実装例
 
-## Examples
-
-We've prepared examples for integrating with popular UI libraries:
+一般的なUIライブラリと統合する際の例をいくつか紹介します。
 
 - [React Aria Components](../../examples/react-aria/)
 - [Shadcn UI](../../examples/shadcn-ui/)
@@ -88,4 +90,6 @@ We've prepared examples for integrating with popular UI libraries:
 - [Headless UI](../../examples/headless-ui/)
 - [Material UI](../../examples/material-ui/)
 
-If the library you're using isn't listed or you run into issues, [open a discussion](https://github.com/edmundhung/conform/discussions) — we're happy to help. Contributions are also welcome if you'd like to share an example.
+あなたが使っているライブラリがリストにないか、あるいはissueにも挙がっていない場合、[discussonを作成](https://github.com/edmundhung/conform/discussions) してください。
+
+実装例を共有したい場合、コントリビューションも受け入れています。


### PR DESCRIPTION
## Overview

- It seems that there are no issues or discussions about japanese translation of `ui-libraries.md`.
- I translated doc and made this PR.

## Remarks
- This is a literal translation. ( like other ja docs )
- Some words ( e.g. `hidden`) are used without translation.