### PR TITLE
feat(conform-valibot): add formatResult helpers

### DIFF
--- a/packages/conform-valibot/format.ts
+++ b/packages/conform-valibot/format.ts
@@ -1,0 +1,100 @@
+import {
+	type BaseIssue,
+	GenericSchema,
+	GenericSchemaAsync,
+	SafeParseResult,
+} from 'valibot';
+import { appendPathSegment, type FormError } from '@conform-to/dom/future';
+
+export function formatResult(
+	result: SafeParseResult<GenericSchema | GenericSchemaAsync>,
+): FormError<string> | null;
+export function formatResult<Output, ErrorShape = string>(
+	result: SafeParseResult<GenericSchema | GenericSchemaAsync>,
+	options: {
+		/** Whether to include the parsed value in the returned object */
+		includeValue: true;
+		/** Custom function to format validation issues for each field */
+		formatIssues: (issue: BaseIssue<unknown>[], name: string) => ErrorShape[];
+	},
+): {
+	error: FormError<ErrorShape> | null;
+	value: Output | undefined;
+};
+export function formatResult<Output>(
+	result: SafeParseResult<GenericSchema | GenericSchemaAsync>,
+	options: {
+		includeValue: true;
+		formatIssues?: undefined;
+	},
+): {
+	error: FormError<string> | null;
+	value: Output | undefined;
+};
+export function formatResult<ErrorShape = string>(
+	result: SafeParseResult<GenericSchema | GenericSchemaAsync>,
+	options: {
+		includeValue?: false;
+		formatIssues: (issue: BaseIssue<unknown>[], name: string) => ErrorShape[];
+	},
+): FormError<ErrorShape> | null;
+export function formatResult<Output, ErrorShape = string>(
+	result: SafeParseResult<GenericSchema | GenericSchemaAsync>,
+	options?: {
+		includeValue?: boolean;
+		formatIssues?: (issue: BaseIssue<unknown>[], name: string) => ErrorShape[];
+	},
+):
+	| FormError<string | ErrorShape>
+	| {
+			error: FormError<string | ErrorShape> | null;
+			value: Output | undefined;
+	  }
+	| null {
+	let error: FormError<string | ErrorShape> | null = null;
+
+	if (!result.success) {
+		const errorByName: Record<string, BaseIssue<unknown>[]> = {};
+		for (const issue of result.issues) {
+			if (!issue.path) {
+				errorByName[''] ??= [];
+				errorByName[''].push(issue);
+				continue;
+			}
+
+			const name = issue.path.reduce<string>((name, segment) => {
+				return appendPathSegment(name, segment.key as string | number);
+			}, '');
+
+			errorByName[name] ??= [];
+			errorByName[name].push(issue);
+		}
+
+		const { '': formErrors = [], ...fieldErrors } = Object.entries(
+			errorByName,
+		).reduce<Record<string, string[] | ErrorShape[]>>(
+			(result, [name, issues]) => {
+				result[name] = options?.formatIssues
+					? options.formatIssues(issues, name)
+					: issues.map((issue) => issue.message);
+
+				return result;
+			},
+			{},
+		);
+
+		error = {
+			formErrors,
+			fieldErrors,
+		};
+	}
+
+	if (options?.includeValue) {
+		return {
+			error,
+			value: result.success ? (result.output as Output) : undefined,
+		};
+	}
+
+	return error;
+}

--- a/packages/conform-valibot/future.ts
+++ b/packages/conform-valibot/future.ts
@@ -1,0 +1,3 @@
+export { getValibotConstraint } from './constraint';
+export { coerceFormValue } from './coercion';
+export { formatResult } from './format';

--- a/packages/conform-valibot/package.json
+++ b/packages/conform-valibot/package.json
@@ -14,6 +14,13 @@
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.js",
 			"default": "./dist/index.mjs"
