### PR TITLE
feat(conform-zod): add formatResult and memoize helpers

### DIFF
--- a/.changeset/clean-eggs-try.md
+++ b/.changeset/clean-eggs-try.md
@@ -1,0 +1,10 @@
+---
+'@conform-to/zod': minor
+---
+
+Add `formatResult` and `memoize` helpers to future exports
+
+- **`formatResult`**: Transforms Zod validation results into Conform's error format, supporting value extraction and custom error formatting
+- **`memoize`**: Caches most recent result to prevent redundant API calls during async validation
+
+Both helpers are available in `@conform-to/zod/v3/future` and `@conform-to/zod/v4/future`

--- a/docs/api/zod/future/coerceFormValue.md
+++ b/docs/api/zod/future/coerceFormValue.md
@@ -1,10 +1,12 @@
-# unstable_coerceFormValue
+# coerceFormValue
 
-> The `coerceFormValue` function is also available as part of Conform's future export. [Check it out](./future/coerceFormValue.md) if you want to use it with other future APIs.
+> The `coerceFormValue` function is part of Conform's future export. These APIs are experimental and may change in minor versions. [Learn more](https://github.com/edmundhung/conform/discussions/954)
 
 A helper that enhances the schema with extra preprocessing steps to strip empty value and coerce form value to the expected type.
 
 ```ts
+import { coerceFormValue } from '@conform-to/zod/v3/future'; // Or import `@conform-to/zod/v4/future`.
+
 const enhancedSchema = coerceFormValue(schema, options);
 ```
 
