### PR TITLE
feat(conform-react/future): simplify type signatures

### DIFF
--- a/.changeset/five-bulldogs-repeat.md
+++ b/.changeset/five-bulldogs-repeat.md
@@ -1,0 +1,11 @@
+---
+'@conform-to/react': minor
+---
+
+Simplified type signatures by removing the Metadata generic parameter:
+
+- `FormMetadata<ErrorShape = string>` (previously `FormMetadata<ErrorShape, Metadata>`)
+- `FieldMetadata<FieldShape, ErrorShape = string>` (previously `FieldMetadata<FieldShape, Metadata>`)
+- `Fieldset<FieldShape, ErrorShape = string>` (previously `Fieldset<FieldShape, Metadata>`)
+
+The `Metadata` generic parameter has been removed from all three types and replaced with a more specific `ErrorShape` parameter for `FieldMetadata` and `Fieldset`.

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -42,7 +42,6 @@ import {
 } from './state';
 import type {
 	FormContext,
-	DefaultMetadata,
 	IntentDispatcher,
 	FormMetadata,
 	Fieldset,
@@ -449,7 +448,7 @@ export function useForm<
 	options: FormOptions<FormShape, ErrorShape, Value>,
 ): {
 	form: FormMetadata<ErrorShape>;
-	fields: Fieldset<FormShape, DefaultMetadata<ErrorShape>>;
+	fields: Fieldset<FormShape, ErrorShape>;
 	intent: IntentDispatcher;
 } {
 	const { id, defaultValue, constraint } = options;
@@ -673,12 +672,12 @@ export function useFormMetadata<ErrorShape = string[]>(
  * }
  * ```
  */
-export function useField<FieldShape = any>(
+export function useField<FieldShape = any, ErrorShape = string>(
 	name: FieldName<FieldShape>,
 	options: {
 		formId?: string;
 	} = {},
-): FieldMetadata<FieldShape> {
+): FieldMetadata<FieldShape, ErrorShape> {
 	const config = useContext(FormConfig);
 	const context = useFormContext(options.formId);
 	const field = useMemo(

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -336,7 +336,7 @@ export function getFormMetadata<ErrorShape>(
 	options: {
 		serialize: Serialize;
 	},
-): FormMetadata<ErrorShape, DefaultMetadata<ErrorShape>> {
+): FormMetadata<ErrorShape> {
 	return {
 		key: context.state.resetKey,
 		id: context.formId,
@@ -393,7 +393,7 @@ export function getField<FieldShape, ErrorShape = string>(
 		serialize: Serialize;
 		key?: string;
 	},
-): FieldMetadata<FieldShape, DefaultMetadata<ErrorShape>> {
+): FieldMetadata<FieldShape, ErrorShape> {
 	const id = `${context.formId}-field-${options.name.replace(/[^a-zA-Z0-9._-]/g, '_')}`;
 	const constraint = getConstraint(context, options.name);
 	const metadata: DefaultMetadata<ErrorShape> = {
@@ -459,7 +459,7 @@ export function getFieldset<
 		name?: FieldName<FieldShape>;
 		serialize: Serialize;
 	},
-): Fieldset<FieldShape, DefaultMetadata<ErrorShape>> {
+): Fieldset<FieldShape, ErrorShape> {
 	return new Proxy({} as any, {
 		get(target, name, receiver) {
 			if (typeof name === 'string') {
@@ -487,7 +487,7 @@ export function getFieldList<FieldShape = Array<any>, ErrorShape = string>(
 	[FieldShape] extends [Array<infer ItemShape> | null | undefined]
 		? ItemShape
 		: unknown,
-	DefaultMetadata<ErrorShape>
+	ErrorShape
 >[] {
 	const keys = getListKey(context, options.name);
 

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -344,11 +344,8 @@ export type Combine<T> = {
 };
 
 /** Field metadata object containing field state, validation attributes, and nested field access methods. */
-export type FieldMetadata<
-	FieldShape,
-	Metadata extends Record<string, unknown> = DefaultMetadata<unknown>,
-> = Readonly<
-	Metadata & {
+export type FieldMetadata<FieldShape, ErrorShape = string> = Readonly<
+	DefaultMetadata<ErrorShape> & {
 		/** Unique key for React list rendering (for array fields). */
 		key: string | undefined;
 		/** The field name path exactly as provided. */
@@ -358,7 +355,7 @@ export type FieldMetadata<
 			[FieldShape] extends [Record<string, unknown> | null | undefined]
 				? FieldShape
 				: unknown,
-			Metadata
+			ErrorShape
 		>;
 		/** Method to get array of fields for list/array fields under this field. */
 		getFieldList(): Array<
@@ -366,28 +363,22 @@ export type FieldMetadata<
 				[FieldShape] extends [Array<infer ItemShape> | null | undefined]
 					? ItemShape
 					: unknown,
-				Metadata
+				ErrorShape
 			>
 		>;
 	}
 >;
 
 /** Fieldset object containing all form fields as properties with their respective field metadata. */
-export type Fieldset<
-	FieldShape, // extends Record<string, unknown>,
-	Metadata extends Record<string, unknown>,
-> = {
+export type Fieldset<FieldShape, ErrorShape = string> = {
 	[Key in keyof Combine<FieldShape>]-?: FieldMetadata<
 		Combine<FieldShape>[Key],
-		Metadata
+		ErrorShape
 	>;
 };
 
 /** Form-level metadata and state object containing validation status, errors, and field access methods. */
-export type FormMetadata<
-	ErrorShape,
-	Metadata extends Record<string, unknown> = DefaultMetadata<ErrorShape>,
-> = Readonly<{
+export type FormMetadata<ErrorShape = string> = Readonly<{
 	/** Unique identifier that changes on form reset */
 	key: string;
 	/** The form's unique identifier. */
@@ -419,7 +410,7 @@ export type FormMetadata<
 	/** Method to get metadata for a specific field by name. */
 	getField<FieldShape>(
 		name: FieldName<FieldShape>,
-	): FieldMetadata<FieldShape, Metadata>;
+	): FieldMetadata<FieldShape, ErrorShape>;
 	/** Method to get a fieldset object for nested object fields. */
 	getFieldset<FieldShape>(
 		name?: FieldName<FieldShape>,
@@ -427,7 +418,7 @@ export type FormMetadata<
 		[FieldShape] extends [Record<string, unknown> | null | undefined]
 			? FieldShape
 			: unknown,
-		Metadata
+		ErrorShape
 	>;
 	/** Method to get an array of field objects for array fields. */
 	getFieldList<FieldShape>(
@@ -437,7 +428,7 @@ export type FormMetadata<
 			[FieldShape] extends [Array<infer ItemShape> | null | undefined]
 				? ItemShape
 				: unknown,
-			Metadata
+			ErrorShape
 		>
 	>;
 }>;


### PR DESCRIPTION
This PR simplified type signatures by removing the Metadata generic parameter:

- `FormMetadata<ErrorShape = string>` (previously `FormMetadata<ErrorShape, Metadata>`)
- `FieldMetadata<FieldShape, ErrorShape = string>` (previously `FieldMetadata<FieldShape, Metadata>`)
- `Fieldset<FieldShape, ErrorShape = string>` (previously `Fieldset<FieldShape, Metadata>`)

The `Metadata` generic parameter has been removed from all three types and replaced with a more specific `ErrorShape` parameter for `FieldMetadata` and `Fieldset`.
