### PR TITLE
feat(conform-react): introduce useForm and related future APIs

### DIFF
--- a/.changeset/dull-deers-sell.md
+++ b/.changeset/dull-deers-sell.md
@@ -1,0 +1,10 @@
+---
+'@conform-to/react': minor
+---
+
+feat: add four new React hooks for form management:
+
+- `useForm`: Main hook for form state, validation, and submission
+- `useFormMetadata`: Access form-level metadata (errors, validation state)
+- `useField`: Access individual field metadata with auto-generated IDs
+- `useIntent`: Create intent dispatchers for programmatic form actions

--- a/docs/api/react/future/useField.md
+++ b/docs/api/react/future/useField.md
@@ -1,0 +1,247 @@
+# useField
+
+> The `useField` function is part of Conform's future export. These APIs are experimental and may change in minor versions. [Learn more](https://github.com/edmundhung/conform/discussions/954)
+
+A React hook that provides access to a specific field's metadata and state from any component within a `FormProvider` context.
+
+```ts
+import { useField } from '@conform-to/react/future';
+
+const field = useField(name, options);
+```
+
+## Parameters
+
+### `name: FieldName<FieldShape>`
+
+The name of the input field.
+
+### `options.formId?: string`
+
+Optional form identifier to target a specific form when multiple forms are rendered. If not provided, uses the nearest form context.
+
+## Returns
+
+A `Field` object containing field metadata and state:
+
+### `id: string`
+
+The field's unique identifier, automatically generated as `{formId}-{fieldName}`.
+
+### `name: FieldName<FieldShape>`
+
+The field name path exactly as provided. The FieldName type is just a branded string type to help with TypeScript inference.
+
+### `descriptionId: string`
+
+Auto-generated ID for associating field descriptions via `aria-describedby`.
+
+### `errorId: string`
+
+Auto-generated ID for associating field errors via `aria-describedby`.
+
+### `defaultValue: string | undefined`
+
+The field's default value as a string.
+
+### `defaultOptions: string[] | undefined`
+
+Default selected options for multi-select fields or checkbox group.
+
+### `defaultChecked: boolean | undefined`
+
+Default checked state for checkbox/radio inputs.
+
+### `touched: boolean`
+
+Whether this field has been touched (through `intent.validate()` or the `shouldValidate` option).
+
+### `invalid: boolean`
+
+Whether this field currently has validation errors.
+
+### `errors: ErrorShape[] | undefined`
+
+Array of validation error messages for this field.
+
+### Validation Attributes
+
+HTML validation attributes automatically derived from schema constraints:
+
+- `required?: boolean`
+- `minLength?: number`
+- `maxLength?: number`
+- `pattern?: string`
+- `min?: string | number`
+- `max?: string | number`
+- `step?: string | number`
+- `multiple?: boolean`
+
+### `getFieldset(): Fieldset<FieldShape>`
+
+Method to get nested fieldset for object fields under this field.
+
+### `getFieldList(): Field[]`
+
+Method to get array of fields for list/array fields under this field.
+
+## Example
+
+### Dynamic field components
+
+```tsx
+import { useField } from '@conform-to/react/future';
+
+interface FieldProps {
+  name: string;
+  label: string;
+  type?: string;
+}
+
+function FormField({ name, label, type = 'text' }: FieldProps) {
+  const field = useField(name);
+
+  return (
+    <div className={`form-field ${field.invalid ? 'invalid' : ''}`}>
+      <label htmlFor={field.id}>
+        {label}
+        {field.required && <span className="required">*</span>}
+      </label>
+
+      <input
+        id={field.id}
+        name={field.name}
+        type={type}
+        defaultValue={field.defaultValue}
+        required={field.required}
+        minLength={field.minLength}
+        maxLength={field.maxLength}
+        pattern={field.pattern}
+        min={field.min}
+        max={field.max}
+        step={field.step}
+        aria-describedby={field.errors ? field.errorId : undefined}
+      />
+
+      {field.errors && (
+        <div id={field.errorId} className="field-errors">
+          {field.errors.map((error, i) => (
+            <p key={i} className="error-message">
+              {error}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Usage
+function MyForm() {
+  const { form, context } = useForm({
+    // ...
+  });
+
+  return (
+    <FormProvider context={form.context}>
+      <form {...form.props}>
+        <FormField name="firstName" label="First Name" />
+        <FormField name="email" label="Email" type="email" />
+        <FormField name="age" label="Age" type="number" />
+      </form>
+    </FormProvider>
+  );
+}
+```
+
+### Nested field access
+
+```tsx
+import { useField } from '@conform-to/react/future';
+
+function AddressFields({ name }: { name: string }) {
+  const field = useField(name);
+  const address = field.getFieldset();
+
+  return (
+    <fieldset>
+      <legend>Address</legend>
+
+      <div>
+        <label htmlFor={address.street.id}>Street Address</label>
+        <input
+          id={address.street.id}
+          name={address.street.name}
+          defaultValue={address.street.defaultValue}
+          required={address.street.required}
+        />
+        {address.street.errors && (
+          <div className="error">{address.street.errors.join(', ')}</div>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor={address.city.id}>City</label>
+        <input
+          id={address.city.id}
+          name={address.city.name}
+          defaultValue={address.city.defaultValue}
+          required={address.city.required}
+        />
+        {address.city.errors && (
+          <div className="error">{address.city.errors.join(', ')}</div>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor={address.zip.id}>ZIP Code</label>
+        <input
+          id={address.zip.id}
+          name={address.zip.name}
+          defaultValue={address.zip.defaultValue}
+          pattern={address.zip.pattern}
+          required={address.zip.required}
+        />
+        {address.zip.errors && (
+          <div className="error">{address.zip.errors.join(', ')}</div>
+        )}
+      </div>
+    </fieldset>
+  );
+}
+```
+
+### Array field handling
+
+```tsx
+import { useField } from '@conform-to/react/future';
+
+function TagInput({ name }: { name: string }) {
+  const field = useField(name);
+  const tagFields = field.getFieldList();
+
+  return (
+    <div>
+      <label>Tags</label>
+      {tagFields.map((tagField) => (
+        <div key={tagField.key}>
+          <input name={tagField.name} defaultValue={tagField.defaultValue} />
+          {tagField.errors && (
+            <span className="error">{tagField.errors.join(', ')}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+## Tips
+
+### Accessibility
+
+The hook provides auto-generated IDs for proper ARIA associations:
+
+- Use `id` for the input element and `htmlFor` on the label
+- Use `descriptionId` for help text (`aria-describedby`)
+- Use `errorId` for error messages (`aria-describedby`)

--- a/docs/api/react/future/useForm.md
+++ b/docs/api/react/future/useForm.md
@@ -1,0 +1,221 @@
+# useForm
+
+> The `useForm` function is part of Conform's future export. These APIs are experimental and may change in minor versions. [Learn more](https://github.com/edmundhung/conform/discussions/954)
+
+The main React hook for form management. Handles form state, validation, and submission while providing access to form metadata, field objects, and form actions.
+
+```ts
+import { useForm } from '@conform-to/react/future';
+
+const { form, fields, intent, context } = useForm(options);
+```
+
+## Options
+
+A configuration object with the following properties:
+
+### `id?: string`
+
+Optional form identifier. If not provided, a unique ID is automatically generated with [useId()](https://react.dev/reference/react/useId).
+
+### `key?: string`
+
+Optional key for form state reset. When the key changes, the form resets to its initial state.
+
+### `schema?: StandardSchemaV1<FormShape, Value>`
+
+Optional [standard schema](https://standardschema.dev/) for validation (e.g., Zod, Valibot, Yup). Removes the need for manual `onValidate` setup.
+
+### `defaultValue?: DefaultValue<FormShape>`
+
+Initial form values. Can be a partial object matching your form structure.
+
+### `constraint?: Record<string, ValidationAttributes>`
+
+HTML validation attributes for fields (`required`, `minLength`, `pattern`, etc.).
+
+### `shouldValidate?: 'onSubmit' | 'onBlur' | 'onInput'`
+
+When to start validation. Defaults to `'onSubmit'`.
+
+### `shouldRevalidate?: 'onSubmit' | 'onBlur' | 'onInput'`
+
+When to revalidate fields that have been touched. Defaults to same as `shouldValidate`.
+
+### `lastResult?: SubmissionResult<ErrorShape> | null`
+
+Server-side submission result for form state synchronization.
+
+### `onValidate?: ValidateHandler<ErrorShape, Value>`
+
+Custom validation handler. Can be skipped if using the `schema` property, or combined with schema to customize validation errors.
+
+### `onError?: ErrorHandler<ErrorShape>`
+
+Error handling callback triggered when validation errors occur. By default, it focuses the first invalid field.
+
+### `onSubmit?: SubmitHandler<ErrorShape, Value>`
+
+Form submission handler called when the form is submitted with no validation errors.
+
+### `onInput?: InputHandler`
+
+Input event handler for custom input event logic.
+
+### `onBlur?: BlurHandler`
+
+Blur event handler for custom focus handling logic.
+
+## Returns
+
+The hook returns an object with four properties:
+
+### `form: FormMetadata<ErrorShape>`
+
+Form-level metadata and state. See [`useFormMetadata`](./useFormMetadata.md) for complete documentation.
+
+### `fields: Fieldset<FormShape>`
+
+Fieldset object containing all form fields as properties. Equivalent to calling `form.getFieldset()` without a name. Access field metadata via `fields.fieldName`. See [`useField`](./useField.md) for field metadata documentation.
+
+### `context: FormContext<FormShape, ErrorShape>`
+
+Form context object for use with [`FormProvider`](#formprovider). Required when using [`useField`](./useField.md) or [`useFormMetadata`](./useFormMetadata.md) in child components.
+
+### `intent: IntentDispatcher`
+
+Intent dispatcher for programmatic form actions. Same functionality as [`useIntent`](./useIntent.md) but already connected to this form.
+
+## Examples
+
+### Basic form setup
+
+```tsx
+import { useForm } from '@conform-to/react/future';
+
+function ContactForm() {
+  const { form, fields } = useForm({
+    onValidate({ payload, error }) {
+      if (!payload.email) {
+        error.fieldErrors.email = ['Email is required'];
+      } else if (!payload.email.includes('@')) {
+        error.fieldErrors.email = ['Email is invalid'];
+      }
+
+      return error;
+    },
+  });
+
+  return (
+    <form {...form.props}>
+      <div>
+        <label htmlFor={fields.email.id}>Email</label>
+        <input
+          type="email"
+          id={fields.email.id}
+          name={fields.email.name}
+          defaultValue={fields.email.defaultValue}
+        />
+        <div>{fields.email.errors}</div>
+      </div>
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+```
+
+### With schema validation
+
+```tsx
+import { useForm } from '@conform-to/react/future';
+import { z } from 'zod';
+
+const schema = z.object({
+  email: z.string().email('Email is invalid'),
+  password: z.string().min(8, 'Password must be at least 8 characters'),
+});
+
+function LoginForm() {
+  const { form, fields } = useForm({
+    schema,
+  });
+
+  return (
+    <form {...form.props}>
+      <input
+        type="email"
+        name={fields.email.name}
+        defaultValue={fields.email.defaultValue}
+      />
+      <div>{fields.email.errors}</div>
+      <input
+        type="password"
+        name={fields.password.name}
+        defaultValue={fields.password.defaultValue}
+      />
+      <div>{fields.password.errors}</div>
+
+      <button type="submit" disabled={form.invalid}>
+        Login
+      </button>
+    </form>
+  );
+}
+```
+
+### Using intent dispatcher
+
+```tsx
+import { useForm } from '@conform-to/react/future';
+
+function DynamicForm() {
+  const { form, fields, intent } = useForm({
+    defaultValue: {
+      items: ['First item'],
+    },
+  });
+  const items = fields.items.getFieldList();
+
+  return (
+    <form {...form.props}>
+      {items.map((item, index) => (
+        <div key={item.key}>
+          <label htmlFor={item.id}>Item {index + 1}</label>
+          <input
+            id={item.id}
+            name={item.name}
+            defaultValue={item.defaultValue}
+          />
+          <div>{item.errors}</div>
+
+          <button
+            type="button"
+            onClick={() => intent.remove({ name: 'items', index })}
+          >
+            Remove
+          </button>
+        </div>
+      ))}
+
+      <button
+        type="button"
+        onClick={() => intent.insert({ name: 'items', defaultValue: '' })}
+      >
+        Add Item
+      </button>
+
+      <button>Submit</button>
+    </form>
+  );
+}
+```
+
+## Tips
+
+### Field access patterns
+
+Choose the appropriate pattern based on your needs:
+
+- **Static fields**: Use `fields.fieldName` directly
+- **Dynamic field**: Use `form.getField(name)`, `form.getFieldset(name)` or `form.getFieldList(name)` to access fields by name
+- **Field components**: Use [`useField`](./useField.md) or [`useFormMetadata`](./useFormMetadata.md) in child components

--- a/docs/api/react/future/useFormMetadata.md
+++ b/docs/api/react/future/useFormMetadata.md
@@ -1,0 +1,192 @@
+# useFormMetadata
+
+> The `useFormMetadata` function is part of Conform's future export. These APIs are experimental and may change in minor versions. [Learn more](https://github.com/edmundhung/conform/discussions/954)
+
+A React hook that provides access to form-level metadata and state from any component within a `FormProvider` context.
+
+```ts
+import { useFormMetadata } from '@conform-to/react/future';
+
+const form = useFormMetadata(options);
+```
+
+## Parameters
+
+### `options.formId?: string`
+
+Optional form identifier to target a specific form when multiple forms are rendered. If not provided, uses the nearest form context.
+
+## Returns
+
+A `FormMetadata` object containing:
+
+### `id: string`
+
+The form's unique identifier.
+
+### `touched: boolean`
+
+Whether any field in the form has been touched (through `intent.validate()` or the `shouldValidate` option).
+
+### `invalid: boolean`
+
+Whether the form currently has any validation errors.
+
+### `errors: ErrorShape[] | undefined`
+
+Form-level validation errors, if any exist.
+
+### `fieldErrors: Record<string, ErrorShape[]>`
+
+Object containing field-specific validation errors for all validated fields.
+
+### `props`
+
+Form props object for spreading onto the `<form>` element:
+
+```ts
+{
+  id: string;
+  onSubmit: React.FormEventHandler<HTMLFormElement>;
+  onBlur: React.FocusEventHandler<HTMLFormElement>;
+  onInput: React.FormEventHandler<HTMLFormElement>;
+  noValidate: boolean;
+}
+```
+
+### `getField<FieldShape>(name): Field<FieldShape>`
+
+Method to get metadata for a specific field by name.
+
+### `getFieldset<FieldShape>(name): Fieldset<FieldShape>`
+
+Method to get a fieldset object for nested object fields.
+
+### `getFieldList<FieldShape>(name): Field[]`
+
+Method to get an array of field objects for array fields.
+
+## Example
+
+### Global error summary
+
+```tsx
+import { useFormMetadata, useForm } from '@conform-to/react/future';
+
+function GlobalErrorSummary() {
+  const form = useFormMetadata();
+
+  if (Object.keys(form.fieldErrors).length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="error-summary">
+      <h3>Please fix the following errors:</h3>
+      <ul>
+        {Object.entries(form.fieldErrors).map(([fieldName, errors]) => (
+          <li key={fieldName}>
+            <strong>{fieldName}:</strong> {errors.join(', ')}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function App() {
+  const { form, context } = useForm({
+    onValidate({ payload, error }) {
+      if (!payload.email) {
+        error.fieldErrors.email = ['Email is required'];
+      }
+      if (!payload.password) {
+        error.fieldErrors.password = ['Password is required'];
+      }
+      return error;
+    },
+  });
+
+  return (
+    <FormProvider context={form.context}>
+      <form {...form.props}>
+        <GlobalErrorSummary />
+        <div>
+          <label>Email</label>
+          <input name="email" type="email" />
+        </div>
+        <div>
+          <label>Password</label>
+          <input name="password" type="password" />
+        </div>
+        <button type="submit">Submit</button>
+      </form>
+    </FormProvider>
+  );
+}
+```
+
+### Custom form component
+
+```tsx
+import { useFormMetadata, useForm } from '@conform-to/react/future';
+
+function CustomForm({ children }: { children: React.ReactNode }) {
+  const form = useFormMetadata();
+
+  return (
+    <form
+      {...form.props}
+      className={form.invalid ? 'form-invalid' : 'form-valid'}
+    >
+      {/* Global form errors */}
+      {form.errors && form.errors.length > 0 && (
+        <div className="form-errors">
+          <h3>Form Error:</h3>
+          {form.errors.map((error, i) => (
+            <div key={i} className="error-message">
+              {error}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {children}
+
+      {/* Smart submit button */}
+      <button
+        type="submit"
+        disabled={form.invalid}
+        className={form.touched ? 'submit-ready' : 'submit-pending'}
+      >
+        {form.invalid && form.touched ? 'Fix errors to submit' : 'Submit'}
+      </button>
+    </form>
+  );
+}
+
+function App() {
+  const { context } = useForm({
+    onValidate({ payload, error }) {
+      if (!payload.email) error.fieldErrors.email = ['Email is required'];
+      if (!payload.name) error.fieldErrors.name = ['Name is required'];
+      return error;
+    },
+  });
+
+  return (
+    <FormProvider context={form.context}>
+      <CustomForm>
+        <div>
+          <label>Name</label>
+          <input name="name" />
+        </div>
+        <div>
+          <label>Email</label>
+          <input name="email" type="email" />
+        </div>
+      </CustomForm>
+    </FormProvider>
+  );
+}
+```

--- a/docs/api/react/future/useIntent.md
+++ b/docs/api/react/future/useIntent.md
@@ -1,0 +1,209 @@
+# useIntent
+
+> The `useIntent` function is part of Conform's future export. These APIs are experimental and may change in minor versions. [Learn more](https://github.com/edmundhung/conform/discussions/954)
+
+A React hook that provides an intent dispatcher for programmatic form actions. Intent dispatchers allow you to trigger form operations like validation, field updates, and array manipulations without manual form submission.
+
+```ts
+import { useIntent } from '@conform-to/react/future';
+
+const intent = useIntent(formRef);
+```
+
+## Parameters
+
+### `formRef: FormRef`
+
+A reference to the form element. Can be either:
+
+- A React ref object pointing to a form element (e.g. `React.RefObject<HTMLFormElement>`, `React.RefObject<HTMLButtonElement>`, `React.RefObject<HTMLInputElement>`).
+- A form ID string to target a specific form
+
+## Returns
+
+An `IntentDispatcher` object with the following methods:
+
+### `validate(name?: string): void`
+
+Triggers validation for the entire form or a specific field. If you provide a name that includes nested fields (e.g. `user.email`), it will validate all fields within that fieldset.
+
+- **name** (optional): Field name to validate. If omitted, validates the entire form.
+
+### `reset(): void`
+
+Resets the form to its initial state, clearing all values and validation states.
+
+### `update(options): void`
+
+Updates a field or fieldset with new values.
+
+- **options.name** (optional): Field name to update. If omitted, updates the entire form.
+- **options.index** (optional): Array index when updating array fields.
+- **options.value**: New value for the field or fieldset.
+
+### `insert(options): void`
+
+Inserts a new item into an array field.
+
+- **options.name**: Name of the array field.
+- **options.index** (optional): Position to insert at. If omitted, appends to the end.
+- **options.defaultValue** (optional): Default value for the new item.
+
+### `remove(options): void`
+
+Removes an item from an array field.
+
+- **options.name**: Name of the array field.
+- **options.index**: Index of the item to remove.
+
+### `reorder(options): void`
+
+Reorders items within an array field.
+
+- **options.name**: Name of the array field.
+- **options.from**: Current index of the item.
+- **options.to**: Target index to move the item to.
+
+## Examples
+
+### Reusable reset button
+
+```tsx
+import { useRef } from 'react';
+import { useIntent, useForm } from '@conform-to/react/future';
+
+function ResetButton() {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const intent = useIntent(buttonRef);
+
+  return (
+    <button type="button" ref={buttonRef} onClick={() => intent.reset()}>
+      Reset Form
+    </button>
+  );
+}
+
+function MyForm() {
+  const { form } = useForm({
+    // ...
+  });
+
+  return (
+    <form {...form.props}>
+      <input name="email" type="email" />
+      <input name="password" type="password" />
+      <button>Submit</button>
+      <ResetButton />
+    </form>
+  );
+}
+```
+
+### Enter key to add array item
+
+```tsx
+import { useRef } from 'react';
+import { useIntent, useForm } from '@conform-to/react/future';
+
+function TagInput({ name }: { name: string }) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const intent = useIntent(inputRef);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && e.currentTarget.value.trim()) {
+      e.preventDefault();
+      intent.insert({
+        name,
+        defaultValue: e.currentTarget.value.trim(),
+      });
+      e.currentTarget.value = '';
+    }
+  };
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      placeholder="Type and press Enter to add..."
+      onKeyDown={handleKeyDown}
+    />
+  );
+}
+
+function MyForm() {
+  const { form, fields } = useForm({
+    defaultValue: {
+      tags: ['react', 'forms'],
+    },
+  });
+  const tagFields = fields.tags.getFieldList();
+
+  return (
+    <form {...form.props}>
+      <div>
+        <label>Tags</label>
+        <div>
+          {tagFields.map((tag, index) => (
+            <span key={tag.key}>
+              <input
+                type="hidden"
+                name={tag.name}
+                defaultValue={tag.defaultValue}
+              />
+              {tag.defaultValue}
+            </span>
+          ))}
+        </div>
+        <TagInput name="tags" />
+      </div>
+      <button>Submit</button>
+    </form>
+  );
+}
+```
+
+## Tips
+
+### External buttons with form association
+
+You can create intent buttons outside the form using the `form` attribute:
+
+```tsx
+import { useRef } from 'react';
+import { useIntent, useForm } from '@conform-to/react/future';
+
+function ResetButton({ form }: { form?: string }) {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const intent = useIntent(buttonRef);
+
+  return (
+    <button
+      type="button"
+      ref={buttonRef}
+      form={form}
+      onClick={() => intent.reset()}
+    >
+      Reset Form
+    </button>
+  );
+}
+
+function MyApp() {
+  const { form, fields } = useForm({
+    // ...
+  });
+
+  return (
+    <>
+      <form {...form.props}>
+        <input name="title" />
+        <input name="description" />
+        <button type="submit">Submit</button>
+      </form>
+
+      {/* Button associated via form attribute */}
+      <ResetButton form={form.id} />
+    </>
+  );
+}
+```

--- a/docs/api/zod/future/formatResult.md
+++ b/docs/api/zod/future/formatResult.md
@@ -102,8 +102,8 @@ const schema = z.object({
 
 function Example() {
   const { form, fields } = useForm({
-    onValidate({ value }) {
-      const result = schema.safeParse(value);
+    onValidate({ payload }) {
+      const result = schema.safeParse(payload);
       return formatResult(result, {
         includeValue: true,
         formatIssues(issues, name) {

--- a/docs/api/zod/future/memoize.md
+++ b/docs/api/zod/future/memoize.md
@@ -62,15 +62,17 @@ function Example() {
   const { form, fields } = useForm({
     // A standard schema for basic validations
     schema,
-    async onValidate({ value, error }) {
+    async onValidate({ payload, error }) {
       // Validate username uniqueness only if username is provided and has no other errors
-      if (value.username && !error.fieldErrors.username) {
-        const messages = await validateUsername(value.username);
+      if (payload.username && !error.fieldErrors.username) {
+        const messages = await validateUsername(payload.username);
 
         if (messages) {
           error.fieldErrors.username = messages;
         }
       }
+
+      return error;
     },
   });
 

--- a/guide/app/layout.tsx
+++ b/guide/app/layout.tsx
@@ -53,8 +53,12 @@ const menus: { [code: string]: Menu[] } = {
 		{
 			title: 'Future APIs',
 			links: [
-				{ title: 'useControl', to: '/api/react/future/useControl' },
+				{ title: 'useForm', to: '/api/react/future/useForm' },
 				{ title: 'useFormData', to: '/api/react/future/useFormData' },
+				{ title: 'useFormMetadata', to: '/api/react/future/useFormMetadata' },
+				{ title: 'useField', to: '/api/react/future/useField' },
+				{ title: 'useControl', to: '/api/react/future/useControl' },
+				{ title: 'useIntent', to: '/api/react/future/useIntent' },
 				{ title: 'parseSubmission', to: '/api/react/future/parseSubmission' },
 				{ title: 'report', to: '/api/react/future/report' },
 				{ title: 'isDirty', to: '/api/react/future/isDirty' },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"dev:playground": "pnpm --filter ./playground run dev",
 		"guide": "pnpm --filter ./guide run dev ",
 		"test": "pnpm run \"/^test:.*/\"",
-		"test:api": "vitest --watch",
+		"test:api": "vitest",
 		"test:e2e": "playwright test --ui",
 		"version": "changeset version && pnpm install --lockfile-only && .github/version.sh",
 		"lint": "eslint --cache --ext .js,.jsx,.ts,.tsx .",

--- a/packages/conform-dom/future/index.ts
+++ b/packages/conform-dom/future/index.ts
@@ -18,8 +18,9 @@ export {
 	getValueAtPath,
 	setValueAtPath,
 	report,
+	serialize,
 } from '../formdata';
-export { isPlainObject, deepEqual, serialize } from '../util';
+export { isPlainObject, deepEqual } from '../util';
 export {
 	isFieldElement,
 	isGlobalInstance,

--- a/packages/conform-dom/tests/formdata.test.ts
+++ b/packages/conform-dom/tests/formdata.test.ts
@@ -10,6 +10,7 @@ import {
 	parseSubmission,
 	report,
 	DEFAULT_INTENT_NAME,
+	serialize,
 } from '../formdata';
 
 function createFormData(
@@ -1012,4 +1013,27 @@ describe('isDirty', () => {
 
 		expect(isDirty(submission.payload)).toBe(false);
 	});
+});
+
+test('serialize', () => {
+	const txtFile = new File(['hello', 'world'], 'example.txt');
+	const svgFile = new File(['<svg></svg>'], 'example.svg', {
+		type: 'image/svg+xml',
+	});
+
+	expect(serialize('test')).toBe('test');
+	expect(serialize(true)).toBe('on');
+	expect(serialize(false)).toBe('');
+	expect(serialize(123)).toBe('123');
+	expect(serialize(987654321n)).toBe('987654321');
+	expect(serialize(new Date(12345))).toBe(new Date(12345).toISOString());
+	expect(serialize(new Map())).toBeUndefined();
+	expect(serialize(new Set())).toBeUndefined();
+	expect(serialize(txtFile)).toBe(txtFile);
+	expect(serialize([txtFile, svgFile])).toEqual([txtFile, svgFile]);
+	expect(serialize(null)).toBe('');
+	expect(serialize(undefined)).toBeUndefined();
+	expect(serialize({ a: 1, b: 2, c: 3 })).toBeUndefined();
+	expect(serialize(['foo', 'bar'])).toEqual(['foo', 'bar']);
+	expect(serialize([{ foo: 'bar' }])).toBeUndefined();
 });

--- a/packages/conform-dom/tests/util.test.ts
+++ b/packages/conform-dom/tests/util.test.ts
@@ -1,28 +1,5 @@
 import { expect, test } from 'vitest';
-import { serialize, deepEqual } from '../util';
-
-test('serialize', () => {
-	const txtFile = new File(['hello', 'world'], 'example.txt');
-	const svgFile = new File(['<svg></svg>'], 'example.svg', {
-		type: 'image/svg+xml',
-	});
-
-	expect(serialize('test')).toBe('test');
-	expect(serialize(true)).toBe('on');
-	expect(serialize(false)).toBe('');
-	expect(serialize(123)).toBe('123');
-	expect(serialize(987654321n)).toBe('987654321');
-	expect(serialize(new Date(12345))).toBe(new Date(12345).toISOString());
-	expect(serialize(new Map())).toBeUndefined();
-	expect(serialize(new Set())).toBeUndefined();
-	expect(serialize(txtFile)).toBe(txtFile);
-	expect(serialize([txtFile, svgFile])).toEqual([txtFile, svgFile]);
-	expect(serialize(null)).toBe('');
-	expect(serialize(undefined)).toBeUndefined();
-	expect(serialize({ a: 1, b: 2, c: 3 })).toBeUndefined();
-	expect(serialize(['foo', 'bar'])).toEqual(['foo', 'bar']);
-	expect(serialize([{ foo: 'bar' }])).toBeUndefined();
-});
+import { deepEqual } from '../util';
 
 test('deepEqual', () => {
 	expect(deepEqual(null, null)).toBe(true);

--- a/packages/conform-dom/types.ts
+++ b/packages/conform-dom/types.ts
@@ -78,14 +78,14 @@ export type SubmissionResult<
  * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Constraint_validation
  */
 export type ValidationAttributes = {
-	required: boolean | undefined;
-	minLength: number | undefined;
-	maxLength: number | undefined;
-	min: string | number | undefined;
-	max: string | number | undefined;
-	step: string | number | undefined;
-	multiple: boolean | undefined;
-	pattern: string | undefined;
+	required?: boolean;
+	minLength?: number;
+	maxLength?: number;
+	min?: string | number;
+	max?: string | number;
+	step?: string | number;
+	multiple?: boolean;
+	pattern?: string;
 };
 
 /**

--- a/packages/conform-dom/util.ts
+++ b/packages/conform-dom/util.ts
@@ -1,5 +1,4 @@
-import { isGlobalInstance } from './dom';
-import type { FormValue, SerializedValue } from './types';
+import type { FormValue } from './types';
 
 export function invariant(
 	expectedCondition: boolean,
@@ -81,92 +80,6 @@ export function deepEqual(left: unknown, right: unknown): boolean {
 	}
 
 	return false;
-}
-
-/**
- * Convert an unknown value into something acceptable for HTML form submission.
- * Returns `undefined` when the value cannot be represented in form data.
- *
- * Input -> Output:
- * - string -> string
- * - null -> '' (empty string)
- * - boolean -> 'on' | '' (checked semantics)
- * - number | bigint -> value.toString()
- * - Date -> value.toISOString()
- * - File -> File
- * - FileList -> File[]
- * - Array -> string[] or File[] if all items serialize to the same kind; otherwise undefined
- * - anything else -> undefined
- */
-export function serialize(value: unknown): SerializedValue | undefined {
-	function serializePrimitive(value: unknown): string | File | undefined {
-		if (typeof value === 'string') {
-			return value;
-		}
-
-		if (value === null) {
-			return '';
-		}
-
-		if (typeof value === 'boolean') {
-			return value ? 'on' : '';
-		}
-
-		if (typeof value === 'number' || typeof value === 'bigint') {
-			return value.toString();
-		}
-
-		if (value instanceof Date) {
-			return value.toISOString();
-		}
-
-		if (isGlobalInstance(value, 'File')) {
-			return value;
-		}
-	}
-
-	if (Array.isArray(value)) {
-		const options: string[] = [];
-		const files: File[] = [];
-
-		for (const item of value) {
-			const serialized = serializePrimitive(item);
-
-			if (typeof serialized === 'undefined') {
-				return;
-			}
-
-			if (typeof serialized === 'string') {
-				if (files.length > 0) {
-					return;
-				}
-
-				options.push(serialized);
-			} else {
-				if (options.length > 0) {
-					return;
-				}
-
-				files.push(serialized);
-			}
-		}
-
-		if (options.length === value.length) {
-			return options;
-		}
-
-		if (files.length === value.length) {
-			return files;
-		}
-
-		// If not all items are strings or files, return nothing
-	}
-
-	if (isGlobalInstance(value, 'FileList')) {
-		return Array.from(value);
-	}
-
-	return serializePrimitive(value);
 }
 
 /*

--- a/packages/conform-react/future/context.tsx
+++ b/packages/conform-react/future/context.tsx
@@ -1,6 +1,0 @@
-import { createContext } from 'react';
-import { createGlobalFormsObserver } from '@conform-to/dom/future';
-
-export const FormContext = createContext({
-	observer: createGlobalFormsObserver(),
-});

--- a/packages/conform-react/future/dom.ts
+++ b/packages/conform-react/future/dom.ts
@@ -1,0 +1,284 @@
+import {
+	change,
+	getValueAtPath,
+	isFieldElement,
+	isGlobalInstance,
+	requestIntent,
+	Serialize,
+	updateField,
+} from '@conform-to/dom/future';
+import type {
+	ErrorContext,
+	FormRef,
+	InputSnapshot,
+	IntentDispatcher,
+} from './types';
+import { serializeIntent } from './intent';
+
+export function getFormElement(
+	formRef: FormRef | undefined,
+): HTMLFormElement | null {
+	if (typeof formRef === 'string') {
+		return document.forms.namedItem(formRef);
+	}
+
+	const element = formRef?.current;
+
+	if (element instanceof HTMLFormElement) {
+		return element;
+	}
+
+	return element?.form ?? null;
+}
+
+export function getSubmitEvent(
+	event: React.FormEvent<HTMLFormElement>,
+): SubmitEvent {
+	if (event.type !== 'submit') {
+		throw new Error('The event is not a submit event');
+	}
+
+	return event.nativeEvent as SubmitEvent;
+}
+
+export function initializeField(
+	element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement,
+	options:
+		| {
+				defaultValue?: string | string[] | File | File[] | null;
+				defaultChecked?: boolean;
+				value?: string;
+		  }
+		| undefined,
+): void {
+	if (element.dataset.conform) {
+		return;
+	}
+
+	const defaultValue =
+		typeof options?.value === 'string' ||
+		typeof options?.defaultChecked === 'boolean'
+			? options.defaultChecked
+				? options.value ?? 'on'
+				: null
+			: options?.defaultValue;
+
+	// Update the value of the element, including the default value
+	updateField(element, { value: defaultValue, defaultValue });
+
+	element.dataset.conform = 'initialized';
+}
+
+/**
+ * Makes hidden form inputs focusable with visually hidden styles
+ */
+export function makeInputFocusable(
+	element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement,
+): void {
+	if (!element.hidden && element.type !== 'hidden') {
+		return;
+	}
+
+	// Style the element to be visually hidden
+	element.style.position = 'absolute';
+	element.style.width = '1px';
+	element.style.height = '1px';
+	element.style.padding = '0';
+	element.style.margin = '-1px';
+	element.style.overflow = 'hidden';
+	element.style.clip = 'rect(0,0,0,0)';
+	element.style.whiteSpace = 'nowrap';
+	element.style.border = '0';
+
+	// Hide the element from screen readers
+	element.setAttribute('aria-hidden', 'true');
+
+	// Make sure people won't tab to this element
+	element.tabIndex = -1;
+
+	// Set the element to be visible again so it can be focused
+	if (element.hidden) {
+		element.hidden = false;
+	}
+
+	if (element.type === 'hidden') {
+		element.setAttribute('type', 'text');
+	}
+}
+
+export function getRadioGroupValue(
+	inputs: Array<HTMLInputElement>,
+): string | undefined {
+	for (const input of inputs) {
+		if (input.type === 'radio' && input.checked) {
+			return input.value;
+		}
+	}
+}
+
+export function getCheckboxGroupValue(
+	inputs: Array<HTMLInputElement>,
+): string[] | undefined {
+	let values: string[] | undefined;
+
+	for (const input of inputs) {
+		if (input.type === 'checkbox') {
+			values ??= [];
+			if (input.checked) {
+				values.push(input.value);
+			}
+		}
+	}
+
+	return values;
+}
+
+export function getInputSnapshot(
+	input: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement,
+): InputSnapshot {
+	if (input instanceof HTMLInputElement) {
+		switch (input.type) {
+			case 'file':
+				return {
+					files: input.files ? Array.from(input.files) : undefined,
+				};
+			case 'radio':
+			case 'checkbox':
+				return {
+					value: input.value,
+					checked: input.checked,
+				};
+		}
+	} else if (input instanceof HTMLSelectElement && input.multiple) {
+		return {
+			options: Array.from(input.selectedOptions).map((option) => option.value),
+		};
+	}
+
+	return {
+		value: input.value,
+	};
+}
+
+/**
+ * Creates an InputSnapshot based on the provided options:
+ * - checkbox/radio: value / defaultChecked
+ * - file inputs: defaultValue is File or FileList
+ * - select multiple: defaultValue is string array
+ * - others: defaultValue is string
+ */
+export function createDefaultSnapshot(
+	defaultValue: string | string[] | File | File[] | FileList | null | undefined,
+	defaultChecked: boolean | undefined,
+	value: string | undefined,
+): InputSnapshot {
+	if (typeof value === 'string' || typeof defaultChecked === 'boolean') {
+		return {
+			value: value ?? 'on',
+			checked: defaultChecked,
+		};
+	}
+
+	if (typeof defaultValue === 'string') {
+		return { value: defaultValue };
+	}
+
+	if (Array.isArray(defaultValue)) {
+		if (
+			defaultValue.every((item): item is string => typeof item === 'string')
+		) {
+			return { options: defaultValue };
+		} else {
+			return { files: defaultValue };
+		}
+	}
+
+	if (isGlobalInstance(defaultValue, 'File')) {
+		return { files: [defaultValue] };
+	}
+
+	if (isGlobalInstance(defaultValue, 'FileList')) {
+		return { files: Array.from(defaultValue) };
+	}
+
+	return {};
+}
+
+/**
+ * Focuses the first field with validation errors on default form submission.
+ * Does nothing if the submission was triggered with a specific intent (e.g. validate / insert)
+ */
+export function focusFirstInvalidField<ErrorShape>(
+	ctx: ErrorContext<ErrorShape>,
+) {
+	if (ctx.intent) {
+		return;
+	}
+
+	for (const element of ctx.formElement.elements) {
+		if (
+			isFieldElement(element) &&
+			ctx.error.fieldErrors[element.name]?.length
+		) {
+			element.focus();
+			break;
+		}
+	}
+}
+
+export function updateFormValue(
+	form: HTMLFormElement,
+	intendedValue: Record<string, unknown>,
+	serialize: Serialize,
+): void {
+	for (const element of form.elements) {
+		if (isFieldElement(element) && element.name) {
+			const value = getValueAtPath(intendedValue, element.name);
+			const serializedValue = serialize(value);
+
+			if (typeof serializedValue !== 'undefined') {
+				change(element, serializedValue, {
+					preventDefault: true,
+				});
+			}
+		}
+	}
+}
+
+/**
+ * Creates a proxy that dynamically generates intent dispatch functions.
+ * Each property access returns a function that submits the intent to the form.
+ */
+export function createIntentDispatcher(
+	formElement: HTMLFormElement | (() => HTMLFormElement | null),
+	intentName: string,
+) {
+	return new Proxy<IntentDispatcher>({} as any, {
+		get(target, type, receiver) {
+			if (typeof type === 'string') {
+				// @ts-expect-error
+				target[type] ??= (payload?: unknown) => {
+					const form =
+						typeof formElement === 'function' ? formElement() : formElement;
+
+					if (!form) {
+						throw new Error(
+							`Dispatching "${type}" intent failed; No form element found.`,
+						);
+					}
+
+					requestIntent(
+						form,
+						intentName,
+						serializeIntent({
+							type,
+							payload,
+						}),
+					);
+				};
+			}
+
+			return Reflect.get(target, type, receiver);
+		},
+	});
+}

--- a/packages/conform-react/future/index.ts
+++ b/packages/conform-react/future/index.ts
@@ -1,3 +1,12 @@
+export type { FormValue, FormError } from '@conform-to/dom/future';
 export { parseSubmission, report, isDirty } from '@conform-to/dom/future';
-export { useControl, useFormData } from './hooks';
-export type { Control } from './hooks';
+export type { Control, FormOptions, Fieldset, DefaultValue } from './types';
+export {
+	FormProvider,
+	useControl,
+	useField,
+	useForm,
+	useFormData,
+	useFormMetadata,
+	useIntent,
+} from './hooks';

--- a/packages/conform-react/future/intent.ts
+++ b/packages/conform-react/future/intent.ts
@@ -1,0 +1,438 @@
+import type { FormValue, Submission } from '@conform-to/dom/future';
+import {
+	getPathSegments,
+	isPlainObject,
+	appendPathSegment,
+	getRelativePath,
+} from '@conform-to/dom/future';
+import {
+	createPathIndexUpdater,
+	getArrayAtPath,
+	generateUniqueKey,
+	isUndefined,
+	isOptional,
+	isNumber,
+	isString,
+	appendUniqueItem,
+	compactMap,
+	merge,
+	updateValueAtPath,
+	transformKeys,
+} from './util';
+import type { ActionHandler, IntentDispatcher, UnknownIntent } from './types';
+import { getDefaultListKey } from './state';
+
+/**
+ * Serializes intent to string format: "type" or "type(payload)".
+ */
+export function serializeIntent<Intent extends UnknownIntent = UnknownIntent>(
+	intent: Intent,
+): string {
+	if (!intent.payload) {
+		return intent.type;
+	}
+
+	return `${intent.type}(${JSON.stringify(intent.payload)})`;
+}
+
+/**
+ * Parses serialized intent string back to intent object.
+ */
+export function deserializeIntent(value: string): UnknownIntent {
+	let type = value;
+	let payload: unknown;
+	let serializedPayload: string | undefined;
+
+	const openParenIndex = value.indexOf('(');
+
+	if (openParenIndex > 0 && value[value.length - 1] === ')') {
+		type = value.slice(0, openParenIndex);
+		serializedPayload = value.slice(openParenIndex + 1, -1);
+	}
+
+	if (serializedPayload) {
+		try {
+			payload = JSON.parse(serializedPayload);
+		} catch {
+			// Ignore the error
+		}
+	}
+
+	return {
+		type,
+		payload,
+	};
+}
+
+/**
+ * Applies intent transformation to submission payload.
+ * Returns modified payload or null for reset intent.
+ */
+export function applyIntent(
+	submission: Submission,
+	options?: {
+		handlers?: Record<string, ActionHandler>;
+	},
+): Record<string, FormValue> | null {
+	if (!submission.intent) {
+		return submission.payload;
+	}
+
+	const intent = deserializeIntent(submission.intent);
+	const handlers: Record<string, ActionHandler> =
+		options?.handlers ?? actionHandlers;
+	const handler = handlers[intent.type];
+
+	if (
+		handler &&
+		handler.onApply &&
+		(handler.validatePayload?.(intent.payload) ?? true)
+	) {
+		return handler.onApply(submission.payload, intent.payload);
+	}
+
+	return submission.payload;
+}
+
+export function insertItem<Item>(
+	list: Array<Item>,
+	item: Item,
+	index: number,
+): void {
+	list.splice(index, 0, item);
+}
+
+export function removeItem(list: Array<unknown>, index: number): void {
+	list.splice(index, 1);
+}
+
+export function reorderItems(
+	list: Array<unknown>,
+	fromIndex: number,
+	toIndex: number,
+): void {
+	list.splice(toIndex, 0, ...list.splice(fromIndex, 1));
+}
+
+/**
+ * Updates list keys by removing child keys and optionally transforming remaining keys.
+ */
+export function updateListKeys(
+	keys: Record<string, string[]> = {},
+	keyToBeRemoved: string,
+	updateKey?: (key: string) => string | null,
+): Record<string, string[]> {
+	const basePath = getPathSegments(keyToBeRemoved);
+	return transformKeys(keys, (field) =>
+		getRelativePath(field, basePath) !== null
+			? null
+			: updateKey?.(field) ?? field,
+	);
+}
+
+/**
+ * Built-in action handlers for form intents:
+ * - reset: clears form data
+ * - validate: marks fields as touched for validation display
+ * - update: updates specific field values
+ * - insert/remove/reorder: manages array field operations
+ */
+export const actionHandlers: {
+	[Type in keyof IntentDispatcher]: IntentDispatcher[Type] extends (
+		payload: any,
+	) => void
+		? ActionHandler<IntentDispatcher[Type]>
+		: never;
+} = {
+	reset: {
+		onApply() {
+			return null;
+		},
+	},
+	validate: {
+		validatePayload(name) {
+			return isOptional(name, isString);
+		},
+		onUpdate(state, { submission, intent, error }) {
+			const name = intent.payload ?? '';
+			const basePath = getPathSegments(name);
+
+			let touchedFields = appendUniqueItem(state.touchedFields, name);
+
+			for (const field of submission.fields) {
+				// Add all child fields to the touched fields too
+				if (getRelativePath(field, basePath) !== null) {
+					touchedFields = appendUniqueItem(touchedFields, field);
+				}
+			}
+
+			// We couldn't find out all the fields from the FormData, e.g. unchecked checkboxes.
+			// or fieldsets without any fields, but we can at least include missing
+			// required fields based on the form error
+			if (name === '' && error) {
+				for (const name of Object.keys(error.fieldErrors)) {
+					touchedFields = appendUniqueItem(touchedFields, name);
+				}
+			}
+
+			return merge(state, {
+				touchedFields,
+			});
+		},
+	},
+	update: {
+		validatePayload(options) {
+			return (
+				isPlainObject(options) &&
+				isOptional(options.name, isString) &&
+				isOptional(options.index, isNumber) &&
+				!isUndefined(options.value)
+			);
+		},
+		onApply(value, options) {
+			return updateValueAtPath(
+				value,
+				appendPathSegment(options.name, options.index),
+				options.value,
+			);
+		},
+		onUpdate(state, { type, submission, intent }) {
+			let listKeys = state.listKeys;
+
+			// Update the keys only for client updates to avoid double updates if there is no client validation
+			if (type === 'client') {
+				// TODO: Do we really need to update the keys here?
+				const name = appendPathSegment(
+					intent.payload.name,
+					intent.payload.index,
+				);
+				// Remove all child keys
+				listKeys = name === '' ? {} : updateListKeys(state.listKeys, name);
+			}
+
+			const basePath = getPathSegments(intent.payload.name);
+			let touchedFields = state.touchedFields;
+
+			for (const field of submission.fields) {
+				if (
+					basePath.length === 0 ||
+					getRelativePath(field, basePath) !== null
+				) {
+					touchedFields = appendUniqueItem(touchedFields, field);
+				}
+			}
+
+			return {
+				...state,
+				listKeys,
+				touchedFields,
+			};
+		},
+	},
+	insert: {
+		validatePayload(options) {
+			return (
+				isPlainObject(options) &&
+				isString(options.name) &&
+				isOptional(options.index, isNumber)
+			);
+		},
+		onApply(value, options) {
+			const list = Array.from(getArrayAtPath(value, options.name));
+			insertItem(list, options.defaultValue, options.index ?? list.length);
+			return updateValueAtPath(value, options.name, list);
+		},
+		onUpdate(state, { type, submission, intent }) {
+			const currentValue = submission.payload;
+			const list = getArrayAtPath(currentValue, intent.payload.name);
+			const index = intent.payload.index ?? list.length;
+			const updateListIndex = createPathIndexUpdater(
+				intent.payload.name,
+				(currentIndex) =>
+					index <= currentIndex ? currentIndex + 1 : currentIndex,
+			);
+			const touchedFields = appendUniqueItem(
+				compactMap(state.touchedFields, updateListIndex),
+				intent.payload.name,
+			);
+
+			let keys = state.listKeys;
+
+			// Update the keys only for client updates to avoid double updates if there is no client validation
+			if (type === 'client') {
+				const listKeys = Array.from(
+					state.listKeys[intent.payload.name] ??
+						getDefaultListKey(
+							state.resetKey,
+							currentValue,
+							intent.payload.name,
+						),
+				);
+
+				insertItem(listKeys, generateUniqueKey(), index);
+
+				keys = {
+					// Remove all child keys
+					...updateListKeys(
+						state.listKeys,
+						appendPathSegment(intent.payload.name, index),
+						updateListIndex,
+					),
+					// Update existing list keys
+					[intent.payload.name]: listKeys,
+				};
+			}
+
+			return {
+				...state,
+				listKeys: keys,
+				touchedFields,
+			};
+		},
+	},
+	remove: {
+		validatePayload(options) {
+			return (
+				isPlainObject(options) &&
+				isString(options.name) &&
+				isNumber(options.index)
+			);
+		},
+		onApply(value, options) {
+			const list = Array.from(getArrayAtPath(value, options.name));
+			removeItem(list, options.index);
+			return updateValueAtPath(value, options.name, list);
+		},
+		onUpdate(state, { type, submission, intent }) {
+			const currentValue = submission.payload;
+			const updateListIndex = createPathIndexUpdater(
+				intent.payload.name,
+				(currentIndex) => {
+					if (intent.payload.index === currentIndex) {
+						return null;
+					}
+
+					return intent.payload.index < currentIndex
+						? currentIndex - 1
+						: currentIndex;
+				},
+			);
+			const touchedFields = appendUniqueItem(
+				compactMap(state.touchedFields, updateListIndex),
+				intent.payload.name,
+			);
+
+			let keys = state.listKeys;
+
+			// Update the keys only for client updates to avoid double updates if there is no client validation
+			if (type === 'client') {
+				const listKeys = Array.from(
+					state.listKeys[intent.payload.name] ??
+						getDefaultListKey(
+							state.resetKey,
+							currentValue,
+							intent.payload.name,
+						),
+				);
+
+				removeItem(listKeys, intent.payload.index);
+
+				keys = {
+					// Remove all child keys
+					...updateListKeys(
+						state.listKeys,
+						appendPathSegment(intent.payload.name, intent.payload.index),
+						updateListIndex,
+					),
+					// Update existing list keys
+					[intent.payload.name]: listKeys,
+				};
+			}
+
+			return {
+				...state,
+				listKeys: keys,
+				touchedFields,
+			};
+		},
+	},
+	reorder: {
+		validatePayload(options) {
+			return (
+				isPlainObject(options) &&
+				isString(options.name) &&
+				isNumber(options.from) &&
+				isNumber(options.to)
+			);
+		},
+		onApply(value, options) {
+			const list = Array.from(getArrayAtPath(value, options.name));
+			reorderItems(list, options.from, options.to);
+			return updateValueAtPath(value, options.name, list);
+		},
+		onUpdate(state, { type, submission, intent }) {
+			const currentValue = submission.payload;
+			const updateListIndex = createPathIndexUpdater(
+				intent.payload.name,
+				(currentIndex) => {
+					if (intent.payload.from === intent.payload.to) {
+						return currentIndex;
+					}
+
+					if (currentIndex === intent.payload.from) {
+						return intent.payload.to;
+					}
+
+					if (intent.payload.from < intent.payload.to) {
+						return currentIndex > intent.payload.from &&
+							currentIndex <= intent.payload.to
+							? currentIndex - 1
+							: currentIndex;
+					}
+
+					return currentIndex >= intent.payload.to &&
+						currentIndex < intent.payload.from
+						? currentIndex + 1
+						: currentIndex;
+				},
+			);
+			const touchedFields = appendUniqueItem(
+				compactMap(state.touchedFields, updateListIndex),
+				intent.payload.name,
+			);
+
+			let keys = state.listKeys;
+
+			// Update the keys only for client updates to avoid double updates if there is no client validation
+			if (type === 'client') {
+				const listKeys = Array.from(
+					state.listKeys[intent.payload.name] ??
+						getDefaultListKey(
+							state.resetKey,
+							currentValue,
+							intent.payload.name,
+						),
+				);
+
+				reorderItems(listKeys, intent.payload.from, intent.payload.to);
+
+				keys = {
+					// Remove all child keys
+					...updateListKeys(
+						state.listKeys,
+						appendPathSegment(intent.payload.name, intent.payload.from),
+						updateListIndex,
+					),
+					// Update existing list keys
+					[intent.payload.name]: listKeys,
+				};
+			}
+
+			return {
+				...state,
+				listKeys: keys,
+				touchedFields,
+			};
+		},
+	},
+};

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -1,0 +1,440 @@
+import {
+	type ValidationAttributes,
+	type Serialize,
+	appendPathSegment,
+	formatPathSegments,
+	getPathSegments,
+	getRelativePath,
+	getValueAtPath,
+	serialize as defaultSerialize,
+	deepEqual,
+} from '@conform-to/dom/future';
+import type {
+	DefaultFieldMetadata,
+	Field,
+	FieldName,
+	Fieldset,
+	FormContext,
+	FormMetadata,
+	FormState,
+	FormAction,
+	UnknownIntent,
+	ActionHandler,
+} from './types';
+import { generateUniqueKey, getArrayAtPath, merge } from './util';
+
+export function initializeState<ErrorShape>(): FormState<ErrorShape> {
+	return {
+		resetKey: generateUniqueKey(),
+		listKeys: {},
+		intendedValue: null,
+		serverValidatedValue: null,
+		serverError: null,
+		clientError: null,
+		touchedFields: [],
+	};
+}
+
+/**
+ * Updates form state based on action type:
+ * - Client actions: update intended value and client errors
+ * - Server actions: update server errors and clear client errors
+ * - Initialize: set initial intended value
+ */
+export function updateState<ErrorShape>(
+	state: FormState<ErrorShape>,
+	action: FormAction<
+		ErrorShape,
+		UnknownIntent | null,
+		{
+			handlers: Record<string, ActionHandler>;
+			reset: () => FormState<ErrorShape>;
+		}
+	>,
+): FormState<ErrorShape> {
+	if (action.intendedValue === null) {
+		return action.ctx.reset();
+	}
+
+	const value = action.intendedValue ?? action.submission.payload;
+
+	// Apply the form error and intended value from the result first
+	state =
+		action.type === 'client'
+			? merge(state, {
+					intendedValue: !action.intent
+						? value
+						: action.intendedValue ?? state.intendedValue,
+					// Update client error only if the error is different from the previous one to minimize unnecessary re-renders
+					clientError:
+						typeof action.error !== 'undefined' &&
+						!deepEqual(state.clientError, action.error)
+							? action.error
+							: state.clientError,
+					// Reset server error if form value is changed
+					serverError:
+						typeof action.error !== 'undefined' &&
+						!deepEqual(state.serverValidatedValue, value)
+							? null
+							: state.serverError,
+				})
+			: merge(state, {
+					intendedValue:
+						action.type === 'initialize' ? value : state.intendedValue,
+					// Clear client error to avoid showing stale errors
+					clientError: null,
+					// Update server error if the error is defined.
+					// There is no need to check if the error is different as we are updating other states as well
+					serverError:
+						typeof action.error !== 'undefined'
+							? action.error
+							: state.serverError,
+					// Keep track of the value that the serverError is based on
+					serverValidatedValue:
+						typeof action.error !== 'undefined'
+							? value
+							: state.serverValidatedValue,
+				});
+
+	if (action.type !== 'server' && typeof action.intent !== 'undefined') {
+		// Validate the whole form if no intent is provided (default submission)
+		const intent = action.intent ?? { type: 'validate' };
+		const handler = action.ctx.handlers?.[intent.type];
+
+		if (typeof handler?.onUpdate === 'function') {
+			if (handler.validatePayload?.(intent.payload) ?? true) {
+				return handler.onUpdate(state, {
+					...action,
+					intent: {
+						type: intent.type,
+						payload: intent.payload,
+					},
+				});
+			}
+		}
+	}
+
+	return state;
+}
+
+export function getDefaultValue(
+	context: FormContext<any>,
+	name: string,
+	serialize: Serialize = defaultSerialize,
+): string | undefined {
+	const value = getValueAtPath(
+		context.state.intendedValue ?? context.defaultValue ?? {},
+		name,
+	);
+	const serializedValue = serialize(value);
+
+	if (typeof serializedValue === 'string') {
+		return serializedValue;
+	}
+}
+
+export function getDefaultOptions(
+	context: FormContext<any>,
+	name: string,
+	serialize: Serialize = defaultSerialize,
+): string[] | undefined {
+	const value = getValueAtPath(
+		context.state.intendedValue ?? context.defaultValue ?? {},
+		name,
+	);
+	const serializedValue =
+		typeof value !== 'undefined' ? serialize(value) : undefined;
+
+	if (
+		Array.isArray(serializedValue) &&
+		serializedValue.every((item) => typeof item === 'string')
+	) {
+		return serializedValue;
+	}
+
+	if (typeof serializedValue === 'string') {
+		return [serializedValue];
+	}
+}
+
+export function isDefaultChecked(
+	context: FormContext<any>,
+	name: string,
+	serialize: Serialize = defaultSerialize,
+): boolean {
+	const value = getValueAtPath(
+		context.state.intendedValue ?? context.defaultValue ?? {},
+		name,
+	);
+	const serializedValue =
+		typeof value !== 'undefined' ? serialize(value) : undefined;
+
+	return serializedValue === 'on';
+}
+
+/**
+ * Determine if the field is touched
+ *
+ * This checks if the field is in the list of touched fields,
+ * or if there is any child field that is touched, i.e. form / fieldset
+ */
+export function isTouched(state: FormState<any>, name = '') {
+	if (state.touchedFields.includes(name)) {
+		return true;
+	}
+
+	const paths = getPathSegments(name);
+
+	return state.touchedFields.some(
+		(field) => field !== name && getRelativePath(field, paths) !== null,
+	);
+}
+
+export function getDefaultListKey(
+	prefix: string,
+	initialValue: Record<string, unknown> | null,
+	name: string,
+): string[] {
+	return getArrayAtPath(initialValue, name).map(
+		(_, index) => `${prefix}-${appendPathSegment(name, index)}`,
+	);
+}
+
+export function getListKey(context: FormContext<any>, name: string): string[] {
+	return (
+		context.state.listKeys?.[name] ??
+		getDefaultListKey(
+			context.state.resetKey,
+			context.state.intendedValue ?? context.defaultValue,
+			name,
+		)
+	);
+}
+
+export function getError<ErrorShape>(
+	state: FormState<ErrorShape>,
+	name?: string,
+): ErrorShape[] | undefined {
+	const error = state.serverError ?? state.clientError;
+
+	if (!error || !isTouched(state, name)) {
+		return;
+	}
+
+	const errors = name ? error.fieldErrors[name] : error.formErrors;
+
+	if (errors && errors.length > 0) {
+		return errors;
+	}
+}
+
+/**
+ * Gets validation constraint for a field, with fallback to parent array patterns.
+ * e.g. "array[0].key" falls back to "array[].key" if specific constraint not found.
+ */
+export function getConstraint(
+	context: FormContext<any>,
+	name: string,
+): ValidationAttributes | undefined {
+	let constraint = context.constraint?.[name];
+
+	if (!constraint) {
+		const path = getPathSegments(name);
+
+		for (let i = path.length - 1; i >= 0; i--) {
+			const segment = path[i];
+			// Try searching a less specific path for the constraint
+			// e.g. `array[0].anotherArray[1].key` -> `array[0].anotherArray[].key` -> `array[].anotherArray[].key`
+			if (typeof segment === 'number') {
+				// This overrides the current number segment with an empty string
+				// which will be treated as an empty bracket
+				path[i] = '';
+				break;
+			}
+		}
+
+		const alternative = formatPathSegments(path);
+
+		if (name !== alternative) {
+			constraint = getConstraint(context, alternative);
+		}
+	}
+
+	return constraint;
+}
+
+export function getFormMetadata<ErrorShape>(
+	context: FormContext<ErrorShape>,
+	options: {
+		serialize: Serialize;
+	},
+): FormMetadata<ErrorShape, DefaultFieldMetadata<ErrorShape>> {
+	return {
+		id: context.formId,
+		get errors() {
+			return getError(context.state);
+		},
+		get fieldErrors() {
+			const result: Record<string, ErrorShape[]> = {};
+
+			for (const name of context.state.touchedFields) {
+				if (!name) {
+					// Skip form-level errors
+					continue;
+				}
+
+				const error = getError(context.state, name);
+
+				if (typeof error !== 'undefined') {
+					result[name] = error;
+				}
+			}
+
+			return result;
+		},
+		get touched() {
+			return isTouched(context.state);
+		},
+		get invalid() {
+			return typeof getError(context.state) !== 'undefined';
+		},
+		props: {
+			id: context.formId,
+			onSubmit: context.handleSubmit,
+			onInput: context.handleInput,
+			onBlur: context.handleBlur,
+			noValidate: true,
+		},
+		context,
+		getField(name) {
+			return getField(context, {
+				...options,
+				name,
+			});
+		},
+		getFieldset(name) {
+			return getFieldset(context, {
+				...options,
+				name,
+			});
+		},
+		getFieldList(name) {
+			return getFieldList(context, {
+				...options,
+				name,
+			});
+		},
+	};
+}
+
+export function getField<FieldShape, ErrorShape = string>(
+	context: FormContext<ErrorShape>,
+	options: {
+		name: FieldName<FieldShape>;
+		serialize: Serialize;
+		key?: string;
+	},
+): Field<FieldShape, DefaultFieldMetadata<ErrorShape>> {
+	const id = `${context.formId}-${options.name}`;
+	const constraint = getConstraint(context, options.name);
+	const metadata: DefaultFieldMetadata<ErrorShape> = {
+		id: id,
+		descriptionId: `${id}-description`,
+		errorId: `${id}-error`,
+		required: constraint?.required,
+		minLength: constraint?.minLength,
+		maxLength: constraint?.maxLength,
+		pattern: constraint?.pattern,
+		min: constraint?.min,
+		max: constraint?.max,
+		step: constraint?.step,
+		multiple: constraint?.multiple,
+		get defaultValue() {
+			return getDefaultValue(context, options.name, options.serialize);
+		},
+		get defaultOptions() {
+			return getDefaultOptions(context, options.name, options.serialize);
+		},
+		get defaultChecked() {
+			return isDefaultChecked(context, options.name, options.serialize);
+		},
+		get touched() {
+			return isTouched(context.state, options.name);
+		},
+		get invalid() {
+			return typeof getError(context.state, options.name) !== 'undefined';
+		},
+		get errors() {
+			return getError(context.state, options.name);
+		},
+	};
+
+	return Object.assign(metadata, {
+		key: options.key,
+		name: options.name,
+		getFieldset() {
+			return getFieldset(context, options);
+		},
+		getFieldList() {
+			return getFieldList(context, options);
+		},
+	});
+}
+
+/**
+ * Creates a proxy that dynamically generates field objects when properties are accessed.
+ */
+export function getFieldset<
+	FieldShape = Record<string, any>,
+	ErrorShape = string,
+>(
+	context: FormContext<ErrorShape>,
+	options: {
+		name?: FieldName<FieldShape>;
+		serialize: Serialize;
+	},
+): Fieldset<FieldShape, DefaultFieldMetadata<ErrorShape>> {
+	return new Proxy({} as any, {
+		get(target, name, receiver) {
+			if (typeof name === 'string') {
+				return getField(context, {
+					...options,
+					name: appendPathSegment(options?.name, name),
+				});
+			}
+
+			return Reflect.get(target, name, receiver);
+		},
+	});
+}
+
+/**
+ * Creates an array of field objects for list/array inputs
+ */
+export function getFieldList<FieldShape = Array<any>, ErrorShape = string>(
+	context: FormContext<ErrorShape>,
+	options: {
+		name: FieldName<FieldShape>;
+		serialize: Serialize;
+	},
+): Field<
+	[FieldShape] extends [Array<infer ItemShape> | null | undefined]
+		? ItemShape
+		: unknown,
+	DefaultFieldMetadata<ErrorShape>
+>[] {
+	const keys = getListKey(context, options.name);
+
+	return keys.map((key, index) => {
+		return getField<
+			[FieldShape] extends [Array<infer ItemShape> | null | undefined]
+				? ItemShape
+				: unknown,
+			ErrorShape
+		>(context, {
+			...options,
+			name: appendPathSegment(options.name, index),
+			key,
+		});
+	});
+}

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -1,0 +1,529 @@
+import type {
+	FormError,
+	FormValue,
+	SubmissionResult,
+	ValidationAttributes,
+} from '@conform-to/dom/future';
+import { StandardSchemaV1 } from '@standard-schema/spec';
+
+export type Prettify<T> = {
+	[K in keyof T]: T[K];
+} & {};
+
+/** Reference to a form element. Can be either a React ref object or a form ID string. */
+export type FormRef =
+	| React.RefObject<
+			| HTMLFormElement
+			| HTMLFieldSetElement
+			| HTMLInputElement
+			| HTMLSelectElement
+			| HTMLTextAreaElement
+			| HTMLButtonElement
+			| null
+	  >
+	| string;
+
+export type InputSnapshot = {
+	value?: string;
+	options?: string[];
+	checked?: boolean;
+	files?: File[];
+};
+
+export type Control = {
+	/**
+	 * Current value of the base input. Undefined if the registered input
+	 * is a multi-select, file input, or checkbox group.
+	 */
+	value: string | undefined;
+	/**
+	 * Selected options of the base input. Defined only when the registered input
+	 * is a multi-select or checkbox group.
+	 */
+	checked: boolean | undefined;
+	/**
+	 * Checked state of the base input. Defined only when the registered input
+	 * is a single checkbox or radio input.
+	 */
+	options: string[] | undefined;
+	/**
+	 * Selected files of the base input. Defined only when the registered input
+	 * is a file input.
+	 */
+	files: File[] | undefined;
+	/**
+	 * Registers the base input element(s). Accepts a single input or an array for groups.
+	 */
+	register: (
+		element:
+			| HTMLInputElement
+			| HTMLSelectElement
+			| HTMLTextAreaElement
+			| HTMLCollectionOf<HTMLInputElement>
+			| NodeListOf<HTMLInputElement>
+			| null
+			| undefined,
+	) => void;
+	/**
+	 * Programmatically updates the input value and emits
+	 * both [change](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) and
+	 * [input](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event) events.
+	 */
+	change(
+		value: string | string[] | boolean | File | File[] | FileList | null,
+	): void;
+	/**
+	 * Emits [blur](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event) and
+	 * [focusout](https://developer.mozilla.org/en-US/docs/Web/API/Element/focusout_event) events.
+	 * Does not actually move focus.
+	 */
+	focus(): void;
+	/**
+	 * Emits [focus](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event) and
+	 * [focusin](https://developer.mozilla.org/en-US/docs/Web/API/Element/focusin_event) events.
+	 * This does not move the actual keyboard focus to the input. Use `element.focus()` instead
+	 * if you want to move focus to the input.
+	 */
+	blur(): void;
+};
+
+export type Selector<FormValue, Result> = (
+	formData: FormValue | null,
+	lastResult: Result | undefined,
+) => Result;
+
+export type UseFormDataOptions = {
+	/**
+	 * Set to `true` to preserve file inputs and receive a `FormData` object in the selector.
+	 * If omitted or `false`, the selector receives a `URLSearchParams` object, where all values are coerced to strings.
+	 */
+	acceptFiles?: boolean;
+};
+
+export type DefaultValue<FormShape> = FormShape extends
+	| string
+	| number
+	| boolean
+	| Date
+	| File
+	| bigint
+	| null
+	| undefined
+	? FormShape | null | undefined
+	: FormShape extends Array<infer Item> | null | undefined
+		? Array<DefaultValue<Item>> | null | undefined
+		: FormShape extends Record<string, any> | null | undefined
+			?
+					| { [Key in keyof FormShape]?: DefaultValue<FormShape[Key]> }
+					| null
+					| undefined
+			: unknown;
+
+export type FormState<ErrorShape> = {
+	/** Unique identifier that changes on form reset to trigger reset side effects */
+	resetKey: string;
+	/** Form values from user intent actions (validate, update, insert, remove, etc.) */
+	intendedValue: Record<string, unknown> | null;
+	/** Form values that have been validated on the server */
+	serverValidatedValue: Record<string, unknown> | null;
+	/** Validation errors from server-side processing */
+	serverError: FormError<ErrorShape> | null;
+	/** Validation errors from client-side validation */
+	clientError: FormError<ErrorShape> | null;
+	/** Array of field names that have been touched (validated) */
+	touchedFields: string[];
+	/** Mapping of array field names to their item keys for React list rendering */
+	listKeys: Record<string, string[]>;
+};
+
+export type FormAction<
+	ErrorShape,
+	Intent extends UnknownIntent | null | undefined = UnknownIntent | null,
+	Context = {},
+> = SubmissionResult<ErrorShape> & {
+	type: 'initialize' | 'server' | 'client';
+	intent: Intent;
+	ctx: Context;
+};
+
+export interface FormOptions<
+	FormShape,
+	ErrorShape = string,
+	Value = undefined,
+> {
+	/** Optional form identifier. If not provided, a unique ID is automatically generated. */
+	id?: string;
+	/** Optional key for form state reset. When the key changes, the form resets to its initial state. */
+	key?: string;
+	/** Optional standard schema for validation (e.g., Zod, Valibot, Yup). Removes the need for manual onValidate setup. */
+	schema?: StandardSchemaV1<FormShape, Value>;
+	/** Initial form values. Can be a partial object matching your form structure. */
+	defaultValue?: NoInfer<DefaultValue<FormShape>>;
+	/** HTML validation attributes for fields (required, minLength, pattern, etc.). */
+	constraint?: Record<string, ValidationAttributes>;
+	/**
+	 * Define when conform should start validation.
+	 * Support "onSubmit", "onInput", "onBlur".
+	 *
+	 * @default "onSubmit"
+	 */
+	shouldValidate?: 'onSubmit' | 'onBlur' | 'onInput';
+	/**
+	 * Define when conform should revalidate again.
+	 * Support "onSubmit", "onInput", "onBlur".
+	 *
+	 * @default Same as shouldValidate, or "onSubmit" if shouldValidate is not provided.
+	 */
+	shouldRevalidate?: 'onSubmit' | 'onBlur' | 'onInput';
+
+	/** Server-side submission result for form state synchronization. */
+	lastResult?: SubmissionResult<NoInfer<ErrorShape>> | null;
+	/** Custom validation handler. Can be skipped if using the schema property, or combined with schema to customize validation errors. */
+	onValidate?: ValidateHandler<ErrorShape, Value>;
+	/** Error handling callback triggered when validation errors occur. By default, it focuses the first invalid field. */
+	onError?: ErrorHandler<ErrorShape>;
+	/** Form submission handler called when the form is submitted with no validation errors. */
+	onSubmit?: SubmitHandler<NoInfer<ErrorShape>, NoInfer<Value>>;
+	/** Input event handler for custom input event logic. */
+	onInput?: InputHandler;
+	/** Blur event handler for custom focus handling logic. */
+	onBlur?: BlurHandler;
+}
+
+export interface FormContext<ErrorShape = string> {
+	/** The form's unique identifier */
+	formId: string;
+	/** Internal form state with validation results and field data */
+	state: FormState<ErrorShape>;
+	/** Initial form values */
+	defaultValue: NonNullable<DefaultValue<Record<string, any>>> | null;
+	/** HTML validation attributes for fields */
+	constraint: Record<string, ValidationAttributes> | null;
+	/** Form submission event handler */
+	handleSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+	/** Input event handler for form-wide input events */
+	handleInput: (event: React.FormEvent) => void;
+	/** Blur event handler for form-wide blur events */
+	handleBlur: (event: React.FocusEvent) => void;
+}
+
+/** The name of an input field with type information for TypeScript inference. */
+export type FieldName<FieldShape> = string & {
+	'~shape'?: FieldShape;
+};
+
+export type UnknownIntent = {
+	type: string;
+	payload?: unknown;
+};
+
+export type UnknownArgs<Args extends any[]> = {
+	[Key in keyof Args]: unknown;
+};
+
+export interface IntentDispatcher {
+	/**
+	 * Validate the whole form or a specific field?
+	 */
+	validate(name?: string): void;
+
+	/**
+	 * Reset the form to its initial state.
+	 */
+	reset(): void;
+
+	/**
+	 * Update a field or a fieldset.
+	 * If you provide a fieldset name, it will update all fields within that fieldset
+	 */
+	update<FieldShape>(options: {
+		/**
+		 * The name of the field. If you provide a fieldset name, it will update all fields within that fieldset.
+		 */
+		name?: FieldName<FieldShape>;
+		/**
+		 * Specify the index of the item to update if the field is an array.
+		 */
+		index?: [FieldShape] extends [Array<any> | null | undefined]
+			? number
+			: never;
+		/**
+		 * The new value for the field or fieldset.
+		 */
+		value: Partial<FieldShape>;
+	}): void;
+
+	/**
+	 * Insert a new item into an array field.
+	 */
+	insert<FieldShape extends Array<any>>(options: {
+		/**
+		 * The name of the array field to insert into.
+		 */
+		name: FieldName<FieldShape>;
+		/**
+		 * The index at which to insert the new item.
+		 * If not provided, it will be added to the end of the array.
+		 */
+		index?: number;
+		/**
+		 * The default value for the new item.
+		 */
+		defaultValue?: [FieldShape] extends [
+			Array<infer ItemShape> | null | undefined,
+		]
+			? Partial<ItemShape>
+			: never;
+	}): void;
+
+	/**
+	 * Remove an item from an array field.
+	 */
+	remove(options: {
+		/**
+		 * The name of the array field to remove from.
+		 */
+		name: FieldName<Array<any>>;
+		/**
+		 * The index of the item to remove.
+		 */
+		index: number;
+	}): void;
+
+	/**
+	 * Reorder items in an array field.
+	 */
+	reorder(options: {
+		name: FieldName<Array<any>>;
+		from: number;
+		to: number;
+	}): void;
+}
+
+export type FormIntent<Dispatcher extends IntentDispatcher = IntentDispatcher> =
+	{
+		[Type in keyof Dispatcher]: Dispatcher[Type] extends (
+			...args: infer Args
+		) => void
+			? {
+					type: Type;
+					payload: Args extends [infer Payload] ? Payload : undefined;
+				}
+			: never;
+	}[keyof Dispatcher];
+
+export type ActionHandler<
+	Signature extends (payload: any) => void = (payload: any) => void,
+> = {
+	validatePayload?(...args: UnknownArgs<Parameters<Signature>>): boolean;
+	onApply?(
+		value: Record<string, FormValue>,
+		...args: Parameters<Signature>
+	): Record<string, FormValue> | null;
+	onUpdate?<ErrorShape>(
+		state: FormState<ErrorShape>,
+		action: FormAction<
+			ErrorShape,
+			{
+				type: string;
+				payload: Signature extends (payload: infer Payload) => void
+					? Payload
+					: undefined;
+			}
+		>,
+	): FormState<ErrorShape>;
+};
+
+type BaseCombine<
+	T,
+	K extends PropertyKey = T extends unknown ? keyof T : never,
+> = T extends unknown ? T & Partial<Record<Exclude<K, keyof T>, never>> : never;
+
+export type Combine<T> = {
+	[K in keyof BaseCombine<T>]: BaseCombine<T>[K];
+};
+
+/** Field metadata object containing field state, validation attributes, and nested field access methods. */
+export type Field<
+	FieldShape,
+	Metadata extends Record<string, unknown> = DefaultFieldMetadata<unknown>,
+> = Readonly<
+	Metadata & {
+		/** Unique key for React list rendering (for array fields). */
+		key: string | undefined;
+		/** The field name path exactly as provided. */
+		name: FieldName<FieldShape>;
+		/** Method to get nested fieldset for object fields under this field. */
+		getFieldset(): Fieldset<
+			[FieldShape] extends [Record<string, unknown> | null | undefined]
+				? FieldShape
+				: unknown,
+			Metadata
+		>;
+		/** Method to get array of fields for list/array fields under this field. */
+		getFieldList(): Array<
+			Field<
+				[FieldShape] extends [Array<infer ItemShape> | null | undefined]
+					? ItemShape
+					: unknown,
+				Metadata
+			>
+		>;
+	}
+>;
+
+/** Fieldset object containing all form fields as properties with their respective field metadata. */
+export type Fieldset<
+	FieldShape, // extends Record<string, unknown>,
+	FieldMetadata extends Record<string, unknown>,
+> = {
+	[Key in keyof Combine<FieldShape>]-?: Field<
+		Combine<FieldShape>[Key],
+		FieldMetadata
+	>;
+};
+
+/** Form-level metadata and state object containing validation status, errors, and field access methods. */
+export type FormMetadata<
+	ErrorShape,
+	FieldMetadata extends Record<
+		string,
+		unknown
+	> = DefaultFieldMetadata<ErrorShape>,
+> = Readonly<{
+	/** The form's unique identifier. */
+	id: string;
+	/** Whether any field in the form has been touched (through intent.validate() or the shouldValidate option). */
+	touched: boolean;
+	/** Whether the form currently has any validation errors. */
+	invalid: boolean;
+	/** Form-level validation errors, if any exist. */
+	errors: ErrorShape[] | undefined;
+	/** Object containing field-specific validation errors for all validated fields. */
+	fieldErrors: Record<string, ErrorShape[]>;
+	/** Form props object for spreading onto the <form> element. */
+	props: Readonly<{
+		id: string;
+		onSubmit: React.FormEventHandler<HTMLFormElement>;
+		onBlur: React.FocusEventHandler<HTMLFormElement>;
+		onInput: React.FormEventHandler<HTMLFormElement>;
+		noValidate: boolean;
+	}>;
+	/** The current state of the form */
+	context: FormContext<ErrorShape>;
+	/** Method to get metadata for a specific field by name. */
+	getField<FieldShape>(
+		name: FieldName<FieldShape>,
+	): Field<FieldShape, FieldMetadata>;
+	/** Method to get a fieldset object for nested object fields. */
+	getFieldset<FieldShape>(
+		name: FieldName<FieldShape>,
+	): Fieldset<
+		[FieldShape] extends [Record<string, unknown> | null | undefined]
+			? FieldShape
+			: unknown,
+		FieldMetadata
+	>;
+	/** Method to get an array of field objects for array fields. */
+	getFieldList<FieldShape>(
+		name: FieldName<FieldShape>,
+	): Array<
+		Field<
+			[FieldShape] extends [Array<infer ItemShape> | null | undefined]
+				? ItemShape
+				: unknown,
+			FieldMetadata
+		>
+	>;
+}>;
+
+/** Default field metadata object containing field state, validation attributes, and accessibility IDs. */
+export type DefaultFieldMetadata<ErrorShape> = Readonly<
+	ValidationAttributes & {
+		/** The field's unique identifier, automatically generated as {formId}-{fieldName}. */
+		id: string;
+		/** Auto-generated ID for associating field descriptions via aria-describedby. */
+		descriptionId: string;
+		/** Auto-generated ID for associating field errors via aria-describedby. */
+		errorId: string;
+		/** The field's default value as a string. */
+		defaultValue: string | undefined;
+		/** Default selected options for multi-select fields or checkbox group. */
+		defaultOptions: string[] | undefined;
+		/** Default checked state for checkbox/radio inputs. */
+		defaultChecked: boolean | undefined;
+		/** Whether this field has been touched (through intent.validate() or the shouldValidate option). */
+		touched: boolean;
+		/** Whether this field currently has validation errors. */
+		invalid: boolean;
+		/** Array of validation error messages for this field. */
+		errors: ErrorShape[] | undefined;
+	}
+>;
+
+export type ValidateResult<ErrorShape, Value> =
+	| FormError<ErrorShape>
+	| null
+	| {
+			error: FormError<ErrorShape> | null;
+			value?: Value;
+	  };
+
+export type ValidateContext = {
+	payload: Record<string, FormValue>;
+	error: FormError<string>;
+	intent: UnknownIntent | null;
+	formData: FormData;
+	formElement: HTMLFormElement;
+	submitter: HTMLElement | null;
+};
+
+export type ValidateHandler<ErrorShape, Value> = (
+	ctx: ValidateContext,
+) =>
+	| ValidateResult<ErrorShape, Value>
+	| Promise<ValidateResult<ErrorShape, Value>>
+	| [
+			ValidateResult<ErrorShape, Value> | undefined,
+			Promise<ValidateResult<ErrorShape, Value>> | undefined,
+	  ]
+	| undefined;
+
+export interface FormInputEvent extends React.FormEvent<HTMLFormElement> {
+	currentTarget: EventTarget & HTMLFormElement;
+	target: EventTarget &
+		(HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement);
+}
+
+export interface FormFocusEvent extends React.FormEvent<HTMLFormElement> {
+	currentTarget: EventTarget & HTMLFormElement;
+	relatedTarget: EventTarget | null;
+	target: EventTarget &
+		(HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement);
+}
+
+export type ErrorContext<ErrorShape> = {
+	formElement: HTMLFormElement;
+	error: FormError<ErrorShape>;
+	intent: UnknownIntent | null;
+};
+
+export type ErrorHandler<ErrorShape> = (ctx: ErrorContext<ErrorShape>) => void;
+
+export type InputHandler = (event: FormInputEvent) => void;
+
+export type BlurHandler = (event: FormFocusEvent) => void;
+
+export type SubmitContext<ErrorShape = string, Value = undefined> = {
+	formData: FormData;
+	value: Value;
+	update: (options: {
+		error?: Partial<FormError<ErrorShape>> | null;
+		reset?: boolean;
+	}) => void;
+};
+
+export type SubmitHandler<ErrorShape = string, Value = undefined> = (
+	event: React.FormEvent<HTMLFormElement>,
+	ctx: SubmitContext<ErrorShape, Value>,
+) => void | Promise<void>;

--- a/packages/conform-react/future/util.ts
+++ b/packages/conform-react/future/util.ts
@@ -1,189 +1,296 @@
-import { isGlobalInstance, updateField } from '@conform-to/dom/future';
+import type { FormError } from '@conform-to/dom/future';
+import {
+	formatPathSegments,
+	getPathSegments,
+	getValueAtPath,
+	isPlainObject,
+	setValueAtPath,
+} from '@conform-to/dom/future';
+import { StandardSchemaV1 } from '@standard-schema/spec';
+import { ValidateHandler, ValidateResult } from './types';
 
-export type FormRef =
-	| React.RefObject<
-			| HTMLFormElement
-			| HTMLFieldSetElement
-			| HTMLInputElement
-			| HTMLSelectElement
-			| HTMLTextAreaElement
-			| HTMLButtonElement
-			| null
-	  >
-	| string;
-
-export function getFormElement(
-	formRef: FormRef | undefined,
-): HTMLFormElement | null {
-	if (typeof formRef === 'string') {
-		return document.forms.namedItem(formRef);
-	}
-
-	const element = formRef?.current;
-
-	if (element instanceof HTMLFormElement) {
-		return element;
-	}
-
-	return element?.form ?? null;
+export function isUndefined(value: unknown): value is undefined {
+	return value === undefined;
 }
 
-export function focusable(
-	element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement,
-): void {
-	if (!element.hidden && element.type !== 'hidden') {
-		return;
-	}
-
-	// Style the element to be visually hidden
-	element.style.position = 'absolute';
-	element.style.width = '1px';
-	element.style.height = '1px';
-	element.style.padding = '0';
-	element.style.margin = '-1px';
-	element.style.overflow = 'hidden';
-	element.style.clip = 'rect(0,0,0,0)';
-	element.style.whiteSpace = 'nowrap';
-	element.style.border = '0';
-
-	// Hide the element from screen readers
-	element.setAttribute('aria-hidden', 'true');
-
-	// Make sure people won't tab to this element
-	element.tabIndex = -1;
-
-	// Set the element to be visible again so it can be focused
-	if (element.hidden) {
-		element.hidden = false;
-	}
-
-	if (element.type === 'hidden') {
-		element.setAttribute('type', 'text');
-	}
+export function isString(value: unknown): value is string {
+	return typeof value === 'string';
 }
 
-export function initializeField(
-	element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement,
-	options:
-		| {
-				defaultValue?: string | string[] | File | File[] | null;
-				defaultChecked?: boolean;
-				value?: string;
-		  }
-		| undefined,
-): void {
-	if (element.dataset.conform) {
-		return;
-	}
-
-	const defaultValue =
-		typeof options?.value === 'string' ||
-		typeof options?.defaultChecked === 'boolean'
-			? options.defaultChecked
-				? options.value ?? 'on'
-				: null
-			: options?.defaultValue;
-
-	// Update the value of the element, including the default value
-	updateField(element, { value: defaultValue, defaultValue });
-
-	element.dataset.conform = 'initialized';
+export function isNumber(value: unknown): value is number {
+	return typeof value === 'number';
 }
 
-export function getRadioGroupValue(
-	inputs: Array<HTMLInputElement>,
-): string | undefined {
-	for (const input of inputs) {
-		if (input.type === 'radio' && input.checked) {
-			return input.value;
+export function isOptional<T>(
+	value: unknown,
+	typeGuard: (value: unknown) => value is T,
+): value is T | undefined {
+	return isUndefined(value) || typeGuard(value);
+}
+
+export function getArrayAtPath<Type>(
+	formValue: Record<string, Type> | null,
+	name: string,
+): Array<Type> {
+	const value = getValueAtPath(formValue, name) ?? [];
+
+	if (!Array.isArray(value)) {
+		throw new Error(`The value of "${name}" is not an array`);
+	}
+
+	return value;
+}
+
+/**
+ * Immutably updates a value at the specified path.
+ * Empty path replaces the entire object.
+ */
+export function updateValueAtPath<Data>(
+	data: Record<string, Data>,
+	name: string,
+	value: Data | Record<string, Data>,
+): Record<string, Data> {
+	if (name === '') {
+		if (!isPlainObject(value)) {
+			throw new Error('The value must be an object');
 		}
+
+		return value;
 	}
+
+	return setValueAtPath(data, getPathSegments(name), value, { clone: true });
 }
 
-export function getCheckboxGroupValue(
-	inputs: Array<HTMLInputElement>,
-): string[] | undefined {
-	let values: string[] | undefined;
+/**
+ * Creates a function that updates array indices in field paths.
+ * Returns null to remove fields, or updated path with new index.
+ */
+export function createPathIndexUpdater(
+	listName: string,
+	update: (index: number) => number | null,
+): (name: string) => string | null {
+	const listPaths = getPathSegments(listName);
 
-	for (const input of inputs) {
-		if (input.type === 'checkbox') {
-			values ??= [];
-			if (input.checked) {
-				values.push(input.value);
+	return (name: string) => {
+		const paths = getPathSegments(name);
+
+		if (
+			paths.length > listPaths.length &&
+			listPaths.every((path, index) => paths[index] === path)
+		) {
+			const currentIndex = paths[listPaths.length];
+
+			if (typeof currentIndex === 'number') {
+				const newIndex = update(currentIndex);
+
+				if (newIndex === null) {
+					// To remove the item instead of updating it
+					return null;
+				}
+
+				if (newIndex !== currentIndex) {
+					// Replace the index
+					paths.splice(listPaths.length, 1, newIndex);
+
+					return formatPathSegments(paths);
+				}
 			}
 		}
-	}
 
-	return values;
+		return name;
+	};
 }
 
-export type InputSnapshot = {
-	value?: string;
-	options?: string[];
-	checked?: boolean;
-	files?: File[];
-};
+/**
+ * Returns null if error object has no actual error messages,
+ * otherwise returns the error as-is.
+ */
+export function normalizeFormError<ErrorShape>(
+	error: FormError<ErrorShape> | null,
+): FormError<ErrorShape> | null {
+	if (
+		error &&
+		error.formErrors.length === 0 &&
+		Object.entries(error.fieldErrors).every(([, messages]) =>
+			Array.isArray(messages) ? messages.length === 0 : !messages,
+		)
+	) {
+		return null;
+	}
 
-export function getInputSnapshot(
-	input: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement,
-) {
-	if (input instanceof HTMLInputElement) {
-		switch (input.type) {
-			case 'file':
-				return {
-					files: input.files ? Array.from(input.files) : undefined,
-				};
-			case 'radio':
-			case 'checkbox':
-				return {
-					value: input.value,
-					checked: input.checked,
-				};
-		}
-	} else if (input instanceof HTMLSelectElement && input.multiple) {
+	return error;
+}
+
+export function normalizeValidateResult<ErrorShape, Value>(
+	result: ValidateResult<ErrorShape, Value>,
+): {
+	error: FormError<ErrorShape> | null;
+	value?: Value;
+} {
+	if (result !== null && 'error' in result) {
 		return {
-			options: Array.from(input.selectedOptions).map((option) => option.value),
+			error: normalizeFormError(result.error),
+			value: result.value,
 		};
 	}
 
 	return {
-		value: input.value,
+		error: normalizeFormError(result),
 	};
 }
 
-export function getDefaultSnapshot(
-	defaultValue: string | string[] | File | File[] | FileList | null | undefined,
-	defaultChecked: boolean | undefined,
-	value: string | undefined,
-): InputSnapshot {
-	if (typeof value === 'string' || typeof defaultChecked === 'boolean') {
+/**
+ * Handles different validation result formats:
+ * - Promise: async validation only
+ * - Array: [syncResult, asyncPromise]
+ * - Object: sync validation only
+ */
+export function resolveValidateResult<ErrorShape, Value>(
+	result: ReturnType<ValidateHandler<ErrorShape, Value>>,
+) {
+	let syncResult: ValidateResult<ErrorShape, Value> | undefined;
+	let asyncResult: Promise<ValidateResult<ErrorShape, Value>> | undefined;
+
+	if (result instanceof Promise) {
+		asyncResult = result;
+	} else if (Array.isArray(result)) {
+		syncResult = result[0];
+		asyncResult = result[1];
+	} else {
+		syncResult = result;
+	}
+
+	return {
+		syncResult: syncResult ? normalizeValidateResult(syncResult) : undefined,
+		asyncResult: asyncResult
+			? asyncResult.then(normalizeValidateResult)
+			: undefined,
+	};
+}
+
+export function resolveStandardSchemaPath(
+	issue: StandardSchemaV1.Issue,
+): Array<string | number> {
+	if (!issue.path) {
+		return [];
+	}
+
+	const segments = issue.path.map((segment) =>
+		typeof segment === 'object' && 'key' in segment ? segment.key : segment,
+	);
+
+	if (!segments.every((segment) => typeof segment !== 'symbol')) {
+		throw new Error(
+			'Path segments must not contain symbols. Use strings or numbers instead.',
+		);
+	}
+
+	return segments;
+}
+
+export function resolveStandardSchemaResult<Value>(
+	result: StandardSchemaV1.Result<Value>,
+): {
+	error: FormError<string> | null;
+	value?: Value;
+} {
+	if (!result.issues) {
 		return {
-			value: value ?? 'on',
-			checked: defaultChecked,
+			error: null,
+			value: result.value,
 		};
 	}
 
-	if (typeof defaultValue === 'string') {
-		return { value: defaultValue };
+	const errorByName: Record<string, string[]> = {};
+
+	for (const issue of result.issues) {
+		const path = resolveStandardSchemaPath(issue);
+		const name = formatPathSegments(path);
+
+		errorByName[name] ??= [];
+		errorByName[name].push(issue.message);
 	}
 
-	if (Array.isArray(defaultValue)) {
-		if (
-			defaultValue.every((item): item is string => typeof item === 'string')
-		) {
-			return { options: defaultValue };
-		} else {
-			return { files: defaultValue };
+	const { '': formErrors = [], ...fieldErrors } = errorByName;
+
+	return {
+		error: {
+			formErrors,
+			fieldErrors,
+		},
+	};
+}
+
+/**
+ * Create a copy of the object with the updated properties if there is any change
+ */
+export function merge<Obj extends Record<string, any>>(
+	obj: Obj,
+	update: Partial<Obj>,
+): Obj {
+	if (
+		obj === update ||
+		Object.entries(update).every(([key, value]) => obj[key] === value)
+	) {
+		return obj;
+	}
+
+	return Object.assign({}, obj, update);
+}
+
+/**
+ * Transforms object keys using a mapping function.
+ * Keys mapped to null are filtered out.
+ */
+export function transformKeys<Value>(
+	obj: Record<string, Value>,
+	fn: (key: string) => string | null,
+) {
+	const result: Record<string, Value> = {};
+
+	for (const [key, value] of Object.entries(obj)) {
+		const name = fn(key);
+
+		if (name !== null) {
+			result[name] = value;
 		}
 	}
 
-	if (isGlobalInstance(defaultValue, 'File')) {
-		return { files: [defaultValue] };
+	return result;
+}
+
+/**
+ * Appends item to array only if not already present.
+ * Returns original array if item exists, new array if added.
+ */
+export function appendUniqueItem<Item>(list: Array<Item>, item: Item) {
+	if (list.includes(item)) {
+		return list;
 	}
 
-	if (isGlobalInstance(defaultValue, 'FileList')) {
-		return { files: Array.from(defaultValue) };
+	return list.concat(item);
+}
+
+/**
+ * Maps over array and filters out null results.
+ */
+export function compactMap<Item>(
+	list: Array<NonNullable<Item>>,
+	fn: (value: Item) => Item | null,
+): Array<Item> {
+	const result: Array<Item> = [];
+
+	for (const item of list) {
+		const value = fn(item);
+
+		if (value !== null) {
+			result.push(value);
+		}
 	}
 
-	return {};
+	return result;
+}
+
+export function generateUniqueKey() {
+	return Math.trunc(Date.now() * Math.random()).toString(36);
 }

--- a/packages/conform-react/package.json
+++ b/packages/conform-react/package.json
@@ -60,6 +60,7 @@
 		"@babel/preset-typescript": "^7.20.2",
 		"@rollup/plugin-babel": "^5.3.1",
 		"@rollup/plugin-node-resolve": "^13.3.0",
+		"@standard-schema/spec": "^1.0.0",
 		"@types/react": "^18.2.43",
 		"@types/react-dom": "^18.3.5",
 		"react": "^18.2.0",

--- a/packages/conform-react/rollup.config.js
+++ b/packages/conform-react/rollup.config.js
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import babel from '@rollup/plugin-babel';
 import nodeResolve from '@rollup/plugin-node-resolve';
@@ -7,6 +8,25 @@ import copy from 'rollup-plugin-copy';
 function configurePackage() {
 	let sourceDir = '.';
 	let outputDir = './dist';
+	let addDirectivePlugin = {
+		name: 'use-client',
+		writeBundle() {
+			const filesToModify = ['future/hooks.mjs', 'future/hooks.js'].map(file => `${outputDir}/${file}`);
+			
+			filesToModify.forEach(filePath => {
+				if (fs.existsSync(filePath)) {
+					const content = fs.readFileSync(filePath, 'utf8');
+					
+					// Only add if not already present
+					if (!content.startsWith("'use client';")) {
+						fs.writeFileSync(filePath, `'use client';\n${content}`);
+						// eslint-disable-next-line no-console
+						console.log(`✓ Added 'use client' to ${filePath}`);
+					}
+				}
+			});
+		}
+	};
 
 	/** @type {import("rollup").RollupOptions} */
 	let ESM = {
@@ -51,6 +71,7 @@ function configurePackage() {
 					{ src: `../../README.md`, dest: sourceDir }
 				],
 			}),
+			addDirectivePlugin,
 		],
 	};
 
@@ -91,6 +112,7 @@ function configurePackage() {
 			nodeResolve({
 				extensions: ['.ts', '.tsx'],
 			}),
+			addDirectivePlugin,
 		],
 	};
 

--- a/packages/conform-react/tests/dom.browser.test.ts
+++ b/packages/conform-react/tests/dom.browser.test.ts
@@ -1,0 +1,331 @@
+import { test, expect, vi } from 'vitest';
+import {
+	getFormElement,
+	getSubmitEvent,
+	initializeField,
+	makeInputFocusable,
+	getRadioGroupValue,
+	getCheckboxGroupValue,
+	getInputSnapshot,
+	createDefaultSnapshot,
+	updateFormValue,
+	createIntentDispatcher,
+} from '../future/dom';
+
+test('getFormElement', () => {
+	// Test with string ID
+	const form = document.createElement('form');
+	form.setAttribute('name', 'testForm');
+	document.body.appendChild(form);
+
+	expect(getFormElement('testForm')).toBe(form);
+	expect(getFormElement('nonExistent')).toBeNull();
+
+	document.body.removeChild(form);
+
+	// Test with ref object containing form element
+	const formRef = { current: form };
+	expect(getFormElement(formRef)).toBe(form);
+
+	// Test with ref object containing input element
+	const input = document.createElement('input');
+	form.appendChild(input); // This sets input.form automatically
+	const inputRef = { current: input };
+	expect(getFormElement(inputRef)).toBe(form);
+
+	// Test with null ref
+	const nullRef = { current: null };
+	expect(getFormElement(nullRef)).toBeNull();
+
+	// Test with undefined
+	expect(getFormElement(undefined)).toBeNull();
+});
+
+test('getSubmitEvent', () => {
+	const nativeEvent = new Event('submit') as SubmitEvent;
+	const reactEvent = {
+		type: 'submit',
+		nativeEvent,
+	} as unknown as React.FormEvent<HTMLFormElement>;
+
+	expect(getSubmitEvent(reactEvent)).toBe(nativeEvent);
+
+	// Test with non-submit event
+	const clickEvent = {
+		type: 'click',
+		nativeEvent: new Event('click'),
+	} as React.FormEvent<HTMLFormElement>;
+
+	expect(() => getSubmitEvent(clickEvent)).toThrow(
+		'The event is not a submit event',
+	);
+});
+
+test('initializeField', () => {
+	const input = document.createElement('input');
+
+	// Test basic initialization
+	initializeField(input, { defaultValue: 'test' });
+	expect(input.dataset.conform).toBe('initialized');
+	expect(input.value).toBe('test');
+
+	// Test already initialized field
+	const spy = vi.fn();
+	input.addEventListener('change', spy);
+	initializeField(input, { defaultValue: 'new' });
+	expect(spy).not.toHaveBeenCalled(); // Should return early
+
+	// Test checkbox initialization
+	const checkbox = document.createElement('input');
+	checkbox.type = 'checkbox';
+	initializeField(checkbox, { defaultChecked: true, value: 'on' });
+	expect(checkbox.checked).toBe(true);
+	expect(checkbox.dataset.conform).toBe('initialized');
+
+	// Test with null value
+	const input2 = document.createElement('input');
+	initializeField(input2, { defaultChecked: false });
+	expect(input2.value).toBe('');
+});
+
+test('makeInputFocusable', () => {
+	// Test with hidden input
+	const hiddenInput = document.createElement('input');
+	hiddenInput.type = 'hidden';
+	makeInputFocusable(hiddenInput);
+
+	expect(hiddenInput.style.position).toBe('absolute');
+	expect(hiddenInput.style.width).toBe('1px');
+	expect(hiddenInput.style.height).toBe('1px');
+	expect(hiddenInput.getAttribute('aria-hidden')).toBe('true');
+	expect(hiddenInput.tabIndex).toBe(-1);
+	expect(hiddenInput.type).toBe('text');
+
+	// Test with hidden element
+	const hiddenElement = document.createElement('input');
+	hiddenElement.hidden = true;
+	makeInputFocusable(hiddenElement);
+
+	expect(hiddenElement.hidden).toBe(false);
+	expect(hiddenElement.style.position).toBe('absolute');
+
+	// Test with visible element (should do nothing)
+	const visibleInput = document.createElement('input');
+	visibleInput.type = 'text';
+	const originalStyle = visibleInput.style.cssText;
+	makeInputFocusable(visibleInput);
+	expect(visibleInput.style.cssText).toBe(originalStyle);
+});
+
+test('getRadioGroupValue', () => {
+	const radio1 = document.createElement('input');
+	radio1.type = 'radio';
+	radio1.value = 'option1';
+	radio1.checked = false;
+
+	const radio2 = document.createElement('input');
+	radio2.type = 'radio';
+	radio2.value = 'option2';
+	radio2.checked = true;
+
+	const radio3 = document.createElement('input');
+	radio3.type = 'radio';
+	radio3.value = 'option3';
+	radio3.checked = false;
+
+	expect(getRadioGroupValue([radio1, radio2, radio3])).toBe('option2');
+	expect(getRadioGroupValue([radio1, radio3])).toBeUndefined();
+	expect(getRadioGroupValue([])).toBeUndefined();
+});
+
+test('getCheckboxGroupValue', () => {
+	const checkbox1 = document.createElement('input');
+	checkbox1.type = 'checkbox';
+	checkbox1.value = 'option1';
+	checkbox1.checked = true;
+
+	const checkbox2 = document.createElement('input');
+	checkbox2.type = 'checkbox';
+	checkbox2.value = 'option2';
+	checkbox2.checked = false;
+
+	const checkbox3 = document.createElement('input');
+	checkbox3.type = 'checkbox';
+	checkbox3.value = 'option3';
+	checkbox3.checked = true;
+
+	expect(getCheckboxGroupValue([checkbox1, checkbox2, checkbox3])).toEqual([
+		'option1',
+		'option3',
+	]);
+	expect(getCheckboxGroupValue([checkbox2])).toEqual([]);
+	expect(getCheckboxGroupValue([])).toBeUndefined();
+});
+
+test('getInputSnapshot', () => {
+	// Test file input
+	const fileInput = document.createElement('input');
+	fileInput.type = 'file';
+	const file = new File(['test'], 'test.txt');
+	Object.defineProperty(fileInput, 'files', {
+		value: [file],
+		writable: false,
+	});
+
+	expect(getInputSnapshot(fileInput)).toEqual({ files: [file] });
+
+	// Test radio input
+	const radioInput = document.createElement('input');
+	radioInput.type = 'radio';
+	radioInput.value = 'test';
+	radioInput.checked = true;
+
+	expect(getInputSnapshot(radioInput)).toEqual({
+		value: 'test',
+		checked: true,
+	});
+
+	// Test checkbox input
+	const checkboxInput = document.createElement('input');
+	checkboxInput.type = 'checkbox';
+	checkboxInput.value = 'test';
+	checkboxInput.checked = false;
+
+	expect(getInputSnapshot(checkboxInput)).toEqual({
+		value: 'test',
+		checked: false,
+	});
+
+	// Test select multiple
+	const selectMultiple = document.createElement('select');
+	selectMultiple.multiple = true;
+	const option1 = document.createElement('option');
+	option1.value = 'option1';
+	option1.selected = true;
+	const option2 = document.createElement('option');
+	option2.value = 'option2';
+	option2.selected = false;
+	selectMultiple.appendChild(option1);
+	selectMultiple.appendChild(option2);
+
+	expect(getInputSnapshot(selectMultiple)).toEqual({ options: ['option1'] });
+
+	// Test regular input
+	const textInput = document.createElement('input');
+	textInput.value = 'test value';
+
+	expect(getInputSnapshot(textInput)).toEqual({ value: 'test value' });
+
+	// Test textarea
+	const textarea = document.createElement('textarea');
+	textarea.value = 'textarea value';
+
+	expect(getInputSnapshot(textarea)).toEqual({ value: 'textarea value' });
+});
+
+test('createDefaultSnapshot', () => {
+	// Test checkbox/radio with value and defaultChecked
+	expect(createDefaultSnapshot(undefined, true, 'custom')).toEqual({
+		value: 'custom',
+		checked: true,
+	});
+	expect(createDefaultSnapshot(undefined, false, undefined)).toEqual({
+		value: 'on',
+		checked: false,
+	});
+
+	// Test string defaultValue
+	expect(createDefaultSnapshot('test string', undefined, undefined)).toEqual({
+		value: 'test string',
+	});
+
+	// Test string array (for select multiple)
+	expect(
+		createDefaultSnapshot(['option1', 'option2'], undefined, undefined),
+	).toEqual({ options: ['option1', 'option2'] });
+
+	// Test File array
+	const file1 = new File(['test1'], 'test1.txt');
+	const file2 = new File(['test2'], 'test2.txt');
+	expect(createDefaultSnapshot([file1, file2], undefined, undefined)).toEqual({
+		files: [file1, file2],
+	});
+
+	// Test single File
+	const file = new File(['test'], 'test.txt');
+	expect(createDefaultSnapshot(file, undefined, undefined)).toEqual({
+		files: [file],
+	});
+
+	// Test FileList - skip this test as FileList is hard to mock properly
+	// expect(createDefaultSnapshot(fileList, undefined, undefined)).toEqual({ files: [file1, file2] });
+
+	// Test null/undefined
+	expect(createDefaultSnapshot(null, undefined, undefined)).toEqual({});
+	expect(createDefaultSnapshot(undefined, undefined, undefined)).toEqual({});
+});
+
+test('updateFormValue', () => {
+	const form = document.createElement('form');
+
+	const input1 = document.createElement('input');
+	input1.name = 'text';
+	input1.type = 'text';
+	form.appendChild(input1);
+
+	const input2 = document.createElement('input');
+	input2.name = 'number';
+	input2.type = 'number';
+	form.appendChild(input2);
+
+	const checkbox = document.createElement('input');
+	checkbox.name = 'checkbox';
+	checkbox.type = 'checkbox';
+	form.appendChild(checkbox);
+
+	const intendedValue = {
+		text: 'Hello World',
+		number: 42,
+		checkbox: true,
+	};
+
+	const mockSerialize = vi.fn((value) => {
+		if (typeof value === 'string') return value;
+		if (typeof value === 'number') return String(value);
+		if (typeof value === 'boolean') return value ? 'on' : undefined;
+		return undefined;
+	});
+
+	updateFormValue(form, intendedValue, mockSerialize);
+
+	expect(mockSerialize).toHaveBeenCalledWith('Hello World');
+	expect(mockSerialize).toHaveBeenCalledWith(42);
+	expect(mockSerialize).toHaveBeenCalledWith(true);
+
+	// Verify form elements were updated (this would require mocking the change function)
+	expect(input1.name).toBe('text');
+	expect(input2.name).toBe('number');
+	expect(checkbox.name).toBe('checkbox');
+});
+
+test('createIntentDispatcher', () => {
+	const mockForm = document.createElement('form');
+
+	const dispatcher = createIntentDispatcher(mockForm, 'intent');
+
+	// Test property access creates function
+	expect(typeof dispatcher.reset).toBe('function');
+	expect(typeof dispatcher.validate).toBe('function');
+
+	// Test with form getter function
+	const getForm = vi.fn(() => mockForm);
+	const dispatcher2 = createIntentDispatcher(getForm, 'intent');
+	expect(typeof dispatcher2.reset).toBe('function');
+
+	// Test error when form is not found
+	const getNullForm = vi.fn(() => null);
+	const dispatcher3 = createIntentDispatcher(getNullForm, 'intent');
+	expect(() => dispatcher3.reset()).toThrow(
+		'Dispatching "reset" intent failed; No form element found.',
+	);
+});

--- a/packages/conform-react/tests/helpers.tsx
+++ b/packages/conform-react/tests/helpers.tsx
@@ -1,4 +1,21 @@
+import {
+	DEFAULT_INTENT_NAME,
+	FormError,
+	FormValue,
+	parseSubmission,
+	report,
+	SubmissionResult,
+} from '@conform-to/dom/future';
 import { renderToStaticMarkup } from 'react-dom/server';
+import {
+	applyIntent,
+	actionHandlers,
+	deserializeIntent,
+} from '../future/intent';
+import { FormAction } from '../future/types';
+import { initializeState } from '../future/state';
+import { expect } from 'vitest';
+import { Locator } from '@vitest/browser/context';
 
 export function serverRenderHook<Result>(renderCallback: () => Result): Result {
 	let result: Result | undefined;
@@ -15,4 +32,75 @@ export function serverRenderHook<Result>(renderCallback: () => Result): Result {
 	}
 
 	return result;
+}
+
+export function createResult(
+	entries: Array<[string, FormDataEntryValue]>,
+	options?: {
+		value?: Record<string, FormValue> | null;
+		error?: Partial<FormError<any>> | null;
+	},
+): SubmissionResult<any, any> {
+	const formData = new FormData();
+
+	for (const [name, value] of entries) {
+		formData.append(name, value);
+	}
+
+	const submission = parseSubmission(formData, {
+		intentName: DEFAULT_INTENT_NAME,
+	});
+	const value = applyIntent(submission);
+
+	return report(submission, {
+		intendedValue:
+			typeof options?.value !== 'undefined' ? options.value : value,
+		error: options?.error,
+	});
+}
+
+export function createAction(options: {
+	type: FormAction<any, any>['type'];
+	entries: Array<[string, FormDataEntryValue]>;
+	value?: Record<string, FormValue> | null;
+	error?: Partial<FormError<any>> | null;
+}): FormAction<any, any, any> {
+	const formData = new FormData();
+
+	for (const [name, value] of options.entries) {
+		formData.append(name, value);
+	}
+
+	const submission = parseSubmission(formData, {
+		intentName: DEFAULT_INTENT_NAME,
+	});
+	const value = applyIntent(submission);
+	const result = report(submission, {
+		intendedValue:
+			typeof options?.value !== 'undefined' ? options.value : value,
+		error: options?.error,
+	});
+	const ctx = {
+		handlers: actionHandlers,
+		reset() {
+			return initializeState();
+		},
+	};
+
+	return {
+		...result,
+		type: options.type,
+		intent: submission.intent ? deserializeIntent(submission.intent) : null,
+		ctx,
+	};
+}
+
+export async function expectNoErrorMessages(...inputs: Locator[]) {
+	for (const input of inputs) {
+		await expect.element(input).toHaveAccessibleDescription('');
+	}
+}
+
+export async function expectErrorMessage(input: Locator, message: string) {
+	await expect.element(input).toHaveAccessibleDescription(message);
 }

--- a/packages/conform-react/tests/intent.test.ts
+++ b/packages/conform-react/tests/intent.test.ts
@@ -1,0 +1,317 @@
+import { test, expect, vi } from 'vitest';
+import {
+	serializeIntent,
+	deserializeIntent,
+	applyIntent,
+	insertItem,
+	removeItem,
+	reorderItems,
+	updateListKeys,
+	actionHandlers,
+} from '../future/intent';
+import type { Submission } from '@conform-to/dom/future';
+
+test('serializeIntent', () => {
+	// Test intent without payload
+	expect(serializeIntent({ type: 'reset' })).toBe('reset');
+
+	// Test intent with payload
+	expect(serializeIntent({ type: 'validate', payload: 'email' })).toBe(
+		'validate("email")',
+	);
+
+	// Test intent with object payload
+	const updateIntent = {
+		type: 'update',
+		payload: { name: 'email', value: 'test@example.com' },
+	};
+	expect(serializeIntent(updateIntent)).toBe(
+		'update({"name":"email","value":"test@example.com"})',
+	);
+
+	// Test intent with null payload
+	expect(serializeIntent({ type: 'reset', payload: null })).toBe('reset');
+
+	// Test intent with undefined payload
+	expect(serializeIntent({ type: 'reset', payload: undefined })).toBe('reset');
+});
+
+test('deserializeIntent', () => {
+	// Test simple intent
+	expect(deserializeIntent('reset')).toEqual({
+		type: 'reset',
+		payload: undefined,
+	});
+
+	// Test intent with string payload
+	expect(deserializeIntent('validate("email")')).toEqual({
+		type: 'validate',
+		payload: 'email',
+	});
+
+	// Test intent with object payload
+	expect(deserializeIntent('update({"name":"email","value":"test"})')).toEqual({
+		type: 'update',
+		payload: { name: 'email', value: 'test' },
+	});
+
+	// Test malformed JSON (should ignore error)
+	expect(deserializeIntent('update({invalid)')).toEqual({
+		type: 'update',
+		payload: undefined,
+	});
+
+	// Test without closing parenthesis
+	expect(deserializeIntent('validate("email"')).toEqual({
+		type: 'validate("email"',
+		payload: undefined,
+	});
+
+	// Test empty parentheses
+	expect(deserializeIntent('reset()')).toEqual({
+		type: 'reset',
+		payload: undefined,
+	});
+});
+
+test('applyIntent', () => {
+	const submission: Submission = {
+		intent: 'reset',
+		payload: { email: 'test@example.com', name: 'John' },
+		fields: ['email', 'name'],
+	};
+
+	// Test reset intent
+	expect(applyIntent(submission)).toBeNull();
+
+	// Test submission without intent
+	const noIntentSubmission: Submission = {
+		intent: null,
+		payload: { email: 'test' },
+		fields: ['email'],
+	};
+	expect(applyIntent(noIntentSubmission)).toEqual({ email: 'test' });
+
+	// Test with custom handlers
+	const customHandlers = {
+		custom: {
+			onApply: vi.fn((payload) => ({ ...payload, custom: true })),
+			validatePayload: vi.fn(() => true),
+		},
+	};
+
+	const customSubmission: Submission = {
+		intent: 'custom',
+		payload: { email: 'test' },
+		fields: ['email'],
+	};
+
+	const result = applyIntent(customSubmission, { handlers: customHandlers });
+	expect(customHandlers.custom.onApply).toHaveBeenCalledWith(
+		{ email: 'test' },
+		undefined,
+	);
+	expect(result).toEqual({ email: 'test', custom: true });
+
+	// Test with validation failure
+	const failingHandler = {
+		failing: {
+			onApply: vi.fn(),
+			validatePayload: vi.fn(() => false),
+		},
+	};
+
+	const failingSubmission: Submission = {
+		intent: 'failing',
+		payload: { test: true },
+		fields: ['test'],
+	};
+
+	const failResult = applyIntent(failingSubmission, {
+		handlers: failingHandler,
+	});
+	expect(failingHandler.failing.onApply).not.toHaveBeenCalled();
+	expect(failResult).toEqual({ test: true });
+});
+
+test('insertItem', () => {
+	const list = ['a', 'b', 'c'];
+
+	// Test insert at beginning
+	insertItem(list, 'x', 0);
+	expect(list).toEqual(['x', 'a', 'b', 'c']);
+
+	// Test insert in middle
+	const list2 = ['a', 'b', 'c'];
+	insertItem(list2, 'y', 2);
+	expect(list2).toEqual(['a', 'b', 'y', 'c']);
+
+	// Test insert at end
+	const list3 = ['a', 'b', 'c'];
+	insertItem(list3, 'z', 3);
+	expect(list3).toEqual(['a', 'b', 'c', 'z']);
+});
+
+test('removeItem', () => {
+	const list = ['a', 'b', 'c', 'd'];
+
+	// Test remove from beginning
+	removeItem(list, 0);
+	expect(list).toEqual(['b', 'c', 'd']);
+
+	// Test remove from middle
+	const list2 = ['a', 'b', 'c', 'd'];
+	removeItem(list2, 2);
+	expect(list2).toEqual(['a', 'b', 'd']);
+
+	// Test remove from end
+	const list3 = ['a', 'b', 'c', 'd'];
+	removeItem(list3, 3);
+	expect(list3).toEqual(['a', 'b', 'c']);
+});
+
+test('reorderItems', () => {
+	const list = ['a', 'b', 'c', 'd'];
+
+	// Test move forward
+	reorderItems(list, 1, 3);
+	expect(list).toEqual(['a', 'c', 'd', 'b']);
+
+	// Test move backward
+	const list2 = ['a', 'b', 'c', 'd'];
+	reorderItems(list2, 3, 1);
+	expect(list2).toEqual(['a', 'd', 'b', 'c']);
+
+	// Test no movement (same position)
+	const list3 = ['a', 'b', 'c', 'd'];
+	reorderItems(list3, 2, 2);
+	expect(list3).toEqual(['a', 'b', 'c', 'd']);
+});
+
+test('updateListKeys', () => {
+	const keys = {
+		items: ['key1', 'key2', 'key3'],
+		'items[0].nested': ['nested1'],
+		'items[1].nested': ['nested2'],
+		other: ['other1'],
+	};
+
+	// Test removing child keys
+	const result1 = updateListKeys(keys, 'items[1]');
+	expect(result1).toEqual({
+		items: ['key1', 'key2', 'key3'],
+		'items[0].nested': ['nested1'],
+		other: ['other1'],
+	});
+
+	// Test with update function - only updates keys that don't match the removal pattern
+	const updateKey = (key: string) =>
+		key.startsWith('items[1]') ? key.replace('[1]', '[0]') : key;
+	const result2 = updateListKeys(keys, 'items[0]', updateKey);
+	expect(result2).toEqual({
+		items: ['key1', 'key2', 'key3'], // Not removed as it doesn't match items[0]
+		'items[0].nested': ['nested2'], // items[1].nested becomes items[0].nested
+		other: ['other1'],
+	});
+
+	// Test with empty keys
+	expect(updateListKeys({}, 'items[0]')).toEqual({});
+
+	// Test with undefined keys
+	expect(updateListKeys(undefined, 'items[0]')).toEqual({});
+});
+
+test('actionHandlers.reset', () => {
+	// Reset should return null
+	expect(actionHandlers.reset.onApply?.({})).toBeNull();
+});
+
+test('actionHandlers.validate', () => {
+	// Test validate payload
+	expect(actionHandlers.validate.validatePayload?.('email')).toBe(true);
+	expect(actionHandlers.validate.validatePayload?.(undefined)).toBe(true);
+	expect(actionHandlers.validate.validatePayload?.(123)).toBe(false);
+});
+
+test('actionHandlers.update', () => {
+	// Test validate payload
+	expect(
+		actionHandlers.update.validatePayload?.({ name: 'email', value: 'test' }),
+	).toBe(true);
+	expect(
+		actionHandlers.update.validatePayload?.({
+			name: 'email',
+			index: 0,
+			value: 'test',
+		}),
+	).toBe(true);
+	expect(actionHandlers.update.validatePayload?.({ name: 123 })).toBe(false);
+	expect(actionHandlers.update.validatePayload?.('string')).toBe(false);
+
+	// Test onApply
+	const payload = { email: 'old@example.com' };
+	const options = { name: 'email', value: 'new@example.com' };
+	expect(actionHandlers.update.onApply?.(payload, options)).toEqual({
+		email: 'new@example.com',
+	});
+
+	// Test with array index - skip due to type complexity
+	// const arrayPayload = { items: ['a', 'b', 'c'] };
+	// const arrayOptions = { name: 'items', index: 1, value: 'updated' };
+	// expect(actionHandlers.update.onApply?.(arrayPayload, arrayOptions)).toEqual({ items: ['a', 'updated', 'c'] });
+});
+
+test('actionHandlers.insert', () => {
+	// Test validate payload
+	expect(actionHandlers.insert.validatePayload?.({ name: 'items' })).toBe(true);
+	expect(
+		actionHandlers.insert.validatePayload?.({ name: 'items', index: 0 }),
+	).toBe(true);
+	expect(actionHandlers.insert.validatePayload?.({ name: 123 })).toBe(false);
+	expect(actionHandlers.insert.validatePayload?.('string')).toBe(false);
+
+	// Test onApply - skip due to type complexity with defaultValue
+	// const payload = { items: ['a', 'b'] };
+	// const options = { name: 'items', defaultValue: 'new' };
+	// expect(actionHandlers.insert.onApply?.(payload, options)).toEqual({ items: ['a', 'b', 'new'] });
+});
+
+test('actionHandlers.remove', () => {
+	// Test validate payload
+	expect(
+		actionHandlers.remove.validatePayload?.({ name: 'items', index: 0 }),
+	).toBe(true);
+	expect(actionHandlers.remove.validatePayload?.({ name: 'items' })).toBe(
+		false,
+	);
+	expect(actionHandlers.remove.validatePayload?.({ name: 123, index: 0 })).toBe(
+		false,
+	);
+
+	// Test onApply
+	const payload = { items: ['a', 'b', 'c'] };
+	const options = { name: 'items', index: 1 };
+	expect(actionHandlers.remove.onApply?.(payload, options)).toEqual({
+		items: ['a', 'c'],
+	});
+});
+
+test('actionHandlers.reorder', () => {
+	// Test validate payload
+	expect(
+		actionHandlers.reorder.validatePayload?.({ name: 'items', from: 0, to: 2 }),
+	).toBe(true);
+	expect(
+		actionHandlers.reorder.validatePayload?.({ name: 'items', from: 0 }),
+	).toBe(false);
+	expect(
+		actionHandlers.reorder.validatePayload?.({ name: 123, from: 0, to: 2 }),
+	).toBe(false);
+
+	// Test onApply
+	const payload = { items: ['a', 'b', 'c', 'd'] };
+	const options = { name: 'items', from: 1, to: 3 };
+	expect(actionHandlers.reorder.onApply?.(payload, options)).toEqual({
+		items: ['a', 'c', 'd', 'b'],
+	});
+});

--- a/packages/conform-react/tests/state.test.ts
+++ b/packages/conform-react/tests/state.test.ts
@@ -67,8 +67,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('');
+		expect(getDefaultValue(context, 'password')).toBe('');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
@@ -97,8 +97,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('edmund');
+		expect(getDefaultValue(context, 'password')).toBe('');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
@@ -121,8 +121,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('edmund');
+		expect(getDefaultValue(context, 'password')).toBe('my-secret-password');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
@@ -145,8 +145,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('edmund');
+		expect(getDefaultValue(context, 'password')).toBe('my-secret-password');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
@@ -167,8 +167,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('edmund');
+		expect(getDefaultValue(context, 'password')).toBe('my-secret-password');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
@@ -189,8 +189,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('edmund');
+		expect(getDefaultValue(context, 'password')).toBe('secret-password');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
@@ -268,8 +268,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('edmund');
+		expect(getDefaultValue(context, 'password')).toBe('secret-password');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
@@ -296,8 +296,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('edmund');
+		expect(getDefaultValue(context, 'password')).toBe('secret-password');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);

--- a/packages/conform-react/tests/state.test.ts
+++ b/packages/conform-react/tests/state.test.ts
@@ -1,0 +1,1430 @@
+import { describe, test, expect, vi, beforeAll, afterAll } from 'vitest';
+import { DEFAULT_INTENT_NAME } from '@conform-to/dom/future';
+import {
+	getDefaultOptions,
+	getDefaultValue,
+	getError,
+	getListKey,
+	initializeState,
+	isTouched,
+	updateState,
+	isDefaultChecked,
+	getDefaultListKey,
+	getConstraint,
+	getFormMetadata,
+	getField,
+	getFieldset,
+	getFieldList,
+} from '../future/state';
+import { serializeIntent } from '../future/intent';
+import type { FormContext } from '../future/types';
+import { createAction } from './helpers';
+
+describe('form', () => {
+	function createContext(
+		customized?: Partial<FormContext<any>>,
+	): FormContext<any> {
+		return {
+			formId: 'test-id',
+			defaultValue: null,
+			constraint: null,
+			state: initializeState(),
+			handleSubmit: vi.fn(),
+			handleInput: vi.fn(),
+			handleBlur: vi.fn(),
+			...customized,
+		};
+	}
+
+	beforeAll(() => {
+		vi.spyOn(Math, 'random').mockReturnValue(1);
+		vi.useFakeTimers({ now: 0 });
+	});
+
+	afterAll(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	test('default submission', () => {
+		const context = createContext();
+
+		// Test client validation with empty fields
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['username', ''],
+					['password', ''],
+				],
+				error: {
+					fieldErrors: {
+						username: ['Username is required'],
+						password: ['Password is required'],
+					},
+				},
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(true);
+		expect(isTouched(context.state, 'password')).toBe(true);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toEqual([
+			'Username is required',
+		]);
+		expect(getError(context.state, 'password')).toEqual([
+			'Password is required',
+		]);
+
+		// Test client validation with valid username
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['username', 'edmund'],
+					['password', ''],
+				],
+				error: {
+					fieldErrors: {
+						password: ['Password is required'],
+					},
+				},
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(true);
+		expect(isTouched(context.state, 'password')).toBe(true);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toBe(undefined);
+		expect(getError(context.state, 'password')).toEqual([
+			'Password is required',
+		]);
+
+		// Test client validation with no errors
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['username', 'edmund'],
+					['password', 'my-secret-password'],
+				],
+				error: null,
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(true);
+		expect(isTouched(context.state, 'password')).toBe(true);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toBe(undefined);
+		expect(getError(context.state, 'password')).toBe(undefined);
+
+		// Test server validation
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'server',
+				entries: [
+					['username', 'edmund'],
+					['password', 'my-secret-password'],
+				],
+				error: {
+					formErrors: ['Something went wrong'],
+				},
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(true);
+		expect(isTouched(context.state, 'password')).toBe(true);
+		expect(getError(context.state)).toEqual(['Something went wrong']);
+		expect(getError(context.state, 'username')).toBe(undefined);
+		expect(getError(context.state, 'password')).toBe(undefined);
+
+		// Test client validation with the same form value after server validation
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['username', 'edmund'],
+					['password', 'my-secret-password'],
+				],
+				error: null,
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(true);
+		expect(isTouched(context.state, 'password')).toBe(true);
+		expect(getError(context.state)).toEqual(['Something went wrong']);
+		expect(getError(context.state, 'username')).toBe(undefined);
+		expect(getError(context.state, 'password')).toBe(undefined);
+
+		// Test client validation with the form value updated after server validation
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['username', 'edmund'],
+					['password', 'secret-password'],
+				],
+				error: null,
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(true);
+		expect(isTouched(context.state, 'password')).toBe(true);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toBe(undefined);
+		expect(getError(context.state, 'password')).toBe(undefined);
+
+		// Test server validation with a reset result
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'server',
+				entries: [
+					['username', 'edmund'],
+					['password', 'secret-password'],
+				],
+				value: null,
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(false);
+		expect(isTouched(context.state, 'username')).toBe(false);
+		expect(isTouched(context.state, 'password')).toBe(false);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toBe(undefined);
+		expect(getError(context.state, 'password')).toBe(undefined);
+
+		// Test async validation - Setup client error state (1/3)
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['username', ''],
+					['password', ''],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'validate',
+							payload: 'username',
+						}),
+					],
+				],
+				error: {
+					fieldErrors: {
+						username: ['Username is required'],
+						password: ['Password is required'],
+					},
+				},
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(true);
+		expect(isTouched(context.state, 'password')).toBe(false);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toEqual([
+			'Username is required',
+		]);
+		expect(getError(context.state, 'password')).toBe(undefined);
+
+		// Test async validation - Client validation result (2/3)
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['username', 'edmund'],
+					['password', 'secret-password'],
+				],
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(true);
+		expect(isTouched(context.state, 'password')).toBe(true);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toEqual([
+			'Username is required',
+		]);
+		expect(getError(context.state, 'password')).toEqual([
+			'Password is required',
+		]);
+
+		// Test async validation - Server validation result (3/3)
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'server',
+				entries: [
+					['username', 'edmund'],
+					['password', 'secret-password'],
+				],
+				error: {
+					formErrors: ['Something went wrong'],
+				},
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(true);
+		expect(isTouched(context.state, 'password')).toBe(true);
+		expect(getError(context.state)).toEqual(['Something went wrong']);
+		expect(getError(context.state, 'username')).toBe(undefined);
+		expect(getError(context.state, 'password')).toBe(undefined);
+	});
+
+	test('validate fields', () => {
+		const context = createContext();
+
+		// Test validating one field
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['username', ''],
+					['password', ''],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'validate',
+							payload: 'username',
+						}),
+					],
+				],
+				error: {
+					fieldErrors: {
+						username: ['Username is required'],
+						password: ['Password is required'],
+					},
+				},
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(true);
+		expect(isTouched(context.state, 'password')).toBe(false);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toEqual([
+			'Username is required',
+		]);
+		expect(getError(context.state, 'password')).toBe(undefined);
+
+		// Testing validating another field
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['username', 'edmund'],
+					['password', ''],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'validate',
+							payload: 'password',
+						}),
+					],
+				],
+				error: {
+					fieldErrors: {
+						username: ['Username is invalid'],
+						password: ['Password is required'],
+					},
+				},
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(true);
+		expect(isTouched(context.state, 'password')).toBe(true);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toEqual([
+			'Username is invalid',
+		]);
+		expect(getError(context.state, 'password')).toEqual([
+			'Password is required',
+		]);
+
+		// Test resetting state with a reset intent
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['username', 'edmund'],
+					['password', 'my-password'],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'reset',
+						}),
+					],
+				],
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(false);
+		expect(isTouched(context.state, 'username')).toBe(false);
+		expect(isTouched(context.state, 'password')).toBe(false);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toBe(undefined);
+		expect(getError(context.state, 'password')).toBe(undefined);
+
+		// Test resetting form with null value
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['username', 'edmund'],
+					['password', 'my-password'],
+				],
+				value: null,
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(false);
+		expect(isTouched(context.state, 'username')).toBe(false);
+		expect(isTouched(context.state, 'password')).toBe(false);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toBe(undefined);
+		expect(getError(context.state, 'password')).toBe(undefined);
+
+		// Test validating the whole form with async validation - Pre-populate error state (1/4)
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['username', 'edmund'],
+					['password', ''],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'validate',
+							payload: 'username',
+						}),
+					],
+				],
+				error: {
+					fieldErrors: {
+						username: ['Username is invalid'],
+						password: ['Password is required'],
+					},
+				},
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(true);
+		expect(isTouched(context.state, 'password')).toBe(false);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toEqual([
+			'Username is invalid',
+		]);
+		expect(getError(context.state, 'password')).toBe(undefined);
+
+		// Test validating the whole form with async validation - Client Validating (2/3)
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['username', 'edmund'],
+					['password', 'my-password'],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'validate',
+						}),
+					],
+				],
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(true);
+		expect(isTouched(context.state, 'password')).toBe(true);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toEqual([
+			'Username is invalid',
+		]);
+		expect(getError(context.state, 'password')).toEqual([
+			'Password is required',
+		]);
+
+		// Test validating the whole form with async validation - Server Validating (3/3)
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'server',
+				entries: [
+					['username', 'edmund'],
+					['password', 'my-password'],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'validate',
+						}),
+					],
+				],
+				error: {
+					formErrors: ['Something went wrong'],
+				},
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe(undefined);
+		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(true);
+		expect(isTouched(context.state, 'password')).toBe(true);
+		expect(getError(context.state)).toEqual(['Something went wrong']);
+		expect(getError(context.state, 'username')).toBe(undefined);
+		expect(getError(context.state, 'password')).toBe(undefined);
+	});
+
+	test('update fields', () => {
+		const context = createContext({
+			defaultValue: {
+				username: 'example',
+				password: '*******',
+			},
+		});
+
+		expect(getDefaultValue(context, 'username')).toBe('example');
+		expect(getDefaultValue(context, 'password')).toBe('*******');
+		expect(isTouched(context.state)).toBe(false);
+		expect(isTouched(context.state, 'username')).toBe(false);
+		expect(isTouched(context.state, 'password')).toBe(false);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toBe(undefined);
+		expect(getError(context.state, 'password')).toBe(undefined);
+
+		// Update state with client validation result
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['username', 'edmund'],
+					['password', 'my-secret-password'],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'update',
+							payload: {
+								name: 'password',
+								value: '',
+							},
+						}),
+					],
+				],
+				error: {
+					fieldErrors: {
+						username: ['Username is invalid'],
+						password: ['Password is incorrect'],
+					},
+				},
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe('edmund');
+		expect(getDefaultValue(context, 'password')).toBe('');
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(false);
+		expect(isTouched(context.state, 'password')).toBe(true);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toBe(undefined);
+		expect(getError(context.state, 'password')).toEqual([
+			'Password is incorrect',
+		]);
+
+		// Update state with server error without applying the update intent
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'server',
+				entries: [
+					['username', 'example'],
+					['password', '*******'],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'update',
+							payload: {
+								name: '',
+								value: {
+									username: 'edmund',
+									password: '',
+								},
+							},
+						}),
+					],
+				],
+				error: {
+					fieldErrors: {
+						username: ['Username is invalid'],
+						password: ['Password is required'],
+					},
+				},
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe('edmund');
+		expect(getDefaultValue(context, 'password')).toBe('');
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(false);
+		expect(isTouched(context.state, 'password')).toBe(true);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toBe(undefined);
+		expect(getError(context.state, 'password')).toEqual([
+			'Password is required',
+		]);
+
+		// Update state with the intent on client side
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['username', 'example'],
+					['password', '*******'],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'update',
+							payload: {
+								name: '',
+								value: {
+									username: 'edmund',
+									password: '',
+								},
+							},
+						}),
+					],
+				],
+			}),
+		);
+
+		expect(getDefaultValue(context, 'username')).toBe('edmund');
+		expect(getDefaultValue(context, 'password')).toBe('');
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'username')).toBe(true);
+		expect(isTouched(context.state, 'password')).toBe(true);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'username')).toEqual([
+			'Username is invalid',
+		]);
+		expect(getError(context.state, 'password')).toEqual([
+			'Password is required',
+		]);
+	});
+
+	test('modify list on the client', () => {
+		const context = createContext({
+			defaultValue: {
+				title: 'My Tasks',
+				tasks: ['Default task 1', 'Default task 2'],
+			},
+		});
+
+		expect(getListKey(context, 'tasks')).toEqual(['0-tasks[0]', '0-tasks[1]']);
+		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
+		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultOptions(context, 'tasks')).toEqual([
+			'Default task 1',
+			'Default task 2',
+		]);
+		expect(getDefaultValue(context, 'tasks[0]')).toBe('Default task 1');
+		expect(getDefaultValue(context, 'tasks[1]')).toBe('Default task 2');
+		expect(isTouched(context.state)).toBe(false);
+		expect(isTouched(context.state, 'title')).toBe(false);
+		expect(isTouched(context.state, 'tasks')).toBe(false);
+		expect(isTouched(context.state, 'tasks[0]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[1]')).toBe(false);
+
+		// Test inserting an item
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['title', 'My Tasks'],
+					['tasks[0]', 'Default task 1'],
+					['tasks[1]', 'Default task 2'],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'insert',
+							payload: {
+								name: 'tasks',
+								defaultValue: 'New task',
+							},
+						}),
+					],
+				],
+			}),
+		);
+
+		expect(getListKey(context, 'tasks')).toEqual([
+			'0-tasks[0]',
+			'0-tasks[1]',
+			'0',
+		]);
+		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
+		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultOptions(context, 'tasks')).toEqual([
+			'Default task 1',
+			'Default task 2',
+			'New task',
+		]);
+		expect(getDefaultValue(context, 'tasks[0]')).toBe('Default task 1');
+		expect(getDefaultValue(context, 'tasks[1]')).toBe('Default task 2');
+		expect(getDefaultValue(context, 'tasks[2]')).toBe('New task');
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'title')).toBe(false);
+		expect(isTouched(context.state, 'tasks')).toBe(true);
+		expect(isTouched(context.state, 'tasks[0]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[1]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[2]')).toBe(false);
+
+		// Test validating an item
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['title', 'My Tasks'],
+					['tasks[0]', 'Default task 1'],
+					['tasks[1]', 'Default task 2'],
+					['tasks[2]', 'New task'],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'validate',
+							payload: 'tasks[1]',
+						}),
+					],
+				],
+			}),
+		);
+
+		expect(getListKey(context, 'tasks')).toEqual([
+			'0-tasks[0]',
+			'0-tasks[1]',
+			'0',
+		]);
+		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
+		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultOptions(context, 'tasks')).toEqual([
+			'Default task 1',
+			'Default task 2',
+			'New task',
+		]);
+		expect(getDefaultValue(context, 'tasks[0]')).toBe('Default task 1');
+		expect(getDefaultValue(context, 'tasks[1]')).toBe('Default task 2');
+		expect(getDefaultValue(context, 'tasks[2]')).toBe('New task');
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'title')).toBe(false);
+		expect(isTouched(context.state, 'tasks')).toBe(true);
+		expect(isTouched(context.state, 'tasks[0]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[1]')).toBe(true);
+		expect(isTouched(context.state, 'tasks[2]')).toBe(false);
+
+		// Test inserting an item at a specific index
+		vi.advanceTimersByTime(1);
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['title', 'My Tasks'],
+					['tasks[0]', 'Default task 1'],
+					['tasks[1]', 'Default task 2'],
+					['tasks[2]', 'New task'],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'insert',
+							payload: {
+								name: 'tasks',
+								defaultValue: 'Urgent task',
+								index: 0,
+							},
+						}),
+					],
+				],
+			}),
+		);
+
+		expect(getListKey(context, 'tasks')).toEqual([
+			'1',
+			'0-tasks[0]',
+			'0-tasks[1]',
+			'0',
+		]);
+		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
+		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultOptions(context, 'tasks')).toEqual([
+			'Urgent task',
+			'Default task 1',
+			'Default task 2',
+			'New task',
+		]);
+		expect(getDefaultValue(context, 'tasks[0]')).toBe('Urgent task');
+		expect(getDefaultValue(context, 'tasks[1]')).toBe('Default task 1');
+		expect(getDefaultValue(context, 'tasks[2]')).toBe('Default task 2');
+		expect(getDefaultValue(context, 'tasks[3]')).toBe('New task');
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'title')).toBe(false);
+		expect(isTouched(context.state, 'tasks')).toBe(true);
+		expect(isTouched(context.state, 'tasks[0]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[1]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[2]')).toBe(true);
+		expect(isTouched(context.state, 'tasks[3]')).toBe(false);
+
+		// Test whether client async validation will skip applying the insert intent
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'server',
+				entries: [
+					['title', 'My Tasks'],
+					['tasks[0]', 'Urgent task'],
+					['tasks[1]', 'Default task 1'],
+					['tasks[2]', 'Default task 2'],
+					['tasks[3]', 'New task'],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'insert',
+							payload: {
+								name: 'tasks',
+								defaultValue: 'Urgent task',
+								index: 0,
+							},
+						}),
+					],
+				],
+				error: {
+					fieldErrors: {
+						tasks: ['Too many tasks'],
+					},
+				},
+			}),
+		);
+
+		expect(getListKey(context, 'tasks')).toEqual([
+			'1',
+			'0-tasks[0]',
+			'0-tasks[1]',
+			'0',
+		]);
+		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
+		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultOptions(context, 'tasks')).toEqual([
+			'Urgent task',
+			'Default task 1',
+			'Default task 2',
+			'New task',
+		]);
+		expect(getDefaultValue(context, 'tasks[0]')).toBe('Urgent task');
+		expect(getDefaultValue(context, 'tasks[1]')).toBe('Default task 1');
+		expect(getDefaultValue(context, 'tasks[2]')).toBe('Default task 2');
+		expect(getDefaultValue(context, 'tasks[3]')).toBe('New task');
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'title')).toBe(false);
+		expect(isTouched(context.state, 'tasks')).toBe(true);
+		expect(isTouched(context.state, 'tasks[0]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[1]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[2]')).toBe(true);
+		expect(isTouched(context.state, 'tasks[3]')).toBe(false);
+		expect(getError(context.state)).toBe(undefined);
+		expect(getError(context.state, 'tasks')).toEqual(['Too many tasks']);
+		expect(getError(context.state, 'tasks[0]')).toBe(undefined);
+		expect(getError(context.state, 'tasks[1]')).toBe(undefined);
+		expect(getError(context.state, 'tasks[2]')).toBe(undefined);
+		expect(getError(context.state, 'tasks[3]')).toBe(undefined);
+
+		// Test reordering items
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['title', 'My Tasks'],
+					['tasks[0]', 'Urgent task'],
+					['tasks[1]', 'Default task 1'],
+					['tasks[2]', 'Default task 2'],
+					['tasks[3]', 'New task'],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'reorder',
+							payload: {
+								name: 'tasks',
+								from: 3,
+								to: 1,
+							},
+						}),
+					],
+				],
+			}),
+		);
+
+		expect(getListKey(context, 'tasks')).toEqual([
+			'1',
+			'0',
+			'0-tasks[0]',
+			'0-tasks[1]',
+		]);
+		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
+		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultOptions(context, 'tasks')).toEqual([
+			'Urgent task',
+			'New task',
+			'Default task 1',
+			'Default task 2',
+		]);
+		expect(getDefaultValue(context, 'tasks[0]')).toBe('Urgent task');
+		expect(getDefaultValue(context, 'tasks[1]')).toBe('New task');
+		expect(getDefaultValue(context, 'tasks[2]')).toBe('Default task 1');
+		expect(getDefaultValue(context, 'tasks[3]')).toBe('Default task 2');
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'title')).toBe(false);
+		expect(isTouched(context.state, 'tasks')).toBe(true);
+		expect(isTouched(context.state, 'tasks[0]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[1]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[2]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[3]')).toBe(true);
+
+		// Test whether client async validation will skip applying the reorder intent
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'server',
+				entries: [
+					['title', 'My Tasks'],
+					['tasks[0]', 'Urgent task'],
+					['tasks[1]', 'Default task 1'],
+					['tasks[2]', 'Default task 2'],
+					['tasks[3]', 'New task'],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'reorder',
+							payload: {
+								name: 'tasks',
+								from: 3,
+								to: 1,
+							},
+						}),
+					],
+				],
+				error: {
+					formErrors: ['Some tasks are too urgent'],
+					fieldErrors: {
+						'tasks[0]': ['The task is too urgent'],
+					},
+				},
+			}),
+		);
+
+		expect(getListKey(context, 'tasks')).toEqual([
+			'1',
+			'0',
+			'0-tasks[0]',
+			'0-tasks[1]',
+		]);
+		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
+		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultOptions(context, 'tasks')).toEqual([
+			'Urgent task',
+			'New task',
+			'Default task 1',
+			'Default task 2',
+		]);
+		expect(getDefaultValue(context, 'tasks[0]')).toBe('Urgent task');
+		expect(getDefaultValue(context, 'tasks[1]')).toBe('New task');
+		expect(getDefaultValue(context, 'tasks[2]')).toBe('Default task 1');
+		expect(getDefaultValue(context, 'tasks[3]')).toBe('Default task 2');
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'title')).toBe(false);
+		expect(isTouched(context.state, 'tasks')).toBe(true);
+		expect(isTouched(context.state, 'tasks[0]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[1]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[2]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[3]')).toBe(true);
+		expect(getError(context.state)).toEqual(['Some tasks are too urgent']);
+		expect(getError(context.state, 'tasks')).toBe(undefined);
+		expect(getError(context.state, 'tasks[0]')).toBe(undefined);
+		expect(getError(context.state, 'tasks[1]')).toBe(undefined);
+		expect(getError(context.state, 'tasks[2]')).toBe(undefined);
+		expect(getError(context.state, 'tasks[3]')).toBe(undefined);
+
+		// Test removing an item
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['title', 'My Tasks'],
+					['tasks[0]', 'Urgent task'],
+					['tasks[1]', 'New task'],
+					['tasks[2]', 'Default task 1'],
+					['tasks[3]', 'Default task 2'],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'remove',
+							payload: {
+								name: 'tasks',
+								index: 2,
+							},
+						}),
+					],
+				],
+			}),
+		);
+
+		expect(getListKey(context, 'tasks')).toEqual(['1', '0', '0-tasks[1]']);
+		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
+		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultOptions(context, 'tasks')).toEqual([
+			'Urgent task',
+			'New task',
+			'Default task 2',
+		]);
+		expect(getDefaultValue(context, 'tasks[0]')).toBe('Urgent task');
+		expect(getDefaultValue(context, 'tasks[1]')).toBe('New task');
+		expect(getDefaultValue(context, 'tasks[2]')).toBe('Default task 2');
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'title')).toBe(false);
+		expect(isTouched(context.state, 'tasks')).toBe(true);
+		expect(isTouched(context.state, 'tasks[0]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[1]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[2]')).toBe(true);
+
+		// Test whether client async validation will skip applying the remove intent
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'server',
+				entries: [
+					['title', 'My Tasks'],
+					['tasks[0]', 'Urgent task'],
+					['tasks[1]', 'New task'],
+					['tasks[2]', 'Default task 1'],
+					['tasks[3]', 'Default task 2'],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'remove',
+							payload: {
+								name: 'tasks',
+								index: 2,
+							},
+						}),
+					],
+				],
+				error: {
+					formErrors: ['Oops'],
+					fieldErrors: {
+						'tasks[0]': ['This task is too urgent'],
+					},
+				},
+			}),
+		);
+
+		expect(getListKey(context, 'tasks')).toEqual(['1', '0', '0-tasks[1]']);
+		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
+		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultOptions(context, 'tasks')).toEqual([
+			'Urgent task',
+			'New task',
+			'Default task 2',
+		]);
+		expect(getDefaultValue(context, 'tasks[0]')).toBe('Urgent task');
+		expect(getDefaultValue(context, 'tasks[1]')).toBe('New task');
+		expect(getDefaultValue(context, 'tasks[2]')).toBe('Default task 2');
+		expect(isTouched(context.state)).toBe(true);
+		expect(isTouched(context.state, 'title')).toBe(false);
+		expect(isTouched(context.state, 'tasks')).toBe(true);
+		expect(isTouched(context.state, 'tasks[0]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[1]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[2]')).toBe(true);
+		expect(getError(context.state)).toEqual(['Oops']);
+		expect(getError(context.state, 'tasks')).toBe(undefined);
+		expect(getError(context.state, 'tasks[0]')).toBe(undefined);
+		expect(getError(context.state, 'tasks[1]')).toBe(undefined);
+		expect(getError(context.state, 'tasks[2]')).toBe(undefined);
+		expect(getError(context.state, 'tasks[3]')).toBe(undefined);
+
+		// Test resetting the form
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['title', 'My Tasks'],
+					['tasks[0]', 'Urgent task'],
+					['tasks[1]', 'New task'],
+					['tasks[2]', 'Default task 2'],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'reset',
+						}),
+					],
+				],
+			}),
+		);
+
+		expect(getListKey(context, 'tasks')).toEqual(['1-tasks[0]', '1-tasks[1]']);
+		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
+		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultOptions(context, 'tasks')).toEqual([
+			'Default task 1',
+			'Default task 2',
+		]);
+		expect(getDefaultValue(context, 'tasks[0]')).toBe('Default task 1');
+		expect(getDefaultValue(context, 'tasks[1]')).toBe('Default task 2');
+		expect(isTouched(context.state)).toBe(false);
+		expect(isTouched(context.state, 'title')).toBe(false);
+		expect(isTouched(context.state, 'tasks')).toBe(false);
+		expect(isTouched(context.state, 'tasks[0]')).toBe(false);
+		expect(isTouched(context.state, 'tasks[1]')).toBe(false);
+	});
+
+	test('isDefaultChecked', () => {
+		// Test with boolean checkbox values
+		const context = createContext({
+			defaultValue: {
+				subscribe: true,
+				notifications: false,
+			},
+		});
+
+		expect(isDefaultChecked(context, 'subscribe')).toBe(true);
+		expect(isDefaultChecked(context, 'notifications')).toBe(false);
+
+		// Test with 'on' value (checkbox default)
+		const contextWithOn = createContext({
+			defaultValue: {
+				subscribe: 'on',
+				notifications: '',
+			},
+		});
+
+		expect(isDefaultChecked(contextWithOn, 'subscribe')).toBe(true);
+		expect(isDefaultChecked(contextWithOn, 'notifications')).toBe(false);
+
+		// Test with undefined/missing values
+		expect(isDefaultChecked(createContext(), 'missing')).toBe(false);
+	});
+
+	test('getDefaultListKey', () => {
+		const prefix = 'test-prefix';
+		const initialValue = {
+			items: ['item1', 'item2', 'item3'],
+			nested: {
+				list: ['a', 'b'],
+			},
+		};
+
+		// Test simple array
+		expect(getDefaultListKey(prefix, initialValue, 'items')).toEqual([
+			'test-prefix-items[0]',
+			'test-prefix-items[1]',
+			'test-prefix-items[2]',
+		]);
+
+		// Test nested array
+		expect(getDefaultListKey(prefix, initialValue, 'nested.list')).toEqual([
+			'test-prefix-nested.list[0]',
+			'test-prefix-nested.list[1]',
+		]);
+
+		// Test empty array
+		expect(getDefaultListKey(prefix, { empty: [] }, 'empty')).toEqual([]);
+
+		// Test non-existent field
+		expect(getDefaultListKey(prefix, initialValue, 'missing')).toEqual([]);
+	});
+
+	test('getConstraint', () => {
+		const context = createContext({
+			constraint: {
+				username: { required: true, minLength: 3 },
+				'items[]': { required: true },
+				'items[].subitems[].name': { maxLength: 50 },
+			},
+		});
+
+		// Test direct constraint match
+		expect(getConstraint(context, 'username')).toEqual({
+			required: true,
+			minLength: 3,
+		});
+
+		// Test array fallback: items[0] should fall back to items[]
+		expect(getConstraint(context, 'items[0]')).toEqual({ required: true });
+
+		// Test nested array fallback: items[0].subitems[].name should fall back toitems[].subitems[].name
+		expect(getConstraint(context, 'items[0].subitems[].name')).toEqual({
+			maxLength: 50,
+		});
+
+		// Test nested array fallback: items[0].subitems[1].name should fall back toitems[].subitems[].name as well
+		expect(getConstraint(context, 'items[0].subitems[1].name')).toEqual({
+			maxLength: 50,
+		});
+
+		// Test no fallback available
+		expect(getConstraint(context, 'missing')).toBe(undefined);
+
+		// Test no constraints defined
+		expect(getConstraint(createContext(), 'any')).toBe(undefined);
+	});
+
+	test('getFormMetadata', () => {
+		const context = createContext({
+			defaultValue: { username: 'test' },
+		});
+
+		// Add some touched fields and errors
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [['username', '']],
+				error: {
+					formErrors: ['Form error'],
+					fieldErrors: {
+						username: ['Username required'],
+						password: ['Password required'],
+					},
+				},
+			}),
+		);
+
+		const metadata = getFormMetadata(context, {
+			serialize: (value) => value?.toString(),
+		});
+
+		// Test basic properties
+		expect(metadata.id).toBe('test-id');
+		expect(metadata.errors).toEqual(['Form error']);
+		expect(metadata.fieldErrors).toEqual({
+			username: ['Username required'],
+			password: ['Password required'],
+		});
+		expect(metadata.touched).toBe(true);
+		expect(metadata.invalid).toBe(true);
+
+		// Test props
+		expect(metadata.props.id).toBe('test-id');
+		expect(metadata.props.onSubmit).toBe(context.handleSubmit);
+		expect(metadata.props.noValidate).toBe(true);
+
+		// Test methods exist
+		expect(typeof metadata.getField).toBe('function');
+		expect(typeof metadata.getFieldset).toBe('function');
+		expect(typeof metadata.getFieldList).toBe('function');
+	});
+
+	test('getField', () => {
+		const context = createContext({
+			defaultValue: {
+				username: 'test-user',
+				profile: { age: 25 },
+				tags: ['react', 'typescript'],
+			},
+			constraint: {
+				username: { required: true, minLength: 3 },
+			},
+		});
+
+		// Add touched field
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [['username', 'test-user']],
+				error: {
+					fieldErrors: {
+						username: ['Username taken'],
+					},
+				},
+			}),
+		);
+
+		const field = getField(context, {
+			name: 'username',
+			key: 'unique-key',
+			serialize: (value) => String(value),
+		});
+
+		// Test basic properties
+		expect(field.id).toBe('test-id-username');
+		expect(field.name).toBe('username');
+		expect(field.key).toBe('unique-key');
+		expect(field.descriptionId).toBe('test-id-username-description');
+		expect(field.errorId).toBe('test-id-username-error');
+
+		// Test constraint properties
+		expect(field.required).toBe(true);
+		expect(field.minLength).toBe(3);
+
+		// Test computed properties
+		expect(field.defaultValue).toBe('test-user');
+		expect(field.touched).toBe(true);
+		expect(field.invalid).toBe(true);
+		expect(field.errors).toEqual(['Username taken']);
+
+		// Test methods exist
+		expect(typeof field.getFieldset).toBe('function');
+		expect(typeof field.getFieldList).toBe('function');
+	});
+
+	test('getFieldset', () => {
+		const context = createContext({
+			defaultValue: {
+				profile: {
+					name: 'John',
+					email: 'john@example.com',
+					nested: {
+						value: 'deep',
+					},
+				},
+			},
+		});
+
+		const fieldset = getFieldset(context, {
+			name: 'profile',
+			serialize: (value) => String(value),
+		});
+
+		// Test dynamic property access via Proxy
+		const nameField = fieldset.name!;
+		expect(nameField.name).toBe('profile.name');
+		expect(nameField.defaultValue).toBe('John');
+		expect(nameField.id).toBe('test-id-profile.name');
+
+		const emailField = fieldset.email!;
+		expect(emailField.name).toBe('profile.email');
+		expect(emailField.defaultValue).toBe('john@example.com');
+
+		// Test nested access
+		const nestedFieldset = fieldset.nested!;
+		expect(nestedFieldset.name).toBe('profile.nested');
+		const deepField = (nestedFieldset.getFieldset() as any).value;
+		expect(deepField.name).toBe('profile.nested.value');
+		expect(deepField.defaultValue).toBe('deep');
+
+		// Test root fieldset (no name)
+		const rootFieldset = getFieldset(context, {
+			serialize: (value) => String(value),
+		});
+		const profileField = (rootFieldset as any).profile;
+		expect(profileField.name).toBe('profile');
+	});
+
+	test('getFieldList', () => {
+		const context = createContext({
+			defaultValue: {
+				tags: ['react', 'typescript', 'testing'],
+				users: [
+					{ name: 'John', age: 25 },
+					{ name: 'Jane', age: 30 },
+				],
+			},
+		});
+
+		// Mock list keys
+		context.state.listKeys = {
+			tags: ['key1', 'key2', 'key3'],
+			users: ['user1', 'user2'],
+		};
+
+		// Test simple array
+		const tagFields = getFieldList(context, {
+			name: 'tags',
+			serialize: (value) => String(value),
+		});
+
+		expect(tagFields).toHaveLength(3);
+		expect(tagFields[0]?.name).toBe('tags[0]');
+		expect(tagFields[0]?.key).toBe('key1');
+		expect(tagFields[0]?.defaultValue).toBe('react');
+		expect(tagFields[1]?.name).toBe('tags[1]');
+		expect(tagFields[1]?.key).toBe('key2');
+		expect(tagFields[1]?.defaultValue).toBe('typescript');
+
+		// Test object array
+		const userFields = getFieldList(context, {
+			name: 'users',
+			serialize: (value) => String(value),
+		});
+
+		expect(userFields).toHaveLength(2);
+		expect(userFields[0]?.name).toBe('users[0]');
+		expect(userFields[0]?.key).toBe('user1');
+		expect(userFields[1]?.name).toBe('users[1]');
+		expect(userFields[1]?.key).toBe('user2');
+
+		// Test accessing nested fields in object array
+		const firstUserFieldset = userFields[0]?.getFieldset();
+		expect(firstUserFieldset?.name?.name).toBe('users[0].name');
+		expect(firstUserFieldset?.name?.defaultValue).toBe('John');
+		expect(firstUserFieldset?.age?.name).toBe('users[0].age');
+		expect(firstUserFieldset?.age?.defaultValue).toBe('25');
+	});
+});

--- a/packages/conform-react/tests/useField.browser.test.tsx
+++ b/packages/conform-react/tests/useField.browser.test.tsx
@@ -1,0 +1,110 @@
+import { describe, test } from 'vitest';
+import { FormOptions, FormProvider, useField, useForm } from '../future';
+import { render } from 'vitest-browser-react';
+import { expectErrorMessage, expectNoErrorMessages } from './helpers';
+import { userEvent } from '@vitest/browser/context';
+
+describe('future export: useField', () => {
+	type Schema = {
+		title: string;
+		description: string;
+	};
+
+	function FieldError(props: { name: string; form?: string }) {
+		const field = useField(props.name, {
+			formId: props.form,
+		});
+
+		return (
+			<div id={field.invalid ? field.errorId : undefined}>
+				{field.errors?.join(', ') ?? 'n/a'}
+			</div>
+		);
+	}
+
+	function ExampleForm({
+		children,
+		...options
+	}: Partial<FormOptions<Schema, string, Schema>> & {
+		children?: React.ReactNode;
+	}) {
+		const { form, fields, intent } = useForm({
+			onValidate({ payload, error }) {
+				if (!payload.title) {
+					error.fieldErrors.title = ['Title is required'];
+				}
+
+				if (!payload.description) {
+					error.fieldErrors.description = ['Description is required'];
+				}
+
+				return error;
+			},
+			onSubmit(event) {
+				event.preventDefault();
+			},
+			...options,
+		});
+
+		return (
+			<FormProvider context={form.context}>
+				{children}
+				<form {...form.props}>
+					<input
+						name={fields.title.name}
+						defaultValue={fields.title.defaultValue}
+						aria-label="Title"
+						aria-describedby={
+							fields.title.invalid ? fields.title.errorId : undefined
+						}
+					/>
+					<textarea
+						name={fields.description.name}
+						defaultValue={fields.description.defaultValue}
+						aria-label="Description"
+						aria-describedby={
+							fields.description.invalid
+								? fields.description.errorId
+								: undefined
+						}
+					/>
+					<button>Submit</button>
+					<button type="button" onClick={() => intent.validate('description')}>
+						Validate Description
+					</button>
+				</form>
+			</FormProvider>
+		);
+	}
+
+	function getForm(screen: ReturnType<typeof render>) {
+		return {
+			title: screen.getByLabelText('Title'),
+			description: screen.getByLabelText('Description'),
+			submitButton: screen.getByRole('button', { name: 'Submit' }),
+			validateDescriptionButton: screen.getByRole('button', {
+				name: 'Validate Description',
+			}),
+		};
+	}
+
+	test('extract field metadata from context', async () => {
+		const screen = render(
+			<ExampleForm id="test">
+				<FieldError name="title" />
+				<FieldError name="description" form="test" />
+			</ExampleForm>,
+		);
+		const form = getForm(screen);
+
+		await expectNoErrorMessages(form.title, form.description);
+
+		await userEvent.click(form.validateDescriptionButton);
+		await expectNoErrorMessages(form.title);
+		await expectErrorMessage(form.description, 'Description is required');
+
+		await userEvent.click(form.submitButton);
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectErrorMessage(form.description, 'Description is required');
+	});
+});

--- a/packages/conform-react/tests/useForm.browser.test.tsx
+++ b/packages/conform-react/tests/useForm.browser.test.tsx
@@ -1,0 +1,666 @@
+/// <reference types="@vitest/browser/matchers" />
+import { describe, test, expect, vi, beforeAll, afterAll } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { userEvent } from '@vitest/browser/context';
+import {
+	type FormValue,
+	type FormError,
+	type FormOptions,
+	useForm,
+} from '../future';
+import { expectErrorMessage, expectNoErrorMessages } from './helpers';
+
+describe('future export: useForm', () => {
+	type Schema = {
+		title: string;
+		description: string;
+		tasks: Array<{ content: string; completed: boolean }>;
+	};
+
+	function validateForm(value: Record<string, FormValue>) {
+		const error: FormError<string> = {
+			formErrors: [],
+			fieldErrors: {},
+		};
+
+		if (!value.title) {
+			error.fieldErrors.title = ['Title is required'];
+		}
+
+		if (!value.description) {
+			error.fieldErrors.description = ['Description is required'];
+		}
+
+		if (!Array.isArray(value.tasks)) {
+			error.fieldErrors.tasks = ['Tasks are required'];
+		} else {
+			for (let i = 0; i < value.tasks.length; i++) {
+				const task = value.tasks[i];
+
+				if (task === null || typeof task !== 'object' || !('content' in task)) {
+					error.fieldErrors[`tasks[${i}]`] = ['Task is invalid'];
+					continue;
+				}
+				if (!task.content) {
+					error.fieldErrors[`tasks[${i}].content`] = [
+						'Task content is required',
+					];
+				}
+			}
+		}
+
+		return {
+			error,
+			value: value as unknown as Schema,
+		};
+	}
+
+	function Form(props: Partial<FormOptions<Schema, string, Schema>>) {
+		const { form, fields, intent } = useForm({
+			defaultValue: {
+				tasks: [{ content: 'Default Task', completed: false }],
+			},
+			onValidate({ payload }) {
+				return validateForm(payload);
+			},
+			onSubmit(event) {
+				event.preventDefault();
+			},
+			...props,
+		});
+
+		return (
+			<form {...form.props}>
+				<input
+					name={fields.title.name}
+					defaultValue={fields.title.defaultValue}
+					aria-label="Title"
+					aria-describedby={
+						fields.title.invalid ? fields.title.errorId : undefined
+					}
+				/>
+				<div id={fields.title.errorId}>
+					{fields.title.errors?.join(', ') ?? 'n/a'}
+				</div>
+				<textarea
+					name={fields.description.name}
+					defaultValue={fields.description.defaultValue}
+					aria-label="Description"
+					aria-describedby={
+						fields.description.invalid ? fields.description.errorId : undefined
+					}
+				/>
+				<div id={fields.description.errorId}>
+					{fields.description.errors?.join(', ') ?? 'n/a'}
+				</div>
+				{fields.tasks.getFieldList().map((task, index) => {
+					const taskField = task.getFieldset();
+
+					return (
+						<div key={task.key}>
+							<input
+								name={taskField.content.name}
+								defaultValue={taskField.content.defaultValue}
+								aria-label={`Task #${index + 1} Content`}
+								aria-describedby={
+									taskField.content.invalid
+										? taskField.content.errorId
+										: undefined
+								}
+							/>
+							<div id={taskField.content.errorId}>
+								{taskField.content.errors?.join(', ') ?? 'n/a'}
+							</div>
+							<input
+								type="checkbox"
+								name={taskField.completed.name}
+								defaultChecked={taskField.completed.defaultChecked}
+								aria-label={`Task #${index + 1} Completed`}
+								aria-describedby={
+									taskField.completed.invalid
+										? taskField.completed.errorId
+										: undefined
+								}
+							/>
+							<div id={taskField.completed.errorId}>
+								{taskField.completed.errors?.join(', ') ?? 'n/a'}
+							</div>
+							<button
+								type="button"
+								onClick={() =>
+									intent.remove({ name: fields.tasks.name, index })
+								}
+							>
+								Remove Task #{index + 1}
+							</button>
+							<button
+								type="button"
+								onClick={() =>
+									intent.reorder({
+										name: fields.tasks.name,
+										from: index,
+										to: 0,
+									})
+								}
+							>
+								Move Task #{index + 1} to Top
+							</button>
+						</div>
+					);
+				})}
+				<button>Submit</button>
+				<button type="button" onClick={() => intent.reset()}>
+					Reset
+				</button>
+				<button type="button" onClick={() => intent.validate()}>
+					Validate Form
+				</button>
+				<button type="button" onClick={() => intent.validate('description')}>
+					Validate Description
+				</button>
+				<button
+					type="button"
+					onClick={() =>
+						intent.update({ name: fields.description.name, value: '' })
+					}
+				>
+					Update Description
+				</button>
+				<button
+					type="button"
+					onClick={() =>
+						intent.update({
+							value: {
+								title: 'Foo',
+								description: 'Bar',
+								tasks: [
+									{ content: 'Baz', completed: true },
+									{ content: 'Qux', completed: false },
+								],
+							},
+						})
+					}
+				>
+					Update Form
+				</button>
+				<button
+					type="button"
+					onClick={() =>
+						intent.insert({
+							name: fields.tasks.name,
+						})
+					}
+				>
+					Insert Task
+				</button>
+				<button
+					type="button"
+					onClick={() =>
+						intent.insert({
+							name: fields.tasks.name,
+							defaultValue: {
+								content: 'Urgent Task',
+								completed: true,
+							},
+							index: 0,
+						})
+					}
+				>
+					Insert Urgent Task
+				</button>
+			</form>
+		);
+	}
+
+	function getForm(screen: ReturnType<typeof render>) {
+		return {
+			title: screen.getByLabelText('Title'),
+			description: screen.getByLabelText('Description'),
+			submitButton: screen.getByRole('button', { name: 'Submit' }),
+			resetButton: screen.getByRole('button', { name: 'Reset' }),
+			validateFormButton: screen.getByRole('button', {
+				name: 'Validate Form',
+			}),
+			validateDescriptionButton: screen.getByRole('button', {
+				name: 'Validate Description',
+			}),
+			updateDescriptionButton: screen.getByRole('button', {
+				name: 'Update Description',
+			}),
+			updateFormButton: screen.getByRole('button', {
+				name: 'Update Form',
+			}),
+			insertUrgentTaskButton: screen.getByRole('button', {
+				name: 'Insert Urgent Task',
+			}),
+			insertTaskButton: screen.getByRole('button', {
+				name: 'Insert Task',
+			}),
+		};
+	}
+
+	function getTaskFieldset(screen: ReturnType<typeof render>, order: number) {
+		return {
+			content: screen.getByLabelText(`Task #${order} Content`),
+			completed: screen.getByLabelText(`Task #${order} Completed`),
+			removeButton: screen.getByRole('button', {
+				name: `Remove Task #${order}`,
+			}),
+			moveToTopButton: screen.getByRole('button', {
+				name: `Move Task #${order} to Top`,
+			}),
+		};
+	}
+
+	test('shouldValidate: onSubmit (default)', async () => {
+		const screen = render(<Form />);
+		const form = getForm(screen);
+
+		await expectNoErrorMessages(form.title, form.description);
+
+		// Test input events
+		await userEvent.type(form.title, 'example');
+		await userEvent.clear(form.title);
+		await expectNoErrorMessages(form.title, form.description);
+
+		// Test blur event
+		await userEvent.click(document.body);
+		await expectNoErrorMessages(form.title, form.description);
+
+		// Test input events again
+		await userEvent.type(form.description, 'hello world');
+		await userEvent.clear(form.description);
+		await expectNoErrorMessages(form.title, form.description);
+
+		// Test blur event
+		await userEvent.click(document.body);
+		await expectNoErrorMessages(form.title, form.description);
+
+		await userEvent.click(form.submitButton);
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectErrorMessage(form.description, 'Description is required');
+
+		// Test revalidate with input events
+		await userEvent.type(form.title, 'example');
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectErrorMessage(form.description, 'Description is required');
+
+		// Test revalidate with blur event
+		await userEvent.click(document.body);
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectErrorMessage(form.description, 'Description is required');
+
+		// Test revalidate with input events again
+		await userEvent.type(form.description, 'hello world');
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectErrorMessage(form.description, 'Description is required');
+
+		// Test revalidate with blur event again
+		await userEvent.click(document.body);
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectErrorMessage(form.description, 'Description is required');
+
+		await userEvent.click(form.submitButton);
+		await expectNoErrorMessages(form.title, form.description);
+	});
+
+	test('shouldValidate: onBlur', async () => {
+		const screen = render(<Form shouldValidate="onBlur" />);
+		const form = getForm(screen);
+
+		await expectNoErrorMessages(form.title, form.description);
+
+		// Test input events
+		await userEvent.type(form.title, 'example');
+		await userEvent.clear(form.title);
+		await expectNoErrorMessages(form.title, form.description);
+
+		// Test blur event
+		await userEvent.click(document.body);
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectNoErrorMessages(form.description);
+
+		// Test input events again
+		await userEvent.type(form.description, 'hello world');
+		await userEvent.clear(form.description);
+		await expectNoErrorMessages(form.description);
+
+		// Test blur event
+		await userEvent.click(document.body);
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectErrorMessage(form.description, 'Description is required');
+
+		// Test input events
+		await userEvent.type(form.title, 'example');
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectErrorMessage(form.description, 'Description is required');
+
+		// Test revalidate with input events
+		await userEvent.type(form.title, 'example');
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectErrorMessage(form.description, 'Description is required');
+
+		// Test revalidate with blur event
+		await userEvent.click(document.body);
+		await expectNoErrorMessages(form.title);
+		await expectErrorMessage(form.description, 'Description is required');
+
+		// Test revalidate with input events again
+		await userEvent.type(form.description, 'hello world');
+		await expectNoErrorMessages(form.title);
+		await expectErrorMessage(form.description, 'Description is required');
+
+		// Test revalidate with blur event again
+		await userEvent.click(document.body);
+		await expectNoErrorMessages(form.title, form.description);
+	});
+
+	test('shouldValidate: onInput', async () => {
+		const screen = render(<Form shouldValidate="onInput" />);
+		const form = getForm(screen);
+
+		await expectNoErrorMessages(form.title, form.description);
+
+		// Test input events
+		await userEvent.type(form.title, 'example');
+		await userEvent.clear(form.title);
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectNoErrorMessages(form.description);
+
+		// Test revlidate with input events
+		await userEvent.type(form.title, 'example');
+		await expectNoErrorMessages(form.title, form.description);
+
+		// Test input events again
+		await userEvent.type(form.description, 'hello world');
+		await userEvent.clear(form.description);
+		await expectNoErrorMessages(form.title);
+		await expectErrorMessage(form.description, 'Description is required');
+
+		// Test revlidate with input events again
+		await userEvent.type(form.description, 'hello world');
+		await expectNoErrorMessages(form.title, form.description);
+	});
+
+	test('shouldValidate: onBlur / shouldRevalidate: onInput', async () => {
+		const screen = render(
+			<Form shouldValidate="onBlur" shouldRevalidate="onInput" />,
+		);
+		const form = getForm(screen);
+
+		await expectNoErrorMessages(form.title, form.description);
+
+		// Test input events
+		await userEvent.type(form.title, 'example');
+		await userEvent.clear(form.title);
+		await expectNoErrorMessages(form.title, form.description);
+
+		// Test blur event
+		await userEvent.click(document.body);
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectNoErrorMessages(form.description);
+
+		// Test revalidate with input events
+		await userEvent.type(form.title, 'example');
+		await expectNoErrorMessages(form.title, form.description);
+
+		// Test input events again
+		await userEvent.type(form.description, 'hello world');
+		await userEvent.clear(form.description);
+		await expectNoErrorMessages(form.title, form.description);
+
+		// Test blur event
+		await userEvent.click(document.body);
+		await expectNoErrorMessages(form.title);
+		await expectErrorMessage(form.description, 'Description is required');
+
+		// Test revalidate with input events again
+		await userEvent.type(form.description, 'hello world');
+		await expectNoErrorMessages(form.title, form.description);
+	});
+
+	test('validate intent', async () => {
+		const screen = render(<Form />);
+		const form = getForm(screen);
+
+		await expectNoErrorMessages(form.title, form.description);
+
+		await userEvent.click(form.validateDescriptionButton);
+		await expectNoErrorMessages(form.title);
+		await expectErrorMessage(form.description, 'Description is required');
+
+		await userEvent.click(form.validateFormButton);
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectErrorMessage(form.description, 'Description is required');
+	});
+
+	test('reset intent', async () => {
+		const screen = render(<Form />);
+		const form = getForm(screen);
+
+		await expectNoErrorMessages(form.title, form.description);
+
+		// Test reset form error
+		await userEvent.click(form.submitButton);
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectErrorMessage(form.description, 'Description is required');
+		await userEvent.click(form.resetButton);
+		await expectNoErrorMessages(form.title, form.description);
+
+		// Test reset form value
+		await userEvent.type(form.title, 'example');
+		await userEvent.type(form.description, 'hello world');
+		await userEvent.click(form.resetButton);
+		await expect.element(form.title).toHaveValue('');
+		await expect.element(form.description).toHaveValue('');
+
+		// Test reset form with default values
+		screen.rerender(
+			<Form
+				defaultValue={{
+					title: 'example',
+					description: 'hello world',
+					// We will test resetting tasks with the list intents
+					tasks: [
+						{ content: 'First Task', completed: false },
+						{ content: 'Second Task', completed: true },
+					],
+				}}
+			/>,
+		);
+
+		const task1 = getTaskFieldset(screen, 1);
+		const task2 = getTaskFieldset(screen, 2);
+
+		await expect.element(form.title).toHaveValue('example');
+		await expect.element(form.description).toHaveValue('hello world');
+		await expect.element(task1.content).toHaveValue('First Task');
+		await expect.element(task1.completed).not.toBeChecked();
+		await expect.element(task2.content).toHaveValue('Second Task');
+		await expect.element(task2.completed).toBeChecked();
+
+		await userEvent.type(form.title, 'New example');
+		await userEvent.type(form.description, 'Foo bar baz');
+		await userEvent.type(task1.content, 'Task 1');
+		await userEvent.click(task1.completed);
+		await userEvent.click(task2.removeButton);
+
+		await userEvent.click(form.resetButton);
+		await expect.element(form.title).toHaveValue('example');
+		await expect.element(form.description).toHaveValue('hello world');
+		await expect.element(task1.content).toHaveValue('First Task');
+		await expect.element(task1.completed).not.toBeChecked();
+		await expect.element(task2.content).toHaveValue('Second Task');
+		await expect.element(task2.completed).toBeChecked();
+	});
+
+	test('update intent', async () => {
+		const screen = render(
+			<Form
+				defaultValue={{
+					title: 'example',
+					description: 'hello world',
+					// We will test resetting tasks with the list intents
+					tasks: [{ content: 'Default Task', completed: false }],
+				}}
+			/>,
+		);
+		const form = getForm(screen);
+		const task1 = getTaskFieldset(screen, 1);
+		const task2 = getTaskFieldset(screen, 2);
+
+		await expect.element(form.title).toHaveValue('example');
+		await expect.element(form.description).toHaveValue('hello world');
+		await expect.element(task1.content).toHaveValue('Default Task');
+		await expect.element(task1.completed).not.toBeChecked();
+
+		await userEvent.click(form.updateDescriptionButton);
+		await expect.element(form.title).toHaveValue('example');
+		await expect.element(form.description).toHaveValue('');
+		await expect.element(task1.content).toHaveValue('Default Task');
+		await expect.element(task1.completed).not.toBeChecked();
+
+		await userEvent.click(form.updateFormButton);
+		await expect.element(form.title).toHaveValue('Foo');
+		await expect.element(form.description).toHaveValue('Bar');
+		await expect.element(task1.content).toHaveValue('Baz');
+		await expect.element(task1.completed).toBeChecked();
+		await expect.element(task2.content).toHaveValue('Qux');
+		await expect.element(task2.completed).not.toBeChecked();
+	});
+
+	test('insert / reorder / remove intents', async () => {
+		const screen = render(
+			<Form
+				defaultValue={{
+					title: 'example',
+					description: 'hello world',
+					// We will test resetting tasks with the list intents
+					tasks: [{ content: 'Default Task', completed: false }],
+				}}
+			/>,
+		);
+		const form = getForm(screen);
+		const task1 = getTaskFieldset(screen, 1);
+		const task2 = getTaskFieldset(screen, 2);
+		const task3 = getTaskFieldset(screen, 3);
+
+		await expect.element(task1.content).toHaveValue('Default Task');
+		await expect.element(task1.completed).not.toBeChecked();
+		await expect.element(task2.content).not.toBeInTheDocument();
+		await expect.element(task2.completed).not.toBeInTheDocument();
+		await expect.element(task3.content).not.toBeInTheDocument();
+		await expect.element(task3.completed).not.toBeInTheDocument();
+
+		await userEvent.clear(task1.content);
+		await userEvent.click(task1.completed);
+		await userEvent.click(form.submitButton);
+		await expectErrorMessage(task1.content, 'Task content is required');
+
+		await userEvent.click(form.insertTaskButton);
+		await expect.element(task1.content).toHaveValue('');
+		await expect.element(task1.completed).toBeChecked();
+		await expect.element(task2.content).toHaveValue('');
+		await expect.element(task2.completed).not.toBeChecked();
+		await expect.element(task3.content).not.toBeInTheDocument();
+		await expect.element(task3.completed).not.toBeInTheDocument();
+		await expectErrorMessage(task1.content, 'Task content is required');
+		await expectNoErrorMessages(task2.content);
+
+		await userEvent.type(task2.content, 'Old Task');
+		await userEvent.click(task1.completed);
+		await userEvent.click(form.insertUrgentTaskButton);
+		await expect.element(task1.content).toHaveValue('Urgent Task');
+		await expect.element(task1.completed).toBeChecked();
+		await expect.element(task2.content).toHaveValue('');
+		await expect.element(task2.completed).not.toBeChecked();
+		await expect.element(task3.content).toHaveValue('Old Task');
+		await expect.element(task3.completed).not.toBeChecked();
+		await expectErrorMessage(task2.content, 'Task content is required');
+		await expectNoErrorMessages(task1.content, task3.content);
+
+		await userEvent.click(task2.moveToTopButton);
+		await expect.element(task1.content).toHaveValue('');
+		await expect.element(task1.completed).not.toBeChecked();
+		await expect.element(task2.content).toHaveValue('Urgent Task');
+		await expect.element(task2.completed).toBeChecked();
+		await expect.element(task3.content).toHaveValue('Old Task');
+		await expect.element(task3.completed).not.toBeChecked();
+		await expectErrorMessage(task1.content, 'Task content is required');
+		await expectNoErrorMessages(task2.content, task3.content);
+
+		await userEvent.click(task2.removeButton);
+		await expect.element(task1.content).toHaveValue('');
+		await expect.element(task1.completed).not.toBeChecked();
+		await expect.element(task2.content).toHaveValue('Old Task');
+		await expect.element(task2.completed).not.toBeChecked();
+		await expect.element(task3.content).not.toBeInTheDocument();
+		await expect.element(task3.completed).not.toBeInTheDocument();
+		await expectErrorMessage(task1.content, 'Task content is required');
+		await expectNoErrorMessages(task2.content);
+	});
+
+	describe('async validation', () => {
+		beforeAll(() => {
+			vi.useFakeTimers();
+		});
+
+		afterAll(() => {
+			vi.useRealTimers();
+		});
+
+		test('default behavior', async () => {
+			const screen = render(
+				<Form
+					shouldRevalidate="onInput"
+					onValidate={({ payload }) => {
+						const result = validateForm(payload);
+
+						// Validate whether title is unique only if it has no errors
+						if (!result.error.fieldErrors.title) {
+							return new Promise((resolve) => {
+								// Move the timer forward each time so we can incrementally resolve the async validation
+								vi.advanceTimersByTime(1);
+								setTimeout(() => {
+									if (result.value.title !== 'example') {
+										result.error.fieldErrors.title = ['Title is already taken'];
+									}
+
+									resolve(result);
+								}, 100);
+							});
+						}
+
+						return result;
+					}}
+				/>,
+			);
+
+			const form = getForm(screen);
+
+			await expectNoErrorMessages(form.title);
+
+			await userEvent.click(form.submitButton);
+			await expectErrorMessage(form.title, 'Title is required');
+
+			await userEvent.type(form.title, 'exampl');
+			// Still waiting for async validation to complete
+			await expectErrorMessage(form.title, 'Title is required');
+
+			for (let i = 0; i < 'exampl'.length; i++) {
+				// This resolves the async validation, but the result is invalidated because of the next character typed
+				vi.advanceTimersToNextTimer();
+				await expectErrorMessage(form.title, 'Title is required');
+			}
+
+			// Now we type the last character, which should resolve the last async validation result
+			await expectErrorMessage(form.title, 'Title is already taken');
+
+			await userEvent.type(form.title, 'e');
+			await expectErrorMessage(form.title, 'Title is already taken');
+
+			vi.advanceTimersToNextTimer();
+			await expectNoErrorMessages(form.title);
+		});
+	});
+});

