### PR TITLE
chore: drop all references to invalid metadata in examples

### DIFF
--- a/docs/api/react/future/useField.md
+++ b/docs/api/react/future/useField.md
@@ -66,7 +66,7 @@ Whether this field currently has no validation errors.
 
 ### `invalid: boolean`
 
-> **⚠️ Deprecated:** Use `valid` instead. This property will be removed in version 1.10.0.
+> **⚠️ Deprecated:** Use `valid` instead. This property will be removed in version 1.11.0.
 
 Whether this field currently has validation errors. This is equivalent to `!valid`.
 

--- a/docs/api/react/future/useForm.md
+++ b/docs/api/react/future/useForm.md
@@ -151,7 +151,7 @@ function LoginForm() {
       />
       <div>{fields.password.errors}</div>
 
-      <button type="submit" disabled={form.invalid}>
+      <button type="submit" disabled={!form.valid}>
         Login
       </button>
     </form>

--- a/docs/api/react/future/useFormMetadata.md
+++ b/docs/api/react/future/useFormMetadata.md
@@ -46,7 +46,7 @@ Whether the form currently has no validation errors.
 
 ### `invalid: boolean`
 
-> **⚠️ Deprecated:** Use `valid` instead. This property will be removed in version 1.10.0.
+> **⚠️ Deprecated:** Use `valid` instead. This property will be removed in version 1.11.0.
 
 Whether the form currently has any validation errors. This is equivalent to `!valid`.
 

--- a/examples/nextjs/app/login/_form.tsx
+++ b/examples/nextjs/app/login/_form.tsx
@@ -23,7 +23,7 @@ export function LoginForm() {
 				<label>Email</label>
 				<input
 					type="text"
-					className={fields.email.invalid ? 'error' : ''}
+					className={!fields.email.valid ? 'error' : ''}
 					name={fields.email.name}
 					defaultValue={fields.email.defaultValue}
 				/>
@@ -33,7 +33,7 @@ export function LoginForm() {
 				<label>Password</label>
 				<input
 					type="password"
-					className={fields.password.invalid ? 'error' : ''}
+					className={!fields.password.valid ? 'error' : ''}
 					name={fields.password.name}
 					defaultValue={fields.password.defaultValue}
 				/>

--- a/examples/nextjs/app/signup-async-schema/_form.tsx
+++ b/examples/nextjs/app/signup-async-schema/_form.tsx
@@ -34,7 +34,7 @@ export function SignupAsyncSchemaForm() {
 				<div>Username</div>
 				<input
 					type="text"
-					className={fields.username.invalid ? 'error' : ''}
+					className={!fields.username.valid ? 'error' : ''}
 					name={fields.username.name}
 					defaultValue={fields.username.defaultValue}
 				/>
@@ -44,7 +44,7 @@ export function SignupAsyncSchemaForm() {
 				<div>Password</div>
 				<input
 					type="password"
-					className={fields.password.invalid ? 'error' : ''}
+					className={!fields.password.valid ? 'error' : ''}
 					name={fields.password.name}
 					defaultValue={fields.password.defaultValue}
 				/>
@@ -54,7 +54,7 @@ export function SignupAsyncSchemaForm() {
 				<div>Confirm Password</div>
 				<input
 					type="password"
-					className={fields.confirmPassword.invalid ? 'error' : ''}
+					className={!fields.confirmPassword.valid ? 'error' : ''}
 					name={fields.confirmPassword.name}
 					defaultValue={fields.confirmPassword.defaultValue}
 				/>

--- a/examples/nextjs/app/signup/_form.tsx
+++ b/examples/nextjs/app/signup/_form.tsx
@@ -47,7 +47,7 @@ export function SignupForm() {
 				<div>Username</div>
 				<input
 					type="text"
-					className={fields.username.invalid ? 'error' : ''}
+					className={!fields.username.valid ? 'error' : ''}
 					name={fields.username.name}
 					defaultValue={fields.username.defaultValue}
 				/>
@@ -57,7 +57,7 @@ export function SignupForm() {
 				<div>Password</div>
 				<input
 					type="password"
-					className={fields.password.invalid ? 'error' : ''}
+					className={!fields.password.valid ? 'error' : ''}
 					name={fields.password.name}
 					defaultValue={fields.password.defaultValue}
 				/>
@@ -67,7 +67,7 @@ export function SignupForm() {
 				<div>Confirm Password</div>
 				<input
 					type="password"
-					className={fields.confirmPassword.invalid ? 'error' : ''}
+					className={!fields.confirmPassword.valid ? 'error' : ''}
 					name={fields.confirmPassword.name}
 					defaultValue={fields.confirmPassword.defaultValue}
 				/>

--- a/examples/nextjs/app/todos/_form.tsx
+++ b/examples/nextjs/app/todos/_form.tsx
@@ -34,7 +34,7 @@ export function TodoForm({
 			<div>
 				<label>Title</label>
 				<input
-					className={fields.title.invalid ? 'error' : ''}
+					className={!fields.title.valid ? 'error' : ''}
 					name={fields.title.name}
 					defaultValue={fields.title.defaultValue}
 				/>
@@ -50,7 +50,7 @@ export function TodoForm({
 						<div>
 							<label>Task #{index + 1}</label>
 							<input
-								className={taskFields.content.invalid ? 'error' : ''}
+								className={!taskFields.content.valid ? 'error' : ''}
 								name={taskFields.content.name}
 								defaultValue={taskFields.content.defaultValue}
 							/>
@@ -61,7 +61,7 @@ export function TodoForm({
 								<span>Completed</span>
 								<input
 									type="checkbox"
-									className={taskFields.completed.invalid ? 'error' : ''}
+									className={!taskFields.completed.valid ? 'error' : ''}
 									name={taskFields.completed.name}
 									defaultChecked={taskFields.completed.defaultValue === 'on'}
 								/>

--- a/examples/react-router/app/routes/login-fetcher.tsx
+++ b/examples/react-router/app/routes/login-fetcher.tsx
@@ -44,7 +44,7 @@ export default function LoginWithFetcher() {
 				<label>Email</label>
 				<input
 					type="email"
-					className={fields.email.invalid ? 'error' : ''}
+					className={!fields.email.valid ? 'error' : ''}
 					name={fields.email.name}
 					defaultValue={fields.email.defaultValue}
 				/>
@@ -54,7 +54,7 @@ export default function LoginWithFetcher() {
 				<label>Password</label>
 				<input
 					type="password"
-					className={fields.password.invalid ? 'error' : ''}
+					className={!fields.password.valid ? 'error' : ''}
 					name={fields.password.name}
 					defaultValue={fields.password.defaultValue}
 				/>

--- a/examples/react-router/app/routes/login.tsx
+++ b/examples/react-router/app/routes/login.tsx
@@ -66,7 +66,7 @@ export default function Login({ actionData }: Route.ComponentProps) {
 				<label>Email</label>
 				<input
 					type="email"
-					className={fields.email.invalid ? 'error' : ''}
+					className={!fields.email.valid ? 'error' : ''}
 					name={fields.email.name}
 					defaultValue={fields.email.defaultValue}
 				/>
@@ -76,7 +76,7 @@ export default function Login({ actionData }: Route.ComponentProps) {
 				<label>Password</label>
 				<input
 					type="password"
-					className={fields.password.invalid ? 'error' : ''}
+					className={!fields.password.valid ? 'error' : ''}
 					name={fields.password.name}
 					defaultValue={fields.password.defaultValue}
 				/>

--- a/examples/react-router/app/routes/signup-async-schema.tsx
+++ b/examples/react-router/app/routes/signup-async-schema.tsx
@@ -108,7 +108,7 @@ export default function Signup({ actionData }: Route.ComponentProps) {
 				<div>Username</div>
 				<input
 					type="text"
-					className={fields.username.invalid ? 'error' : ''}
+					className={!fields.username.valid ? 'error' : ''}
 					name={fields.username.name}
 					defaultValue={fields.username.defaultValue}
 				/>
@@ -118,7 +118,7 @@ export default function Signup({ actionData }: Route.ComponentProps) {
 				<div>Password</div>
 				<input
 					type="password"
-					className={fields.password.invalid ? 'error' : ''}
+					className={!fields.password.valid ? 'error' : ''}
 					name={fields.password.name}
 					defaultValue={fields.password.defaultValue}
 				/>
@@ -128,7 +128,7 @@ export default function Signup({ actionData }: Route.ComponentProps) {
 				<div>Confirm Password</div>
 				<input
 					type="password"
-					className={fields.confirmPassword.invalid ? 'error' : ''}
+					className={!fields.confirmPassword.valid ? 'error' : ''}
 					name={fields.confirmPassword.name}
 					defaultValue={fields.confirmPassword.defaultValue}
 				/>

--- a/examples/react-router/app/routes/signup-server-validation.tsx
+++ b/examples/react-router/app/routes/signup-server-validation.tsx
@@ -103,7 +103,7 @@ export default function Signup({ actionData }: Route.ComponentProps) {
 				<div>Username</div>
 				<input
 					type="text"
-					className={fields.username.invalid ? 'error' : ''}
+					className={!fields.username.valid ? 'error' : ''}
 					name={fields.username.name}
 					defaultValue={fields.username.defaultValue}
 				/>
@@ -113,7 +113,7 @@ export default function Signup({ actionData }: Route.ComponentProps) {
 				<div>Password</div>
 				<input
 					type="password"
-					className={fields.password.invalid ? 'error' : ''}
+					className={!fields.password.valid ? 'error' : ''}
 					name={fields.password.name}
 					defaultValue={fields.password.defaultValue}
 				/>
@@ -123,7 +123,7 @@ export default function Signup({ actionData }: Route.ComponentProps) {
 				<div>Confirm Password</div>
 				<input
 					type="password"
-					className={fields.confirmPassword.invalid ? 'error' : ''}
+					className={!fields.confirmPassword.valid ? 'error' : ''}
 					name={fields.confirmPassword.name}
 					defaultValue={fields.confirmPassword.defaultValue}
 				/>

--- a/examples/react-router/app/routes/signup.tsx
+++ b/examples/react-router/app/routes/signup.tsx
@@ -120,7 +120,7 @@ export default function Signup({ actionData }: Route.ComponentProps) {
 				<div>Username</div>
 				<input
 					type="text"
-					className={fields.username.invalid ? 'error' : ''}
+					className={!fields.username.valid ? 'error' : ''}
 					name={fields.username.name}
 					defaultValue={fields.username.defaultValue}
 				/>
@@ -130,7 +130,7 @@ export default function Signup({ actionData }: Route.ComponentProps) {
 				<div>Password</div>
 				<input
 					type="password"
-					className={fields.password.invalid ? 'error' : ''}
+					className={!fields.password.valid ? 'error' : ''}
 					name={fields.password.name}
 					defaultValue={fields.password.defaultValue}
 				/>
@@ -140,7 +140,7 @@ export default function Signup({ actionData }: Route.ComponentProps) {
 				<div>Confirm Password</div>
 				<input
 					type="password"
-					className={fields.confirmPassword.invalid ? 'error' : ''}
+					className={!fields.confirmPassword.valid ? 'error' : ''}
 					name={fields.confirmPassword.name}
 					defaultValue={fields.confirmPassword.defaultValue}
 				/>

--- a/examples/react-router/app/routes/todos.tsx
+++ b/examples/react-router/app/routes/todos.tsx
@@ -78,7 +78,7 @@ export default function Example({
 			<div>
 				<label>Title</label>
 				<input
-					className={fields.title.invalid ? 'error' : ''}
+					className={!fields.title.valid ? 'error' : ''}
 					name={fields.title.name}
 					defaultValue={fields.title.defaultValue ?? ''}
 				/>
@@ -94,7 +94,7 @@ export default function Example({
 						<div>
 							<label>Task #{index + 1}</label>
 							<input
-								className={taskFields.content.invalid ? 'error' : ''}
+								className={!taskFields.content.valid ? 'error' : ''}
 								name={taskFields.content.name}
 								defaultValue={taskFields.content.defaultValue}
 							/>
@@ -105,7 +105,7 @@ export default function Example({
 								<span>Completed</span>
 								<input
 									type="checkbox"
-									className={taskFields.completed.invalid ? 'error' : ''}
+									className={!taskFields.completed.valid ? 'error' : ''}
 									name={taskFields.completed.name}
 									defaultChecked={taskFields.completed.defaultChecked}
 								/>

--- a/examples/react-spa/package.json
+++ b/examples/react-spa/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "react-spa-example",
 	"private": true,
-	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/examples/react-spa/src/routes/login.tsx
+++ b/examples/react-spa/src/routes/login.tsx
@@ -58,7 +58,7 @@ export default function Login() {
 				<label>Email</label>
 				<input
 					type="email"
-					className={fields.email.invalid ? 'error' : ''}
+					className={!fields.email.valid ? 'error' : ''}
 					name={fields.email.name}
 					defaultValue={fields.email.defaultValue}
 				/>
@@ -68,7 +68,7 @@ export default function Login() {
 				<label>Password</label>
 				<input
 					type="password"
-					className={fields.password.invalid ? 'error' : ''}
+					className={!fields.password.valid ? 'error' : ''}
 					name={fields.password.name}
 					defaultValue={fields.password.defaultValue}
 				/>

--- a/examples/react-spa/src/routes/signup-async-schema.tsx
+++ b/examples/react-spa/src/routes/signup-async-schema.tsx
@@ -96,7 +96,7 @@ export default function SignupAsyncSchema() {
 				<div>Username</div>
 				<input
 					type="text"
-					className={fields.username.invalid ? 'error' : ''}
+					className={!fields.username.valid ? 'error' : ''}
 					name={fields.username.name}
 					defaultValue={fields.username.defaultValue}
 				/>
@@ -106,7 +106,7 @@ export default function SignupAsyncSchema() {
 				<div>Password</div>
 				<input
 					type="password"
-					className={fields.password.invalid ? 'error' : ''}
+					className={!fields.password.valid ? 'error' : ''}
 					name={fields.password.name}
 					defaultValue={fields.password.defaultValue}
 				/>
@@ -116,7 +116,7 @@ export default function SignupAsyncSchema() {
 				<div>Confirm Password</div>
 				<input
 					type="password"
-					className={fields.confirmPassword.invalid ? 'error' : ''}
+					className={!fields.confirmPassword.valid ? 'error' : ''}
 					name={fields.confirmPassword.name}
 					defaultValue={fields.confirmPassword.defaultValue}
 				/>

--- a/examples/react-spa/src/routes/signup.tsx
+++ b/examples/react-spa/src/routes/signup.tsx
@@ -97,7 +97,7 @@ export default function Signup() {
 				<div>Username</div>
 				<input
 					type="text"
-					className={fields.username.invalid ? 'error' : ''}
+					className={!fields.username.valid ? 'error' : ''}
 					name={fields.username.name}
 					defaultValue={fields.username.defaultValue}
 				/>
@@ -107,7 +107,7 @@ export default function Signup() {
 				<div>Password</div>
 				<input
 					type="password"
-					className={fields.password.invalid ? 'error' : ''}
+					className={!fields.password.valid ? 'error' : ''}
 					name={fields.password.name}
 					defaultValue={fields.password.defaultValue}
 				/>
@@ -117,7 +117,7 @@ export default function Signup() {
 				<div>Confirm Password</div>
 				<input
 					type="password"
-					className={fields.confirmPassword.invalid ? 'error' : ''}
+					className={!fields.confirmPassword.valid ? 'error' : ''}
 					name={fields.confirmPassword.name}
 					defaultValue={fields.confirmPassword.defaultValue}
 				/>

--- a/examples/react-spa/src/routes/todos.tsx
+++ b/examples/react-spa/src/routes/todos.tsx
@@ -66,7 +66,7 @@ export default function Todos() {
 			<div>
 				<label>Title</label>
 				<input
-					className={fields.title.invalid ? 'error' : ''}
+					className={!fields.title.valid ? 'error' : ''}
 					name={fields.title.name}
 					defaultValue={fields.title.defaultValue ?? ''}
 				/>
@@ -82,7 +82,7 @@ export default function Todos() {
 						<div>
 							<label>Task #{index + 1}</label>
 							<input
-								className={taskFields.content.invalid ? 'error' : ''}
+								className={!taskFields.content.valid ? 'error' : ''}
 								name={taskFields.content.name}
 								defaultValue={taskFields.content.defaultValue}
 							/>
@@ -93,7 +93,7 @@ export default function Todos() {
 								<span>Completed</span>
 								<input
 									type="checkbox"
-									className={taskFields.completed.invalid ? 'error' : ''}
+									className={!taskFields.completed.valid ? 'error' : ''}
 									name={taskFields.completed.name}
 									defaultChecked={taskFields.completed.defaultChecked}
 								/>

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -623,7 +623,7 @@ export function useForm<
  * function ErrorSummary() {
  *   const form = useFormMetadata();
  *
- *   if (!form.invalid) return null;
+ *   if (form.valid) return null;
  *
  *   return (
  *     <div>Please fix {Object.keys(form.fieldErrors).length} errors</div>


### PR DESCRIPTION
This removes all reference to the deprecated `invalid` metadata in the examples. We are also 
postponing the removal of the `invalid` metadata to `1.11.0` to give people a bit more time to migrate.