+		},
+		"./future": {
+			"types": "./dist/future.d.ts",
+			"module": "./dist/future.mjs",
+			"import": "./dist/future.mjs",
+			"require": "./dist/future.js",
+			"default": "./dist/future.mjs"
 		}
 	},
 	"files": [

--- a/packages/conform-valibot/rollup.config.js
+++ b/packages/conform-valibot/rollup.config.js
@@ -13,7 +13,10 @@ function configurePackage() {
 		external(id) {
 			return !id.startsWith('.') && !path.isAbsolute(id);
 		},
-		input: `${sourceDir}/index.ts`,
+		input: [
+			`${sourceDir}/index.ts`,
+			`${sourceDir}/future.ts`,
+		],
 		output: {
 			dir: outputDir,
 			format: 'esm',
@@ -58,7 +61,10 @@ function configurePackage() {
 		external(id) {
 			return !id.startsWith('.') && !path.isAbsolute(id);
 		},
-		input: `${sourceDir}/index.ts`,
+		input: [
+			`${sourceDir}/index.ts`,
+			`${sourceDir}/future.ts`,
+		],
 		output: {
 			dir: outputDir,
 			format: 'cjs',

--- a/packages/conform-valibot/tests/format.test.ts
+++ b/packages/conform-valibot/tests/format.test.ts
@@ -1,0 +1,242 @@
+import { describe, test, expect } from 'vitest';
+import { formatResult } from '../format';
+import * as v from 'valibot';
+
+describe('formatResult', () => {
+	test('returns null for successful validation', () => {
+		const schema = v.object({ name: v.string() });
+		const result = v.safeParse(schema, { name: 'John' });
+		const formatted = formatResult(result);
+
+		expect(formatted).toBeNull();
+	});
+
+	test('returns error and value with includeValue option', () => {
+		const schema = v.object({ name: v.string(), age: v.number() });
+		const result = v.safeParse(schema, { name: 'John', age: 25 });
+		const formatted = formatResult(result, { includeValue: true });
+
+		expect(formatted).toEqual({
+			error: null,
+			value: { name: 'John', age: 25 },
+		});
+	});
+
+	test('formats field errors', () => {
+		const schema = v.object({
+			name: v.pipe(v.string(), v.minLength(1, 'Name is required')),
+			age: v.pipe(v.number(), v.minValue(18, 'Must be at least 18')),
+		});
+		const result = v.safeParse(schema, { name: '', age: 16 });
+		const formatted = formatResult(result);
+
+		expect(formatted).toEqual({
+			formErrors: [],
+			fieldErrors: {
+				name: ['Name is required'],
+				age: ['Must be at least 18'],
+			},
+		});
+	});
+
+	test('formats nested field errors', () => {
+		const schema = v.object({
+			user: v.object({
+				name: v.pipe(v.string(), v.minLength(1, 'Name is required')),
+				email: v.pipe(v.string(), v.email('Invalid email')),
+			}),
+		});
+		const result = v.safeParse(schema, {
+			user: { name: '', email: 'invalid' },
+		});
+		const formatted = formatResult(result);
+
+		expect(formatted).toEqual({
+			formErrors: [],
+			fieldErrors: {
+				'user.name': ['Name is required'],
+				'user.email': ['Invalid email'],
+			},
+		});
+	});
+
+	test('formats array field errors', () => {
+		const schema = v.object({
+			items: v.array(
+				v.pipe(v.string(), v.minLength(1, 'Item cannot be empty')),
+			),
+		});
+		const result = v.safeParse(schema, { items: ['', 'valid', ''] });
+
+		const formatted = formatResult(result);
+
+		expect(formatted).toEqual({
+			formErrors: [],
+			fieldErrors: {
+				'items[0]': ['Item cannot be empty'],
+				'items[2]': ['Item cannot be empty'],
+			},
+		});
+	});
+
+	test('formats form-level errors', () => {
+		const schema = v.pipe(
+			v.object({
+				password: v.string(),
+				confirmPassword: v.string(),
+			}),
+			v.check(
+				(data) => data.password === data.confirmPassword,
+				'Passwords do not match',
+			),
+		);
+		const result = v.safeParse(schema, {
+			password: 'secret',
+			confirmPassword: 'different',
+		});
+		const formatted = formatResult(result);
+
+		expect(formatted).toEqual({
+			formErrors: ['Passwords do not match'],
+			fieldErrors: {},
+		});
+	});
+
+	test('includes value with includeValue when validation fails', () => {
+		const schema = v.object({
+			name: v.pipe(v.string(), v.minLength(1, 'Name is required')),
+		});
+		const result = v.safeParse(schema, { name: '' });
+
+		const formatted = formatResult(result, { includeValue: true });
+
+		expect(formatted).toEqual({
+			error: {
+				formErrors: [],
+				fieldErrors: {
+					name: ['Name is required'],
+				},
+			},
+			value: undefined,
+		});
+	});
+
+	test('uses custom formatIssues function', () => {
+		const schema = v.object({
+			name: v.pipe(v.string(), v.minLength(1, 'Name is required')),
+			age: v.pipe(v.number(), v.minValue(18, 'Must be at least 18')),
+		});
+		const result = v.safeParse(schema, { name: '', age: 16 });
+
+		const formatted = formatResult(result, {
+			formatIssues: (issues, name) =>
+				issues.map((issue) => ({
+					message: issue.message,
+					expected: issue.expected,
+					field: name,
+				})),
+		});
+
+		expect(formatted).toEqual({
+			formErrors: [],
+			fieldErrors: {
+				name: [
+					{
+						message: 'Name is required',
+						expected: '>=1',
+						field: 'name',
+					},
+				],
+				age: [
+					{
+						message: 'Must be at least 18',
+						expected: '>=18',
+						field: 'age',
+					},
+				],
+			},
+		});
+	});
+
+	test('combines custom formatIssues with includeValue', () => {
+		const schema = v.object({
+			email: v.pipe(v.string(), v.email('Invalid email')),
+		});
+		const result = v.safeParse(schema, { email: 'invalid' });
+
+		const formatted = formatResult(result, {
+			includeValue: true,
+			formatIssues: (issues) => issues.map((issue) => issue.received),
+		});
+
+		expect(formatted).toEqual({
+			error: {
+				formErrors: [],
+				fieldErrors: {
+					email: ['"invalid"'],
+				},
+			},
+			value: undefined,
+		});
+	});
+
+	test('aggregates multiple issues per field with custom formatIssues', () => {
+		const schema = v.object({
+			password: v.pipe(
+				v.string(),
+				v.minLength(8, 'Too short'),
+				v.regex(/[A-Z]/, 'Must contain uppercase'),
+				v.regex(/[0-9]/, 'Must contain number'),
+			),
+		});
+		const result = v.safeParse(schema, { password: 'abc' });
+
+		const formatted = formatResult(result, {
+			formatIssues: (issues, fieldName) => [
+				`${fieldName} has ${issues.length} errors: ${issues.map((i) => i.message).join(', ')}`,
+			],
+		});
+
+		expect(formatted).toEqual({
+			formErrors: [],
+			fieldErrors: {
+				password: [
+					'password has 3 errors: Too short, Must contain uppercase, Must contain number',
+				],
+			},
+		});
+	});
+
+	test('preserves form-level error structure when no field errors exist', () => {
+		const schema = v.pipe(
+			v.string(),
+			v.check(() => false, 'Always fails'),
+		);
+		const result = v.safeParse(schema, 'test');
+
+		const formatted = formatResult(result);
+
+		expect(formatted).toEqual({
+			formErrors: ['Always fails'],
+			fieldErrors: {},
+		});
+	});
+
+	test('returns null for empty object validation', () => {
+		const schema = v.object({});
+		const result = v.safeParse(schema, {});
+
+		expect(formatResult(result)).toBeNull();
+	});
+
+	test('ignores formatIssues when validation succeeds', () => {
+		const schema = v.object({ name: v.string() });
+		const result = v.safeParse(schema, { name: 'John' });
+
+		const formatted = formatResult(result, {
+			formatIssues: () => ['Should not be called'],
+		});
+
+		expect(formatted).toBeNull();
+	});
+});


### PR DESCRIPTION
## Overview

The `formResult` API added to Zod will be added to Valibot as well.
https://github.com/edmundhung/conform/pull/1010

## TODO

- [ ] How to handle the `memoize` API added to Zod.
- [ ] Create documentation
