### PR TITLE
fix(conform-react): restore missing v1 metadata in future useForm hook

### DIFF
--- a/.changeset/gold-geese-cough.md
+++ b/.changeset/gold-geese-cough.md
@@ -1,0 +1,14 @@
+---
+'@conform-to/react': patch
+---
+
+fix(conform-react): restore missing v1 metadata in future `useForm` hook
+
+This restores form and field metadata that were present in v1 but accidentally omitted from the future `useForm` hook release:
+
+- Add `key`, `errorId` and `descriptionId` properties to form metadata
+- Add `valid` property to both form and field metadata with `invalid` deprecated and to be removed in 1.10.0
+- Add `formId` property to field metadata
+- Add `fieldErrors` to field metadata (renamed from v1's `allErrors`) with improvements:
+  - Keys use relative paths scoped to the parent field instead of full field names
+  - Excludes the current field's own errors (only includes child field errors)

--- a/docs/api/react/future/useField.md
+++ b/docs/api/react/future/useField.md
@@ -26,11 +26,15 @@ A `Field` object containing field metadata and state:
 
 ### `id: string`
 
-The field's unique identifier, automatically generated as `{formId}-{fieldName}`.
+The field's unique identifier, automatically generated as `{formId}-field-{fieldName}`.
 
 ### `name: FieldName<FieldShape>`
 
 The field name path exactly as provided. The FieldName type is just a branded string type to help with TypeScript inference.
+
+### `formId: string`
+
+The form's unique identifier for associating field via the `form` attribute.
 
 ### `descriptionId: string`
 
@@ -56,13 +60,23 @@ Default checked state for checkbox/radio inputs.
 
 Whether this field has been touched (through `intent.validate()` or the `shouldValidate` option).
 
+### `valid: boolean`
+
+Whether this field currently has no validation errors.
+
 ### `invalid: boolean`
 
-Whether this field currently has validation errors.
+> **⚠️ Deprecated:** Use `valid` instead. This property will be removed in version 1.10.0.
+
+Whether this field currently has validation errors. This is equivalent to `!valid`.
 
 ### `errors: ErrorShape[] | undefined`
 
 Array of validation error messages for this field.
+
+### `fieldErrors: Record<string, ErrorShape[]>`
+
+Object containing errors for all touched subfields.
 
 ### Validation Attributes
 
@@ -102,7 +116,7 @@ function FormField({ name, label, type = 'text' }: FieldProps) {
   const field = useField(name);
 
   return (
-    <div className={`form-field ${field.invalid ? 'invalid' : ''}`}>
+    <div className={`form-field ${field.valid ? 'valid' : 'invalid'}`}>
       <label htmlFor={field.id}>
         {label}
         {field.required && <span className="required">*</span>}

--- a/docs/api/react/future/useFormMetadata.md
+++ b/docs/api/react/future/useFormMetadata.md
@@ -24,13 +24,31 @@ A `FormMetadata` object containing:
 
 The form's unique identifier.
 
+### `key: string`
+
+Unique identifier that changes on form reset.
+
+### `errorId: string`
+
+Auto-generated ID for associating form-level errors via `aria-describedby`. Follows the pattern `{formId}-form-error`.
+
+### `descriptionId: string`
+
+Auto-generated ID for associating form-level descriptions via `aria-describedby`. Follows the pattern `{formId}-form-description`.
+
 ### `touched: boolean`
 
 Whether any field in the form has been touched (through `intent.validate()` or the `shouldValidate` option).
 
+### `valid: boolean`
+
+Whether the form currently has no validation errors.
+
 ### `invalid: boolean`
 
-Whether the form currently has any validation errors.
+> **⚠️ Deprecated:** Use `valid` instead. This property will be removed in version 1.10.0.
+
+Whether the form currently has any validation errors. This is equivalent to `!valid`.
 
 ### `errors: ErrorShape[] | undefined`
 
@@ -38,7 +56,7 @@ Form-level validation errors, if any exist.
 
 ### `fieldErrors: Record<string, ErrorShape[]>`
 
-Object containing field-specific validation errors for all validated fields.
+Object containing errors for all touched fields.
 
 ### `props: FormProps`
 
@@ -141,7 +159,7 @@ function CustomForm({ children }: { children: React.ReactNode }) {
   return (
     <form
       {...form.props}
-      className={form.invalid ? 'form-invalid' : 'form-valid'}
+      className={form.valid ? 'form-valid' : 'form-invalid'}
     >
       {/* Global form errors */}
       {form.errors && form.errors.length > 0 && (
@@ -160,10 +178,10 @@ function CustomForm({ children }: { children: React.ReactNode }) {
       {/* Smart submit button */}
       <button
         type="submit"
-        disabled={form.invalid}
+        disabled={!form.valid}
         className={form.touched ? 'submit-ready' : 'submit-pending'}
       >
-        {form.invalid && form.touched ? 'Fix errors to submit' : 'Submit'}
+        {!form.valid && form.touched ? 'Fix errors to submit' : 'Submit'}
       </button>
     </form>
   );

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -391,15 +391,23 @@ export type FormMetadata<
 		unknown
 	> = DefaultFieldMetadata<ErrorShape>,
 > = Readonly<{
+	/** Unique identifier that changes on form reset */
+	key: string;
 	/** The form's unique identifier. */
 	id: string;
+	/** Auto-generated ID for associating form descriptions via aria-describedby. */
+	descriptionId: string;
+	/** Auto-generated ID for associating form errors via aria-describedby. */
+	errorId: string;
 	/** Whether any field in the form has been touched (through intent.validate() or the shouldValidate option). */
 	touched: boolean;
-	/** Whether the form currently has any validation errors. */
+	/** Whether the form currently has no validation errors. */
+	valid: boolean;
+	/** @deprecated Use `.valid` instead. This was not an intentionl breaking change and would be removed in the next minor version soon  */
 	invalid: boolean;
 	/** Form-level validation errors, if any exist. */
 	errors: ErrorShape[] | undefined;
-	/** Object containing field-specific validation errors for all validated fields. */
+	/** Object containing errors for all touched fields. */
 	fieldErrors: Record<string, ErrorShape[]>;
 	/** Form props object for spreading onto the <form> element. */
 	props: Readonly<{
@@ -440,12 +448,14 @@ export type FormMetadata<
 /** Default field metadata object containing field state, validation attributes, and accessibility IDs. */
 export type DefaultFieldMetadata<ErrorShape> = Readonly<
 	ValidationAttributes & {
-		/** The field's unique identifier, automatically generated as {formId}-{fieldName}. */
+		/** The field's unique identifier, automatically generated as {formId}-field-{fieldName}. */
 		id: string;
 		/** Auto-generated ID for associating field descriptions via aria-describedby. */
 		descriptionId: string;
 		/** Auto-generated ID for associating field errors via aria-describedby. */
 		errorId: string;
+		/** The form's unique identifier for associating field via the `form` attribute. */
+		formId: string;
 		/** The field's default value as a string. */
 		defaultValue: string | undefined;
 		/** Default selected options for multi-select fields or checkbox group. */
@@ -454,10 +464,14 @@ export type DefaultFieldMetadata<ErrorShape> = Readonly<
 		defaultChecked: boolean | undefined;
 		/** Whether this field has been touched (through intent.validate() or the shouldValidate option). */
 		touched: boolean;
-		/** Whether this field currently has validation errors. */
+		/** Whether this field currently has no validation errors. */
+		valid: boolean;
+		/** @deprecated Use `.valid` instead. This was not an intentionl breaking change and would be removed in the next minor version soon  */
 		invalid: boolean;
 		/** Array of validation error messages for this field. */
 		errors: ErrorShape[] | undefined;
+		/** Object containing errors for all touched subfields. */
+		fieldErrors: Record<string, ErrorShape[]>;
 	}
 >;
 

--- a/packages/conform-react/tests/state.test.ts
+++ b/packages/conform-react/tests/state.test.ts
@@ -3,7 +3,7 @@ import { DEFAULT_INTENT_NAME } from '@conform-to/dom/future';
 import {
 	getDefaultOptions,
 	getDefaultValue,
-	getError,
+	getErrors,
 	getListKey,
 	initializeState,
 	isTouched,
@@ -72,11 +72,11 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toEqual([
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toEqual([
 			'Username is required',
 		]);
-		expect(getError(context.state, 'password')).toEqual([
+		expect(getErrors(context.state, 'password')).toEqual([
 			'Password is required',
 		]);
 
@@ -102,9 +102,9 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toBe(undefined);
-		expect(getError(context.state, 'password')).toEqual([
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toBe(undefined);
+		expect(getErrors(context.state, 'password')).toEqual([
 			'Password is required',
 		]);
 
@@ -126,9 +126,9 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toBe(undefined);
-		expect(getError(context.state, 'password')).toBe(undefined);
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toBe(undefined);
+		expect(getErrors(context.state, 'password')).toBe(undefined);
 
 		// Test server validation
 		context.state = updateState(
@@ -150,9 +150,9 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
-		expect(getError(context.state)).toEqual(['Something went wrong']);
-		expect(getError(context.state, 'username')).toBe(undefined);
-		expect(getError(context.state, 'password')).toBe(undefined);
+		expect(getErrors(context.state)).toEqual(['Something went wrong']);
+		expect(getErrors(context.state, 'username')).toBe(undefined);
+		expect(getErrors(context.state, 'password')).toBe(undefined);
 
 		// Test client validation with the same form value after server validation
 		context.state = updateState(
@@ -172,9 +172,9 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
-		expect(getError(context.state)).toEqual(['Something went wrong']);
-		expect(getError(context.state, 'username')).toBe(undefined);
-		expect(getError(context.state, 'password')).toBe(undefined);
+		expect(getErrors(context.state)).toEqual(['Something went wrong']);
+		expect(getErrors(context.state, 'username')).toBe(undefined);
+		expect(getErrors(context.state, 'password')).toBe(undefined);
 
 		// Test client validation with the form value updated after server validation
 		context.state = updateState(
@@ -194,9 +194,9 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toBe(undefined);
-		expect(getError(context.state, 'password')).toBe(undefined);
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toBe(undefined);
+		expect(getErrors(context.state, 'password')).toBe(undefined);
 
 		// Test server validation with a reset result
 		context.state = updateState(
@@ -216,9 +216,9 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(false);
 		expect(isTouched(context.state, 'username')).toBe(false);
 		expect(isTouched(context.state, 'password')).toBe(false);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toBe(undefined);
-		expect(getError(context.state, 'password')).toBe(undefined);
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toBe(undefined);
+		expect(getErrors(context.state, 'password')).toBe(undefined);
 
 		// Test async validation - Setup client error state (1/3)
 		context.state = updateState(
@@ -250,11 +250,11 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(false);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toEqual([
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toEqual([
 			'Username is required',
 		]);
-		expect(getError(context.state, 'password')).toBe(undefined);
+		expect(getErrors(context.state, 'password')).toBe(undefined);
 
 		// Test async validation - Client validation result (2/3)
 		context.state = updateState(
@@ -273,11 +273,11 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toEqual([
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toEqual([
 			'Username is required',
 		]);
-		expect(getError(context.state, 'password')).toEqual([
+		expect(getErrors(context.state, 'password')).toEqual([
 			'Password is required',
 		]);
 
@@ -301,9 +301,9 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
-		expect(getError(context.state)).toEqual(['Something went wrong']);
-		expect(getError(context.state, 'username')).toBe(undefined);
-		expect(getError(context.state, 'password')).toBe(undefined);
+		expect(getErrors(context.state)).toEqual(['Something went wrong']);
+		expect(getErrors(context.state, 'username')).toBe(undefined);
+		expect(getErrors(context.state, 'password')).toBe(undefined);
 	});
 
 	test('validate fields', () => {
@@ -339,11 +339,11 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(false);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toEqual([
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toEqual([
 			'Username is required',
 		]);
-		expect(getError(context.state, 'password')).toBe(undefined);
+		expect(getErrors(context.state, 'password')).toBe(undefined);
 
 		// Testing validating another field
 		context.state = updateState(
@@ -375,11 +375,11 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toEqual([
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toEqual([
 			'Username is invalid',
 		]);
-		expect(getError(context.state, 'password')).toEqual([
+		expect(getErrors(context.state, 'password')).toEqual([
 			'Password is required',
 		]);
 
@@ -406,9 +406,9 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(false);
 		expect(isTouched(context.state, 'username')).toBe(false);
 		expect(isTouched(context.state, 'password')).toBe(false);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toBe(undefined);
-		expect(getError(context.state, 'password')).toBe(undefined);
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toBe(undefined);
+		expect(getErrors(context.state, 'password')).toBe(undefined);
 
 		// Test resetting form with null value
 		context.state = updateState(
@@ -428,9 +428,9 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(false);
 		expect(isTouched(context.state, 'username')).toBe(false);
 		expect(isTouched(context.state, 'password')).toBe(false);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toBe(undefined);
-		expect(getError(context.state, 'password')).toBe(undefined);
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toBe(undefined);
+		expect(getErrors(context.state, 'password')).toBe(undefined);
 
 		// Test validating the whole form with async validation - Pre-populate error state (1/4)
 		context.state = updateState(
@@ -462,11 +462,11 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(false);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toEqual([
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toEqual([
 			'Username is invalid',
 		]);
-		expect(getError(context.state, 'password')).toBe(undefined);
+		expect(getErrors(context.state, 'password')).toBe(undefined);
 
 		// Test validating the whole form with async validation - Client Validating (2/3)
 		context.state = updateState(
@@ -491,11 +491,11 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toEqual([
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toEqual([
 			'Username is invalid',
 		]);
-		expect(getError(context.state, 'password')).toEqual([
+		expect(getErrors(context.state, 'password')).toEqual([
 			'Password is required',
 		]);
 
@@ -525,9 +525,9 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
-		expect(getError(context.state)).toEqual(['Something went wrong']);
-		expect(getError(context.state, 'username')).toBe(undefined);
-		expect(getError(context.state, 'password')).toBe(undefined);
+		expect(getErrors(context.state)).toEqual(['Something went wrong']);
+		expect(getErrors(context.state, 'username')).toBe(undefined);
+		expect(getErrors(context.state, 'password')).toBe(undefined);
 	});
 
 	test('update fields', () => {
@@ -543,9 +543,9 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(false);
 		expect(isTouched(context.state, 'username')).toBe(false);
 		expect(isTouched(context.state, 'password')).toBe(false);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toBe(undefined);
-		expect(getError(context.state, 'password')).toBe(undefined);
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toBe(undefined);
+		expect(getErrors(context.state, 'password')).toBe(undefined);
 
 		// Update state with client validation result
 		context.state = updateState(
@@ -580,9 +580,9 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(false);
 		expect(isTouched(context.state, 'password')).toBe(true);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toBe(undefined);
-		expect(getError(context.state, 'password')).toEqual([
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toBe(undefined);
+		expect(getErrors(context.state, 'password')).toEqual([
 			'Password is incorrect',
 		]);
 
@@ -622,9 +622,9 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(false);
 		expect(isTouched(context.state, 'password')).toBe(true);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toBe(undefined);
-		expect(getError(context.state, 'password')).toEqual([
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toBe(undefined);
+		expect(getErrors(context.state, 'password')).toEqual([
 			'Password is required',
 		]);
 
@@ -658,11 +658,11 @@ describe('form', () => {
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'username')).toEqual([
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'username')).toEqual([
 			'Username is invalid',
 		]);
-		expect(getError(context.state, 'password')).toEqual([
+		expect(getErrors(context.state, 'password')).toEqual([
 			'Password is required',
 		]);
 	});
@@ -886,12 +886,12 @@ describe('form', () => {
 		expect(isTouched(context.state, 'tasks[1]')).toBe(false);
 		expect(isTouched(context.state, 'tasks[2]')).toBe(true);
 		expect(isTouched(context.state, 'tasks[3]')).toBe(false);
-		expect(getError(context.state)).toBe(undefined);
-		expect(getError(context.state, 'tasks')).toEqual(['Too many tasks']);
-		expect(getError(context.state, 'tasks[0]')).toBe(undefined);
-		expect(getError(context.state, 'tasks[1]')).toBe(undefined);
-		expect(getError(context.state, 'tasks[2]')).toBe(undefined);
-		expect(getError(context.state, 'tasks[3]')).toBe(undefined);
+		expect(getErrors(context.state)).toBe(undefined);
+		expect(getErrors(context.state, 'tasks')).toEqual(['Too many tasks']);
+		expect(getErrors(context.state, 'tasks[0]')).toBe(undefined);
+		expect(getErrors(context.state, 'tasks[1]')).toBe(undefined);
+		expect(getErrors(context.state, 'tasks[2]')).toBe(undefined);
+		expect(getErrors(context.state, 'tasks[3]')).toBe(undefined);
 
 		// Test reordering items
 		context.state = updateState(
@@ -1002,12 +1002,12 @@ describe('form', () => {
 		expect(isTouched(context.state, 'tasks[1]')).toBe(false);
 		expect(isTouched(context.state, 'tasks[2]')).toBe(false);
 		expect(isTouched(context.state, 'tasks[3]')).toBe(true);
-		expect(getError(context.state)).toEqual(['Some tasks are too urgent']);
-		expect(getError(context.state, 'tasks')).toBe(undefined);
-		expect(getError(context.state, 'tasks[0]')).toBe(undefined);
-		expect(getError(context.state, 'tasks[1]')).toBe(undefined);
-		expect(getError(context.state, 'tasks[2]')).toBe(undefined);
-		expect(getError(context.state, 'tasks[3]')).toBe(undefined);
+		expect(getErrors(context.state)).toEqual(['Some tasks are too urgent']);
+		expect(getErrors(context.state, 'tasks')).toBe(undefined);
+		expect(getErrors(context.state, 'tasks[0]')).toBe(undefined);
+		expect(getErrors(context.state, 'tasks[1]')).toBe(undefined);
+		expect(getErrors(context.state, 'tasks[2]')).toBe(undefined);
+		expect(getErrors(context.state, 'tasks[3]')).toBe(undefined);
 
 		// Test removing an item
 		context.state = updateState(
@@ -1100,12 +1100,12 @@ describe('form', () => {
 		expect(isTouched(context.state, 'tasks[0]')).toBe(false);
 		expect(isTouched(context.state, 'tasks[1]')).toBe(false);
 		expect(isTouched(context.state, 'tasks[2]')).toBe(true);
-		expect(getError(context.state)).toEqual(['Oops']);
-		expect(getError(context.state, 'tasks')).toBe(undefined);
-		expect(getError(context.state, 'tasks[0]')).toBe(undefined);
-		expect(getError(context.state, 'tasks[1]')).toBe(undefined);
-		expect(getError(context.state, 'tasks[2]')).toBe(undefined);
-		expect(getError(context.state, 'tasks[3]')).toBe(undefined);
+		expect(getErrors(context.state)).toEqual(['Oops']);
+		expect(getErrors(context.state, 'tasks')).toBe(undefined);
+		expect(getErrors(context.state, 'tasks[0]')).toBe(undefined);
+		expect(getErrors(context.state, 'tasks[1]')).toBe(undefined);
+		expect(getErrors(context.state, 'tasks[2]')).toBe(undefined);
+		expect(getErrors(context.state, 'tasks[3]')).toBe(undefined);
 
 		// Test resetting the form
 		context.state = updateState(
@@ -1261,12 +1261,16 @@ describe('form', () => {
 
 		// Test basic properties
 		expect(metadata.id).toBe('test-id');
+		expect(metadata.key).toBe(context.state.resetKey);
+		expect(metadata.errorId).toBe('test-id-form-error');
+		expect(metadata.descriptionId).toBe('test-id-form-description');
 		expect(metadata.errors).toEqual(['Form error']);
 		expect(metadata.fieldErrors).toEqual({
 			username: ['Username required'],
 			password: ['Password required'],
 		});
 		expect(metadata.touched).toBe(true);
+		expect(metadata.valid).toBe(false);
 		expect(metadata.invalid).toBe(true);
 
 		// Test props
@@ -1313,11 +1317,12 @@ describe('form', () => {
 		});
 
 		// Test basic properties
-		expect(field.id).toBe('test-id-username');
+		expect(field.id).toBe('test-id-field-username');
 		expect(field.name).toBe('username');
 		expect(field.key).toBe('unique-key');
-		expect(field.descriptionId).toBe('test-id-username-description');
-		expect(field.errorId).toBe('test-id-username-error');
+		expect(field.descriptionId).toBe('test-id-field-username-description');
+		expect(field.errorId).toBe('test-id-field-username-error');
+		expect(field.formId).toBe('test-id');
 
 		// Test constraint properties
 		expect(field.required).toBe(true);
@@ -1326,8 +1331,10 @@ describe('form', () => {
 		// Test computed properties
 		expect(field.defaultValue).toBe('test-user');
 		expect(field.touched).toBe(true);
+		expect(field.valid).toBe(false);
 		expect(field.invalid).toBe(true);
 		expect(field.errors).toEqual(['Username taken']);
+		expect(field.fieldErrors).toEqual({}); // No child fields, so empty
 
 		// Test methods exist
 		expect(typeof field.getFieldset).toBe('function');
@@ -1356,7 +1363,7 @@ describe('form', () => {
 		const nameField = fieldset.name!;
 		expect(nameField.name).toBe('profile.name');
 		expect(nameField.defaultValue).toBe('John');
-		expect(nameField.id).toBe('test-id-profile.name');
+		expect(nameField.id).toBe('test-id-field-profile.name');
 
 		const emailField = fieldset.email!;
 		expect(emailField.name).toBe('profile.email');
@@ -1375,6 +1382,48 @@ describe('form', () => {
 		});
 		const profileField = (rootFieldset as any).profile;
 		expect(profileField.name).toBe('profile');
+
+		// Test fieldErrors with nested structure
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client',
+				entries: [
+					['profile.name', 'John'],
+					['profile.email', 'invalid-email'],
+					['profile.nested.value', 'deep'],
+				],
+				error: {
+					fieldErrors: {
+						'profile.name': ['Name is too short'],
+						'profile.email': ['Invalid email format'],
+						'profile.nested.value': ['Invalid value'],
+					},
+				},
+			}),
+		);
+
+		// Test scoped fieldErrors for profile fieldset
+		const profileFieldWithErrors = getField(context, {
+			name: 'profile',
+			serialize: (value) => String(value),
+		});
+
+		expect(profileFieldWithErrors.fieldErrors).toEqual({
+			name: ['Name is too short'],
+			email: ['Invalid email format'],
+			'nested.value': ['Invalid value'],
+		});
+
+		// Test deeply nested fieldErrors
+		const nestedFieldWithErrors = getField(context, {
+			name: 'profile.nested',
+			serialize: (value) => String(value),
+		});
+
+		expect(nestedFieldWithErrors.fieldErrors).toEqual({
+			value: ['Invalid value'],
+		});
 	});
 
 	test('getFieldList', () => {

--- a/packages/conform-react/tests/useField.browser.test.tsx
+++ b/packages/conform-react/tests/useField.browser.test.tsx
@@ -16,7 +16,7 @@ describe('future export: useField', () => {
 		});
 
 		return (
-			<div id={field.invalid ? field.errorId : undefined}>
+			<div id={!field.valid ? field.errorId : undefined}>
 				{field.errors?.join(', ') ?? 'n/a'}
 			</div>
 		);

--- a/packages/conform-react/tests/useFormMetadata.browser.test.tsx
+++ b/packages/conform-react/tests/useFormMetadata.browser.test.tsx
@@ -19,7 +19,7 @@ describe('future export: useFormMetadata', () => {
 					const field = form.getField(name);
 
 					return (
-						<div key={name} id={field.invalid ? field.errorId : undefined}>
+						<div key={name} id={!field.valid ? field.errorId : undefined}>
 							{errors?.join(', ') ?? 'n/a'}
 						</div>
 					);


### PR DESCRIPTION
Fix https://github.com/edmundhung/conform/discussions/1014#discussioncomment-14355524

This restores form and field metadata that were present in v1 but accidentally omitted from the future `useForm` hook release:

  - Add `key`, `errorId` and `descriptionId` properties to form metadata
  - Add `valid` property to both form and field metadata with `invalid` deprecated and to be removed in 1.10.0
  - Add `formId` property to field metadata  
  - Add `fieldErrors` to field metadata (renamed from v1's `allErrors`) with improvements:
    - Keys use relative paths scoped to the parent field instead of full field names
    - Excludes the current field's own errors (only includes child field errors)