### PR TITLE
fix(conform-dom): Metadata cannot be retrieved correctly when an array of objects nested two or more levels deep is defined

### DIFF
--- a/.changeset/forty-flies-love.md
+++ b/.changeset/forty-flies-love.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/dom': patch
+---
+
+fix(conform-dom): Metadata cannot be retrieved correctly when an array of objects nested two or more levels deep is defined

--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -519,7 +519,7 @@ function createConstraintProxy(
 					// This overrides the current number segment with an empty string
 					// which will be treated as an empty bracket
 					path[i] = '';
-					break;
+					continue;
 				}
 			}
 


### PR DESCRIPTION
## Overview

Fix #1005 
