### PR TITLE
feat(conform-dom): add standard schema issue support to report

### DIFF
--- a/.changeset/fresh-tips-begin.md
+++ b/.changeset/fresh-tips-begin.md
@@ -1,0 +1,18 @@
+---
+'@conform-to/react': minor
+'@conform-to/dom': minor
+---
+
+feat: add standard schema issue support to `report`
+
+The `report` function now accepts standard schema issues directly, eliminating the need to use `formatResult` in most cases:
+
+```diff
+return report(submission, {
++  error: { issues: result.error.issues },  // Zod
++  error: { issues: result.issues },        // Valibot
+-  error: formatResult(result),
+});
+```
+
+This simplifies error handling by allowing direct pass-through of validation results from Zod and Valibot. The `formatResult` function is still useful when you need to customize the error shape.

--- a/docs/api/react/future/report.md
+++ b/docs/api/react/future/report.md
@@ -16,12 +16,14 @@ const result = report(submission, options);
 
 The form submission object created by [`parseSubmission(formData)`](./parseSubmission.md). Contains parsed form data with structured payload, field names, and submission intent.
 
-### `options.error?: Partial<FormError> | null`
+### `options.error?: { issues: StandardSchemaV1.Issue[] } | Partial<FormError> | null`
 
-Error information to include in the result. Can contain:
+Error information to include in the result. Can be:
 
-- `formErrors?: string[]` - Form-level error messages
-- `fieldErrors?: Record<string, string[]>` - Field-specific error messages
+- `Partial<FormError>` - Error object with:
+  - `formErrors?: string[]` - Form-level error messages
+  - `fieldErrors?: Record<string, string[]>` - Field-specific error messages
+- `{ issues: StandardSchemaV1.Issue[] }` - Standard Schema issues. Zod and Valibot issues are also compatible.
 
 Set to `null` to indicate validation passed with no errors.
 

--- a/examples/nextjs/app/signup-async-schema/_action.tsx
+++ b/examples/nextjs/app/signup-async-schema/_action.tsx
@@ -2,7 +2,6 @@
 
 import { redirect } from 'next/navigation';
 import { parseSubmission, report } from '@conform-to/react/future';
