### PR TITLE
docs: add FormProvider details

### DIFF
--- a/docs/api/react/future/FormProvider.md
+++ b/docs/api/react/future/FormProvider.md
@@ -1,0 +1,70 @@
+# FormProvider
+
+> The `FormProvider` component is part of Conform's future export. These APIs are experimental and may change in minor versions. [Learn more](https://github.com/edmundhung/conform/discussions/954)
+
+A React component that renders a [Context Provider](https://react.dev/reference/react/createContext#provider) for the form context. It is required if you want to use [useField](./useField.md) or [useFormMetadata](./useFormMetadata.md) hook.
+
+```tsx
+import { FormProvider, useForm } from '@conform-to/react/future';
+
+export default function SomeParent() {
+  const { form } = useForm();
+
+  return <FormProvider context={form.context}>{/* ... */}</FormProvider>;
+}
+```
+
+## Props
+
+### `context`
+
+The form context. It is created with [useForm](./useForm.md) and can be accessed through `form.context`.
+
+## Tips
+
+### FormProvider can be nested
+
+This is useful if you need to have one form inside another due to layout constraints.
+
+```tsx
+import { FormProvider, useForm, useField } from '@conform-to/react/future';
+
+function Layout({ children }) {
+  const { form, fields } = useForm({ id: 'search' });
+
+  return (
+    <FormProvider context={form.context}>
+      <aside>
+        <form {...form.props}>
+          <Field name={fields.query.name} />
+          <button>Search</button>
+        </form>
+      </aside>
+      <main>{children}</main>
+    </FormProvider>
+  );
+}
+
+function LoginForm() {
+  const { form, fields } = useForm({ id: 'login' });
+
+  return (
+    <Layout>
+      <FormProvider context={form.context}>
+        <form {...form.props}>
+          <Field name={fields.username.name} />
+          <Field name={fields.password.name} />
+          <button>Login</button>
+        </form>
+      </FormProvider>
+    </Layout>
+  );
+}
+
+function Field({ name, formId }) {
+  //  useField will look for the closest FormContext if no formId is provided
+  const field = useField(name, { formId });
+
+  return <input name={field.name} form={field.form} />;
+}
+```

--- a/docs/api/react/future/useForm.md
+++ b/docs/api/react/future/useForm.md
@@ -7,7 +7,7 @@ The main React hook for form management. Handles form state, validation, and sub
 ```ts
 import { useForm } from '@conform-to/react/future';
 
-const { form, fields, intent, context } = useForm(options);
+const { form, fields, intent } = useForm(options);
 ```
 
 ## Options
@@ -77,10 +77,6 @@ Form-level metadata and state. See [`useFormMetadata`](./useFormMetadata.md) for
 ### `fields: Fieldset<FormShape>`
 
 Fieldset object containing all form fields as properties. Equivalent to calling `form.getFieldset()` without a name. Access field metadata via `fields.fieldName`. See [`useField`](./useField.md) for field metadata documentation.
-
-### `context: FormContext<FormShape, ErrorShape>`
-
-Form context object for use with [`FormProvider`](#formprovider). Required when using [`useField`](./useField.md) or [`useFormMetadata`](./useFormMetadata.md) in child components.
 
 ### `intent: IntentDispatcher`
 

--- a/docs/api/react/future/useFormMetadata.md
+++ b/docs/api/react/future/useFormMetadata.md
@@ -40,7 +40,7 @@ Form-level validation errors, if any exist.
 
 Object containing field-specific validation errors for all validated fields.
 
-### `props`
+### `props: FormProps`
 
 Form props object for spreading onto the `<form>` element:
 
@@ -53,6 +53,10 @@ Form props object for spreading onto the `<form>` element:
   noValidate: boolean;
 }
 ```
+
+### `context: FormContext<FormShape, ErrorShape>`
+
+Form context object for use with [`FormProvider`](./FormProvider.md). Required when using [`useField`](./useField.md) or [`useFormMetadata`](./useFormMetadata.md) in child components.
 
 ### `getField<FieldShape>(name): Field<FieldShape>`
 

--- a/guide/app/layout.tsx
+++ b/guide/app/layout.tsx
@@ -62,6 +62,7 @@ const menus: { [code: string]: Menu[] } = {
 				{ title: 'parseSubmission', to: '/api/react/future/parseSubmission' },
 				{ title: 'report', to: '/api/react/future/report' },
 				{ title: 'isDirty', to: '/api/react/future/isDirty' },
+				{ title: 'FormProvider', to: '/api/react/future/FormProvider' },
 			],
 		},
 		{


### PR DESCRIPTION
This is pretty much copied from the v1 FormProvider docs, except using future APIs in the example.