### PR TITLE
feat: add schemaValue prop to the onValidate callback

### DIFF
--- a/.changeset/nine-foxes-grin.md
+++ b/.changeset/nine-foxes-grin.md
@@ -1,0 +1,17 @@
+---
+'@conform-to/react': minor
+---
+
+Add `schemaValue` property to the `onValidate` callback argument containing the validated value from successful schema validation. This property is `undefined` when no schema is provided or when validation fails.
+
+```ts
+const form = useForm({
+  schema: z.object({ email: z.string().email() }),
+  onValidate({ schemaValue }) {
+    if (schemaValue) {
+      // Access the validated data: { email: string }
+      console.log(schemaValue.email);
+    }
+  },
+});
+```

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -326,6 +326,7 @@ export function useConform<ErrorShape, Value = undefined>(
 								formElement,
 								submitter: submitEvent.submitter,
 								formData,
+								schemaValue: undefined,
 							})
 						: { error: null };
 
@@ -491,6 +492,8 @@ export function useForm<
 				if (resolvedResult.error) {
 					ctx.error = resolvedResult.error;
 				}
+
+				ctx.schemaValue = resolvedResult.value;
 
 				const validateResult = resolveValidateResult(options.onValidate(ctx));
 

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -471,17 +471,42 @@ export type ValidateResult<ErrorShape, Value> =
 			value?: Value;
 	  };
 
-export type ValidateContext = {
+export type ValidateContext<Value> = {
+	/**
+	 * The submitted values mapped by field name.
+	 * Supports nested names like `user.email` and indexed names like `items[0].id`.
+	 */
 	payload: Record<string, FormValue>;
+	/**
+	 * Form error object. Initially empty, but populated with schema validation
+	 * errors when a schema is provided and validation fails.
+	 */
 	error: FormError<string>;
+	/**
+	 * The submission intent derived from the button that triggered the form submission.
+	 */
 	intent: UnknownIntent | null;
+	/**
+	 * The raw FormData object of the submission.
+	 */
 	formData: FormData;
+	/**
+	 * Reference to the HTML form element that triggered the submission.
+	 */
 	formElement: HTMLFormElement;
+	/**
+	 * The specific element (button/input) that triggered the form submission.
+	 */
 	submitter: HTMLElement | null;
+	/**
+	 * The validated value from schema validation. Only defined when a schema is provided
+	 * and the validation succeeds. Undefined if no schema is provided or validation fails.
+	 */
+	schemaValue: Value | undefined;
 };
 
 export type ValidateHandler<ErrorShape, Value> = (
-	ctx: ValidateContext,
+	ctx: ValidateContext<Value>,
 ) =>
 	| ValidateResult<ErrorShape, Value>
 	| Promise<ValidateResult<ErrorShape, Value>>


### PR DESCRIPTION
Fix https://github.com/edmundhung/conform/discussions/1014#discussioncomment-14481799

This adds a `schemaValue` property to the `onValidate` callback argument containing the validated value from successful schema validation. This property is `undefined` when no schema is provided or when validation fails.

```ts
const form = useForm({
  schema: z.object({ email: z.string().email() }),
  onValidate({ schemaValue }) {
    if (schemaValue) {
      // Access the validated data: { email: string }
      console.log(schemaValue.email);
    }
  },
});
```