-import { formatResult } from '@conform-to/zod/v3/future';
 import { createSignupSchema } from '../signup/_schema';
 
 export async function signupAsyncSchema(
@@ -23,7 +22,9 @@ export async function signupAsyncSchema(
 
 	if (!result.success) {
 		return report(submission, {
-			error: formatResult(result),
+			error: {
+				issues: result.error.issues,
+			},
 		});
 	}
 

--- a/examples/nextjs/app/signup/_action.ts
+++ b/examples/nextjs/app/signup/_action.ts
@@ -1,7 +1,6 @@
 'use server';
 
 import { parseSubmission, report } from '@conform-to/react/future';
-import { formatResult } from '@conform-to/zod/v3/future';
 import { redirect } from 'next/navigation';
 import { signupSchema } from './_schema';
 
@@ -11,7 +10,9 @@ export async function signup(_: unknown, formData: FormData) {
 
 	if (!result.success) {
 		return report(submission, {
-			error: formatResult(result),
+			error: {
+				issues: result.error.issues,
+			},
 		});
 	}
 

--- a/examples/nextjs/app/todos/_action.ts
+++ b/examples/nextjs/app/todos/_action.ts
@@ -1,7 +1,6 @@
 'use server';
 
 import { parseSubmission, report } from '@conform-to/react/future';
-import { formatResult } from '@conform-to/zod/v3/future';
 import { revalidatePath } from 'next/cache';
 import { updateTodos } from '@/app/todos/_store';
 import { schema } from './_schema';
@@ -12,7 +11,9 @@ export async function createTodos(_: unknown, formData: FormData) {
 
 	if (!result.success) {
 		return report(submission, {
-			error: formatResult(result),
+			error: {
+				issues: result.error.issues,
+			},
 		});
 	}
 

--- a/examples/react-router/app/routes/file-upload.tsx
+++ b/examples/react-router/app/routes/file-upload.tsx
@@ -2,7 +2,7 @@ import { parseSubmission, report, useForm } from '@conform-to/react/future';
 import { z } from 'zod';
 import { Form, redirect } from 'react-router';
 import type { Route } from './+types/file-upload';
-import { coerceFormValue, formatResult } from '@conform-to/zod/v3/future';
+import { coerceFormValue } from '@conform-to/zod/v3/future';
 
 const schema = coerceFormValue(
 	z.object({
@@ -19,7 +19,9 @@ export async function action({ request }: Route.ActionArgs) {
 	if (!result.success) {
 		return {
 			result: report(submission, {
-				error: formatResult(result),
+				error: {
+					issues: result.error.issues,
+				},
 			}),
 		};
 	}

--- a/examples/react-router/app/routes/login-fetcher.tsx
+++ b/examples/react-router/app/routes/login-fetcher.tsx
@@ -1,5 +1,5 @@
 import { useForm, parseSubmission, report } from '@conform-to/react/future';
-import { coerceFormValue, formatResult } from '@conform-to/zod/v3/future';
+import { coerceFormValue } from '@conform-to/zod/v3/future';
 import { redirect, useFetcher } from 'react-router';
 import { z } from 'zod';
 import type { Route } from './+types/login-fetcher';
@@ -20,7 +20,9 @@ export async function action({ request }: Route.ActionArgs) {
 	if (!result.success) {
 		return {
 			result: report(submission, {
-				error: formatResult(result),
+				error: {
+					issues: result.error.issues,
+				},
 			}),
 		};
 	}

--- a/examples/react-router/app/routes/signup-async-schema.tsx
+++ b/examples/react-router/app/routes/signup-async-schema.tsx
@@ -4,7 +4,7 @@ import {
 	memoize,
 	report,
 } from '@conform-to/react/future';
-import { coerceFormValue, formatResult } from '@conform-to/zod/v3/future';
+import { coerceFormValue } from '@conform-to/zod/v3/future';
 import { useMemo } from 'react';
 import { Form, redirect } from 'react-router';
 import { z } from 'zod';
@@ -62,7 +62,9 @@ export async function action({ request }: Route.ActionArgs) {
 	if (!result.success) {
 		return {
 			result: report(submission, {
-				error: formatResult(result),
+				error: {
+					issues: result.error.issues,
+				},
 			}),
 		};
 	}

--- a/examples/react-router/app/routes/signup.tsx
+++ b/examples/react-router/app/routes/signup.tsx
@@ -4,7 +4,7 @@ import {
 	memoize,
 	report,
 } from '@conform-to/react/future';
-import { coerceFormValue, formatResult } from '@conform-to/zod/v3/future';
+import { coerceFormValue } from '@conform-to/zod/v3/future';
 import { useMemo } from 'react';
 import { Form, redirect } from 'react-router';
 import { z } from 'zod';
@@ -43,7 +43,9 @@ export async function action({ request }: Route.ActionArgs) {
 	if (!result.success) {
 		return {
 			result: report(submission, {
-				error: formatResult(result),
+				error: {
+					issues: result.error.issues,
+				},
 			}),
 		};
 	}

--- a/examples/react-router/app/routes/todos.tsx
+++ b/examples/react-router/app/routes/todos.tsx
@@ -5,7 +5,7 @@ import {
 	useForm,
 	useFormData,
 } from '@conform-to/react/future';
-import { coerceFormValue, formatResult } from '@conform-to/zod/v3/future';
+import { coerceFormValue } from '@conform-to/zod/v3/future';
 import { Form, useNavigation } from 'react-router';
 import { z } from 'zod';
 import { createInMemoryStore } from '~/store';
@@ -35,10 +35,12 @@ export async function action({ request }: Route.ActionArgs) {
 	const submission = parseSubmission(formData);
 	const result = schema.safeParse(submission.payload);
 
-	if (!result.success || submission.intent) {
+	if (!result.success) {
 		return {
 			result: report(submission, {
-				error: formatResult(result),
+				error: {
+					issues: result.error.issues,
+				},
 			}),
 		};
 	}

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -9,6 +9,8 @@ import type {
 } from './types';
 import { isGlobalInstance, isSubmitter } from './dom';
 import { deepEqual, isPlainObject, stripFiles } from './util';
+import type { StandardSchemaIssue } from './standard-schema';
+import { formatIssues } from './standard-schema';
 
 export const DEFAULT_INTENT_NAME = '__INTENT__';
 
@@ -446,6 +448,26 @@ export function report<ErrorShape = string>(
 		reset?: boolean;
 	},
 ): SubmissionResult<ErrorShape>;
+export function report(
+	submission: Submission,
+	options?: {
+		keepFiles?: false;
+		error?: { issues: ReadonlyArray<StandardSchemaIssue> };
+		intendedValue?: Record<string, FormValue> | null;
+		hideFields?: string[];
+		reset?: boolean;
+	},
+): SubmissionResult<string, Exclude<JsonPrimitive | FormDataEntryValue, File>>;
+export function report(
+	submission: Submission,
+	options?: {
+		keepFiles: true;
+		error?: { issues: ReadonlyArray<StandardSchemaIssue> };
+		intendedValue?: Record<string, FormValue> | null;
+		hideFields?: string[];
+		reset?: boolean;
+	},
+): SubmissionResult<string>;
 export function report<ErrorShape = string>(
 	submission: Submission,
 	options: {
@@ -458,7 +480,10 @@ export function report<ErrorShape = string>(
 		 * Error information to include in the result.
 		 * Set to `null` to indicate validation passed with no errors.
 		 */
-		error?: Partial<FormError<ErrorShape>> | null;
+		error?:
+			| { issues: ReadonlyArray<StandardSchemaIssue> }
+			| Partial<FormError<ErrorShape>>
+			| null;
 		/**
 		 * The intended form values to track what the form should contain
 		 * vs. what was actually submitted.
@@ -474,7 +499,7 @@ export function report<ErrorShape = string>(
 		 */
 		reset?: boolean;
 	} = {},
-): SubmissionResult<ErrorShape> {
+): SubmissionResult<ErrorShape | string> {
 	const intendedValue = options.reset
 		? null
 		: typeof options.intendedValue === 'undefined' ||
@@ -483,12 +508,15 @@ export function report<ErrorShape = string>(
 			: options.intendedValue && !options.keepFiles
 				? stripFiles(options.intendedValue)
 				: options.intendedValue;
-	const error = !options.error
-		? options.error
-		: {
-				formErrors: options.error.formErrors ?? [],
-				fieldErrors: options.error.fieldErrors ?? {},
-			};
+	const error =
+		options.error == null
+			? options.error
+			: 'issues' in options.error
+				? formatIssues(options.error.issues)
+				: {
+						formErrors: options.error.formErrors ?? [],
+						fieldErrors: options.error.fieldErrors ?? {},
+					};
 
 	if (options.hideFields) {
 		for (const name of options.hideFields) {

--- a/packages/conform-dom/future/index.ts
+++ b/packages/conform-dom/future/index.ts
@@ -37,3 +37,4 @@ export {
 	requestSubmit,
 	requestIntent,
 } from '../dom';
+export { formatIssues } from '../standard-schema';

--- a/packages/conform-dom/standard-schema.ts
+++ b/packages/conform-dom/standard-schema.ts
@@ -1,0 +1,51 @@
+import type { FormError } from './types';
+import { formatPathSegments } from './formdata';
+import { isPlainObject } from './util';
+
+/**
+ * A widened version of `StandardSchemaV1.Issue`.
+ *
+ * The `path` elements and `PropertyKey` fields are loosened to `unknown`
+ * to stay compatible with Valibot's native issue type.
+ */
+export type StandardSchemaIssue = {
+	readonly message: string;
+	readonly path?: ReadonlyArray<unknown | { key: unknown }> | undefined;
+};
+
+export function formatIssues(
+	issues: Readonly<StandardSchemaIssue[]>,
+): FormError<string> {
+	const error: FormError<string> = {
+		formErrors: [],
+		fieldErrors: {},
+	};
+
+	for (const issue of issues) {
+		const segments =
+			issue.path?.map((segment) => {
+				const path =
+					isPlainObject(segment) && 'key' in segment ? segment.key : segment;
+
+				if (typeof path !== 'string' && typeof path !== 'number') {
+					throw new Error(
+						`Only string or numeric path segment schemes are supported. Received segment: ${String(
+							path,
+						)}`,
+					);
+				}
+
+				return path;
+			}) ?? [];
+		const name = formatPathSegments(segments ?? []);
+
+		if (!name) {
+			error.formErrors.push(issue.message);
+		} else {
+			error.fieldErrors[name] ??= [];
+			error.fieldErrors[name].push(issue.message);
+		}
+	}
+
+	return error;
+}

--- a/packages/conform-react/future/util.ts
+++ b/packages/conform-react/future/util.ts
@@ -1,5 +1,6 @@
 import type { FormError } from '@conform-to/dom/future';
 import {
+	formatIssues,
 	formatPathSegments,
 	getPathSegments,
 	getValueAtPath,
@@ -168,26 +169,6 @@ export function resolveValidateResult<ErrorShape, Value>(
 	};
 }
 
-export function resolveStandardSchemaPath(
-	issue: StandardSchemaV1.Issue,
-): Array<string | number> {
-	if (!issue.path) {
-		return [];
-	}
-
-	const segments = issue.path.map((segment) =>
-		typeof segment === 'object' && 'key' in segment ? segment.key : segment,
-	);
-
-	if (!segments.every((segment) => typeof segment !== 'symbol')) {
-		throw new Error(
-			'Path segments must not contain symbols. Use strings or numbers instead.',
-		);
-	}
-
-	return segments;
-}
-
 export function resolveStandardSchemaResult<Value>(
 	result: StandardSchemaV1.Result<Value>,
 ): {
@@ -201,23 +182,8 @@ export function resolveStandardSchemaResult<Value>(
 		};
 	}
 
-	const errorByName: Record<string, string[]> = {};
-
-	for (const issue of result.issues) {
-		const path = resolveStandardSchemaPath(issue);
-		const name = formatPathSegments(path);
-
-		errorByName[name] ??= [];
-		errorByName[name].push(issue.message);
-	}
-
-	const { '': formErrors = [], ...fieldErrors } = errorByName;
-
 	return {
-		error: {
-			formErrors,
-			fieldErrors,
-		},
+		error: formatIssues(result.issues),
 	};
 }
 

--- a/packages/conform-zod/v3/tests/format.test.ts
+++ b/packages/conform-zod/v3/tests/format.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from 'vitest';
+import { formatIssues } from '@conform-to/dom/future';
 import { formatResult } from '../format';
 import { z } from 'zod';
 
@@ -6,9 +7,9 @@ describe('formatResult', () => {
 	test('returns null for successful validation', () => {
 		const schema = z.object({ name: z.string() });
 		const result = schema.safeParse({ name: 'John' });
-		const formatted = formatResult(result);
+		const error = formatResult(result);
 
-		expect(formatted).toBeNull();
+		expect(error).toBeNull();
 	});
 
 	test('returns error and value with includeValue option', () => {
@@ -28,9 +29,9 @@ describe('formatResult', () => {
 			age: z.number().min(18, 'Must be at least 18'),
 		});
 		const result = schema.safeParse({ name: '', age: 16 });
-		const formatted = formatResult(result);
+		const error = formatResult(result);
 
-		expect(formatted).toEqual({
+		expect(error).toEqual({
 			formErrors: [],
 			fieldErrors: {
 				name: ['Name is required'],
@@ -49,9 +50,9 @@ describe('formatResult', () => {
 		const result = schema.safeParse({
 			user: { name: '', email: 'invalid' },
 		});
-		const formatted = formatResult(result);
+		const error = formatResult(result);
 
-		expect(formatted).toEqual({
+		expect(error).toEqual({
 			formErrors: [],
 			fieldErrors: {
 				'user.name': ['Name is required'],
@@ -66,9 +67,9 @@ describe('formatResult', () => {
 		});
 		const result = schema.safeParse({ items: ['', 'valid', ''] });
 
-		const formatted = formatResult(result);
+		const error = formatResult(result);
 
-		expect(formatted).toEqual({
+		expect(error).toEqual({
 			formErrors: [],
 			fieldErrors: {
 				'items[0]': ['Item cannot be empty'],
@@ -90,9 +91,9 @@ describe('formatResult', () => {
 			password: 'secret',
 			confirmPassword: 'different',
 		});
-		const formatted = formatResult(result);
+		const error = formatResult(result);
 
-		expect(formatted).toEqual({
+		expect(error).toEqual({
 			formErrors: ['Passwords do not match'],
 			fieldErrors: {},
 		});
@@ -124,7 +125,7 @@ describe('formatResult', () => {
 		});
 		const result = schema.safeParse({ name: '', age: 16 });
 
-		const formatted = formatResult(result, {
+		const error = formatResult(result, {
 			formatIssues: (issues, name) =>
 				issues.map((issue) => ({
 					message: issue.message,
@@ -133,7 +134,7 @@ describe('formatResult', () => {
 				})),
 		});
 
-		expect(formatted).toEqual({
+		expect(error).toEqual({
 			formErrors: [],
 			fieldErrors: {
 				name: [
@@ -185,14 +186,13 @@ describe('formatResult', () => {
 				.regex(/[0-9]/, 'Must contain number'),
 		});
 		const result = schema.safeParse({ password: 'abc' });
-
-		const formatted = formatResult(result, {
+		const error = formatResult(result, {
 			formatIssues: (issues, fieldName) => [
 				`${fieldName} has ${issues.length} errors: ${issues.map((i) => i.message).join(', ')}`,
 			],
 		});
 
-		expect(formatted).toEqual({
+		expect(error).toEqual({
 			formErrors: [],
 			fieldErrors: {
 				password: [
@@ -205,10 +205,9 @@ describe('formatResult', () => {
 	test('preserves form-level error structure when no field errors exist', () => {
 		const schema = z.string().refine(() => false, 'Always fails');
 		const result = schema.safeParse('test');
+		const error = formatResult(result);
 
-		const formatted = formatResult(result);
-
-		expect(formatted).toEqual({
+		expect(error).toEqual({
 			formErrors: ['Always fails'],
 			fieldErrors: {},
 		});
@@ -225,10 +224,27 @@ describe('formatResult', () => {
 		const schema = z.object({ name: z.string() });
 		const result = schema.safeParse({ name: 'John' });
 
-		const formatted = formatResult(result, {
+		const error = formatResult(result, {
 			formatIssues: () => ['Should not be called'],
 		});
 
-		expect(formatted).toBeNull();
+		expect(error).toBeNull();
+	});
+
+	test('matches standard schema issue format', () => {
+		const schema = z.object({
+			username: z.string().min(1, 'Username is required'),
+			address: z.object({
+				street: z.string().min(1, 'Street is required'),
+				city: z.string().min(1, 'City is required'),
+			}),
+		});
+		const result = schema.safeParse({
+			username: '',
+			address: { street: '', city: 'Test' },
+		});
+		const error = formatResult(result);
+
+		expect(error).toEqual(formatIssues(result.error?.issues ?? []));
 	});
 });


### PR DESCRIPTION
The `report` function now supports standard schema issues and is compatible with both zod and valibot issues, allowing us to skip the `formResult` helper and pass the schema error to it directly:

```diff
return report(submission, {
+  error: { issues: result.error.issues },  // Zod
+  error: { issues: result.issues },        // Valibot
-  error: formatResult(result),
});
```

However, the `formatResult` function is still useful when you need to customize the error shape.