### PR TITLE
fix(conform-react/future): use static reset key for initial form state

### DIFF
--- a/.changeset/flat-balloons-tap.md
+++ b/.changeset/flat-balloons-tap.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/react': patch
+---
+
+Use static reset key for initial form state to fix Next.js prerendering hydration issues

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -133,7 +133,7 @@ export function useConform<ErrorShape, Value = undefined>(
 ): [FormState<ErrorShape>, (event: React.FormEvent<HTMLFormElement>) => void] {
 	const { lastResult } = options;
 	const [state, setState] = useState<FormState<ErrorShape>>(() => {
-		let state = initializeState<ErrorShape>();
+		let state = initializeState<ErrorShape>('initial');
 
 		if (lastResult) {
 			state = updateState(state, {

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -74,6 +74,10 @@ import {
 	updateFormValue,
 } from './dom';
 
+// Static reset key for consistent hydration during Next.js prerendering
+// See: https://nextjs.org/docs/messages/next-prerender-current-time-client
+export const INITIAL_KEY = 'INITIAL_KEY';
+
 export const FormConfig = createContext({
 	intentName: DEFAULT_INTENT_NAME,
 	observer: createGlobalFormsObserver(),
@@ -133,7 +137,7 @@ export function useConform<ErrorShape, Value = undefined>(
 ): [FormState<ErrorShape>, (event: React.FormEvent<HTMLFormElement>) => void] {
 	const { lastResult } = options;
 	const [state, setState] = useState<FormState<ErrorShape>>(() => {
-		let state = initializeState<ErrorShape>('initial');
+		let state = initializeState<ErrorShape>(INITIAL_KEY);
 
 		if (lastResult) {
 			state = updateState(state, {

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -23,9 +23,9 @@ import type {
 } from './types';
 import { generateUniqueKey, getArrayAtPath, merge } from './util';
 
-export function initializeState<ErrorShape>(): FormState<ErrorShape> {
+export function initializeState<ErrorShape>(resetKey?: string): FormState<ErrorShape> {
 	return {
-		resetKey: generateUniqueKey(),
+		resetKey: resetKey ?? generateUniqueKey(),
 		listKeys: {},
 		clientIntendedValue: null,
 		serverIntendedValue: null,

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -23,7 +23,9 @@ import type {
 } from './types';
 import { generateUniqueKey, getArrayAtPath, merge } from './util';
 
-export function initializeState<ErrorShape>(resetKey?: string): FormState<ErrorShape> {
+export function initializeState<ErrorShape>(
+	resetKey?: string,
+): FormState<ErrorShape> {
 	return {
 		resetKey: resetKey ?? generateUniqueKey(),
 		listKeys: {},

--- a/packages/conform-react/tests/useForm.node.test.tsx
+++ b/packages/conform-react/tests/useForm.node.test.tsx
@@ -17,6 +17,15 @@ describe('future export: useForm', () => {
 		expect(fields.title.errors).toBe(undefined);
 		expect(fields.description.defaultValue).toBe(undefined);
 		expect(fields.description.errors).toBe(undefined);
+
+		// Test if the form state is stable
+		const secondUseFormResult = serverRenderHook(() =>
+			useForm<{ title: string; description: string }, string>({
+				onValidate: () => undefined,
+			}),
+		);
+
+		expect(form.context.state).toEqual(secondUseFormResult.form.context.state);
 	});
 
 	test('default value', () => {


### PR DESCRIPTION
Fix #1030
Close #1035

This is originally submitted in #1035 by @apostolos, but I can't push any changes to it as it is made from the default branch of a fork.