### PR TITLE
feat(conform-react/future): expose internal types

### DIFF
--- a/.changeset/good-insects-tell.md
+++ b/.changeset/good-insects-tell.md
@@ -1,0 +1,16 @@
+---
+'@conform-to/react': minor
+---
+
+feat(future): expose internal types
+
+This exposes some additional types from the future export that were previously not accessible to users, but is likely useful if you are building additional abstractions on top of Conform.
+
+- Submission
+- SubmissionResult
+- FormContext
+- FormMetadata
+- FormRef
+- FieldMetadata
+- FieldName
+- IntentDispatcher

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -42,14 +42,14 @@ import {
 } from './state';
 import type {
 	FormContext,
-	DefaultFieldMetadata,
+	DefaultMetadata,
 	IntentDispatcher,
 	FormMetadata,
 	Fieldset,
 	ValidateResult,
 	FormOptions,
 	FieldName,
-	Field,
+	FieldMetadata,
 	Control,
 	Selector,
 	UseFormDataOptions,
@@ -445,7 +445,7 @@ export function useForm<
 	options: FormOptions<FormShape, ErrorShape, Value>,
 ): {
 	form: FormMetadata<ErrorShape>;
-	fields: Fieldset<FormShape, DefaultFieldMetadata<ErrorShape>>;
+	fields: Fieldset<FormShape, DefaultMetadata<ErrorShape>>;
 	intent: IntentDispatcher;
 } {
 	const { id, defaultValue, constraint } = options;
@@ -674,7 +674,7 @@ export function useField<FieldShape = any>(
 	options: {
 		formId?: string;
 	} = {},
-): Field<FieldShape> {
+): FieldMetadata<FieldShape> {
 	const config = useContext(FormConfig);
 	const context = useFormContext(options.formId);
 	const field = useMemo(

--- a/packages/conform-react/future/index.ts
+++ b/packages/conform-react/future/index.ts
@@ -1,6 +1,22 @@
-export type { FormValue, FormError } from '@conform-to/dom/future';
+export type {
+	FormError,
+	FormValue,
+	Submission,
+	SubmissionResult,
+} from '@conform-to/dom/future';
 export { parseSubmission, report, isDirty } from '@conform-to/dom/future';
-export type { Control, FormOptions, Fieldset, DefaultValue } from './types';
+export type {
+	Control,
+	DefaultValue,
+	FormContext,
+	FormMetadata,
+	FormOptions,
+	FormRef,
+	FieldMetadata,
+	FieldName,
+	Fieldset,
+	IntentDispatcher,
+} from './types';
 export {
 	FormProvider,
 	useControl,

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -10,8 +10,8 @@ import {
 	deepEqual,
 } from '@conform-to/dom/future';
 import type {
-	DefaultFieldMetadata,
-	Field,
+	DefaultMetadata,
+	FieldMetadata,
 	FieldName,
 	Fieldset,
 	FormContext,
@@ -334,7 +334,7 @@ export function getFormMetadata<ErrorShape>(
 	options: {
 		serialize: Serialize;
 	},
-): FormMetadata<ErrorShape, DefaultFieldMetadata<ErrorShape>> {
+): FormMetadata<ErrorShape, DefaultMetadata<ErrorShape>> {
 	return {
 		key: context.state.resetKey,
 		id: context.formId,
@@ -391,10 +391,10 @@ export function getField<FieldShape, ErrorShape = string>(
 		serialize: Serialize;
 		key?: string;
 	},
-): Field<FieldShape, DefaultFieldMetadata<ErrorShape>> {
+): FieldMetadata<FieldShape, DefaultMetadata<ErrorShape>> {
 	const id = `${context.formId}-field-${options.name.replace(/[^a-zA-Z0-9._-]/g, '_')}`;
 	const constraint = getConstraint(context, options.name);
-	const metadata: DefaultFieldMetadata<ErrorShape> = {
+	const metadata: DefaultMetadata<ErrorShape> = {
 		id: id,
 		descriptionId: `${id}-description`,
 		errorId: `${id}-error`,
@@ -457,7 +457,7 @@ export function getFieldset<
 		name?: FieldName<FieldShape>;
 		serialize: Serialize;
 	},
-): Fieldset<FieldShape, DefaultFieldMetadata<ErrorShape>> {
+): Fieldset<FieldShape, DefaultMetadata<ErrorShape>> {
 	return new Proxy({} as any, {
 		get(target, name, receiver) {
 			if (typeof name === 'string') {
@@ -481,11 +481,11 @@ export function getFieldList<FieldShape = Array<any>, ErrorShape = string>(
 		name: FieldName<FieldShape>;
 		serialize: Serialize;
 	},
-): Field<
+): FieldMetadata<
 	[FieldShape] extends [Array<infer ItemShape> | null | undefined]
 		? ItemShape
 		: unknown,
-	DefaultFieldMetadata<ErrorShape>
+	DefaultMetadata<ErrorShape>
 >[] {
 	const keys = getListKey(context, options.name);
 

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -344,9 +344,9 @@ export type Combine<T> = {
 };
 
 /** Field metadata object containing field state, validation attributes, and nested field access methods. */
-export type Field<
+export type FieldMetadata<
 	FieldShape,
-	Metadata extends Record<string, unknown> = DefaultFieldMetadata<unknown>,
+	Metadata extends Record<string, unknown> = DefaultMetadata<unknown>,
 > = Readonly<
 	Metadata & {
 		/** Unique key for React list rendering (for array fields). */
@@ -362,7 +362,7 @@ export type Field<
 		>;
 		/** Method to get array of fields for list/array fields under this field. */
 		getFieldList(): Array<
-			Field<
+			FieldMetadata<
 				[FieldShape] extends [Array<infer ItemShape> | null | undefined]
 					? ItemShape
 					: unknown,
@@ -375,21 +375,18 @@ export type Field<
 /** Fieldset object containing all form fields as properties with their respective field metadata. */
 export type Fieldset<
 	FieldShape, // extends Record<string, unknown>,
-	FieldMetadata extends Record<string, unknown>,
+	Metadata extends Record<string, unknown>,
 > = {
-	[Key in keyof Combine<FieldShape>]-?: Field<
+	[Key in keyof Combine<FieldShape>]-?: FieldMetadata<
 		Combine<FieldShape>[Key],
-		FieldMetadata
+		Metadata
 	>;
 };
 
 /** Form-level metadata and state object containing validation status, errors, and field access methods. */
 export type FormMetadata<
 	ErrorShape,
-	FieldMetadata extends Record<
-		string,
-		unknown
-	> = DefaultFieldMetadata<ErrorShape>,
+	Metadata extends Record<string, unknown> = DefaultMetadata<ErrorShape>,
 > = Readonly<{
 	/** Unique identifier that changes on form reset */
 	key: string;
@@ -422,7 +419,7 @@ export type FormMetadata<
 	/** Method to get metadata for a specific field by name. */
 	getField<FieldShape>(
 		name: FieldName<FieldShape>,
-	): Field<FieldShape, FieldMetadata>;
+	): FieldMetadata<FieldShape, Metadata>;
 	/** Method to get a fieldset object for nested object fields. */
 	getFieldset<FieldShape>(
 		name: FieldName<FieldShape>,
@@ -430,23 +427,23 @@ export type FormMetadata<
 		[FieldShape] extends [Record<string, unknown> | null | undefined]
 			? FieldShape
 			: unknown,
-		FieldMetadata
+		Metadata
 	>;
 	/** Method to get an array of field objects for array fields. */
 	getFieldList<FieldShape>(
 		name: FieldName<FieldShape>,
 	): Array<
-		Field<
+		FieldMetadata<
 			[FieldShape] extends [Array<infer ItemShape> | null | undefined]
 				? ItemShape
 				: unknown,
-			FieldMetadata
+			Metadata
 		>
 	>;
 }>;
 
 /** Default field metadata object containing field state, validation attributes, and accessibility IDs. */
-export type DefaultFieldMetadata<ErrorShape> = Readonly<
+export type DefaultMetadata<ErrorShape> = Readonly<
 	ValidationAttributes & {
 		/** The field's unique identifier, automatically generated as {formId}-field-{fieldName}. */
 		id: string;


### PR DESCRIPTION
This exposes some additional types from the future export that were previously not accessible to users, but is likely useful if you are building additional abstractions on top of Conform.

- Submission
- SubmissionResult
- FormContext
- FormMetadata
- FormRef
- FieldMetadata
- FieldName
- IntentDispatcher