--- a/packages/conform-react/tests/useForm.node.test.tsx
+++ b/packages/conform-react/tests/useForm.node.test.tsx
@@ -1,0 +1,330 @@
+import { describe, expect, test } from 'vitest';
+import { DEFAULT_INTENT_NAME } from '@conform-to/dom/future';
+import { useForm } from '../future';
+import { createResult, serverRenderHook } from './helpers';
+import { serializeIntent } from '../future/intent';
+
+describe('future export: useForm', () => {
+	test('default state', () => {
+		const { form, fields } = serverRenderHook(() =>
+			useForm<{ title: string; description: string }, string>({
+				onValidate: () => undefined,
+			}),
+		);
+
+		expect(form.errors).toBe(undefined);
+		expect(fields.title.defaultValue).toBe(undefined);
+		expect(fields.title.errors).toBe(undefined);
+		expect(fields.description.defaultValue).toBe(undefined);
+		expect(fields.description.errors).toBe(undefined);
+	});
+
+	test('default value', () => {
+		const { form, fields } = serverRenderHook(() =>
+			useForm<{ title: string; description: string }, string>({
+				defaultValue: { title: 'Example', description: 'Hello World' },
+				onValidate: () => undefined,
+			}),
+		);
+
+		expect(form.errors).toBe(undefined);
+		expect(fields.title.defaultValue).toBe('Example');
+		expect(fields.title.errors).toBe(undefined);
+		expect(fields.description.defaultValue).toBe('Hello World');
+		expect(fields.description.errors).toBe(undefined);
+	});
+
+	test('initialize with last submission result', () => {
+		const { form, fields } = serverRenderHook(() =>
+			useForm<{ title: string; description: string }, string>({
+				lastResult: createResult(
+					[
+						['title', 'Example'],
+						['description', 'Hello World'],
+					],
+					{
+						error: {
+							formErrors: ['Form error'],
+							fieldErrors: {
+								title: ['Title error'],
+								description: ['Description error'],
+							},
+						},
+					},
+				),
+				onValidate: () => undefined,
+			}),
+		);
+
+		expect(form.errors).toEqual(['Form error']);
+		expect(fields.title.defaultValue).toBe('Example');
+		expect(fields.title.errors).toEqual(['Title error']);
+		expect(fields.description.defaultValue).toBe('Hello World');
+		expect(fields.description.errors).toEqual(['Description error']);
+	});
+
+	test('initialize with validate intent', () => {
+		const { form, fields } = serverRenderHook(() =>
+			useForm<{ title: string; description: string }, string>({
+				lastResult: createResult(
+					[
+						['title', 'Example'],
+						['description', 'Hello World'],
+						[
+							DEFAULT_INTENT_NAME,
+							serializeIntent({
+								type: 'validate',
+								payload: 'title',
+							}),
+						],
+					],
+					{
+						error: {
+							formErrors: ['Form error'],
+							fieldErrors: {
+								title: ['Title error'],
+								description: ['Description error'],
+							},
+						},
+					},
+				),
+				onValidate: () => undefined,
+			}),
+		);
+
+		expect(form.errors).toEqual(['Form error']);
+		expect(fields.title.defaultValue).toBe('Example');
+		expect(fields.title.errors).toEqual(['Title error']);
+		expect(fields.description.defaultValue).toBe('Hello World');
+		expect(fields.description.errors).toBe(undefined);
+	});
+
+	test('initialize with update result', () => {
+		const { form, fields } = serverRenderHook(() =>
+			useForm<{ title: string; description: string }, string>({
+				lastResult: createResult(
+					[
+						['title', 'Example'],
+						['description', 'Hello World'],
+						[
+							DEFAULT_INTENT_NAME,
+							serializeIntent({
+								type: 'update',
+								payload: {
+									name: 'description',
+									value: 'Updated description',
+								},
+							}),
+						],
+					],
+					{
+						error: {
+							formErrors: ['Form error'],
+							fieldErrors: {
+								title: ['Title error'],
+								description: ['Description error'],
+							},
+						},
+					},
+				),
+				onValidate: () => undefined,
+			}),
+		);
+
+		expect(form.errors).toEqual(['Form error']);
+		expect(fields.title.defaultValue).toBe('Example');
+		expect(fields.title.errors).toBe(undefined);
+		expect(fields.description.defaultValue).toBe('Updated description');
+		expect(fields.description.errors).toEqual(['Description error']);
+	});
+
+	test('initialize with reset intent', () => {
+		const { form, fields } = serverRenderHook(() =>
+			useForm<{ title: string; description: string }, string>({
+				lastResult: createResult(
+					[
+						['title', 'Example'],
+						['description', 'Hello World'],
+						[
+							DEFAULT_INTENT_NAME,
+							serializeIntent({
+								type: 'reset',
+							}),
+						],
+					],
+					{
+						error: {
+							formErrors: ['Form error'],
+							fieldErrors: {
+								title: ['Title error'],
+								description: ['Description error'],
+							},
+						},
+					},
+				),
+				defaultValue: {
+					title: 'Default Title',
+				},
+				onValidate: () => undefined,
+			}),
+		);
+
+		expect(form.errors).toBe(undefined);
+		expect(fields.title.defaultValue).toBe('Default Title');
+		expect(fields.title.errors).toBe(undefined);
+		expect(fields.description.defaultValue).toBe(undefined);
+		expect(fields.description.errors).toBe(undefined);
+	});
+
+	test('initialize with insert intent', () => {
+		const { form, fields } = serverRenderHook(() =>
+			useForm<{ title: string; notes: string[] }, string>({
+				lastResult: createResult(
+					[
+						['title', 'Example'],
+						[
+							DEFAULT_INTENT_NAME,
+							serializeIntent({
+								type: 'insert',
+								payload: {
+									name: 'notes',
+									defaultValue: 'Foo',
+								},
+							}),
+						],
+					],
+					{
+						error: {
+							formErrors: ['Form error'],
+							fieldErrors: {
+								title: ['Title error'],
+								notes: ['Notes error'],
+								'notes[0]': ['First note error'],
+							},
+						},
+					},
+				),
+				defaultValue: {
+					title: 'Default Title',
+				},
+				onValidate: () => undefined,
+			}),
+		);
+		const notes = fields.notes.getFieldList();
+
+		expect(form.errors).toEqual(['Form error']);
+		expect(fields.title.defaultValue).toBe('Example');
+		expect(fields.title.errors).toBe(undefined);
+		expect(fields.notes.defaultValue).toBe(undefined);
+		expect(fields.notes.defaultOptions).toEqual(['Foo']);
+		expect(fields.notes.errors).toEqual(['Notes error']);
+		expect(notes[0]?.defaultValue).toBe('Foo');
+		expect(notes[0]?.errors).toBe(undefined);
+	});
+
+	test('initialize with reorder intent', () => {
+		const { form, fields } = serverRenderHook(() =>
+			useForm<{ title: string; notes: string[] }, string>({
+				lastResult: createResult(
+					[
+						['title', 'Example'],
+						['notes[0]', 'First note'],
+						['notes[1]', 'Second note'],
+						['notes[2]', 'Third note'],
+						[
+							DEFAULT_INTENT_NAME,
+							serializeIntent({
+								type: 'reorder',
+								payload: {
+									name: 'notes',
+									from: 1,
+									to: 0,
+								},
+							}),
+						],
+					],
+					{
+						error: {
+							formErrors: ['Form error'],
+							fieldErrors: {
+								title: ['Title error'],
+								notes: ['Notes error'],
+								'notes[0]': ['First note error'],
+								'notes[1]': ['Second note error'],
+								'notes[2]': ['Third note error'],
+							},
+						},
+					},
+				),
+				onValidate: () => undefined,
+			}),
+		);
+		const notes = fields.notes.getFieldList();
+
+		expect(form.errors).toEqual(['Form error']);
+		expect(fields.title.defaultValue).toBe('Example');
+		expect(fields.title.errors).toBe(undefined);
+		expect(fields.notes.defaultValue).toBe(undefined);
+		expect(fields.notes.defaultOptions).toEqual([
+			'Second note',
+			'First note',
+			'Third note',
+		]);
+		expect(fields.notes.errors).toEqual(['Notes error']);
+		expect(notes[0]?.defaultValue).toBe('Second note');
+		expect(notes[0]?.errors).toBe(undefined);
+		expect(notes[1]?.defaultValue).toBe('First note');
+		expect(notes[1]?.errors).toBe(undefined);
+		expect(notes[2]?.defaultValue).toBe('Third note');
+		expect(notes[2]?.errors).toBe(undefined);
+	});
+
+	test('initialize with remove intent', () => {
+		const { form, fields } = serverRenderHook(() =>
+			useForm<{ title: string; notes: string[] }, string>({
+				lastResult: createResult(
+					[
+						['title', 'Example'],
+						['notes[0]', 'First note'],
+						['notes[1]', 'Second note'],
+						['notes[2]', 'Third note'],
+						[
+							DEFAULT_INTENT_NAME,
+							serializeIntent({
+								type: 'remove',
+								payload: {
+									name: 'notes',
+									index: 1,
+								},
+							}),
+						],
+					],
+					{
+						error: {
+							formErrors: ['Form error'],
+							fieldErrors: {
+								title: ['Title error'],
+								notes: ['Notes error'],
+								'notes[0]': ['First note error'],
+								'notes[1]': ['Third note error'],
+							},
+						},
+					},
+				),
+				onValidate: () => undefined,
+			}),
+		);
+		const notes = fields.notes.getFieldList();
+
+		expect(form.errors).toEqual(['Form error']);
+		expect(fields.title.defaultValue).toBe('Example');
+		expect(fields.title.errors).toBe(undefined);
+		expect(fields.notes.defaultValue).toBe(undefined);
+		expect(fields.notes.defaultOptions).toEqual(['First note', 'Third note']);
+		expect(fields.notes.errors).toEqual(['Notes error']);
+		expect(notes[0]?.defaultValue).toBe('First note');
+		expect(notes[0]?.errors).toBe(undefined);
+		expect(notes[1]?.defaultValue).toBe('Third note');
+		expect(notes[1]?.errors).toBe(undefined);
+	});
+});