@@ -33,11 +35,8 @@ Optional. Use it to [define custom coercion](#define-custom-coercion) for a spec
 ## Example
 
 ```ts
-import {
-  parseWithZod,
-  unstable_coerceFormValue as coerceFormValue,
-} from '@conform-to/zod'; // Or, import `@conform-to/zod/v4`.
-import { useForm } from '@conform-to/react';
+import { coerceFormValue } from '@conform-to/zod/v3/future'; // Or import `@conform-to/zod/v4/future`.
+import { useForm } from '@conform-to/react/future';
 import { z } from 'zod';
 
 const schema = coerceFormValue(
@@ -50,13 +49,8 @@ const schema = coerceFormValue(
 );
 
 function Example() {
-  const [form, fields] = useForm({
-    onValidate({ formData }) {
-      return parseWithZod(formData, {
-        schema,
-        disableAutoCoercion: true,
-      });
-    },
+  const { form, fields } = useForm({
+    schema,
   });
 
   // ...
@@ -134,11 +128,7 @@ const schema = z.object({
 You can customize coercion for a specific schema by setting the `customize` option.
 
 ```ts
-import {
-  parseWithZod,
-  unstable_coerceFormValue as coerceFormValue,
-} from '@conform-to/zod';
-import { useForm } from '@conform-to/react';
+import { coerceFormValue } from '@conform-to/zod/v3/future'; // Or import `@conform-to/zod/v4/future`.
 import { z } from 'zod';
 
 const metadata = z.object({
@@ -153,7 +143,7 @@ const schema = coerceFormValue(
   }),
   {
     customize(type) {
-      // Customize how the `metadata` field value is coerced
+      // Customize how the `metadata` schema is coerced
       if (type === metadata) {
         return (value) => {
           if (typeof value !== 'string') {

--- a/docs/api/zod/future/formatResult.md
+++ b/docs/api/zod/future/formatResult.md
@@ -1,0 +1,126 @@
+# formatResult
+
+> The `formatResult` function is part of Conform's future export. These APIs are experimental and may change in minor versions. [Learn more](https://github.com/edmundhung/conform/discussions/954)
+
+A helper that transforms Zod validation results into Conform's error format for form handling.
+
+```ts
+import { formatResult } from '@conform-to/zod/v3/future'; // Or import `@conform-to/zod/v4/future`.
+
+const error = formatResult(result);
+```
+
+## Parameters
+
+### `result: SafeParseReturnType<any, any>`
+
+The Zod validation result to be formatted. This should be the result from `schema.safeParse()` or `schema.safeParseAsync()`.
+
+### `options.includeValue?: boolean`
+
+Optional. Set to `true` if you want both the error and the parsed value returned in an object. This is useful when you are parsing the form value manually and still want to access the parsed value in the `onSubmit` handler on the `useForm` hook.
+
+### `options.formatIssues?: (issues: ZodIssue[], name: string) => ErrorShape[]`
+
+Optional. A function to customize how zod issues are formatted for each field. This is particularly useful if you want to include additional information from the `ZodIssue` object in the error messages, or if you need to support internationalization.
+
+```ts
+const error = formatResult(result, {
+  formatIssues: (issues, name) => {
+    return issues.map((issue) => ({
+      message: issue.message,
+      code: issue.code,
+      path: issue.path,
+    }));
+  },
+});
+```
+
+## Returns
+
+It returns the formatted error object by default:
+
+```ts
+FormError<string> | null;
+```
+
+If `includeValue` is set to `true`, it returns an object containing both the error and the parsed value instead:
+
+```ts
+{
+  error: FormError<string> | null;
+  value: Output | undefined;
+}
+```
+
+## Example
+
+### Format Zod validation result on the server
+
+```ts
+import { formatResult } from '@conform-to/zod/v3/future'; // Or import `@conform-to/zod/v4/future`.
+import { parseSubmission } from '@conform-to/react/future';
+import { z } from 'zod';
+
+const schema = z.object({
+  email: z.string().email(),
+  age: z.number().min(18),
+  terms: z.boolean().refine((val) => val === true),
+});
+
+export async function action({ request }) {
+  const formData = await request.formData();
+  const submission = parseSubmission(formData);
+  const result = schema.safeParse(submission.payload);
+
+  if (!result.success) {
+    return {
+      result: report(submission, {
+        error: formatResult(result),
+      }),
+    };
+  }
+
+  // Submission succeeded, process the parsed value with `result.data`
+}
+```
+
+## Tips
+
+### Customize error shapes
+
+The `useForm` hook offers built-in support of standard schema through the `schema` option. However, if you need to customize the error shapes, you will need to use the `onValidate` option instead and format the result manually with `formatResult`.
+
+```ts
+import { useForm } from '@conform-to/react/future';
+import { formatResult } from '@conform-to/zod/v3/future';
+import { z } from 'zod';
+
+const schema = z.object({
+  // ...
+});
+
+function Example() {
+  const { form, fields } = useForm({
+    onValidate({ value }) {
+      const result = schema.safeParse(value);
+      return formatResult(result, {
+        includeValue: true,
+        formatIssues(issues, name) {
+          return issues.map(
+            (issue) => `Field "${name}" is invalid: ${issue.message}`,
+          );
+        },
+      });
+    },
+    onSubmit(event, { value }) {
+      event.preventDefault();
+
+      // This is called only if there are no validation errors with the parsed `value`.
+      // It will throw if no value is included in the onValidate return value.
+    },
+  });
+
+  // ...
+}
+```

--- a/docs/api/zod/future/memoize.md
+++ b/docs/api/zod/future/memoize.md
@@ -1,0 +1,103 @@
+# memoize
+
+> The `memoize` function is part of Conform's future export. These APIs are experimental and may change in minor versions. [Learn more](https://github.com/edmundhung/conform/discussions/954)
+
+A utility function that memoizes function calls, caching only the most recent result to prevent redundant async validations in forms.
+
+```ts
+import { memoize } from '@conform-to/zod/v3/future'; // Or import '@conform-to/zod/v4/future'
+
+const memoizedFn = memoize(fn, isEqual);
+```
+
+## Parameters
+
+### `fn: T`
+
+The function to memoize. Can be synchronous or asynchronous.
+
+### `isEqual?: (prevArgs: Parameters<T>, nextArgs: Parameters<T>) => boolean`
+
+Optional custom equality function to compare arguments. Defaults to shallow comparison using `Object.is()`.
+
+```ts
+const memoizedFn = memoize(
+  async (user: { id: string; name: string }) => {
+    return await validateUser(user);
+  },
+  // Custom equality - only compare by ID
+  (prevArgs, nextArgs) => prevArgs[0].id === nextArgs[0].id,
+);
+```
+
+## Returns
+
+A memoized function with the same signature as the original function, plus:
+
+### `clearCache(): void`
+
+Method to manually clear the memoization cache.
+
+## Example
+
+```ts
+import { memoize } from '@conform-to/zod/v3/future'; // Or import '@conform-to/zod/v4/future'
+import { useMemo } from 'react';
+
+function Example() {
+  const validateUsername = useMemo(
+    () =>
+      memoize(async function isUsernameUnique(username: string) {
+        const response = await fetch(`/api/users/${username}`);
+
+        if (!response.ok) {
+          return ['Username is already taken'];
+        }
+
+        return null;
+      }),
+    [],
+  );
+
+  const { form, fields } = useForm({
+    // A standard schema for basic validations
+    schema,
+    async onValidate({ value, error }) {
+      // Validate username uniqueness only if username is provided and has no other errors
+      if (value.username && !error.fieldErrors.username) {
+        const messages = await validateUsername(value.username);
+
+        if (messages) {
+          error.fieldErrors.username = messages;
+        }
+      }
+    },
+  });
+
+  // ...
+}
+```
+
+## Tips
+
+### Schema-level validation
+
+`memoize` can also be used directly in schema libraries with async validation support, such as Zod:
+
+```ts
+const schema = z.object({
+  username: z.string().refine(memoize(isUsernameUnique), {
+    message: 'Username is already taken',
+  }),
+});
+```
+
+### Memoize at the component level
+
+Always wrap memoized functions in `useMemo` to prevent recreating them on each render:
+
+```ts
+const validateUsername = useMemo(() => memoize(isUsernameUnique), []);
+```
+
+Avoid defining memoized functions in the global scope, as this can lead to shared state across multiple component instances.

--- a/guide/app/layout.tsx
+++ b/guide/app/layout.tsx
@@ -61,6 +61,14 @@ const menus: { [code: string]: Menu[] } = {
 			],
 		},
 		{
+			title: 'Future APIs (Zod Schema)',
+			links: [
+				{ title: 'coerceFormValue', to: '/api/zod/future/coerceFormValue' },
+				{ title: 'formatResult', to: '/api/zod/future/formatResult' },
+				{ title: 'memoize', to: '/api/zod/future/memoize' },
+			],
+		},
+		{
 			title: 'Utilities',
 			links: [
 				{ title: 'getFormProps', to: '/api/react/getFormProps' },

--- a/packages/conform-zod/memoize.ts
+++ b/packages/conform-zod/memoize.ts
@@ -1,0 +1,107 @@
+/**
+ * A memoized function with cache clearing capability.
+ */
+export type Memoized<T extends (...args: any) => any> = {
+	(this: ThisParameterType<T>, ...args: Parameters<T>): ReturnType<T>;
+	/** Clears the memoization cache */
+	clearCache: () => void;
+};
+
+/**
+ * Default equality check that compares arguments using Object.is().
+ *
+ * @param prevArgs - Previous function arguments
+ * @param nextArgs - Current function arguments
+ * @returns True if all arguments are equal
+ */
+export function defaultEqualityCheck(prevArgs: any[], nextArgs: any[]) {
+	if (prevArgs.length !== nextArgs.length) {
+		return false;
+	}
+
+	for (let i = 0; i < prevArgs.length; i++) {
+		if (!Object.is(prevArgs[i], nextArgs[i])) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Memoizes function calls, caching only the most recent result to prevent redundant async validations.
+ *
+ * Built-in implementation based on memoize-one with enhanced async support.
+ * Can be replaced with other memoization libraries if needed.
+ *
+ * @param fn - The function to memoize
+ * @param isEqual - Custom equality function to compare arguments (defaults to shallow comparison)
+ * @returns Memoized function with cache clearing capability
+ *
+ * @example
+ * ```ts
+ * // Async validation with API call
+ * const validateUsername = useMemo(
+ *   () => memoize(async function isUnique(username: string) {
+ *     const response = await fetch(`/api/users/${username}`);
+ *     return response.ok ? null : ['Username is already taken'];
+ *   }),
+ *   []
+ * );
+ *
+ * // Usage in form validation
+ * async onValidate({ value, error }) {
+ *   if (value.username && !error.fieldErrors.username) {
+ *     const messages = await validateUsername(value.username);
+ *     if (messages) error.fieldErrors.username = messages;
+ *   }
+ * }
+ * ```
+ */
+export function memoize<T extends (...args: any) => any>(
+	fn: T,
+	isEqual: (
+		prevArgs: Parameters<T>,
+		nextArgs: Parameters<T>,
+	) => boolean = defaultEqualityCheck,
+): Memoized<T> {
+	let cache: {
+		this: ThisParameterType<T>;
+		args: Parameters<T>;
+		result: ReturnType<T>;
+	} | null = null;
+
+	function memoized(this: ThisParameterType<T>, ...args: Parameters<T>) {
+		// Check if new arguments match last arguments including the context (this)
+		if (cache && cache.this === this && isEqual(cache.args, args)) {
+			return cache.result;
+		}
+
+		let result = fn.apply(this, args);
+
+		if (result instanceof Promise) {
+			result = result.catch((e) => {
+				// If the promise is rejected, clear the cache so that the next call will re-invoke fn
+				cache = null;
+
+				// Re-throw the exception so that it can be handled by the caller
+				throw e;
+			});
+		}
+
+		// Update the cache
+		cache = {
+			this: this,
+			args,
+			result,
+		};
+
+		return result;
+	}
+
+	memoized.clearCache = function clearCache() {
+		cache = null;
+	};
+
+	return memoized;
+}

--- a/packages/conform-zod/package.json
+++ b/packages/conform-zod/package.json
@@ -15,12 +15,33 @@
 			"require": "./dist/v3/index.js",
 			"default": "./dist/v3/index.mjs"
 		},
+		"./v3": {
+			"types": "./dist/v3/index.d.ts",
+			"module": "./dist/v3/index.mjs",
+			"import": "./dist/v3/index.mjs",
+			"require": "./dist/v3/index.js",
+			"default": "./dist/v3/index.mjs"
+		},
+		"./v3/future": {
+			"types": "./dist/v3/future.d.ts",
+			"module": "./dist/v3/future.mjs",
+			"import": "./dist/v3/future.mjs",
+			"require": "./dist/v3/future.js",
+			"default": "./dist/v3/future.mjs"
+		},
 		"./v4": {
 			"types": "./dist/v4/index.d.ts",
 			"module": "./dist/v4/index.mjs",
 			"import": "./dist/v4/index.mjs",
 			"require": "./dist/v4/index.js",
 			"default": "./dist/v4/index.mjs"
+		},
+		"./v4/future": {
+			"types": "./dist/v4/future.d.ts",
+			"module": "./dist/v4/future.mjs",
+			"import": "./dist/v4/future.mjs",
+			"require": "./dist/v4/future.js",
+			"default": "./dist/v4/future.mjs"
 		}
 	},
 	"files": [

--- a/packages/conform-zod/rollup.config.js
+++ b/packages/conform-zod/rollup.config.js
@@ -13,7 +13,12 @@ function configurePackage() {
 		external(id) {
 			return !id.startsWith('.') && !path.isAbsolute(id);
 		},
-		input: [`${sourceDir}/v3/index.ts`, `${sourceDir}/v4/index.ts`],
+		input: [
+			`${sourceDir}/v3/index.ts`,
+			`${sourceDir}/v3/future.ts`,
+			`${sourceDir}/v4/index.ts`,
+			`${sourceDir}/v4/future.ts`,
+		],
 		output: {
 			dir: outputDir,
 			format: 'esm',
@@ -58,7 +63,12 @@ function configurePackage() {
 		external(id) {
 			return !id.startsWith('.') && !path.isAbsolute(id);
 		},
-		input: [`${sourceDir}/v3/index.ts`, `${sourceDir}/v4/index.ts`],
+		input: [
+			`${sourceDir}/v3/index.ts`,
+			`${sourceDir}/v3/future.ts`,
+			`${sourceDir}/v4/index.ts`,
+			`${sourceDir}/v4/future.ts`,
+		],
 		output: {
 			dir: outputDir,
 			format: 'cjs',

--- a/packages/conform-zod/tests/memoize.test.ts
+++ b/packages/conform-zod/tests/memoize.test.ts
@@ -1,0 +1,208 @@
+import { describe, test, expect, vi } from 'vitest';
+import { memoize, defaultEqualityCheck } from '../memoize';
+
+describe('defaultEqualityCheck', () => {
+	test('returns true for identical primitive arguments', () => {
+		expect(defaultEqualityCheck([1, 'hello'], [1, 'hello'])).toBe(true);
+		expect(defaultEqualityCheck([true, false], [true, false])).toBe(true);
+		expect(defaultEqualityCheck([null, undefined], [null, undefined])).toBe(
+			true,
+		);
+	});
+
+	test('returns false for different primitive arguments', () => {
+		expect(defaultEqualityCheck([1, 'hello'], [2, 'hello'])).toBe(false);
+		expect(defaultEqualityCheck([1, 'hello'], [1, 'world'])).toBe(false);
+		expect(defaultEqualityCheck([true], [false])).toBe(false);
+	});
+
+	test('returns false for different argument lengths', () => {
+		expect(defaultEqualityCheck([1, 2], [1, 2, 3])).toBe(false);
+		expect(defaultEqualityCheck([1, 2, 3], [1, 2])).toBe(false);
+	});
+
+	test('handles NaN correctly', () => {
+		expect(defaultEqualityCheck([NaN], [NaN])).toBe(true);
+		expect(defaultEqualityCheck([NaN, 1], [NaN, 1])).toBe(true);
+	});
+
+	test('uses reference equality for objects', () => {
+		const obj = { id: 1 };
+		expect(defaultEqualityCheck([obj], [obj])).toBe(true);
+		expect(defaultEqualityCheck([{ id: 1 }], [{ id: 1 }])).toBe(false);
+	});
+});
+
+describe('memoize function', () => {
+	test('caches and returns the same result for identical arguments', () => {
+		const mockFn = vi.fn((a: number, b: string) => `${a}-${b}`);
+		const memoized = memoize(mockFn);
+
+		const result1 = memoized(1, 'hello');
+		const result2 = memoized(1, 'hello');
+
+		expect(result1).toBe('1-hello');
+		expect(result2).toBe('1-hello');
+		expect(mockFn).toHaveBeenCalledTimes(1);
+	});
+
+	test('calls function again for different arguments', () => {
+		const mockFn = vi.fn((a: number) => a * 2);
+		const memoized = memoize(mockFn);
+
+		const result1 = memoized(5);
+		const result2 = memoized(10);
+
+		expect(result1).toBe(10);
+		expect(result2).toBe(20);
+		expect(mockFn).toHaveBeenCalledTimes(2);
+	});
+
+	test('only caches the most recent call', () => {
+		const mockFn = vi.fn((a: number) => a * 2);
+		const memoized = memoize(mockFn);
+
+		memoized(1); // First call
+		memoized(2); // Second call (clears cache)
+		memoized(1); // Should call function again
+		memoized(1); // Cached
+
+		expect(mockFn).toHaveBeenCalledTimes(3);
+		expect(mockFn).toHaveBeenNthCalledWith(1, 1);
+		expect(mockFn).toHaveBeenNthCalledWith(2, 2);
+		expect(mockFn).toHaveBeenNthCalledWith(3, 1);
+	});
+
+	test('handles async functions', async () => {
+		const mockFn = vi.fn(async (input: string) => {
+			return Promise.resolve(`processed-${input}`);
+		});
+		const memoized = memoize(mockFn);
+
+		const result1 = await memoized('test');
+		const result2 = await memoized('test');
+
+		expect(result1).toBe('processed-test');
+		expect(result2).toBe('processed-test');
+		expect(mockFn).toHaveBeenCalledTimes(1);
+	});
+
+	test('clears cache when async function rejects', async () => {
+		let shouldFail = true;
+		const mockFn = vi.fn(async (input: string) => {
+			if (shouldFail) {
+				shouldFail = false;
+				throw new Error('Network error');
+			}
+			return `success-${input}`;
+		});
+		const memoized = memoize(mockFn);
+
+		// First call should fail and clear cache
+		await expect(memoized('test')).rejects.toThrow('Network error');
+
+		// Second call should succeed (function called again)
+		await expect(memoized('test')).resolves.toBe('success-test');
+		expect(mockFn).toHaveBeenCalledTimes(2);
+
+		// Third call with same args should be cached
+		await expect(memoized('test')).resolves.toBe('success-test');
+		expect(mockFn).toHaveBeenCalledTimes(2);
+	});
+
+	test('preserves this context', () => {
+		class TestClass {
+			value = 42;
+
+			getValue(multiplier: number) {
+				return this.value * multiplier;
+			}
+		}
+
+		const instance = new TestClass();
+		const memoized = memoize(instance.getValue);
+
+		const result1 = memoized.call(instance, 2);
+		const result2 = memoized.call(instance, 2);
+
+		expect(result1).toBe(84);
+		expect(result2).toBe(84);
+	});
+
+	test('handles different this contexts', () => {
+		const mockFn = vi.fn(function (this: { id: number }, input: string) {
+			return `${this.id}-${input}`;
+		});
+
+		const memoized = memoize(mockFn);
+		const context1 = { id: 1 };
+		const context2 = { id: 2 };
+
+		const result1 = memoized.call(context1, 'test');
+		const result2 = memoized.call(context1, 'test'); // Same context, same args - should be cached
+		const result3 = memoized.call(context2, 'test'); // Different context - should call function
+
+		expect(result1).toBe('1-test');
+		expect(result2).toBe('1-test');
+		expect(result3).toBe('2-test');
+		expect(mockFn).toHaveBeenCalledTimes(2);
+	});
+
+	test('supports custom equality function', () => {
+		const mockFn = vi.fn(
+			(user: { id: number; name: string }) => `User: ${user.name}`,
+		);
+
+		// Custom equality that only compares by ID
+		const memoized = memoize(mockFn, (prevArgs, nextArgs) => {
+			return prevArgs[0].id === nextArgs[0].id;
+		});
+
+		const result1 = memoized({ id: 1, name: 'Alice' });
+		const result2 = memoized({ id: 1, name: 'Bob' }); // Different name, same ID - should be cached
+
+		expect(result1).toBe('User: Alice');
+		expect(result2).toBe('User: Alice'); // Returns cached result from first call
+		expect(mockFn).toHaveBeenCalledTimes(1);
+	});
+
+	test('provides clearCache method', () => {
+		const mockFn = vi.fn((input: string) => input.toUpperCase());
+		const memoized = memoize(mockFn);
+
+		memoized('hello');
+		memoized('hello'); // Should be cached
+
+		memoized.clearCache();
+		memoized('hello'); // Should call function again after cache clear
+
+		expect(mockFn).toHaveBeenCalledTimes(2);
+	});
+
+	test('handles functions with no arguments', () => {
+		const mockFn = vi.fn(() => Math.random());
+		const memoized = memoize(mockFn);
+
+		const result1 = memoized();
+		const result2 = memoized();
+
+		expect(result1).toBe(result2);
+		expect(mockFn).toHaveBeenCalledTimes(1);
+	});
+
+	test('handles functions with multiple return types', () => {
+		const mockFn = vi.fn((returnError: boolean) => {
+			return returnError ? null : ['Error message'];
+		});
+		const memoized = memoize(mockFn);
+
+		const result1 = memoized(false);
+		const result2 = memoized(false);
+		const result3 = memoized(true);
+
+		expect(result1).toEqual(['Error message']);
+		expect(result2).toEqual(['Error message']);
+		expect(result3).toBeNull();
+		expect(mockFn).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/conform-zod/v3/coercion.ts
+++ b/packages/conform-zod/v3/coercion.ts
@@ -378,7 +378,7 @@ export function enableTypeCoercion<Schema extends ZodTypeAny>(
  * @example
  *
  * ```tsx
- * import { parseWithZod, unstable_coerceFormValue as coerceFormValue } from '@conform-to/zod';
+ * import { coerceFormValue } from '@conform-to/zod/v3/future'; // Or import `@conform-to/zod/v4/future`.
  * import { z } from 'zod';
  *
  * // Coerce the form value with default behaviour

--- a/packages/conform-zod/v3/format.ts
+++ b/packages/conform-zod/v3/format.ts
@@ -1,0 +1,101 @@
+import type { SafeParseReturnType, ZodIssue } from 'zod';
+import type { FormError } from '@conform-to/dom/future';
+import { formatPathSegments } from '@conform-to/dom/future';
+
+/**
+ * Transforms Zod validation results into Conform's error format.
+ *
+ * @example
+ * ```ts
+ * const result = schema.safeParse(formData);
+ * const error = formatResult(result);
+ * ```
+ */
+export function formatResult(
+	result: SafeParseReturnType<any, any>,
+): FormError<string> | null;
+export function formatResult<Output, ErrorShape>(
+	result: SafeParseReturnType<any, Output>,
+	options: {
+		/** Whether to include the parsed value in the returned object */
+		includeValue: true;
+		/** Custom function to format validation issues for each field */
+		formatIssues: (issue: ZodIssue[], name: string) => ErrorShape[];
+	},
+): {
+	error: FormError<ErrorShape> | null;
+	value: Output | undefined;
+};
+export function formatResult<Output>(
+	result: SafeParseReturnType<any, Output>,
+	options: {
+		includeValue: true;
+		formatIssues?: undefined;
+	},
+): {
+	error: FormError<string> | null;
+	value: Output | undefined;
+};
+export function formatResult<Output, ErrorShape>(
+	result: SafeParseReturnType<any, Output>,
+	options: {
+		includeValue?: false;
+		formatIssues: (issue: ZodIssue[], name: string) => ErrorShape[];
+	},
+): FormError<ErrorShape> | null;
+export function formatResult<Output, Input, ErrorShape>(
+	result: SafeParseReturnType<Input, Output>,
+	options?: {
+		includeValue?: boolean;
+		formatIssues?: (issue: ZodIssue[], name: string) => ErrorShape[];
+	},
+):
+	| FormError<string | ErrorShape>
+	| null
+	| {
+			error: FormError<string | ErrorShape> | null;
+			value: Output | undefined;
+	  } {
+	let error: FormError<string | ErrorShape> | null = null;
+	let value: Output | undefined = undefined;
+
+	if (!result.success) {
+		const errorByName: Record<string, ZodIssue[]> = {};
+
+		for (const issue of result.error.issues) {
+			const name = formatPathSegments(issue.path);
+
+			errorByName[name] ??= [];
+			errorByName[name].push(issue);
+		}
+
+		const { '': formErrors = [], ...fieldErrors } = Object.entries(
+			errorByName,
+		).reduce<Record<string, string[] | ErrorShape[]>>(
+			(result, [name, issues]) => {
+				result[name] = options?.formatIssues
+					? options.formatIssues(issues, name)
+					: issues.map((issue) => issue.message);
+
+				return result;
+			},
+			{},
+		);
+
+		error = {
+			formErrors,
+			fieldErrors,
+		};
+	} else {
+		value = result.data;
+	}
+
+	if (!options?.includeValue) {
+		return error;
+	}
+
+	return {
+		error,
+		value,
+	};
+}

--- a/packages/conform-zod/v3/future.ts
+++ b/packages/conform-zod/v3/future.ts
@@ -1,0 +1,4 @@
+export { getZodConstraint } from './constraint';
+export { coerceFormValue } from './coercion';
+export { formatResult } from './format';
+export { memoize } from '../memoize';

--- a/packages/conform-zod/v3/tests/format.test.ts
+++ b/packages/conform-zod/v3/tests/format.test.ts
@@ -1,0 +1,234 @@
+import { describe, test, expect } from 'vitest';
+import { formatResult } from '../format';
+import { z } from 'zod';
+
+describe('formatResult', () => {
+	test('returns null for successful validation', () => {
+		const schema = z.object({ name: z.string() });
+		const result = schema.safeParse({ name: 'John' });
+		const formatted = formatResult(result);
+
+		expect(formatted).toBeNull();
+	});
+
+	test('returns error and value with includeValue option', () => {
+		const schema = z.object({ name: z.string(), age: z.number() });
+		const result = schema.safeParse({ name: 'John', age: 25 });
+		const formatted = formatResult(result, { includeValue: true });
+
+		expect(formatted).toEqual({
+			error: null,
+			value: { name: 'John', age: 25 },
+		});
+	});
+
+	test('formats field errors', () => {
+		const schema = z.object({
+			name: z.string().min(1, 'Name is required'),
+			age: z.number().min(18, 'Must be at least 18'),
+		});
+		const result = schema.safeParse({ name: '', age: 16 });
+		const formatted = formatResult(result);
+
+		expect(formatted).toEqual({
+			formErrors: [],
+			fieldErrors: {
+				name: ['Name is required'],
+				age: ['Must be at least 18'],
+			},
+		});
+	});
+
+	test('formats nested field errors', () => {
+		const schema = z.object({
+			user: z.object({
+				name: z.string().min(1, 'Name is required'),
+				email: z.string().email('Invalid email'),
+			}),
+		});
+		const result = schema.safeParse({
+			user: { name: '', email: 'invalid' },
+		});
+		const formatted = formatResult(result);
+
+		expect(formatted).toEqual({
+			formErrors: [],
+			fieldErrors: {
+				'user.name': ['Name is required'],
+				'user.email': ['Invalid email'],
+			},
+		});
+	});
+
+	test('formats array field errors', () => {
+		const schema = z.object({
+			items: z.array(z.string().min(1, 'Item cannot be empty')),
+		});
+		const result = schema.safeParse({ items: ['', 'valid', ''] });
+
+		const formatted = formatResult(result);
+
+		expect(formatted).toEqual({
+			formErrors: [],
+			fieldErrors: {
+				'items[0]': ['Item cannot be empty'],
+				'items[2]': ['Item cannot be empty'],
+			},
+		});
+	});
+
+	test('formats form-level errors', () => {
+		const schema = z
+			.object({
+				password: z.string(),
+				confirmPassword: z.string(),
+			})
+			.refine((data) => data.password === data.confirmPassword, {
+				message: 'Passwords do not match',
+			});
+		const result = schema.safeParse({
+			password: 'secret',
+			confirmPassword: 'different',
+		});
+		const formatted = formatResult(result);
+
+		expect(formatted).toEqual({
+			formErrors: ['Passwords do not match'],
+			fieldErrors: {},
+		});
+	});
+
+	test('includes value with includeValue when validation fails', () => {
+		const schema = z.object({
+			name: z.string().min(1, 'Name is required'),
+		});
+		const result = schema.safeParse({ name: '' });
+
+		const formatted = formatResult(result, { includeValue: true });
+
+		expect(formatted).toEqual({
+			error: {
+				formErrors: [],
+				fieldErrors: {
+					name: ['Name is required'],
+				},
+			},
+			value: undefined,
+		});
+	});
+
+	test('uses custom formatIssues function', () => {
+		const schema = z.object({
+			name: z.string().min(1, 'Name is required'),
+			age: z.number().min(18, 'Must be at least 18'),
+		});
+		const result = schema.safeParse({ name: '', age: 16 });
+
+		const formatted = formatResult(result, {
+			formatIssues: (issues, name) =>
+				issues.map((issue) => ({
+					message: issue.message,
+					code: issue.code,
+					field: name,
+				})),
+		});
+
+		expect(formatted).toEqual({
+			formErrors: [],
+			fieldErrors: {
+				name: [
+					{
+						message: 'Name is required',
+						code: 'too_small',
+						field: 'name',
+					},
+				],
+				age: [
+					{
+						message: 'Must be at least 18',
+						code: 'too_small',
+						field: 'age',
+					},
+				],
+			},
+		});
+	});
+
+	test('combines custom formatIssues with includeValue', () => {
+		const schema = z.object({
+			email: z.string().email('Invalid email'),
+		});
+		const result = schema.safeParse({ email: 'invalid' });
+
+		const formatted = formatResult(result, {
+			includeValue: true,
+			formatIssues: (issues) => issues.map((issue) => issue.code),
+		});
+
+		expect(formatted).toEqual({
+			error: {
+				formErrors: [],
+				fieldErrors: {
+					email: ['invalid_string'],
+				},
+			},
+			value: undefined,
+		});
+	});
+
+	test('aggregates multiple issues per field with custom formatIssues', () => {
+		const schema = z.object({
+			password: z
+				.string()
+				.min(8, 'Too short')
+				.regex(/[A-Z]/, 'Must contain uppercase')
+				.regex(/[0-9]/, 'Must contain number'),
+		});
+		const result = schema.safeParse({ password: 'abc' });
+
+		const formatted = formatResult(result, {
+			formatIssues: (issues, fieldName) => [
+				`${fieldName} has ${issues.length} errors: ${issues.map((i) => i.message).join(', ')}`,
+			],
+		});
+
+		expect(formatted).toEqual({
+			formErrors: [],
+			fieldErrors: {
+				password: [
+					'password has 3 errors: Too short, Must contain uppercase, Must contain number',
+				],
+			},
+		});
+	});
+
+	test('preserves form-level error structure when no field errors exist', () => {
+		const schema = z.string().refine(() => false, 'Always fails');
+		const result = schema.safeParse('test');
+
+		const formatted = formatResult(result);
+
+		expect(formatted).toEqual({
+			formErrors: ['Always fails'],
+			fieldErrors: {},
+		});
+	});
+
+	test('returns null for empty object validation', () => {
+		const schema = z.object({});
+		const result = schema.safeParse({});
+
+		expect(formatResult(result)).toBeNull();
+	});
+
+	test('ignores formatIssues when validation succeeds', () => {
+		const schema = z.object({ name: z.string() });
+		const result = schema.safeParse({ name: 'John' });
+
+		const formatted = formatResult(result, {
+			formatIssues: () => ['Should not be called'],
+		});
+
+		expect(formatted).toBeNull();
+	});
+});

--- a/packages/conform-zod/v4/format.ts
+++ b/packages/conform-zod/v4/format.ts
@@ -1,0 +1,110 @@
+import type { ZodSafeParseResult, core } from 'zod/v4';
+import type { FormError } from '@conform-to/dom/future';
+import { appendPathSegment } from '@conform-to/dom/future';
+
+/**
+ * Transforms Zod validation results into Conform's error format.
+ *
+ * @example
+ * ```ts
+ * const result = schema.safeParse(formData);
+ * const error = formatResult(result);
+ * ```
+ */
+export function formatResult<Output>(
+	result: ZodSafeParseResult<Output>,
+): FormError<string> | null;
+export function formatResult<Output, ErrorShape = string>(
+	result: ZodSafeParseResult<Output>,
+	options: {
+		/** Whether to include the parsed value in the returned object */
+		includeValue: true;
+		/** Custom function to format validation issues for each field */
+		formatIssues: (issue: core.$ZodIssue[], name: string) => ErrorShape[];
+	},
+): {
+	error: FormError<ErrorShape> | null;
+	value: Output | undefined;
+};
+export function formatResult<Output>(
+	result: ZodSafeParseResult<Output>,
+	options: {
+		includeValue: true;
+		formatIssues?: undefined;
+	},
+): {
+	error: FormError<string> | null;
+	value: Output | undefined;
+};
+export function formatResult<Output, ErrorShape = string>(
+	result: ZodSafeParseResult<Output>,
+	options: {
+		includeValue?: false;
+		formatIssues: (issue: core.$ZodIssue[], name: string) => ErrorShape[];
+	},
+): FormError<ErrorShape> | null;
+export function formatResult<Output, ErrorShape = string>(
+	result: ZodSafeParseResult<Output>,
+	options?: {
+		includeValue?: boolean;
+		formatIssues?: (issue: core.$ZodIssue[], name: string) => ErrorShape[];
+	},
+):
+	| FormError<string | ErrorShape>
+	| null
+	| {
+			error: FormError<string | ErrorShape> | null;
+			value: Output | undefined;
+	  } {
+	let error: FormError<string | ErrorShape> | null = null;
+	let value: Output | undefined = undefined;
+
+	if (!result.success) {
+		const errorByName: Record<string, core.$ZodIssue[]> = {};
+
+		for (const issue of result.error.issues) {
+			const name = issue.path.reduce<string>((name, segment) => {
+				if (typeof segment === 'symbol') {
+					throw new Error(
+						'Symbol path segments are not supported. Received segment: ' +
+							segment.toString(),
+					);
+				}
+
+				return appendPathSegment(name, segment);
+			}, '');
+
+			errorByName[name] ??= [];
+			errorByName[name].push(issue);
+		}
+
+		const { '': formErrors = [], ...fieldErrors } = Object.entries(
+			errorByName,
+		).reduce<Record<string, string[] | ErrorShape[]>>(
+			(result, [name, issues]) => {
+				result[name] = options?.formatIssues
+					? options.formatIssues(issues, name)
+					: issues.map((issue) => issue.message);
+
+				return result;
+			},
+			{},
+		);
+
+		error = {
+			formErrors,
+			fieldErrors,
+		};
+	} else {
+		value = result.data;
+	}
+
+	if (!options?.includeValue) {
+		return error;
+	}
+
+	return {
+		error,
+		value,
+	};
+}

--- a/packages/conform-zod/v4/future.ts
+++ b/packages/conform-zod/v4/future.ts
@@ -1,0 +1,4 @@
+export { getZodConstraint } from './constraint';
+export { coerceFormValue } from './coercion';
+export { formatResult } from './format';
+export { memoize } from '../memoize';

--- a/packages/conform-zod/v4/tests/format.test.ts
+++ b/packages/conform-zod/v4/tests/format.test.ts
@@ -1,0 +1,234 @@
+import { describe, test, expect } from 'vitest';
+import { formatResult } from '../format';
+import { z } from 'zod-v4';
+
+describe('formatResult', () => {
+	test('returns null for successful validation', () => {
+		const schema = z.object({ name: z.string() });
+		const result = schema.safeParse({ name: 'John' });
+		const formatted = formatResult(result);
+
+		expect(formatted).toBeNull();
+	});
+
+	test('returns error and value with includeValue option', () => {
+		const schema = z.object({ name: z.string(), age: z.number() });
+		const result = schema.safeParse({ name: 'John', age: 25 });
+		const formatted = formatResult(result, { includeValue: true });
+
+		expect(formatted).toEqual({
+			error: null,
+			value: { name: 'John', age: 25 },
+		});
+	});
+
+	test('formats field errors', () => {
+		const schema = z.object({
+			name: z.string().min(1, 'Name is required'),
+			age: z.number().min(18, 'Must be at least 18'),
+		});
+		const result = schema.safeParse({ name: '', age: 16 });
+		const formatted = formatResult(result);
+
+		expect(formatted).toEqual({
+			formErrors: [],
+			fieldErrors: {
+				name: ['Name is required'],
+				age: ['Must be at least 18'],
+			},
+		});
+	});
+
+	test('formats nested field errors', () => {
+		const schema = z.object({
+			user: z.object({
+				name: z.string().min(1, 'Name is required'),
+				email: z.string().email('Invalid email'),
+			}),
+		});
+		const result = schema.safeParse({
+			user: { name: '', email: 'invalid' },
+		});
+		const formatted = formatResult(result);
+
+		expect(formatted).toEqual({
+			formErrors: [],
+			fieldErrors: {
+				'user.name': ['Name is required'],
+				'user.email': ['Invalid email'],
+			},
+		});
+	});
+
+	test('formats array field errors', () => {
+		const schema = z.object({
+			items: z.array(z.string().min(1, 'Item cannot be empty')),
+		});
+		const result = schema.safeParse({ items: ['', 'valid', ''] });
+
+		const formatted = formatResult(result);
+
+		expect(formatted).toEqual({
+			formErrors: [],
+			fieldErrors: {
+				'items[0]': ['Item cannot be empty'],
+				'items[2]': ['Item cannot be empty'],
+			},
+		});
+	});
+
+	test('formats form-level errors', () => {
+		const schema = z
+			.object({
+				password: z.string(),
+				confirmPassword: z.string(),
+			})
+			.refine((data) => data.password === data.confirmPassword, {
+				message: 'Passwords do not match',
+			});
+		const result = schema.safeParse({
+			password: 'secret',
+			confirmPassword: 'different',
+		});
+		const formatted = formatResult(result);
+
+		expect(formatted).toEqual({
+			formErrors: ['Passwords do not match'],
+			fieldErrors: {},
+		});
+	});
+
+	test('includes value with includeValue when validation fails', () => {
+		const schema = z.object({
+			name: z.string().min(1, 'Name is required'),
+		});
+		const result = schema.safeParse({ name: '' });
+
+		const formatted = formatResult(result, { includeValue: true });
+
+		expect(formatted).toEqual({
+			error: {
+				formErrors: [],
+				fieldErrors: {
+					name: ['Name is required'],
+				},
+			},
+			value: undefined,
+		});
+	});
+
+	test('uses custom formatIssues function', () => {
+		const schema = z.object({
+			name: z.string().min(1, 'Name is required'),
+			age: z.number().min(18, 'Must be at least 18'),
+		});
+		const result = schema.safeParse({ name: '', age: 16 });
+
+		const formatted = formatResult(result, {
+			formatIssues: (issues, name) =>
+				issues.map((issue) => ({
+					message: issue.message,
+					code: issue.code,
+					field: name,
+				})),
+		});
+
+		expect(formatted).toEqual({
+			formErrors: [],
+			fieldErrors: {
+				name: [
+					{
+						message: 'Name is required',
+						code: 'too_small',
+						field: 'name',
+					},
+				],
+				age: [
+					{
+						message: 'Must be at least 18',
+						code: 'too_small',
+						field: 'age',
+					},
+				],
+			},
+		});
+	});
+
+	test('combines custom formatIssues with includeValue', () => {
+		const schema = z.object({
+			email: z.string().email('Invalid email'),
+		});
+		const result = schema.safeParse({ email: 'invalid' });
+
+		const formatted = formatResult(result, {
+			includeValue: true,
+			formatIssues: (issues) => issues.map((issue) => issue.code),
+		});
+
+		expect(formatted).toEqual({
+			error: {
+				formErrors: [],
+				fieldErrors: {
+					email: ['invalid_format'],
+				},
+			},
+			value: undefined,
+		});
+	});
+
+	test('aggregates multiple issues per field with custom formatIssues', () => {
+		const schema = z.object({
+			password: z
+				.string()
+				.min(8, 'Too short')
+				.regex(/[A-Z]/, 'Must contain uppercase')
+				.regex(/[0-9]/, 'Must contain number'),
+		});
+		const result = schema.safeParse({ password: 'abc' });
+
+		const formatted = formatResult(result, {
+			formatIssues: (issues, fieldName) => [
+				`${fieldName} has ${issues.length} errors: ${issues.map((i) => i.message).join(', ')}`,
+			],
+		});
+
+		expect(formatted).toEqual({
+			formErrors: [],
+			fieldErrors: {
+				password: [
+					'password has 3 errors: Too short, Must contain uppercase, Must contain number',
+				],
+			},
+		});
+	});
+
+	test('preserves form-level error structure when no field errors exist', () => {
+		const schema = z.string().refine(() => false, 'Always fails');
+		const result = schema.safeParse('test');
+
+		const formatted = formatResult(result);
+
+		expect(formatted).toEqual({
+			formErrors: ['Always fails'],
+			fieldErrors: {},
+		});
+	});
+
+	test('returns null for empty object validation', () => {
+		const schema = z.object({});
+		const result = schema.safeParse({});
+
+		expect(formatResult(result)).toBeNull();
+	});
+
+	test('ignores formatIssues when validation succeeds', () => {
+		const schema = z.object({ name: z.string() });
+		const result = schema.safeParse({ name: 'John' });
+
+		const formatted = formatResult(result, {
+			formatIssues: () => ['Should not be called'],
+		});
+
+		expect(formatted).toBeNull();
+	});
+});


### PR DESCRIPTION
This PR adds `formatResult` and `memoize` helpers to future exports:

- **`formatResult`**: Transforms Zod validation results into Conform's error format, supporting value extraction and custom error formatting
- **`memoize`**: Caches most recent result to prevent redundant API calls during async validation

Both helpers are available in `@conform-to/zod/v3/future` and `@conform-to/zod/v4/future`