### PR TITLE
fix(conform-react/future): use a static string as resetKey's initial value

### DIFF
--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -133,7 +133,7 @@ export function useConform<ErrorShape, Value = undefined>(
 ): [FormState<ErrorShape>, (event: React.FormEvent<HTMLFormElement>) => void] {
 	const { lastResult } = options;
 	const [state, setState] = useState<FormState<ErrorShape>>(() => {
-		let state = initializeState<ErrorShape>();
+		let state = initializeState<ErrorShape>('initial');
 
 		if (lastResult) {
 			state = updateState(state, {

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -23,9 +23,9 @@ import type {
 } from './types';
 import { generateUniqueKey, getArrayAtPath, merge } from './util';
 
-export function initializeState<ErrorShape>(): FormState<ErrorShape> {
+export function initializeState<ErrorShape>(resetKey?: string): FormState<ErrorShape> {
 	return {
-		resetKey: generateUniqueKey(),
+		resetKey: resetKey ?? generateUniqueKey(),
 		listKeys: {},
 		clientIntendedValue: null,
 		serverIntendedValue: null,


### PR DESCRIPTION
Avoids calling `generateUniqueKey()` when state is first initialized. Its non-deterministic nature causes issues with SSR/PPR render passes that expect stable output.

Fix #1030