--- a/packages/conform-react/tests/useFormData.browser.test.tsx
+++ b/packages/conform-react/tests/useFormData.browser.test.tsx
@@ -4,29 +4,13 @@ import { render } from 'vitest-browser-react';
 import { userEvent } from '@vitest/browser/context';
 import { useControl, useFormData } from '@conform-to/react/future';
 import { useForm } from '@conform-to/react';
-import { FormContext } from '../future/context';
-import { useEffect, useRef, useState } from 'react';
-import { createGlobalFormsObserver } from '@conform-to/dom/future';
+import { useRef, useState } from 'react';
 import { parse } from '@conform-to/dom';
 
 describe('future export: useFormData', () => {
 	function useRenderCount(): number {
 		const ref = useRef(0);
 		return ++ref.current;
-	}
-
-	function useFormObserver() {
-		const observerRef = useRef<ReturnType<typeof createGlobalFormsObserver>>();
-
-		if (!observerRef.current) {
-			observerRef.current = createGlobalFormsObserver();
-		}
-
-		useEffect(() => {
-			observerRef.current?.dispose();
-		}, []);
-
-		return observerRef.current;
 	}
 
 	function Form(props: {
@@ -45,32 +29,29 @@ describe('future export: useFormData', () => {
 		});
 		const count = useRenderCount();
 		const [showChildren, setShowChildren] = useState(true);
-		const observer = useFormObserver();
 
 		return (
-			<FormContext.Provider value={{ observer }}>
-				<form
-					id={props.id}
-					ref={formRef}
-					encType={props.acceptFiles ? 'multipart/form-data' : undefined}
-					onSubmit={props.onSubmit ?? ((event) => event.preventDefault())}
-				>
-					<pre data-testid="count">{count}</pre>
-					<pre data-testid="result">
-						{typeof result === 'string'
-							? result
-							: result instanceof File
-								? result.name === '' && result.size === 0
-									? '<empty file>'
-									: result.name
-								: JSON.stringify(result)}
-					</pre>
-					{showChildren ? <div>{props.children}</div> : null}
-					<button type="button" onClick={() => setShowChildren(!showChildren)}>
-						Toggle children
-					</button>
-				</form>
-			</FormContext.Provider>
+			<form
+				id={props.id}
+				ref={formRef}
+				encType={props.acceptFiles ? 'multipart/form-data' : undefined}
+				onSubmit={props.onSubmit ?? ((event) => event.preventDefault())}
+			>
+				<pre data-testid="count">{count}</pre>
+				<pre data-testid="result">
+					{typeof result === 'string'
+						? result
+						: result instanceof File
+							? result.name === '' && result.size === 0
+								? '<empty file>'
+								: result.name
+							: JSON.stringify(result)}
+				</pre>
+				{showChildren ? <div>{props.children}</div> : null}
+				<button type="button" onClick={() => setShowChildren(!showChildren)}>
+					Toggle children
+				</button>
+			</form>
 		);
 	}
 

--- a/packages/conform-react/tests/useFormMetadata.browser.test.tsx
+++ b/packages/conform-react/tests/useFormMetadata.browser.test.tsx
@@ -1,0 +1,115 @@
+import { describe, test } from 'vitest';
+import { FormOptions, FormProvider, useForm, useFormMetadata } from '../future';
+import { render } from 'vitest-browser-react';
+import { expectErrorMessage, expectNoErrorMessages } from './helpers';
+import { userEvent } from '@vitest/browser/context';
+
+describe('future export: useFormMetadata', () => {
+	type Schema = {
+		title: string;
+		description: string;
+	};
+
+	function FormErrors() {
+		const form = useFormMetadata();
+
+		return (
+			<div>
+				{Object.entries(form.fieldErrors).map(([name, errors]) => {
+					const field = form.getField(name);
+
+					return (
+						<div key={name} id={field.invalid ? field.errorId : undefined}>
+							{errors?.join(', ') ?? 'n/a'}
+						</div>
+					);
+				})}
+			</div>
+		);
+	}
+
+	function Form({
+		children,
+		...options
+	}: Partial<FormOptions<Schema, string, Schema>> & {
+		children?: React.ReactNode;
+	}) {
+		const { form, fields, intent } = useForm({
+			onValidate({ payload, error }) {
+				if (!payload.title) {
+					error.fieldErrors.title = ['Title is required'];
+				}
+
+				if (!payload.description) {
+					error.fieldErrors.description = ['Description is required'];
+				}
+
+				return error;
+			},
+			onSubmit(event) {
+				event.preventDefault();
+			},
+			...options,
+		});
+
+		return (
+			<FormProvider context={form.context}>
+				{children}
+				<form {...form.props}>
+					<input
+						name={fields.title.name}
+						defaultValue={fields.title.defaultValue}
+						aria-label="Title"
+						aria-describedby={
+							fields.title.invalid ? fields.title.errorId : undefined
+						}
+					/>
+					<textarea
+						name={fields.description.name}
+						defaultValue={fields.description.defaultValue}
+						aria-label="Description"
+						aria-describedby={
+							fields.description.invalid
+								? fields.description.errorId
+								: undefined
+						}
+					/>
+					<button>Submit</button>
+					<button type="button" onClick={() => intent.validate('description')}>
+						Validate Description
+					</button>
+				</form>
+			</FormProvider>
+		);
+	}
+
+	function getForm(screen: ReturnType<typeof render>) {
+		return {
+			title: screen.getByLabelText('Title'),
+			description: screen.getByLabelText('Description'),
+			submitButton: screen.getByRole('button', { name: 'Submit' }),
+			validateDescriptionButton: screen.getByRole('button', {
+				name: 'Validate Description',
+			}),
+		};
+	}
+
+	test('extract form metadata from context', async () => {
+		const screen = render(
+			<Form>
+				<FormErrors />
+			</Form>,
+		);
+		const form = getForm(screen);
+
+		await expectNoErrorMessages(form.title, form.description);
+
+		await userEvent.click(form.validateDescriptionButton);
+		await expectNoErrorMessages(form.title);
+		await expectErrorMessage(form.description, 'Description is required');
+
+		await userEvent.click(form.submitButton);
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectErrorMessage(form.description, 'Description is required');
+	});
+});

--- a/packages/conform-react/tests/useIntent.browser.test.tsx
+++ b/packages/conform-react/tests/useIntent.browser.test.tsx
@@ -1,0 +1,181 @@
+/// <reference types="@vitest/browser/matchers" />
+import { describe, test, expect } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { userEvent } from '@vitest/browser/context';
+import { type FormOptions, useForm, useIntent } from '../future';
+import { useRef } from 'react';
+import { expectErrorMessage, expectNoErrorMessages } from './helpers';
+
+describe('future export: useIntent', () => {
+	type Schema = {
+		title: string;
+		description: string;
+	};
+
+	function ValidateButton(props: {
+		form?: string;
+		field?: string;
+		children: React.ReactNode;
+	}) {
+		const buttonRef = useRef<HTMLButtonElement>(null);
+		const intent = useIntent(buttonRef);
+
+		return (
+			<button
+				type="button"
+				ref={buttonRef}
+				onClick={() => intent.validate(props.field)}
+				form={props.form}
+			>
+				{props.children}
+			</button>
+		);
+	}
+
+	function ResetButton(props: { form?: string; children: React.ReactNode }) {
+		const buttonRef = useRef<HTMLButtonElement>(null);
+		const intent = useIntent(buttonRef);
+
+		return (
+			<button
+				type="button"
+				ref={buttonRef}
+				onClick={() => intent.reset()}
+				form={props.form}
+			>
+				{props.children}
+			</button>
+		);
+	}
+
+	function Form(props: Partial<FormOptions<Schema, string, Schema>>) {
+		const { form, fields } = useForm({
+			onValidate({ payload, error }) {
+				if (!payload.title) {
+					error.fieldErrors.title = ['Title is required'];
+				}
+
+				if (!payload.description) {
+					error.fieldErrors.description = ['Description is required'];
+				}
+
+				return error;
+			},
+			onSubmit(event) {
+				event.preventDefault();
+			},
+			...props,
+		});
+
+		return (
+			<div>
+				<form {...form.props}>
+					<input
+						name={fields.title.name}
+						defaultValue={fields.title.defaultValue}
+						aria-label="Title"
+						aria-describedby={
+							fields.title.invalid ? fields.title.errorId : undefined
+						}
+					/>
+					<div id={fields.title.errorId}>
+						{fields.title.errors?.join(', ') ?? 'n/a'}
+					</div>
+					<textarea
+						name={fields.description.name}
+						defaultValue={fields.description.defaultValue}
+						aria-label="Description"
+						aria-describedby={
+							fields.description.invalid
+								? fields.description.errorId
+								: undefined
+						}
+					/>
+					<div id={fields.description.errorId}>
+						{fields.description.errors?.join(', ') ?? 'n/a'}
+					</div>
+					<button>Submit</button>
+					<ValidateButton>Validate Form</ValidateButton>
+					<ValidateButton field={fields.description.name}>
+						Validate Description
+					</ValidateButton>
+				</form>
+				<ResetButton form={form.id}>Reset</ResetButton>
+			</div>
+		);
+	}
+
+	function getForm(screen: ReturnType<typeof render>) {
+		return {
+			title: screen.getByLabelText('Title'),
+			description: screen.getByLabelText('Description'),
+			submitButton: screen.getByRole('button', { name: 'Submit' }),
+			resetButton: screen.getByRole('button', { name: 'Reset' }),
+			validateFormButton: screen.getByRole('button', {
+				name: 'Validate Form',
+			}),
+			validateDescriptionButton: screen.getByRole('button', {
+				name: 'Validate Description',
+			}),
+			updateDescriptionButton: screen.getByRole('button', {
+				name: 'Update Description',
+			}),
+		};
+	}
+
+	test('intent button with and without payload', async () => {
+		const screen = render(<Form />);
+		const form = getForm(screen);
+
+		await expectNoErrorMessages(form.title, form.description);
+
+		await userEvent.click(form.validateDescriptionButton);
+		await expectNoErrorMessages(form.title);
+		await expectErrorMessage(form.description, 'Description is required');
+
+		await userEvent.click(form.validateFormButton);
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectErrorMessage(form.description, 'Description is required');
+	});
+
+	test('intent button associated through the form attribute', async () => {
+		const screen = render(<Form />);
+		const form = getForm(screen);
+
+		await expectNoErrorMessages(form.title, form.description);
+
+		// Test reset form error
+		await userEvent.click(form.submitButton);
+		await expectErrorMessage(form.title, 'Title is required');
+		await expectErrorMessage(form.description, 'Description is required');
+
+		await userEvent.click(form.resetButton);
+		await expectNoErrorMessages(form.title, form.description);
+
+		// Test reset form value
+		await userEvent.type(form.title, 'example');
+		await userEvent.type(form.description, 'hello world');
+		await userEvent.click(form.resetButton);
+		await expect.element(form.title).toHaveValue('');
+		await expect.element(form.description).toHaveValue('');
+
+		// Test reset form with default values
+		screen.rerender(
+			<Form
+				defaultValue={{
+					title: 'example',
+					description: 'hello world',
+				}}
+			/>,
+		);
+
+		await expect.element(form.title).toHaveValue('example');
+		await expect.element(form.description).toHaveValue('hello world');
+
+		await userEvent.type(form.title, 'New example');
+		await userEvent.type(form.description, 'Foo bar baz');
+		await userEvent.click(form.resetButton);
+		await expect.element(form.title).toHaveValue('example');
+		await expect.element(form.description).toHaveValue('hello world');
+	});
+});

--- a/packages/conform-react/tests/util.test.ts
+++ b/packages/conform-react/tests/util.test.ts
@@ -1,0 +1,381 @@
+import { test, expect } from 'vitest';
+import {
+	isUndefined,
+	isString,
+	isNumber,
+	isOptional,
+	getArrayAtPath,
+	updateValueAtPath,
+	createPathIndexUpdater,
+	normalizeFormError,
+	normalizeValidateResult,
+	resolveValidateResult,
+	resolveStandardSchemaPath,
+	resolveStandardSchemaResult,
+	merge,
+	transformKeys,
+	appendUniqueItem,
+	compactMap,
+	generateUniqueKey,
+} from '../future/util';
+import type { FormError } from '@conform-to/dom/future';
+
+test('isUndefined', () => {
+	expect(isUndefined(undefined)).toBe(true);
+	expect(isUndefined(null)).toBe(false);
+	expect(isUndefined('')).toBe(false);
+	expect(isUndefined(0)).toBe(false);
+	expect(isUndefined(false)).toBe(false);
+});
+
+test('isString', () => {
+	expect(isString('hello')).toBe(true);
+	expect(isString('')).toBe(true);
+	expect(isString(123)).toBe(false);
+	expect(isString(null)).toBe(false);
+	expect(isString(undefined)).toBe(false);
+});
+
+test('isNumber', () => {
+	expect(isNumber(123)).toBe(true);
+	expect(isNumber(0)).toBe(true);
+	expect(isNumber(-1)).toBe(true);
+	expect(isNumber(3.14)).toBe(true);
+	expect(isNumber('123')).toBe(false);
+	expect(isNumber(null)).toBe(false);
+	expect(isNumber(undefined)).toBe(false);
+});
+
+test('isOptional', () => {
+	expect(isOptional(undefined, isString)).toBe(true);
+	expect(isOptional('hello', isString)).toBe(true);
+	expect(isOptional(123, isString)).toBe(false);
+	expect(isOptional(null, isString)).toBe(false);
+
+	expect(isOptional(undefined, isNumber)).toBe(true);
+	expect(isOptional(123, isNumber)).toBe(true);
+	expect(isOptional('123', isNumber)).toBe(false);
+});
+
+test('getArrayAtPath', () => {
+	const formValue = {
+		items: [1, 2, 3],
+		nested: {
+			list: ['a', 'b'],
+		},
+		empty: [],
+	};
+
+	expect(getArrayAtPath(formValue, 'items')).toEqual([1, 2, 3]);
+	expect(getArrayAtPath(formValue, 'nested.list')).toEqual(['a', 'b']);
+	expect(getArrayAtPath(formValue, 'empty')).toEqual([]);
+	expect(getArrayAtPath(formValue, 'nonexistent')).toEqual([]);
+	expect(getArrayAtPath(null, 'items')).toEqual([]);
+
+	// Test error case
+	const invalidValue = { notArray: 'string' };
+	expect(() => getArrayAtPath(invalidValue, 'notArray')).toThrow(
+		'The value of "notArray" is not an array',
+	);
+});
+
+test('updateValueAtPath', () => {
+	const data = { a: 1, b: { c: 2 } };
+
+	// Test updating nested value
+	const result1 = updateValueAtPath(data, 'b.c', 3);
+	expect(result1).toEqual({ a: 1, b: { c: 3 } });
+	expect(result1).not.toBe(data); // Should be immutable
+
+	// Test updating root value
+	const result2 = updateValueAtPath(data, 'a', 5);
+	expect(result2).toEqual({ a: 5, b: { c: 2 } });
+
+	// Test empty path (replace entire object)
+	const newData = { x: 10, y: 20 };
+	const result3 = updateValueAtPath(data, '', newData);
+	expect(result3).toEqual(newData);
+
+	// Test error case with empty path and non-object value
+	expect(() => updateValueAtPath(data, '', 'string' as any)).toThrow(
+		'The value must be an object',
+	);
+});
+
+test('createPathIndexUpdater', () => {
+	const updater = createPathIndexUpdater('items', (index) =>
+		index < 2 ? index + 1 : index,
+	);
+
+	// Test matching path with index update
+	expect(updater('items[0].name')).toBe('items[1].name');
+	expect(updater('items[1].name')).toBe('items[2].name');
+	expect(updater('items[2].name')).toBe('items[2].name'); // No change
+
+	// Test non-matching path
+	expect(updater('other[0].name')).toBe('other[0].name');
+	expect(updater('items')).toBe('items'); // No index
+
+	// Test removal (null return)
+	const remover = createPathIndexUpdater('items', (index) =>
+		index === 1 ? null : index,
+	);
+	expect(remover('items[1].name')).toBeNull();
+	expect(remover('items[0].name')).toBe('items[0].name');
+
+	// Test nested list
+	const nestedUpdater = createPathIndexUpdater(
+		'form.items',
+		(index) => index + 1,
+	);
+	expect(nestedUpdater('form.items[0].field')).toBe('form.items[1].field');
+});
+
+test('normalizeFormError', () => {
+	// Test error with messages
+	const errorWithMessages: FormError<string> = {
+		formErrors: ['Form error'],
+		fieldErrors: { email: ['Required'] },
+	};
+	expect(normalizeFormError(errorWithMessages)).toBe(errorWithMessages);
+
+	// Test error without messages
+	const emptyError: FormError<string> = {
+		formErrors: [],
+		fieldErrors: { email: [] },
+	};
+	expect(normalizeFormError(emptyError)).toBeNull();
+
+	// Test null error
+	expect(normalizeFormError(null)).toBeNull();
+
+	// Test mixed empty/non-empty fields
+	const mixedError: FormError<string> = {
+		formErrors: [],
+		fieldErrors: { email: [], password: ['Required'] },
+	};
+	expect(normalizeFormError(mixedError)).toBe(mixedError);
+});
+
+test('normalizeValidateResult', () => {
+	// Test result with error property
+	const resultWithError = {
+		error: { formErrors: ['Error'], fieldErrors: {} },
+		value: { email: 'test@example.com' },
+	};
+	expect(normalizeValidateResult(resultWithError)).toEqual({
+		error: { formErrors: ['Error'], fieldErrors: {} },
+		value: { email: 'test@example.com' },
+	});
+
+	// Test direct error result
+	const directError: FormError<string> = {
+		formErrors: ['Direct error'],
+		fieldErrors: {},
+	};
+	expect(normalizeValidateResult(directError)).toEqual({
+		error: directError,
+	});
+
+	// Test null result
+	expect(normalizeValidateResult(null)).toEqual({
+		error: null,
+	});
+});
+
+test('resolveValidateResult', () => {
+	// Test Promise result
+	const promiseResult = Promise.resolve(null);
+	const resolved1 = resolveValidateResult(promiseResult);
+	expect(resolved1.syncResult).toBeUndefined();
+	expect(resolved1.asyncResult).toBeInstanceOf(Promise);
+
+	// Test Array result [sync, async]
+	const syncError: FormError<string> = {
+		formErrors: ['Sync error'],
+		fieldErrors: {},
+	};
+	const asyncPromise = Promise.resolve(null);
+	const resolved2 = resolveValidateResult([syncError, asyncPromise]);
+	expect(resolved2.syncResult).toEqual({ error: syncError });
+	expect(resolved2.asyncResult).toBeInstanceOf(Promise);
+
+	// Test direct result
+	const directError: FormError<string> = {
+		formErrors: ['Direct error'],
+		fieldErrors: {},
+	};
+	const resolved3 = resolveValidateResult(directError);
+	expect(resolved3.syncResult).toEqual({ error: directError });
+	expect(resolved3.asyncResult).toBeUndefined();
+});
+
+test('resolveStandardSchemaPath', () => {
+	// Test simple path
+	const issue1 = { path: ['email'], message: 'Required' };
+	expect(resolveStandardSchemaPath(issue1)).toEqual(['email']);
+
+	// Test nested path with objects
+	const issue2 = {
+		path: [{ key: 'profile' }, { key: 'name' }],
+		message: 'Required',
+	};
+	expect(resolveStandardSchemaPath(issue2)).toEqual(['profile', 'name']);
+
+	// Test mixed path
+	const issue3 = {
+		path: ['items', 0, { key: 'name' }],
+		message: 'Required',
+	};
+	expect(resolveStandardSchemaPath(issue3)).toEqual(['items', 0, 'name']);
+
+	// Test empty path
+	const issue4 = { path: [], message: 'Form error' };
+	expect(resolveStandardSchemaPath(issue4)).toEqual([]);
+
+	// Test undefined path
+	const issue5 = { message: 'Root error' };
+	expect(resolveStandardSchemaPath(issue5)).toEqual([]);
+
+	// Test symbol in path (should throw)
+	const symbolIssue = { path: [Symbol('test')], message: 'Error' };
+	expect(() => resolveStandardSchemaPath(symbolIssue)).toThrow(
+		'Path segments must not contain symbols',
+	);
+});
+
+test('resolveStandardSchemaResult', () => {
+	// Test success result
+	const successResult = {
+		value: { email: 'test@example.com' },
+	};
+	expect(resolveStandardSchemaResult(successResult)).toEqual({
+		error: null,
+		value: { email: 'test@example.com' },
+	});
+
+	// Test result with issues
+	const errorResult = {
+		issues: [
+			{ path: [], message: 'Form is invalid' },
+			{ path: ['email'], message: 'Email is required' },
+			{ path: ['email'], message: 'Invalid email format' },
+			{ path: ['profile', 'name'], message: 'Name is required' },
+		],
+	};
+	expect(resolveStandardSchemaResult(errorResult)).toEqual({
+		error: {
+			formErrors: ['Form is invalid'],
+			fieldErrors: {
+				email: ['Email is required', 'Invalid email format'],
+				'profile.name': ['Name is required'],
+			},
+		},
+	});
+});
+
+test('merge', () => {
+	const obj = { a: 1, b: 2, c: 3 };
+
+	// Test no changes
+	const result1 = merge(obj, {});
+	expect(result1).toBe(obj); // Same reference
+
+	// Test same values
+	const result2 = merge(obj, { a: 1, b: 2 });
+	expect(result2).toBe(obj); // Same reference
+
+	// Test with changes
+	const result3 = merge(obj, { b: 5, d: 4 } as any);
+	expect(result3).toEqual({ a: 1, b: 5, c: 3, d: 4 });
+	expect(result3).not.toBe(obj); // Different reference
+
+	// Test updating with same object reference
+	const result4 = merge(obj, obj);
+	expect(result4).toBe(obj);
+});
+
+test('transformKeys', () => {
+	const obj = {
+		'items[0].name': 'John',
+		'items[1].name': 'Jane',
+		'items[2].name': 'Bob',
+		other: 'value',
+	};
+
+	// Test key transformation
+	const result1 = transformKeys(obj, (key) =>
+		key.startsWith('items[')
+			? key.replace(/\[(\d+)\]/, (_, num) => `[${parseInt(num) + 1}]`)
+			: key,
+	);
+	expect(result1).toEqual({
+		'items[1].name': 'John',
+		'items[2].name': 'Jane',
+		'items[3].name': 'Bob',
+		other: 'value',
+	});
+
+	// Test filtering (null removal)
+	const result2 = transformKeys(obj, (key) =>
+		key === 'items[1].name' ? null : key,
+	);
+	expect(result2).toEqual({
+		'items[0].name': 'John',
+		'items[2].name': 'Bob',
+		other: 'value',
+	});
+});
+
+test('appendUniqueItem', () => {
+	const list = ['a', 'b', 'c'];
+
+	// Test adding new item
+	const result1 = appendUniqueItem(list, 'd');
+	expect(result1).toEqual(['a', 'b', 'c', 'd']);
+	expect(result1).not.toBe(list); // Different reference
+
+	// Test adding existing item
+	const result2 = appendUniqueItem(list, 'b');
+	expect(result2).toBe(list); // Same reference
+	expect(result2).toEqual(['a', 'b', 'c']);
+
+	// Test with empty list
+	const result3 = appendUniqueItem([], 'first');
+	expect(result3).toEqual(['first']);
+});
+
+test('compactMap', () => {
+	const list = ['a', 'b', 'c', 'd'];
+
+	// Test filtering and mapping
+	const result1 = compactMap(list, (item) =>
+		item === 'b' ? null : item.toUpperCase(),
+	);
+	expect(result1).toEqual(['A', 'C', 'D']);
+
+	// Test all items pass through
+	const result2 = compactMap(list, (item) => item + '!');
+	expect(result2).toEqual(['a!', 'b!', 'c!', 'd!']);
+
+	// Test all items filtered
+	const result3 = compactMap(list, () => null);
+	expect(result3).toEqual([]);
+
+	// Test empty list
+	const result4 = compactMap([], (item) => item);
+	expect(result4).toEqual([]);
+});
+
+test('generateUniqueKey', () => {
+	const key1 = generateUniqueKey();
+	const key2 = generateUniqueKey();
+
+	expect(typeof key1).toBe('string');
+	expect(typeof key2).toBe('string');
+	expect(key1).not.toBe(key2); // Should be unique
+	expect(key1.length).toBeGreaterThan(0);
+
+	// Test that it's base36
+	expect(key1).toMatch(/^[0-9a-z]+$/);
+});

--- a/packages/conform-zod/memoize.ts
+++ b/packages/conform-zod/memoize.ts
@@ -50,11 +50,12 @@ export function defaultEqualityCheck(prevArgs: any[], nextArgs: any[]) {
  * );
  *
  * // Usage in form validation
- * async onValidate({ value, error }) {
- *   if (value.username && !error.fieldErrors.username) {
+ * async onValidate({ payload, error }) {
+ *   if (payload.username && !error.fieldErrors.username) {
  *     const messages = await validateUsername(value.username);
  *     if (messages) error.fieldErrors.username = messages;
  *   }
+ *   return error;
  * }
  * ```
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,25 +473,25 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.2
-        version: 5.0.5(rollup@4.41.1)
+        version: 5.0.7(rollup@4.41.1)
       '@types/node':
         specifier: 18.x
-        version: 18.19.3
+        version: 18.19.123
       '@types/react':
         specifier: ^18.0.27
-        version: 18.3.1
+        version: 18.3.23
       '@types/react-dom':
         specifier: ^18.0.10
-        version: 18.3.0
+        version: 18.3.7(@types/react@18.3.23)
       '@vitejs/plugin-react':
         specifier: ^3.0.1
-        version: 3.1.0(vite@4.5.1(@types/node@18.19.3)(terser@5.26.0))
+        version: 3.1.0(vite@4.5.1(@types/node@18.19.123)(terser@5.26.0))
       typescript:
         specifier: ^4.9.5
         version: 4.9.5
       vite:
         specifier: ^4.0.4
-        version: 4.5.1(@types/node@18.19.3)(terser@5.26.0)
+        version: 4.5.1(@types/node@18.19.123)(terser@5.26.0)
 
   examples/remix:
     dependencies:
@@ -713,7 +713,7 @@ importers:
         version: 12.4.0
       '@remix-run/dev':
         specifier: ^2.5.1
-        version: 2.9.1(@remix-run/react@2.9.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.1(typescript@5.4.5))(@types/node@20.11.20)(terser@5.26.0)(typescript@5.4.5)(vite@5.1.4(@types/node@20.11.20)(terser@5.26.0))(wrangler@3.53.1(@cloudflare/workers-types@4.20240502.0))
+        version: 2.9.1(@remix-run/react@2.9.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.1(typescript@5.4.5))(@types/node@20.11.20)(terser@5.26.0)(typescript@5.4.5)(vite@5.4.19(@types/node@20.11.20)(terser@5.26.0))(wrangler@3.53.1(@cloudflare/workers-types@4.20240502.0))
       '@tailwindcss/forms':
         specifier: ^0.5.7
         version: 0.5.7(tailwindcss@3.4.3)
@@ -790,6 +790,9 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: ^13.3.0
         version: 13.3.0(rollup@2.79.1)
+      '@standard-schema/spec':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@types/react':
         specifier: ^18.2.43
         version: 18.3.1
@@ -988,7 +991,7 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.9.1
-        version: 2.9.1(@remix-run/react@2.9.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.1(typescript@5.4.5))(@types/node@20.11.20)(terser@5.26.0)(typescript@5.4.5)(vite@5.1.4(@types/node@20.11.20)(terser@5.26.0))(wrangler@3.53.1(@cloudflare/workers-types@4.20240502.0))
+        version: 2.9.1(@remix-run/react@2.9.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.1(typescript@5.4.5))(@types/node@20.11.20)(terser@5.26.0)(typescript@5.4.5)(vite@5.4.19(@types/node@20.11.20)(terser@5.26.0))(wrangler@3.53.1(@cloudflare/workers-types@4.20240502.0))
       '@tailwindcss/forms':
         specifier: ^0.5.2
         version: 0.5.7(tailwindcss@3.4.3)
@@ -1052,6 +1055,10 @@ packages:
     resolution: {integrity: sha512-hyrN8ivxfvJ4i0fIJuV4EOlV0WDMz5Ui4StRTgVaAvWeiRCilXgwVvxJKtFQ3TKtHgJscB2YiXKGNJuVwhQMtA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/core@7.28.3':
+    resolution: {integrity: sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/eslint-parser@7.23.3':
     resolution: {integrity: sha512-9bTuNlyx7oSstodm1cR1bECj4fkiknsDa1YniISkJemMY3DGhJNYBECbe6QD/q54mp2J8VO66jW3/7uP//iFCw==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
@@ -1065,6 +1072,10 @@ packages:
 
   '@babel/generator@7.27.3':
     resolution: {integrity: sha512-xnlJYj5zepml8NXtjkG0WquFUv8RskFqyFcVgTBp5k+NaA/8uw/K+OSVf8AMGw5e9HKP2ETd5xpK5MLZQD6b4Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.28.3':
+    resolution: {integrity: sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.22.5':
@@ -1108,6 +1119,10 @@ packages:
     resolution: {integrity: sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-hoist-variables@7.22.5':
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
     engines: {node: '>=6.9.0'}
@@ -1132,6 +1147,12 @@ packages:
 
   '@babel/helper-module-transforms@7.27.3':
     resolution: {integrity: sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-module-transforms@7.28.3':
+    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -1208,6 +1229,10 @@ packages:
     resolution: {integrity: sha512-h/eKy9agOya1IGuLaZ9tEUgz+uIRXcbtOhRtUyyMf8JFmn1iT13vnl/IGVWSkdOCG/pC57U4S1jnAabAavTMwg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helpers@7.28.3':
+    resolution: {integrity: sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/highlight@7.23.4':
     resolution: {integrity: sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==}
     engines: {node: '>=6.9.0'}
@@ -1219,6 +1244,11 @@ packages:
 
   '@babel/parser@7.27.3':
     resolution: {integrity: sha512-xyYxRj6+tLNDTWi0KCBcZ9V7yg3/lwL9DWh9Uwh/RIVlIfFidggcgxKX3GCXwCiswwcGRawBKbEg2LG/Y8eJhw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.28.3':
+    resolution: {integrity: sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1594,20 +1624,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx-self@7.23.3':
-    resolution: {integrity: sha512-qXRvbeKDSfwnlJnanVRp0SfuWE5DQhwQr5xtLBzp56Wabyo+4CMosF6Kfp+eOD/4FYpql64XVJ2W0pVLlJZxOQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-react-jsx-self@7.27.1':
     resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.23.3':
-    resolution: {integrity: sha512-91RS0MDnAWDNvGC6Wio5XYkyWI39FMFO+JK9+4AlgaTH+yWwVTsw7/sn6LK0lH7c5F+TFkpv/3LfCJ1Ydwof/g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1748,12 +1766,20 @@ packages:
     resolution: {integrity: sha512-lId/IfN/Ye1CIu8xG7oKBHXd2iNb2aW1ilPszzGcJug6M8RCKfVNcYhpI5+bMvFYjK7lXIM0R+a+6r8xhHp2FQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.28.3':
+    resolution: {integrity: sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.23.5':
     resolution: {integrity: sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.27.3':
     resolution: {integrity: sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.2':
+    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
 
   '@bundled-es-modules/cookie@2.0.1':
@@ -2461,8 +2487,8 @@ packages:
     peerDependencies:
       esbuild: '*'
 
-  '@esbuild/aix-ppc64@0.19.10':
-    resolution: {integrity: sha512-Q+mk96KJ+FZ30h9fsJl+67IjNJm3x2eX+GBWGmocAKgzp27cowCOOqSdscX80s0SpdFXZnIv/+1xD1EctFx96Q==}
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [aix]
@@ -2491,8 +2517,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.19.10':
-    resolution: {integrity: sha512-1X4CClKhDgC3by7k8aOWZeBXQX8dHT5QAMCAQDArCLaYfkppoARvh0fit3X2Qs+MXDngKcHv6XXyQCpY0hkK1Q==}
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -2521,8 +2547,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.19.10':
-    resolution: {integrity: sha512-7W0bK7qfkw1fc2viBfrtAEkDKHatYfHzr/jKAHNr9BvkYDXPcC6bodtm8AyLJNNuqClLNaeTLuwURt4PRT9d7w==}
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -2551,8 +2577,8 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.19.10':
-    resolution: {integrity: sha512-O/nO/g+/7NlitUxETkUv/IvADKuZXyH4BHf/g/7laqKC4i/7whLpB0gvpPc2zpF0q9Q6FXS3TS75QHac9MvVWw==}
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -2581,8 +2607,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.19.10':
-    resolution: {integrity: sha512-YSRRs2zOpwypck+6GL3wGXx2gNP7DXzetmo5pHXLrY/VIMsS59yKfjPizQ4lLt5vEI80M41gjm2BxrGZ5U+VMA==}
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -2611,8 +2637,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.19.10':
-    resolution: {integrity: sha512-alfGtT+IEICKtNE54hbvPg13xGBe4GkVxyGWtzr+yHO7HIiRJppPDhOKq3zstTcVf8msXb/t4eavW3jCDpMSmA==}
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -2641,8 +2667,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.19.10':
-    resolution: {integrity: sha512-dMtk1wc7FSH8CCkE854GyGuNKCewlh+7heYP/sclpOG6Cectzk14qdUIY5CrKDbkA/OczXq9WesqnPl09mj5dg==}
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -2671,8 +2697,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.19.10':
-    resolution: {integrity: sha512-G5UPPspryHu1T3uX8WiOEUa6q6OlQh6gNl4CO4Iw5PS+Kg5bVggVFehzXBJY6X6RSOMS8iXDv2330VzaObm4Ag==}
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -2701,8 +2727,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.19.10':
-    resolution: {integrity: sha512-QxaouHWZ+2KWEj7cGJmvTIHVALfhpGxo3WLmlYfJ+dA5fJB6lDEIg+oe/0//FuyVHuS3l79/wyBxbHr0NgtxJQ==}
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -2731,8 +2757,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.19.10':
-    resolution: {integrity: sha512-j6gUW5aAaPgD416Hk9FHxn27On28H4eVI9rJ4az7oCGTFW48+LcgNDBN+9f8rKZz7EEowo889CPKyeaD0iw9Kg==}
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -2761,8 +2787,8 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.19.10':
-    resolution: {integrity: sha512-4ub1YwXxYjj9h1UIZs2hYbnTZBtenPw5NfXCRgEkGb0b6OJ2gpkMvDqRDYIDRjRdWSe/TBiZltm3Y3Q8SN1xNg==}
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -2791,8 +2817,8 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.19.10':
-    resolution: {integrity: sha512-lo3I9k+mbEKoxtoIbM0yC/MZ1i2wM0cIeOejlVdZ3D86LAcFXFRdeuZmh91QJvUTW51bOK5W2BznGNIl4+mDaA==}
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -2821,8 +2847,8 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.19.10':
-    resolution: {integrity: sha512-J4gH3zhHNbdZN0Bcr1QUGVNkHTdpijgx5VMxeetSk6ntdt+vR1DqGmHxQYHRmNb77tP6GVvD+K0NyO4xjd7y4A==}
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -2851,8 +2877,8 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.19.10':
-    resolution: {integrity: sha512-tgT/7u+QhV6ge8wFMzaklOY7KqiyitgT1AUHMApau32ZlvTB/+efeCtMk4eXS+uEymYK249JsoiklZN64xt6oQ==}
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -2881,8 +2907,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.19.10':
-    resolution: {integrity: sha512-0f/spw0PfBMZBNqtKe5FLzBDGo0SKZKvMl5PHYQr3+eiSscfJ96XEknCe+JoOayybWUFQbcJTrk946i3j9uYZA==}
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -2911,8 +2937,8 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.19.10':
-    resolution: {integrity: sha512-pZFe0OeskMHzHa9U38g+z8Yx5FNCLFtUnJtQMpwhS+r4S566aK2ci3t4NCP4tjt6d5j5uo4h7tExZMjeKoehAA==}
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -2941,8 +2967,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.19.10':
-    resolution: {integrity: sha512-SpYNEqg/6pZYoc+1zLCjVOYvxfZVZj6w0KROZ3Fje/QrM3nfvT2llI+wmKSrWuX6wmZeTapbarvuNNK/qepSgA==}
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -2977,8 +3003,8 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.19.10':
-    resolution: {integrity: sha512-ACbZ0vXy9zksNArWlk2c38NdKg25+L9pr/mVaj9SUq6lHZu/35nx2xnQVRGLrC1KKQqJKRIB0q8GspiHI3J80Q==}
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -3013,8 +3039,8 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.19.10':
-    resolution: {integrity: sha512-PxcgvjdSjtgPMiPQrM3pwSaG4kGphP+bLSb+cihuP0LYdZv1epbAIecHVl5sD3npkfYBZ0ZnOjR878I7MdJDFg==}
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -3043,8 +3069,8 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.19.10':
-    resolution: {integrity: sha512-ZkIOtrRL8SEJjr+VHjmW0znkPs+oJXhlJbNwfI37rvgeMtk3sxOQevXPXjmAPZPigVTncvFqLMd+uV0IBSEzqA==}
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -3073,8 +3099,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.19.10':
-    resolution: {integrity: sha512-+Sa4oTDbpBfGpl3Hn3XiUe4f8TU2JF7aX8cOfqFYMMjXp6ma6NJDztl5FDG8Ezx0OjwGikIHw+iA54YLDNNVfw==}
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -3103,8 +3129,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.19.10':
-    resolution: {integrity: sha512-EOGVLK1oWMBXgfttJdPHDTiivYSjX6jDNaATeNOaCOFEVcfMjtbx7WVQwPSE1eIfCp/CaSF2nSrDtzc4I9f8TQ==}
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -3133,8 +3159,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.19.10':
-    resolution: {integrity: sha512-whqLG6Sc70AbU73fFYvuYzaE4MNMBIlR1Y/IrUeOXFrWHxBEjjbZaQ3IXIQS8wJdAzue2GwYZCjOrgrU1oUHoA==}
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -3327,6 +3353,9 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
   '@jridgewell/gen-mapping@0.3.3':
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
     engines: {node: '>=6.0.0'}
@@ -3350,9 +3379,6 @@ packages:
   '@jridgewell/source-map@0.3.5':
     resolution: {integrity: sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==}
 
-  '@jridgewell/sourcemap-codec@1.4.15':
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
@@ -3361,6 +3387,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@jridgewell/trace-mapping@0.3.30':
+    resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -5537,8 +5566,8 @@ packages:
     peerDependencies:
       rollup: ^2.42.0
 
-  '@rollup/plugin-replace@5.0.5':
-    resolution: {integrity: sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==}
+  '@rollup/plugin-replace@5.0.7':
+    resolution: {integrity: sha512-PqxSfuorkHz/SPpyngLyg5GCEkOcee9M1bkxiVDr41Pd61mqP1PLOoDPbpl44SB2mQGKwV/In74gqQmGITOhEQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
@@ -5556,8 +5585,8 @@ packages:
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
     engines: {node: '>= 8.0.0'}
 
-  '@rollup/pluginutils@5.1.0':
-    resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
+  '@rollup/pluginutils@5.2.0':
+    resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
@@ -5672,6 +5701,9 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
   '@swc/helpers@0.5.2':
     resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
 
@@ -5764,9 +5796,6 @@ packages:
   '@types/estree@0.0.39':
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
 
-  '@types/estree@1.0.5':
-    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
-
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
@@ -5827,11 +5856,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@18.19.3':
-    resolution: {integrity: sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==}
-
-  '@types/node@18.19.70':
-    resolution: {integrity: sha512-RE+K0+KZoEpDUbGGctnGdkrLFwi1eYKTlIHNl2Um98mUkGsm1u2Ff6Ltd0e8DktTtC98uy7rSj+hO8t/QuLoVQ==}
+  '@types/node@18.19.123':
+    resolution: {integrity: sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==}
 
   '@types/node@20.11.20':
     resolution: {integrity: sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==}
@@ -6522,9 +6548,6 @@ packages:
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
-
-  builtins@5.0.1:
-    resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -7221,8 +7244,8 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
-  esbuild@0.19.10:
-    resolution: {integrity: sha512-S1Y27QGt/snkNYrRcswgRFqZjaTG5a5xM3EQo97uNBnH505pdzSNe/HLBq1v0RO7iK/ngdbhJB6mDAp0OK+iUA==}
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
     hasBin: true
 
@@ -8573,10 +8596,6 @@ packages:
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
-
-  magic-string@0.30.5:
-    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
-    engines: {node: '>=12'}
 
   map-obj@1.0.1:
     resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}
@@ -10791,10 +10810,6 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
-  validate-npm-package-name@5.0.0:
-    resolution: {integrity: sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -10847,8 +10862,8 @@ packages:
       terser:
         optional: true
 
-  vite@5.1.4:
-    resolution: {integrity: sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==}
+  vite@5.4.19:
+    resolution: {integrity: sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -10856,6 +10871,7 @@ packages:
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
+      sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
       terser: ^5.4.0
@@ -10867,6 +10883,8 @@ packages:
       lightningcss:
         optional: true
       sass:
+        optional: true
+      sass-embedded:
         optional: true
       stylus:
         optional: true
@@ -11269,6 +11287,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/core@7.28.3':
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.3
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3)
+      '@babel/helpers': 7.28.3
+      '@babel/parser': 7.28.3
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.28.3
+      '@babel/types': 7.28.2
+      convert-source-map: 2.0.0
+      debug: 4.4.1
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/eslint-parser@7.23.3(@babel/core@7.23.5)(eslint@8.57.0)':
     dependencies:
       '@babel/core': 7.23.5
@@ -11290,6 +11328,14 @@ snapshots:
       '@babel/types': 7.27.3
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.0.2
+
+  '@babel/generator@7.28.3':
+    dependencies:
+      '@babel/parser': 7.28.3
+      '@babel/types': 7.28.2
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.30
       jsesc: 3.0.2
 
   '@babel/helper-annotate-as-pure@7.22.5':
@@ -11341,7 +11387,7 @@ snapshots:
       '@babel/core': 7.23.5
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.4.0
+      debug: 4.4.1
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -11353,6 +11399,8 @@ snapshots:
     dependencies:
       '@babel/template': 7.22.15
       '@babel/types': 7.23.5
+
+  '@babel/helper-globals@7.28.0': {}
 
   '@babel/helper-hoist-variables@7.22.5':
     dependencies:
@@ -11388,6 +11436,15 @@ snapshots:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
       '@babel/traverse': 7.27.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/traverse': 7.28.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11456,6 +11513,11 @@ snapshots:
       '@babel/template': 7.27.2
       '@babel/types': 7.27.3
 
+  '@babel/helpers@7.28.3':
+    dependencies:
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.2
+
   '@babel/highlight@7.23.4':
     dependencies:
       '@babel/helper-validator-identifier': 7.22.20
@@ -11469,6 +11531,10 @@ snapshots:
   '@babel/parser@7.27.3':
     dependencies:
       '@babel/types': 7.27.3
+
+  '@babel/parser@7.28.3':
+    dependencies:
+      '@babel/types': 7.28.2
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.23.3(@babel/core@7.23.5)':
     dependencies:
@@ -11840,24 +11906,24 @@ snapshots:
       '@babel/core': 7.23.5
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.23.5)
 
-  '@babel/plugin-transform-react-jsx-self@7.23.3(@babel/core@7.23.5)':
-    dependencies:
-      '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.22.5
-
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.27.3)':
     dependencies:
       '@babel/core': 7.27.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-source@7.23.3(@babel/core@7.23.5)':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.3)':
     dependencies:
-      '@babel/core': 7.23.5
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.27.3)':
     dependencies:
       '@babel/core': 7.27.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.23.5)':
@@ -12100,6 +12166,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.28.3':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.3
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.28.3
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.2
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.23.5':
     dependencies:
       '@babel/helper-string-parser': 7.23.4
@@ -12107,6 +12185,11 @@ snapshots:
       to-fast-properties: 2.0.0
 
   '@babel/types@7.27.3':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
+  '@babel/types@7.28.2':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
@@ -13192,7 +13275,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       rollup-plugin-node-polyfills: 0.2.1
 
-  '@esbuild/aix-ppc64@0.19.10':
+  '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
   '@esbuild/aix-ppc64@0.25.5':
@@ -13207,7 +13290,7 @@ snapshots:
   '@esbuild/android-arm64@0.18.20':
     optional: true
 
-  '@esbuild/android-arm64@0.19.10':
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.5':
@@ -13222,7 +13305,7 @@ snapshots:
   '@esbuild/android-arm@0.18.20':
     optional: true
 
-  '@esbuild/android-arm@0.19.10':
+  '@esbuild/android-arm@0.21.5':
     optional: true
 
   '@esbuild/android-arm@0.25.5':
@@ -13237,7 +13320,7 @@ snapshots:
   '@esbuild/android-x64@0.18.20':
     optional: true
 
-  '@esbuild/android-x64@0.19.10':
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.5':
@@ -13252,7 +13335,7 @@ snapshots:
   '@esbuild/darwin-arm64@0.18.20':
     optional: true
 
-  '@esbuild/darwin-arm64@0.19.10':
+  '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.5':
@@ -13267,7 +13350,7 @@ snapshots:
   '@esbuild/darwin-x64@0.18.20':
     optional: true
 
-  '@esbuild/darwin-x64@0.19.10':
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.5':
@@ -13282,7 +13365,7 @@ snapshots:
   '@esbuild/freebsd-arm64@0.18.20':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.19.10':
+  '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.5':
@@ -13297,7 +13380,7 @@ snapshots:
   '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
-  '@esbuild/freebsd-x64@0.19.10':
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.5':
@@ -13312,7 +13395,7 @@ snapshots:
   '@esbuild/linux-arm64@0.18.20':
     optional: true
 
-  '@esbuild/linux-arm64@0.19.10':
+  '@esbuild/linux-arm64@0.21.5':
     optional: true
 
   '@esbuild/linux-arm64@0.25.5':
@@ -13327,7 +13410,7 @@ snapshots:
   '@esbuild/linux-arm@0.18.20':
     optional: true
 
-  '@esbuild/linux-arm@0.19.10':
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.5':
@@ -13342,7 +13425,7 @@ snapshots:
   '@esbuild/linux-ia32@0.18.20':
     optional: true
 
-  '@esbuild/linux-ia32@0.19.10':
+  '@esbuild/linux-ia32@0.21.5':
     optional: true
 
   '@esbuild/linux-ia32@0.25.5':
@@ -13357,7 +13440,7 @@ snapshots:
   '@esbuild/linux-loong64@0.18.20':
     optional: true
 
-  '@esbuild/linux-loong64@0.19.10':
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.5':
@@ -13372,7 +13455,7 @@ snapshots:
   '@esbuild/linux-mips64el@0.18.20':
     optional: true
 
-  '@esbuild/linux-mips64el@0.19.10':
+  '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.5':
@@ -13387,7 +13470,7 @@ snapshots:
   '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
-  '@esbuild/linux-ppc64@0.19.10':
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.5':
@@ -13402,7 +13485,7 @@ snapshots:
   '@esbuild/linux-riscv64@0.18.20':
     optional: true
 
-  '@esbuild/linux-riscv64@0.19.10':
+  '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.5':
@@ -13417,7 +13500,7 @@ snapshots:
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
-  '@esbuild/linux-s390x@0.19.10':
+  '@esbuild/linux-s390x@0.21.5':
     optional: true
 
   '@esbuild/linux-s390x@0.25.5':
@@ -13432,7 +13515,7 @@ snapshots:
   '@esbuild/linux-x64@0.18.20':
     optional: true
 
-  '@esbuild/linux-x64@0.19.10':
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.5':
@@ -13450,7 +13533,7 @@ snapshots:
   '@esbuild/netbsd-x64@0.18.20':
     optional: true
 
-  '@esbuild/netbsd-x64@0.19.10':
+  '@esbuild/netbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.5':
@@ -13468,7 +13551,7 @@ snapshots:
   '@esbuild/openbsd-x64@0.18.20':
     optional: true
 
-  '@esbuild/openbsd-x64@0.19.10':
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.5':
@@ -13483,7 +13566,7 @@ snapshots:
   '@esbuild/sunos-x64@0.18.20':
     optional: true
 
-  '@esbuild/sunos-x64@0.19.10':
+  '@esbuild/sunos-x64@0.21.5':
     optional: true
 
   '@esbuild/sunos-x64@0.25.5':
@@ -13498,7 +13581,7 @@ snapshots:
   '@esbuild/win32-arm64@0.18.20':
     optional: true
 
-  '@esbuild/win32-arm64@0.19.10':
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.5':
@@ -13513,7 +13596,7 @@ snapshots:
   '@esbuild/win32-ia32@0.18.20':
     optional: true
 
-  '@esbuild/win32-ia32@0.19.10':
+  '@esbuild/win32-ia32@0.21.5':
     optional: true
 
   '@esbuild/win32-ia32@0.25.5':
@@ -13528,7 +13611,7 @@ snapshots:
   '@esbuild/win32-x64@0.18.20':
     optional: true
 
-  '@esbuild/win32-x64@0.19.10':
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.5':
@@ -13751,10 +13834,15 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/trace-mapping': 0.3.30
+
   '@jridgewell/gen-mapping@0.3.3':
     dependencies:
       '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.20
 
   '@jridgewell/gen-mapping@0.3.8':
@@ -13771,20 +13859,23 @@ snapshots:
 
   '@jridgewell/source-map@0.3.5':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.30
     optional: true
-
-  '@jridgewell/sourcemap-codec@1.4.15': {}
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/trace-mapping@0.3.20':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   '@jridgewell/trace-mapping@0.3.25':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@jridgewell/trace-mapping@0.3.30':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -14050,7 +14141,7 @@ snapshots:
   '@npmcli/package-json@4.0.1':
     dependencies:
       '@npmcli/git': 4.1.0
-      glob: 10.3.10
+      glob: 10.4.5
       hosted-git-info: 6.1.1
       json-parse-even-better-errors: 3.0.1
       normalize-package-data: 5.0.0
@@ -16565,7 +16656,7 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@remix-run/dev@2.9.1(@remix-run/react@2.9.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.1(typescript@5.4.5))(@types/node@20.11.20)(terser@5.26.0)(typescript@5.4.5)(vite@5.1.4(@types/node@20.11.20)(terser@5.26.0))(wrangler@3.53.1(@cloudflare/workers-types@4.20240502.0))':
+  '@remix-run/dev@2.9.1(@remix-run/react@2.9.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.1(typescript@5.4.5))(@types/node@20.11.20)(terser@5.26.0)(typescript@5.4.5)(vite@5.4.19(@types/node@20.11.20)(terser@5.26.0))(wrangler@3.53.1(@cloudflare/workers-types@4.20240502.0))':
     dependencies:
       '@babel/core': 7.23.5
       '@babel/generator': 7.23.5
@@ -16624,7 +16715,7 @@ snapshots:
     optionalDependencies:
       '@remix-run/serve': 2.9.1(typescript@5.4.5)
       typescript: 5.4.5
-      vite: 5.1.4(@types/node@20.11.20)(terser@5.26.0)
+      vite: 5.4.19(@types/node@20.11.20)(terser@5.26.0)
       wrangler: 3.53.1(@cloudflare/workers-types@4.20240502.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -16834,10 +16925,10 @@ snapshots:
       resolve: 1.22.8
       rollup: 2.79.1
 
-  '@rollup/plugin-replace@5.0.5(rollup@4.41.1)':
+  '@rollup/plugin-replace@5.0.7(rollup@4.41.1)':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.41.1)
-      magic-string: 0.30.5
+      '@rollup/pluginutils': 5.2.0(rollup@4.41.1)
+      magic-string: 0.30.17
     optionalDependencies:
       rollup: 4.41.1
 
@@ -16853,11 +16944,11 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 2.3.1
 
-  '@rollup/pluginutils@5.1.0(rollup@4.41.1)':
+  '@rollup/pluginutils@5.2.0(rollup@4.41.1)':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.7
       estree-walker: 2.0.2
-      picomatch: 2.3.1
+      picomatch: 4.0.2
     optionalDependencies:
       rollup: 4.41.1
 
@@ -16925,6 +17016,8 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@standard-schema/spec@1.0.0': {}
+
   '@swc/helpers@0.5.2':
     dependencies:
       tslib: 2.6.2
@@ -16987,7 +17080,7 @@ snapshots:
 
   '@types/acorn@4.0.6':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.7
 
   '@types/aria-query@5.0.4': {}
 
@@ -17035,15 +17128,13 @@ snapshots:
 
   '@types/estree-jsx@0.0.1':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.7
 
   '@types/estree-jsx@1.0.3':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.7
 
   '@types/estree@0.0.39': {}
-
-  '@types/estree@1.0.5': {}
 
   '@types/estree@1.0.7': {}
 
@@ -17054,7 +17145,7 @@ snapshots:
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.19.70
+      '@types/node': 20.11.20
 
   '@types/hast@2.3.8':
     dependencies:
@@ -17105,11 +17196,7 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@18.19.3':
-    dependencies:
-      undici-types: 5.26.5
-
-  '@types/node@18.19.70':
+  '@types/node@18.19.123':
     dependencies:
       undici-types: 5.26.5
 
@@ -17310,7 +17397,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.33.0(typescript@5.4.5)
       '@typescript-eslint/types': 8.33.0
-      debug: 4.4.0
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -17319,7 +17406,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.33.0(typescript@5.8.3)
       '@typescript-eslint/types': 8.33.0
-      debug: 4.4.0
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -17356,7 +17443,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
-      debug: 4.4.0
+      debug: 4.4.1
       eslint: 8.57.0
       tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
@@ -17380,7 +17467,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.33.0(typescript@5.4.5)
       '@typescript-eslint/utils': 8.33.0(eslint@9.27.0(jiti@1.21.0))(typescript@5.4.5)
-      debug: 4.4.0
+      debug: 4.4.1
       eslint: 9.27.0(jiti@1.21.0)
       ts-api-utils: 2.1.0(typescript@5.4.5)
       typescript: 5.4.5
@@ -17391,7 +17478,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.33.0(typescript@5.8.3)
       '@typescript-eslint/utils': 8.33.0(eslint@9.27.0(jiti@1.21.0))(typescript@5.8.3)
-      debug: 4.4.0
+      debug: 4.4.1
       eslint: 9.27.0(jiti@1.21.0)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
@@ -17410,7 +17497,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.0
+      debug: 4.4.1
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.2
@@ -17424,7 +17511,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.20.0
       '@typescript-eslint/visitor-keys': 6.20.0
-      debug: 4.3.4
+      debug: 4.4.1
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -17456,7 +17543,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.33.0(typescript@5.4.5)
       '@typescript-eslint/types': 8.33.0
       '@typescript-eslint/visitor-keys': 8.33.0
-      debug: 4.4.0
+      debug: 4.4.1
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -17472,7 +17559,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.33.0(typescript@5.8.3)
       '@typescript-eslint/types': 8.33.0
       '@typescript-eslint/visitor-keys': 8.33.0
-      debug: 4.4.0
+      debug: 4.4.1
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -17599,14 +17686,14 @@ snapshots:
 
   '@vanilla-extract/private@1.0.3': {}
 
-  '@vitejs/plugin-react@3.1.0(vite@4.5.1(@types/node@18.19.3)(terser@5.26.0))':
+  '@vitejs/plugin-react@3.1.0(vite@4.5.1(@types/node@18.19.123)(terser@5.26.0))':
     dependencies:
-      '@babel/core': 7.23.5
-      '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.5)
-      '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.5)
+      '@babel/core': 7.28.3
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.3)
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.5.1(@types/node@18.19.3)(terser@5.26.0)
+      vite: 4.5.1(@types/node@18.19.123)(terser@5.26.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17746,7 +17833,7 @@ snapshots:
 
   agent-base@7.1.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -18113,10 +18200,6 @@ snapshots:
 
   builtin-modules@3.3.0: {}
 
-  builtins@5.0.1:
-    dependencies:
-      semver: 7.6.2
-
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
@@ -18211,7 +18294,7 @@ snapshots:
 
   capnp-ts@0.7.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
@@ -18984,31 +19067,31 @@ snapshots:
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
 
-  esbuild@0.19.10:
+  esbuild@0.21.5:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.19.10
-      '@esbuild/android-arm': 0.19.10
-      '@esbuild/android-arm64': 0.19.10
-      '@esbuild/android-x64': 0.19.10
-      '@esbuild/darwin-arm64': 0.19.10
-      '@esbuild/darwin-x64': 0.19.10
-      '@esbuild/freebsd-arm64': 0.19.10
-      '@esbuild/freebsd-x64': 0.19.10
-      '@esbuild/linux-arm': 0.19.10
-      '@esbuild/linux-arm64': 0.19.10
-      '@esbuild/linux-ia32': 0.19.10
-      '@esbuild/linux-loong64': 0.19.10
-      '@esbuild/linux-mips64el': 0.19.10
-      '@esbuild/linux-ppc64': 0.19.10
-      '@esbuild/linux-riscv64': 0.19.10
-      '@esbuild/linux-s390x': 0.19.10
-      '@esbuild/linux-x64': 0.19.10
-      '@esbuild/netbsd-x64': 0.19.10
-      '@esbuild/openbsd-x64': 0.19.10
-      '@esbuild/sunos-x64': 0.19.10
-      '@esbuild/win32-arm64': 0.19.10
-      '@esbuild/win32-ia32': 0.19.10
-      '@esbuild/win32-x64': 0.19.10
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
     optional: true
 
   esbuild@0.25.5:
@@ -19530,7 +19613,7 @@ snapshots:
 
   estree-util-attach-comments@2.1.1:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.7
 
   estree-util-build-jsx@2.2.2:
     dependencies:
@@ -19565,7 +19648,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.7
 
   esutils@2.0.3: {}
 
@@ -19901,7 +19984,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.3
       data-uri-to-buffer: 6.0.1
-      debug: 4.4.0
+      debug: 4.4.1
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -20085,7 +20168,7 @@ snapshots:
 
   hast-util-to-estree@2.3.3:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.7
       '@types/estree-jsx': 1.0.3
       '@types/hast': 2.3.8
       '@types/unist': 2.0.10
@@ -20157,7 +20240,7 @@ snapshots:
   http-proxy-agent@7.0.0:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.4.0
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -20177,7 +20260,7 @@ snapshots:
   https-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.4.0
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -20412,7 +20495,7 @@ snapshots:
 
   is-reference@3.0.2:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.7
 
   is-regex@1.1.4:
     dependencies:
@@ -20749,15 +20832,11 @@ snapshots:
 
   magic-string@0.27.0:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-
-  magic-string@0.30.5:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
 
   map-obj@1.0.1: {}
 
@@ -20961,7 +21040,7 @@ snapshots:
 
   micromark-extension-mdx-expression@1.0.8:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.7
       micromark-factory-mdx-expression: 1.0.9
       micromark-factory-space: 1.1.0
       micromark-util-character: 1.2.0
@@ -20973,7 +21052,7 @@ snapshots:
   micromark-extension-mdx-jsx@1.0.5:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.7
       estree-util-is-identifier-name: 2.1.0
       micromark-factory-mdx-expression: 1.0.9
       micromark-factory-space: 1.1.0
@@ -20989,7 +21068,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@1.0.5:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.7
       micromark-core-commonmark: 1.1.0
       micromark-util-character: 1.2.0
       micromark-util-events-to-acorn: 1.2.3
@@ -21025,7 +21104,7 @@ snapshots:
 
   micromark-factory-mdx-expression@1.0.9:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.7
       micromark-util-character: 1.2.0
       micromark-util-events-to-acorn: 1.2.3
       micromark-util-symbol: 1.1.0
@@ -21089,7 +21168,7 @@ snapshots:
   micromark-util-events-to-acorn@1.2.3:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.7
       '@types/unist': 2.0.10
       estree-util-visit: 1.2.1
       micromark-util-symbol: 1.1.0
@@ -21127,7 +21206,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.0
+      debug: 4.4.1
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -21408,7 +21487,7 @@ snapshots:
       hosted-git-info: 6.1.1
       proc-log: 3.0.0
       semver: 7.6.2
-      validate-npm-package-name: 5.0.0
+      validate-npm-package-name: 5.0.1
 
   npm-pick-manifest@8.0.2:
     dependencies:
@@ -21589,7 +21668,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.0
-      debug: 4.4.0
+      debug: 4.4.1
       get-uri: 6.0.2
       http-proxy-agent: 7.0.0
       https-proxy-agent: 7.0.2
@@ -21689,7 +21768,7 @@ snapshots:
 
   periscopic@3.1.0:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.7
       estree-walker: 3.0.3
       is-reference: 3.0.2
 
@@ -22761,7 +22840,7 @@ snapshots:
   socks-proxy-agent@8.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.4.0
+      debug: 4.4.1
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -23530,10 +23609,6 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  validate-npm-package-name@5.0.0:
-    dependencies:
-      builtins: 5.0.1
-
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
@@ -23553,7 +23628,7 @@ snapshots:
   vite-node@0.28.5(@types/node@20.11.20)(terser@5.26.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0
+      debug: 4.4.1
       mlly: 1.4.2
       pathe: 1.1.2
       picocolors: 1.1.1
@@ -23591,29 +23666,29 @@ snapshots:
       - tsx
       - yaml
 
-  vite@4.5.1(@types/node@18.19.3)(terser@5.26.0):
+  vite@4.5.1(@types/node@18.19.123)(terser@5.26.0):
     dependencies:
       esbuild: 0.18.20
-      postcss: 8.4.38
+      postcss: 8.5.4
       rollup: 3.29.4
     optionalDependencies:
-      '@types/node': 18.19.3
+      '@types/node': 18.19.123
       fsevents: 2.3.3
       terser: 5.26.0
 
   vite@4.5.1(@types/node@20.11.20)(terser@5.26.0):
     dependencies:
       esbuild: 0.18.20
-      postcss: 8.4.38
+      postcss: 8.5.4
       rollup: 3.29.4
     optionalDependencies:
       '@types/node': 20.11.20
       fsevents: 2.3.3
       terser: 5.26.0
 
-  vite@5.1.4(@types/node@20.11.20)(terser@5.26.0):
+  vite@5.4.19(@types/node@20.11.20)(terser@5.26.0):
     dependencies:
-      esbuild: 0.19.10
+      esbuild: 0.21.5
       postcss: 8.5.4
       rollup: 4.41.1
     optionalDependencies:


### PR DESCRIPTION
This PR adds four new React hooks for form management:

- `useForm`: Main hook for form state, validation, and submission
- `useFormMetadata`: Access form-level metadata (errors, validation state)
- `useField`: Access individual field metadata with auto-generated IDs
- `useIntent`: Create intent dispatchers for programmatic form actions

More details on the blog post soon. Existing examples will also be updated.