### PR TITLE
feat(conform-react): metadata customization

### DIFF
--- a/.changeset/rare-olives-kneel.md
+++ b/.changeset/rare-olives-kneel.md
@@ -56,3 +56,15 @@ function Example() {
   );
 }
 ```
+
+Additionally, you can now customize the base error shape globally using the `CustomTypes` interface:
+
+```tsx
+declare module '@conform-to/react/future' {
+  interface CustomTypes {
+    errorShape: { message: string; code: string };
+  }
+}
+```
+
+This restricts the error shape expected from forms and improves type inference when using `useField` and `useFormMetadata`.

--- a/.changeset/rare-olives-kneel.md
+++ b/.changeset/rare-olives-kneel.md
@@ -1,0 +1,58 @@
+---
+'@conform-to/react': minor
+---
+
+Add metadata customization support to future `useForm` hook
+
+This update introduces a `<FormOptionsProvider />` component that allows users to define global form options, including custom metadata properties that match your form component types when integrating with UI libraries or any custom components:
+
+```tsx
+import {
+  FormOptionsProvider,
+  type BaseMetadata,
+} from '@conform-to/react/future';
+import { TextField } from './components/TextField';
+
+// Define custom metadata properties that matches the type of our custom form components
+function defineCustomMetadata<FieldShape, ErrorShape>(
+  metadata: BaseMetadata<FieldShape, ErrorShape>,
+) {
+  return {
+    get textFieldProps() {
+      return {
+        name: metadata.name,
+        defaultValue: metadata.defaultValue,
+        isInvalid: !metadata.valid,
+      } satisfies Partial<React.ComponentProps<typeof TextField>>;
+    },
+  };
+}
+
+// Extend the CustomMetadata interface with our implementation
+// This makes the custom metadata types available on all field metadata objects
+declare module '@conform-to/react/future' {
+  interface CustomMetadata<FieldShape, ErrorShape>
+    extends ReturnType<typeof defineCustomMetadata<FieldShape, ErrorShape>> {}
+}
+
+// Wrap your app with FormOptionsProvider
+<FormOptionsProvider
+  shouldValidate="onBlur"
+  defineCustomMetadata={defineCustomMetadata}
+>
+  <App />
+</FormOptionsProvider>;
+
+// Use custom metadata properties in your components
+function Example() {
+  const { form, fields } = useForm({
+    // shouldValidate now defaults to "onBlur"
+  });
+
+  return (
+    <form {...form.props}>
+      <TextField {...fields.email.textFieldProps} />
+    </form>
+  );
+}
+```

--- a/docs/api/react/future/FormOptionsProvider.md
+++ b/docs/api/react/future/FormOptionsProvider.md
@@ -1,0 +1,160 @@
+# FormOptionsProvider
+
+> The `FormOptionsProvider` component is part of Conform's future export. These APIs are experimental and may change in minor versions. [Learn more](https://github.com/edmundhung/conform/discussions/954)
+
+A React component that provides global form options to all forms in your application.
+
+```tsx
+import { FormOptionsProvider } from '@conform-to/react/future';
+
+export default function App() {
+  return (
+    <FormOptionsProvider shouldValidate="onBlur" shouldRevalidate="onInput">
+      {/* Your app components */}
+    </FormOptionsProvider>
+  );
+}
+```
+
+## Props
+
+All props are optional. When a prop is not provided, it inherits the default value or from a parent `FormOptionsProvider` if nested.
+
+### `shouldValidate?: 'onSubmit' | 'onBlur' | 'onInput'`
+
+Determines when validation should run for the first time on a field. Default is `onSubmit`.
+
+This option sets the default validation timing for all forms in your application. Individual forms can override this by passing their own `shouldValidate` option to [useForm](./useForm.md).
+
+```tsx
+<FormOptionsProvider shouldValidate="onBlur">
+  {/* All forms will validate on blur by default */}
+</FormOptionsProvider>
+```
+
+### `shouldRevalidate?: 'onSubmit' | 'onBlur' | 'onInput'`
+
+Determines when validation should run again after the field has been validated once. Default is the same as `shouldValidate`.
+
+This is useful when you want an immediate update after the user has interacted with a field. For example, validate on blur initially, but revalidate on every input after the first validation.
+
+```tsx
+<FormOptionsProvider shouldValidate="onBlur" shouldRevalidate="onInput">
+  {/* Validate on blur, but show live feedback after first validation */}
+</FormOptionsProvider>
+```
+
+### `defineCustomMetadata?: <FieldShape, ErrorShape>(metadata: BaseMetadata<FieldShape, ErrorShape>) => CustomMetadata`
+
+A function that defines custom metadata properties for your form fields. This is particularly useful when integrating with UI libraries or custom form components.
+
+```tsx
+import {
+  FormOptionsProvider,
+  type BaseMetadata,
+} from '@conform-to/react/future';
+import type { TextField } from './components/TextField';
+
+// Define custom metadata properties that matches the type of our custom form components
+function defineCustomMetadata<FieldShape, ErrorShape>(
+  metadata: BaseMetadata<FieldShape, ErrorShape>,
+) {
+  return {
+    get textFieldProps() {
+      return {
+        name: metadata.name,
+        defaultValue: metadata.defaultValue,
+        isInvalid: !metadata.valid,
+        errors: metadata.errors,
+      } satisfies Partial<React.ComponentProps<typeof TextField>>;
+    },
+  };
+}
+
+// Extend the CustomMetadata interface with our implementation
+// This makes the custom metadata types available on all field metadata objects
+declare module '@conform-to/react/future' {
+  interface CustomMetadata<FieldShape, ErrorShape>
+    extends ReturnType<typeof defineCustomMetadata<FieldShape, ErrorShape>> {}
+}
+
+// Wrap your app with FormOptionsProvider
+<FormOptionsProvider defineCustomMetadata={defineCustomMetadata}>
+  <App />
+</FormOptionsProvider>;
+```
+
+Once defined, custom metadata properties are available on all field metadata objects:
+
+```tsx
+function LoginForm() {
+  const { form, fields } = useForm({
+    // form options
+  });
+
+  return (
+    <form {...form.props}>
+      {/* TypeScript knows about textFieldProps! */}
+      <TextField {...fields.email.textFieldProps} />
+      <TextField {...fields.password.textFieldProps} />
+      <button>Login</button>
+    </form>
+  );
+}
+```
+
+### `intentName?: string`
+
+The name of the submit button field that indicates the submission intent. Default is `'__intent__'`.
+
+This is an advanced option. You typically don't need to change this unless you have conflicts with existing field names.
+
+### `serialize(value: unknown) => string | string[] | File | File[] | null | undefined`
+
+A custom serialization function for converting form data.
+
+This is an advanced option. You typically don't need to change this unless you have special serialization requirements.
+
+## Tips
+
+### Conditional metadata based on field shape
+
+You can use TypeScript's conditional types to restrict custom metadata based on the field shape:
+
+```tsx
+function defineCustomMetadata<FieldShape, ErrorShape>(
+  metadata: BaseMetadata<FieldShape, ErrorShape>,
+) {
+  return {
+    get dateRangePickerProps() {
+      // Only available for field with start and end properties
+      const rangeFields = metadata.getFieldset<{
+        start: string;
+        end: string;
+      }>();
+
+      return {
+        startName: rangeFields.start.name,
+        endName: rangeFields.end.name,
+        defaultValue: {
+          start: rangeFields.start.defaultValue,
+          end: rangeFields.end.defaultValue,
+        },
+        isInvalid: !metadata.valid,
+        errors: metadata.errors?.map((error) => `${error}`),
+      } satisfies Partial<React.ComponentProps<typeof DateRangePicker>>;
+    },
+  };
+}
+
+declare module '@conform-to/react/future' {
+  interface CustomMetadata<FieldShape, ErrorShape> {
+    // Make dateRangePickerProps only available if the field shape has start and end properties
+    dateRangePickerProps: FieldShape extends { start: string; end: string }
+      ? ReturnType<
+          typeof defineCustomMetadata<FieldShape, ErrorShape>
+        >['dateRangePickerProps']
+      : unknown;
+  }
+}
+```

--- a/docs/api/react/future/useField.md
+++ b/docs/api/react/future/useField.md
@@ -78,6 +78,14 @@ Array of validation error messages for this field.
 
 Object containing errors for all touched subfields.
 
+### `ariaInvalid: boolean | undefined`
+
+Boolean value for the `aria-invalid` attribute. Indicates whether the field has validation errors for screen readers. This is `true` when the field has errors, `undefined` otherwise.
+
+### `ariaDescribedBy: string | undefined`
+
+String value for the `aria-describedby` attribute. Contains the `errorId` when the field is invalid, `undefined` otherwise. If you need to reference both help text and errors, merge with `descriptionId` manually (e.g., `${field.descriptionId} ${field.ariaDescribedBy}`).
+
 ### Validation Attributes
 
 HTML validation attributes automatically derived from schema constraints:
@@ -134,7 +142,8 @@ function FormField({ name, label, type = 'text' }: FieldProps) {
         min={field.min}
         max={field.max}
         step={field.step}
-        aria-describedby={field.errors ? field.errorId : undefined}
+        aria-invalid={field.ariaInvalid}
+        aria-describedby={field.ariaDescribedBy}
       />
 
       {field.errors && (

--- a/examples/chakra-ui/README.md
+++ b/examples/chakra-ui/README.md
@@ -1,6 +1,45 @@
 # Chakra UI Example
 
-This example shows you how to integrate [chakra-ui](https://chakra-ui.com/docs/components) forms components with Conform.
+[Chakra UI](https://chakra-ui.com/) is a simple, modular and accessible component library that gives you the building blocks you need to build your React applications.
+
+This example demonstrates how to integrate Conform with Chakra UI using custom metadata.
+
+## Understanding the Integration
+
+The main application ([`App.tsx`](./src/App.tsx)) uses explicit prop assignment for educational purposes, making it easy to see how field metadata maps to Chakra UI component props:
+
+```tsx
+<Input
+  name={fields.text.name}
+  defaultValue={fields.text.defaultValue}
+  isInvalid={!fields.text.valid}
+/>
+```
+
+While this is clear and straightforward for learning, it becomes repetitive in production applications.
+
+## Custom Metadata
+
+The example also showcases metadata customization for a more DRY approach. Custom metadata properties are defined once in [`main.tsx`](./src/main.tsx) and provide type-safe props that match Chakra UI component types:
+
+```tsx
+// Define custom metadata once
+function defineCustomMetadata(metadata) {
+  return {
+    get inputProps() {
+      return {
+        name: metadata.name,
+        defaultValue: metadata.defaultValue,
+        isInvalid: !metadata.valid,
+      } satisfies Partial<React.ComponentProps<typeof Input>>;
+    },
+    // ... other component props
+  };
+}
+
+// Use with full type safety
+<Input {...fields.text.inputProps} />
+```
 
 ## Compatibility
 
@@ -21,6 +60,8 @@ This example shows you how to integrate [chakra-ui](https://chakra-ui.com/docs/c
 - NumberInput
 - PinInput
 - Slider
+
+## Demo
 
 <!-- sandbox src="/examples/chakra-ui" -->
 

--- a/examples/chakra-ui/src/form.tsx
+++ b/examples/chakra-ui/src/form.tsx
@@ -18,7 +18,7 @@ import {
 } from '@chakra-ui/react';
 import { useRef } from 'react';
 
-type ExampleNumberProps = {
+export type ExampleNumberProps = {
 	name: string;
 	defaultValue?: string;
 };
@@ -48,7 +48,7 @@ export function ExampleNumberInput({ name, defaultValue }: ExampleNumberProps) {
 	);
 }
 
-type ExamplePinProps = {
+export type ExamplePinProps = {
 	name: string;
 	defaultValue?: string;
 };
@@ -77,7 +77,7 @@ export function ExamplePinInput({ name, defaultValue }: ExamplePinProps) {
 	);
 }
 
-type ExampleSliderProps = {
+export type ExampleSliderProps = {
 	name: string;
 	defaultValue?: string;
 };

--- a/examples/chakra-ui/src/main.tsx
+++ b/examples/chakra-ui/src/main.tsx
@@ -1,12 +1,122 @@
+import {
+	type BaseMetadata,
+	FormOptionsProvider,
+} from '@conform-to/react/future';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import { ChakraProvider } from '@chakra-ui/react';
+import type {
+	Input,
+	Select,
+	Textarea,
+	Checkbox,
+	Switch,
+} from '@chakra-ui/react';
+import type {
+	ExampleNumberInput,
+	ExamplePinInput,
+	ExampleSlider,
+	ExampleRadioGroup,
+	ExampleEditable,
+} from './form';
+
+// Define custom metadata properties that matches the type of our custom form components
+function defineCustomMetadata<FieldShape, ErrorShape>(
+	metadata: BaseMetadata<FieldShape, ErrorShape>,
+) {
+	return {
+		get inputProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				required: metadata.required,
+			} satisfies Partial<React.ComponentProps<typeof Input>>;
+		},
+		get selectProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				required: metadata.required,
+			} satisfies Partial<React.ComponentProps<typeof Select>>;
+		},
+		get textareaProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				required: metadata.required,
+			} satisfies Partial<React.ComponentProps<typeof Textarea>>;
+		},
+		get checkboxProps() {
+			return {
+				name: metadata.name,
+				value: 'on',
+				defaultChecked: metadata.defaultChecked,
+				required: metadata.required,
+			} satisfies Partial<React.ComponentProps<typeof Checkbox>>;
+		},
+		get switchProps() {
+			return {
+				name: metadata.name,
+				value: 'on',
+				defaultChecked: metadata.defaultChecked,
+				required: metadata.required,
+			} satisfies Partial<React.ComponentProps<typeof Switch>>;
+		},
+		get numberInputProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+			} satisfies Partial<React.ComponentProps<typeof ExampleNumberInput>>;
+		},
+		get pinInputProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+			} satisfies Partial<React.ComponentProps<typeof ExamplePinInput>>;
+		},
+		get sliderProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+			} satisfies Partial<React.ComponentProps<typeof ExampleSlider>>;
+		},
+		get radioGroupProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+			} satisfies Partial<React.ComponentProps<typeof ExampleRadioGroup>>;
+		},
+		get editableProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+			} satisfies Partial<React.ComponentProps<typeof ExampleEditable>>;
+		},
+	};
+}
+
+type MetadataDefinition<FieldShape, ErrorShape> = ReturnType<
+	typeof defineCustomMetadata<FieldShape, ErrorShape>
+>;
+
+// Extend the CustomMetadata interface with our UI component props
+// This makes the custom metadata available on all field metadata objects
+declare module '@conform-to/react/future' {
+	interface CustomMetadata<FieldShape, ErrorShape>
+		extends MetadataDefinition<FieldShape, ErrorShape> {}
+}
 
 createRoot(document.getElementById('root')!).render(
 	<StrictMode>
 		<ChakraProvider>
-			<App />
+			<FormOptionsProvider
+				shouldValidate="onBlur"
+				shouldRevalidate="onInput"
+				defineCustomMetadata={defineCustomMetadata}
+			>
+				<App />
+			</FormOptionsProvider>
 		</ChakraProvider>
 	</StrictMode>,
 );

--- a/examples/headless-ui/README.md
+++ b/examples/headless-ui/README.md
@@ -1,6 +1,44 @@
 # Headless UI Example
 
-[Headless UI](https://headlessui.com) is a set of completely unstyled, fully accessible UI components for React, designed to integrate beautifully with Tailwind CSS. In this guide, we will show how to integrate its input components with Conform.
+[Headless UI](https://headlessui.com) is a set of completely unstyled, fully accessible UI components for React, designed to integrate beautifully with Tailwind CSS.
+
+This example demonstrates how to integrate Conform with Headless UI using custom metadata.
+
+## Understanding the Integration
+
+The main application ([`App.tsx`](./src/App.tsx)) uses explicit prop assignment for educational purposes, making it easy to see how field metadata maps to Headless UI component props:
+
+```tsx
+<ExampleListBox
+  name={fields.colors.name}
+  defaultValue={fields.colors.defaultOptions}
+  options={colorOptions}
+/>
+```
+
+While this is clear and straightforward for learning, it becomes repetitive in production applications.
+
+## Custom Metadata
+
+The example also showcases metadata customization for a more DRY approach. Custom metadata properties are defined once in [`main.tsx`](./src/main.tsx) and provide type-safe props that match Headless UI component types:
+
+```tsx
+// Define custom metadata once
+function defineCustomMetadata(metadata) {
+  return {
+    get listBoxProps() {
+      return {
+        name: metadata.name,
+        defaultValue: metadata.defaultOptions,
+      } satisfies Partial<React.ComponentProps<typeof ExampleListBox>>;
+    },
+    // ... other component props
+  };
+}
+
+// Use with full type safety
+<ExampleListBox {...fields.colors.listBoxProps} options={colorOptions} />
+```
 
 ## Compatibility
 

--- a/examples/headless-ui/src/form.tsx
+++ b/examples/headless-ui/src/form.tsx
@@ -7,7 +7,7 @@ function classNames(...classes: Array<string | boolean>): string {
 	return classes.filter(Boolean).join(' ');
 }
 
-type ExampleListBoxProps = {
+export type ExampleListBoxProps = {
 	name: string;
 	defaultValue?: string[];
 	options: Array<{ label: string; value: string }>;
@@ -86,7 +86,7 @@ export function ExampleListBox({
 	);
 }
 
-type ExampleComboboxProps = {
+export type ExampleComboboxProps = {
 	name: string;
 	defaultValue?: string;
 	options: Array<{ label: string; value: string }>;
@@ -174,7 +174,7 @@ export function ExampleCombobox({
 	);
 }
 
-type ExampleSwitchProps = {
+export type ExampleSwitchProps = {
 	name: string;
 	value?: string;
 	defaultChecked?: boolean;
@@ -218,7 +218,7 @@ export function ExampleSwitch({
 	);
 }
 
-type ExampleRadioGroupProps = {
+export type ExampleRadioGroupProps = {
 	name: string;
 	defaultValue?: string;
 };

--- a/examples/headless-ui/src/main.tsx
+++ b/examples/headless-ui/src/main.tsx
@@ -1,10 +1,69 @@
+import {
+	type BaseMetadata,
+	FormOptionsProvider,
+} from '@conform-to/react/future';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
+import type {
+	ExampleListBox,
+	ExampleCombobox,
+	ExampleSwitch,
+	ExampleRadioGroup,
+} from './form';
+
+// Define custom metadata properties that matches the type of our custom form components
+function defineCustomMetadata<FieldShape, ErrorShape>(
+	metadata: BaseMetadata<FieldShape, ErrorShape>,
+) {
+	return {
+		get listBoxProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultOptions,
+			} satisfies Partial<React.ComponentProps<typeof ExampleListBox>>;
+		},
+		get comboboxProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+			} satisfies Partial<React.ComponentProps<typeof ExampleCombobox>>;
+		},
+		get switchProps() {
+			return {
+				name: metadata.name,
+				defaultChecked: metadata.defaultChecked,
+			} satisfies Partial<React.ComponentProps<typeof ExampleSwitch>>;
+		},
+		get radioGroupProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+			} satisfies Partial<React.ComponentProps<typeof ExampleRadioGroup>>;
+		},
+	};
+}
+
+type MetadataDefinition<FieldShape, ErrorShape> = ReturnType<
+	typeof defineCustomMetadata<FieldShape, ErrorShape>
+>;
+
+// Extend the CustomMetadata interface with our UI component props
+// This makes the custom metadata available on all field metadata objects
+declare module '@conform-to/react/future' {
+	interface CustomMetadata<FieldShape, ErrorShape>
+		extends MetadataDefinition<FieldShape, ErrorShape> {}
+}
 
 createRoot(document.getElementById('root')!).render(
 	<StrictMode>
-		<App />
+		<FormOptionsProvider
+			shouldValidate="onBlur"
+			shouldRevalidate="onInput"
+			defineCustomMetadata={defineCustomMetadata}
+		>
+			<App />
+		</FormOptionsProvider>
 	</StrictMode>,
 );

--- a/examples/material-ui/README.md
+++ b/examples/material-ui/README.md
@@ -1,6 +1,47 @@
 # Material UI Example
 
-[Material UI](https://mui.com/material-ui) is a comprehensive library of components based on Google's Material Design system. In this guide, we will show how to integrate its form components with Conform.
+[Material UI](https://mui.com/material-ui) is a comprehensive library of components based on Google's Material Design system.
+
+This example demonstrates how to integrate Conform with Material UI using custom metadata.
+
+## Understanding the Integration
+
+The main application ([`App.tsx`](./src/App.tsx)) uses explicit prop assignment for educational purposes, making it easy to see how field metadata maps to Material UI component props:
+
+```tsx
+<TextField
+  name={fields.email.name}
+  defaultValue={fields.email.defaultValue}
+  error={!fields.email.valid}
+  helperText={fields.email.errors}
+/>
+```
+
+While this is clear and straightforward for learning, it becomes repetitive in production applications.
+
+## Custom Metadata
+
+The example also showcases metadata customization for a more DRY approach. Custom metadata properties are defined once in [`main.tsx`](./src/main.tsx) and provide type-safe props that match Material UI component types:
+
+```tsx
+// Define custom metadata once
+function defineCustomMetadata(metadata) {
+  return {
+    get textFieldProps() {
+      return {
+        name: metadata.name,
+        defaultValue: metadata.defaultValue,
+        error: !metadata.valid,
+        helperText: metadata.errors,
+      } satisfies Partial<React.ComponentProps<typeof TextField>>;
+    },
+    // ... other component props
+  };
+}
+
+// Use with full type safety
+<TextField {...fields.email.textFieldProps} />
+```
 
 ## Compatibility
 

--- a/examples/material-ui/src/form.tsx
+++ b/examples/material-ui/src/form.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mui/material';
 import { useRef } from 'react';
 
-type TextFieldProps = React.ComponentProps<typeof MuiTextField> & {
+export type TextFieldProps = React.ComponentProps<typeof MuiTextField> & {
 	defaultValue?: string | string[];
 };
 
@@ -37,7 +37,7 @@ export function TextField({ name, defaultValue, ...props }: TextFieldProps) {
 	);
 }
 
-type AutocompleteProps = {
+export type AutocompleteProps = {
 	name: string;
 	label: string;
 	defaultValue?: string;
@@ -83,7 +83,7 @@ export function Autocomplete({
 	);
 }
 
-type CheckboxProps = {
+export type CheckboxProps = {
 	name: string;
 	value?: string;
 	defaultChecked?: boolean;
@@ -112,7 +112,7 @@ export function Checkbox({ name, value, defaultChecked }: CheckboxProps) {
 	);
 }
 
-type RadioGroupProps = {
+export type RadioGroupProps = {
 	name?: string;
 	defaultValue?: string;
 	children: React.ReactNode;
@@ -150,7 +150,7 @@ export function RadioGroup({ name, defaultValue, children }: RadioGroupProps) {
 	);
 }
 
-type SwitchProps = {
+export type SwitchProps = {
 	name: string;
 	value?: string;
 	defaultChecked?: boolean;
@@ -179,7 +179,7 @@ export function Switch({ name, value, defaultChecked }: SwitchProps) {
 	);
 }
 
-type RatingProps = {
+export type RatingProps = {
 	name: string;
 	defaultValue?: string;
 };
@@ -201,7 +201,7 @@ export function Rating({ name, defaultValue }: RatingProps) {
 	);
 }
 
-type SliderProps = {
+export type SliderProps = {
 	name: string;
 	defaultValue?: string;
 };

--- a/examples/material-ui/src/main.tsx
+++ b/examples/material-ui/src/main.tsx
@@ -1,9 +1,87 @@
+import {
+	type BaseMetadata,
+	FormOptionsProvider,
+} from '@conform-to/react/future';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import type { TextField, Checkbox, RadioGroup, Switch } from '@mui/material';
+import type { Autocomplete, Rating, Slider } from './form';
+
+// Define custom metadata properties that matches the type of our custom form components
+function defineCustomMetadata<FieldShape, ErrorShape>(
+	metadata: BaseMetadata<FieldShape, ErrorShape>,
+) {
+	return {
+		get textFieldProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				error: !metadata.valid,
+				helperText: metadata.errors?.map((error) => `${error}`),
+			} satisfies Partial<React.ComponentProps<typeof TextField>>;
+		},
+		get autocompleteProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				error: metadata.errors?.map((error) => `${error}`),
+			} satisfies Partial<React.ComponentProps<typeof Autocomplete>>;
+		},
+		get checkboxProps() {
+			return {
+				name: metadata.name,
+				value: 'on',
+				defaultChecked: metadata.defaultChecked,
+			} satisfies Partial<React.ComponentProps<typeof Checkbox>>;
+		},
+		get radioGroupProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+			} satisfies Partial<React.ComponentProps<typeof RadioGroup>>;
+		},
+		get switchProps() {
+			return {
+				name: metadata.name,
+				value: 'on',
+				defaultChecked: metadata.defaultChecked,
+			} satisfies Partial<React.ComponentProps<typeof Switch>>;
+		},
+		get ratingProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+			} satisfies Partial<React.ComponentProps<typeof Rating>>;
+		},
+		get sliderProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+			} satisfies Partial<React.ComponentProps<typeof Slider>>;
+		},
+	};
+}
+
+type MetadataDefinition<FieldShape, ErrorShape> = ReturnType<
+	typeof defineCustomMetadata<FieldShape, ErrorShape>
+>;
+
+// Extend the CustomMetadata interface with our UI component props
+// This makes the custom metadata available on all field metadata objects
+declare module '@conform-to/react/future' {
+	interface CustomMetadata<FieldShape, ErrorShape>
+		extends MetadataDefinition<FieldShape, ErrorShape> {}
+}
 
 createRoot(document.getElementById('root')!).render(
 	<StrictMode>
-		<App />
+		<FormOptionsProvider
+			shouldValidate="onBlur"
+			shouldRevalidate="onInput"
+			defineCustomMetadata={defineCustomMetadata}
+		>
+			<App />
+		</FormOptionsProvider>
 	</StrictMode>,
 );

--- a/examples/radix-ui/README.md
+++ b/examples/radix-ui/README.md
@@ -1,7 +1,43 @@
 # Radix UI Example
 
-[Radix UI](https://www.radix-ui.com/) Radix UI is a headless UI library, offering flexible, unstyled primitives for creating customizable and accessible components, allowing developers to manage the visual layer independently.
-This example we leverage [Vite](https://vitejs.dev/) and [Tailwind CSS](https://tailwindcss.com/)
+[Radix UI](https://www.radix-ui.com/) is a headless UI library, offering flexible, unstyled primitives for creating customizable and accessible components, allowing developers to manage the visual layer independently.
+
+This example demonstrates how to integrate Conform with Radix UI using custom metadata. We leverage [Vite](https://vitejs.dev/) and [Tailwind CSS](https://tailwindcss.com/) for styling.
+
+## Understanding the Integration
+
+The main application ([`App.tsx`](./src/App.tsx)) uses explicit prop assignment for educational purposes, making it easy to see how field metadata maps to Radix UI component props:
+
+```tsx
+<ExampleSelect
+  name={fields.category.name}
+  defaultValue={fields.category.defaultValue}
+/>
+```
+
+While this is clear and straightforward for learning, it becomes repetitive in production applications.
+
+## Custom Metadata
+
+The example also showcases metadata customization for a more DRY approach. Custom metadata properties are defined once in [`main.tsx`](./src/main.tsx) and provide type-safe props that match Radix UI component types:
+
+```tsx
+// Define custom metadata once
+function defineCustomMetadata(metadata) {
+  return {
+    get selectProps() {
+      return {
+        name: metadata.name,
+        defaultValue: metadata.defaultValue,
+      } satisfies Partial<React.ComponentProps<typeof ExampleSelect>>;
+    },
+    // ... other component props
+  };
+}
+
+// Use with full type safety
+<ExampleSelect {...fields.category.selectProps} />
+```
 
 ## Required packages
 

--- a/examples/radix-ui/src/form.tsx
+++ b/examples/radix-ui/src/form.tsx
@@ -15,7 +15,7 @@ import {
 import clsx from 'clsx';
 import { type ElementRef, useRef } from 'react';
 
-type ExampleSelectProps = {
+export type ExampleSelectProps = {
 	name: string;
 	items: Array<{ name: string; value: string }>;
 	placeholder?: string;
@@ -96,7 +96,7 @@ export function ExampleSelect({
 	);
 }
 
-type ExampleToggleGroupProps = {
+export type ExampleToggleGroupProps = {
 	name: string;
 	items: Array<{ label: string; value: string }>;
 	defaultValue?: string;
@@ -143,7 +143,7 @@ export function ExampleToggleGroup({
 	);
 }
 
-type ExampleSwitchProps = {
+export type ExampleSwitchProps = {
 	name: string;
 	value?: string;
 	defaultChecked?: boolean;
@@ -179,7 +179,7 @@ export function ExampleSwitch({
 	);
 }
 
-type ExampleSliderProps = {
+export type ExampleSliderProps = {
 	name: string;
 	max?: number;
 	defaultValue?: string;
@@ -224,7 +224,7 @@ export function ExampleSlider({
 	);
 }
 
-type ExampleRadioGroupProps = {
+export type ExampleRadioGroupProps = {
 	name: string;
 	items: Array<{ value: string; label: string }>;
 	defaultValue?: string;
@@ -277,7 +277,7 @@ export function ExampleRadioGroup({
 	);
 }
 
-type ExampleCheckboxProps = {
+export type ExampleCheckboxProps = {
 	name: string;
 	value?: string;
 	defaultChecked?: boolean;

--- a/examples/radix-ui/src/main.tsx
+++ b/examples/radix-ui/src/main.tsx
@@ -1,10 +1,85 @@
+import {
+	type BaseMetadata,
+	FormOptionsProvider,
+} from '@conform-to/react/future';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
+import type {
+	ExampleSelect,
+	ExampleToggleGroup,
+	ExampleSwitch,
+	ExampleSlider,
+	ExampleRadioGroup,
+	ExampleCheckbox,
+} from './form';
+
+// Define custom metadata properties that matches the type of our custom form components
+function defineCustomMetadata<FieldShape, ErrorShape>(
+	metadata: BaseMetadata<FieldShape, ErrorShape>,
+) {
+	return {
+		get selectProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+			} satisfies Partial<React.ComponentProps<typeof ExampleSelect>>;
+		},
+		get toggleGroupProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+			} satisfies Partial<React.ComponentProps<typeof ExampleToggleGroup>>;
+		},
+		get switchProps() {
+			return {
+				name: metadata.name,
+				value: 'on',
+				defaultChecked: metadata.defaultChecked,
+			} satisfies Partial<React.ComponentProps<typeof ExampleSwitch>>;
+		},
+		get sliderProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+			} satisfies Partial<React.ComponentProps<typeof ExampleSlider>>;
+		},
+		get radioGroupProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+			} satisfies Partial<React.ComponentProps<typeof ExampleRadioGroup>>;
+		},
+		get checkboxProps() {
+			return {
+				name: metadata.name,
+				value: 'on',
+				defaultChecked: metadata.defaultChecked,
+			} satisfies Partial<React.ComponentProps<typeof ExampleCheckbox>>;
+		},
+	};
+}
+
+type MetadataDefinition<FieldShape, ErrorShape> = ReturnType<
+	typeof defineCustomMetadata<FieldShape, ErrorShape>
+>;
+
+// Extend the CustomMetadata interface with our UI component props
+// This makes the custom metadata available on all field metadata objects
+declare module '@conform-to/react/future' {
+	interface CustomMetadata<FieldShape, ErrorShape>
+		extends MetadataDefinition<FieldShape, ErrorShape> {}
+}
 
 createRoot(document.getElementById('root')!).render(
 	<StrictMode>
-		<App />
+		<FormOptionsProvider
+			shouldValidate="onBlur"
+			shouldRevalidate="onInput"
+			defineCustomMetadata={defineCustomMetadata}
+		>
+			<App />
+		</FormOptionsProvider>
 	</StrictMode>,
 );

--- a/examples/react-aria/README.md
+++ b/examples/react-aria/README.md
@@ -2,16 +2,48 @@
 
 [React Aria](https://react-spectrum.adobe.com/react-aria/index.html) is a library of unstyled React components and hooks that helps you build accessible, high quality UI components for your application or design system.
 
-## Compatibility
+This example demonstrates how to integrate Conform with React Aria using custom metadata.
 
-> Based on react-aria-components@x.x.x
+## Understanding the Integration
 
-**Integration required**
+The main application ([`App.tsx`](./src/App.tsx)) uses explicit prop assignment for educational purposes, making it easy to see how field metadata maps to React Aria component props:
 
-- ListBox
-- Combobox
-- Switch
-- RadioGroup
+```tsx
+<TextField
+  label="Email"
+  type="email"
+  name={fields.email.name}
+  defaultValue={fields.email.defaultValue}
+  isInvalid={!fields.email.valid}
+  errors={fields.email.errors}
+/>
+```
+
+While this is clear and straightforward for learning, it becomes repetitive in production applications.
+
+## Custom Metadata
+
+The example also showcases metadata customization for a more DRY approach. Custom metadata properties are defined once in [./src/main.tsx](./src/main.tsx) and provide type-safe props that match React Aria component types:
+
+```tsx
+// Define custom metadata once
+function defineCustomMetadata(metadata) {
+  return {
+    get textFieldProps() {
+      return {
+        name: metadata.name,
+        defaultValue: metadata.defaultValue,
+        isInvalid: !metadata.valid,
+        errors: metadata.errors,
+      } satisfies Partial<React.ComponentProps<typeof TextField>>;
+    },
+    // ... other component props
+  };
+}
+
+// Use with full type safety
+<TextField {...fields.email.textFieldProps} />
+```
 
 ## Demo
 

--- a/examples/react-aria/src/main.tsx
+++ b/examples/react-aria/src/main.tsx
@@ -1,4 +1,5 @@
 import {
+	type BaseErrorShape,
 	type BaseMetadata,
 	FormOptionsProvider,
 } from '@conform-to/react/future';
@@ -18,7 +19,7 @@ import type { Checkbox } from './components/Checkbox';
 import type { DateRangePicker } from './components/DateRangePicker';
 
 // Define custom metadata properties that matches the type of our custom form components
-function defineCustomMetadata<FieldShape, ErrorShape>(
+function defineCustomMetadata<FieldShape, ErrorShape extends BaseErrorShape>(
 	metadata: BaseMetadata<FieldShape, ErrorShape>,
 ) {
 	return {
@@ -27,7 +28,7 @@ function defineCustomMetadata<FieldShape, ErrorShape>(
 				name: metadata.name,
 				defaultValue: metadata.defaultValue,
 				isInvalid: !metadata.valid,
-				errors: metadata.errors?.map((error) => `${error}`),
+				errors: metadata.errors,
 			} satisfies Partial<React.ComponentProps<typeof TextField>>;
 		},
 		get numberFieldProps() {
@@ -35,7 +36,7 @@ function defineCustomMetadata<FieldShape, ErrorShape>(
 				name: metadata.name,
 				defaultValue: metadata.defaultValue,
 				isInvalid: !metadata.valid,
-				errors: metadata.errors?.map((error) => `${error}`),
+				errors: metadata.errors,
 			} satisfies Partial<React.ComponentProps<typeof NumberField>>;
 		},
 		get radioGroupProps() {
@@ -43,7 +44,7 @@ function defineCustomMetadata<FieldShape, ErrorShape>(
 				name: metadata.name,
 				defaultValue: metadata.defaultValue,
 				isInvalid: !metadata.valid,
-				errors: metadata.errors?.map((error) => `${error}`),
+				errors: metadata.errors,
 			} satisfies Partial<React.ComponentProps<typeof RadioGroup>>;
 		},
 		get checkboxGroupProps() {
@@ -51,7 +52,7 @@ function defineCustomMetadata<FieldShape, ErrorShape>(
 				name: metadata.name,
 				defaultValue: metadata.defaultOptions,
 				isInvalid: !metadata.valid,
-				errors: metadata.errors?.map((error) => `${error}`),
+				errors: metadata.errors,
 			} satisfies Partial<React.ComponentProps<typeof CheckboxGroup>>;
 		},
 		get datePickerProps() {
@@ -59,7 +60,7 @@ function defineCustomMetadata<FieldShape, ErrorShape>(
 				name: metadata.name,
 				defaultValue: metadata.defaultValue,
 				isInvalid: !metadata.valid,
-				errors: metadata.errors?.map((error) => `${error}`),
+				errors: metadata.errors,
 			} satisfies Partial<React.ComponentProps<typeof DatePicker>>;
 		},
 		get selectProps() {
@@ -67,7 +68,7 @@ function defineCustomMetadata<FieldShape, ErrorShape>(
 				name: metadata.name,
 				defaultValue: metadata.defaultValue,
 				isInvalid: !metadata.valid,
-				errors: metadata.errors?.map((error) => `${error}`),
+				errors: metadata.errors,
 			} satisfies Partial<React.ComponentProps<typeof Select>>;
 		},
 		get comboBoxProps() {
@@ -75,14 +76,14 @@ function defineCustomMetadata<FieldShape, ErrorShape>(
 				name: metadata.name,
 				defaultValue: metadata.defaultValue,
 				isInvalid: !metadata.valid,
-				errors: metadata.errors?.map((error) => `${error}`),
+				errors: metadata.errors,
 			} satisfies Partial<React.ComponentProps<typeof ComboBox>>;
 		},
 		get fileTriggerProps() {
 			return {
 				name: metadata.name,
 				isInvalid: !metadata.valid,
-				errors: metadata.errors?.map((error) => `${error}`),
+				errors: metadata.errors,
 			} satisfies Partial<React.ComponentProps<typeof FileTrigger>>;
 		},
 		get checkboxProps() {
@@ -106,28 +107,30 @@ function defineCustomMetadata<FieldShape, ErrorShape>(
 					end: rangeFields.end.defaultValue,
 				},
 				isInvalid: !metadata.valid,
-				errors: metadata.errors?.map((error) => `${error}`),
+				errors: metadata.errors,
 			} satisfies Partial<React.ComponentProps<typeof DateRangePicker>>;
 		},
 	};
 }
-
-type MetadataDefinition<FieldShape, ErrorShape> = ReturnType<
-	typeof defineCustomMetadata<FieldShape, ErrorShape>
->;
 
 // Extend the CustomMetadata interface with our UI component props
 // This makes the custom metadata available on all field metadata objects
 declare module '@conform-to/react/future' {
 	interface CustomMetadata<FieldShape, ErrorShape>
 		extends Omit<
-			MetadataDefinition<FieldShape, ErrorShape>,
+			ReturnType<typeof defineCustomMetadata<FieldShape, ErrorShape>>,
 			'dateRangePickerProps'
 		> {
 		// Make sure `dateRangePickerProps` is only available when FieldShape has start and end fields
 		dateRangePickerProps: FieldShape extends { start: string; end: string }
-			? MetadataDefinition<FieldShape, ErrorShape>['dateRangePickerProps']
+			? ReturnType<
+					typeof defineCustomMetadata<FieldShape, ErrorShape>
+				>['dateRangePickerProps']
 			: unknown;
+	}
+
+	interface CustomTypes {
+		errorShape: string;
 	}
 }
 

--- a/examples/react-aria/src/main.tsx
+++ b/examples/react-aria/src/main.tsx
@@ -1,10 +1,144 @@
+import {
+	type BaseMetadata,
+	FormOptionsProvider,
+} from '@conform-to/react/future';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
-import App from './App.tsx';
+import App from './App';
+import type { TextField } from './components/TextField';
+import type { NumberField } from './components/NumberField';
+import type { RadioGroup } from './components/RadioGroup';
+import type { CheckboxGroup } from './components/CheckboxGroup';
+import type { DatePicker } from './components/DatePicker';
+import type { Select } from './components/Select';
+import type { ComboBox } from './components/ComboBox';
+import type { FileTrigger } from './components/FileTrigger';
+import type { Checkbox } from './components/Checkbox';
+import type { DateRangePicker } from './components/DateRangePicker';
+
+// Define custom metadata properties that matches the type of our custom form components
+function defineCustomMetadata<FieldShape, ErrorShape>(
+	metadata: BaseMetadata<FieldShape, ErrorShape>,
+) {
+	return {
+		get textFieldProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				isInvalid: !metadata.valid,
+				errors: metadata.errors?.map((error) => `${error}`),
+			} satisfies Partial<React.ComponentProps<typeof TextField>>;
+		},
+		get numberFieldProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				isInvalid: !metadata.valid,
+				errors: metadata.errors?.map((error) => `${error}`),
+			} satisfies Partial<React.ComponentProps<typeof NumberField>>;
+		},
+		get radioGroupProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				isInvalid: !metadata.valid,
+				errors: metadata.errors?.map((error) => `${error}`),
+			} satisfies Partial<React.ComponentProps<typeof RadioGroup>>;
+		},
+		get checkboxGroupProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultOptions,
+				isInvalid: !metadata.valid,
+				errors: metadata.errors?.map((error) => `${error}`),
+			} satisfies Partial<React.ComponentProps<typeof CheckboxGroup>>;
+		},
+		get datePickerProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				isInvalid: !metadata.valid,
+				errors: metadata.errors?.map((error) => `${error}`),
+			} satisfies Partial<React.ComponentProps<typeof DatePicker>>;
+		},
+		get selectProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				isInvalid: !metadata.valid,
+				errors: metadata.errors?.map((error) => `${error}`),
+			} satisfies Partial<React.ComponentProps<typeof Select>>;
+		},
+		get comboBoxProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				isInvalid: !metadata.valid,
+				errors: metadata.errors?.map((error) => `${error}`),
+			} satisfies Partial<React.ComponentProps<typeof ComboBox>>;
+		},
+		get fileTriggerProps() {
+			return {
+				name: metadata.name,
+				isInvalid: !metadata.valid,
+				errors: metadata.errors?.map((error) => `${error}`),
+			} satisfies Partial<React.ComponentProps<typeof FileTrigger>>;
+		},
+		get checkboxProps() {
+			return {
+				name: metadata.name,
+				defaultSelected: metadata.defaultValue === 'on',
+				isInvalid: !metadata.valid,
+			} satisfies Partial<React.ComponentProps<typeof Checkbox>>;
+		},
+		get dateRangePickerProps() {
+			const rangeFields = metadata.getFieldset<{
+				start: string;
+				end: string;
+			}>();
+
+			return {
+				startName: rangeFields.start.name,
+				endName: rangeFields.end.name,
+				defaultValue: {
+					start: rangeFields.start.defaultValue,
+					end: rangeFields.end.defaultValue,
+				},
+				isInvalid: !metadata.valid,
+				errors: metadata.errors?.map((error) => `${error}`),
+			} satisfies Partial<React.ComponentProps<typeof DateRangePicker>>;
+		},
+	};
+}
+
+type MetadataDefinition<FieldShape, ErrorShape> = ReturnType<
+	typeof defineCustomMetadata<FieldShape, ErrorShape>
+>;
+
+// Extend the CustomMetadata interface with our UI component props
+// This makes the custom metadata available on all field metadata objects
+declare module '@conform-to/react/future' {
+	interface CustomMetadata<FieldShape, ErrorShape>
+		extends Omit<
+			MetadataDefinition<FieldShape, ErrorShape>,
+			'dateRangePickerProps'
+		> {
+		// Make sure `dateRangePickerProps` is only available when FieldShape has start and end fields
+		dateRangePickerProps: FieldShape extends { start: string; end: string }
+			? MetadataDefinition<FieldShape, ErrorShape>['dateRangePickerProps']
+			: unknown;
+	}
+}
 
 createRoot(document.getElementById('root')!).render(
 	<StrictMode>
-		<App />
+		<FormOptionsProvider
+			shouldValidate="onBlur"
+			shouldRevalidate="onInput"
+			defineCustomMetadata={defineCustomMetadata}
+		>
+			<App />
+		</FormOptionsProvider>
 	</StrictMode>,
 );

--- a/examples/shadcn-ui/README.md
+++ b/examples/shadcn-ui/README.md
@@ -1,21 +1,57 @@
-# Shadcn UI Integration
+# Shadcn UI Example
 
-[Shadcn UI](https://ui.shadcn.com/)
-Shadcn UI is a comprehensive component library built with React. It provides a wide range of pre-built components that can be easily integrated into your projects. The library is designed to be simple to use, allowing you to add components to your project either by copy/pasting them directly or using the provided CLI.
+[Shadcn UI](https://ui.shadcn.com/) is a comprehensive component library built with React. It provides a wide range of pre-built components that can be easily integrated into your projects.
+
+This example demonstrates how to integrate Conform with Shadcn UI using custom metadata. We leverage [Vite](https://vitejs.dev/) and [Tailwind CSS](https://tailwindcss.com/) for styling.
+
+## Understanding the Integration
+
+The main application ([`App.tsx`](./src/App.tsx)) uses explicit prop assignment for educational purposes, making it easy to see how field metadata maps to Shadcn UI component props:
+
+```tsx
+<Input
+  id={fields.email.id}
+  name={fields.email.name}
+  defaultValue={fields.email.defaultValue}
+  aria-invalid={!fields.email.valid || undefined}
+  aria-describedby={!fields.email.valid ? fields.email.errorId : undefined}
+/>
+```
+
+While this is clear and straightforward for learning, it becomes repetitive in production applications.
+
+## Custom Metadata
+
+The example showcases metadata customization for a more DRY approach. Custom metadata properties are defined once in [`main.tsx`](./src/main.tsx) and provide type-safe props that match Shadcn UI component types:
+
+```tsx
+// Define custom metadata once
+function defineCustomMetadata(metadata) {
+  return {
+    get inputProps() {
+      return {
+        id: metadata.id,
+        name: metadata.name,
+        defaultValue: metadata.defaultValue,
+        'aria-invalid': !metadata.valid || undefined,
+        'aria-describedby': !metadata.valid ? metadata.errorId : undefined,
+      } satisfies Partial<React.ComponentProps<typeof Input>>;
+    },
+    // ... other component props
+  };
+}
+
+// Use with full type safety
+<Input {...fields.email.inputProps} />
+```
+
+This example also includes form components in [`src/components/form.tsx`](./src/components/form.tsx) that extend the base Shadcn components, making it even easier to build complex forms with full validation and error handling.
 
 ## Installation
 
-To install a component, you can simply copy and paste the component code into your project. Alternatively, you can use the Shadcn UI CLI to automatically add components to your project. By default, the CLI will place the components into the `src/components/ui` folder.
+To install Shadcn UI components, you can copy and paste the component code into your project, or use the Shadcn UI CLI to automatically add components. By default, the CLI places components into the `src/components/ui` folder.
 
-## Conform Forms integration
-
-This example includes a set of components in a separate file `src/components/form.tsx` that extend the shadcn components. By using these components, you can quickly and easily build complex forms with full validation and error handling.
-
-## Additional infos
-
-This example we leverage [Vite](https://vitejs.dev/) and [Tailwind CSS](https://tailwindcss.com/)
-
-**Components**
+## Components
 
 - Checkbox
 - Checkbox group

--- a/examples/shadcn-ui/src/components/form.tsx
+++ b/examples/shadcn-ui/src/components/form.tsx
@@ -68,7 +68,7 @@ function Field({
 	);
 }
 
-type FieldErrorProps = {
+export type FieldErrorProps = {
 	id?: string;
 	children: React.ReactNode;
 };
@@ -81,7 +81,7 @@ function FieldError({ id, children }: FieldErrorProps) {
 	);
 }
 
-type DatePickerProps = {
+export type DatePickerProps = {
 	id?: string;
 	name: string;
 	defaultValue?: string;
@@ -150,7 +150,7 @@ const countries = [
 	{ label: 'Uruguay', value: 'UY' },
 ];
 
-type ComboboxProps = {
+export type ComboboxProps = {
 	id?: string;
 	name: string;
 	defaultValue?: string;
@@ -229,7 +229,7 @@ function ComboBox({ name, defaultValue, ...props }: ComboboxProps) {
 	);
 }
 
-type RadioGroupProps = {
+export type RadioGroupProps = {
 	id?: string;
 	name: string;
 	items: Array<{ value: string; label: string }>;
@@ -280,7 +280,7 @@ function RadioGroup({
 	);
 }
 
-type CheckboxProps = {
+export type CheckboxProps = {
 	id?: string;
 	name: string;
 	value?: string;
@@ -313,7 +313,7 @@ function Checkbox({ name, value, defaultChecked, ...props }: CheckboxProps) {
 	);
 }
 
-type SelectProps = {
+export type SelectProps = {
 	id?: string;
 	name: string;
 	items: Array<{ name: string; value: string }>;
@@ -366,7 +366,7 @@ function Select({
 	);
 }
 
-type SliderProps = {
+export type SliderProps = {
 	id?: string;
 	name: string;
 	defaultValue?: string;
@@ -406,7 +406,7 @@ function Slider({ name, defaultValue, ...props }: SliderProps) {
 	);
 }
 
-type SwitchProps = {
+export type SwitchProps = {
 	id?: string;
 	name: string;
 	value?: string;
@@ -439,7 +439,7 @@ function Switch({ name, value, defaultChecked, ...props }: SwitchProps) {
 	);
 }
 
-type SingleToggleGroupProps = {
+export type SingleToggleGroupProps = {
 	name: string;
 	items: Array<{ value: string; label: string }>;
 	defaultValue?: string;
@@ -490,7 +490,7 @@ function SingleToggleGroup({
 	);
 }
 
-type MultiToggleGroupProps = {
+export type MultiToggleGroupProps = {
 	name: string;
 	items: Array<{ value: string; label: string }>;
 	defaultValue?: string[];
@@ -539,7 +539,7 @@ function MultiToggleGroup({
 	);
 }
 
-type InputOTPProps = {
+export type InputOTPProps = {
 	id?: string;
 	name: string;
 	length: number;

--- a/examples/shadcn-ui/src/main.tsx
+++ b/examples/shadcn-ui/src/main.tsx
@@ -1,10 +1,149 @@
+import {
+	type BaseMetadata,
+	FormOptionsProvider,
+} from '@conform-to/react/future';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
+import type {
+	DatePicker,
+	ComboBox,
+	RadioGroup,
+	Checkbox,
+	Select,
+	Slider,
+	Switch,
+	SingleToggleGroup,
+	MultiToggleGroup,
+	InputOTP,
+} from './components/form';
+
+// Define custom metadata properties that matches the type of our custom form components
+function defineCustomMetadata<FieldShape, ErrorShape>(
+	metadata: BaseMetadata<FieldShape, ErrorShape>,
+) {
+	return {
+		get inputProps() {
+			return {
+				id: metadata.id,
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				'aria-describedby': metadata.ariaDescribedBy,
+			} satisfies Partial<React.ComponentProps<'input'>>;
+		},
+		get textareaProps() {
+			return {
+				id: metadata.id,
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				'aria-describedby': metadata.ariaDescribedBy,
+			} satisfies Partial<React.ComponentProps<'textarea'>>;
+		},
+		get datePickerProps() {
+			return {
+				id: metadata.id,
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				'aria-describedby': metadata.ariaDescribedBy,
+			} satisfies Partial<React.ComponentProps<typeof DatePicker>>;
+		},
+		get comboboxProps() {
+			return {
+				id: metadata.id,
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				'aria-describedby': metadata.ariaDescribedBy,
+			} satisfies Partial<React.ComponentProps<typeof ComboBox>>;
+		},
+		get radioGroupProps() {
+			return {
+				id: metadata.id,
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				'aria-describedby': metadata.ariaDescribedBy,
+			} satisfies Partial<React.ComponentProps<typeof RadioGroup>>;
+		},
+		get checkboxProps() {
+			return {
+				id: metadata.id,
+				name: metadata.name,
+				value: 'on',
+				defaultChecked: metadata.defaultChecked,
+				'aria-describedby': metadata.ariaDescribedBy,
+			} satisfies Partial<React.ComponentProps<typeof Checkbox>>;
+		},
+		get selectProps() {
+			return {
+				id: metadata.id,
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				'aria-describedby': metadata.ariaDescribedBy,
+			} satisfies Partial<React.ComponentProps<typeof Select>>;
+		},
+		get sliderProps() {
+			return {
+				id: metadata.id,
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				'aria-describedby': metadata.ariaDescribedBy,
+			} satisfies Partial<React.ComponentProps<typeof Slider>>;
+		},
+		get switchProps() {
+			return {
+				id: metadata.id,
+				name: metadata.name,
+				value: 'on',
+				defaultChecked: metadata.defaultChecked,
+				'aria-describedby': metadata.ariaDescribedBy,
+			} satisfies Partial<React.ComponentProps<typeof Switch>>;
+		},
+		get singleToggleGroupProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				'aria-labelledby': metadata.id,
+				'aria-describedby': metadata.ariaDescribedBy,
+			} satisfies Partial<React.ComponentProps<typeof SingleToggleGroup>>;
+		},
+		get multiToggleGroupProps() {
+			return {
+				name: metadata.name,
+				defaultValue: metadata.defaultOptions,
+				'aria-labelledby': metadata.id,
+				'aria-describedby': metadata.ariaDescribedBy,
+			} satisfies Partial<React.ComponentProps<typeof MultiToggleGroup>>;
+		},
+		get inputOTPProps() {
+			return {
+				id: metadata.id,
+				name: metadata.name,
+				defaultValue: metadata.defaultValue,
+				'aria-describedby': metadata.ariaDescribedBy,
+			} satisfies Partial<React.ComponentProps<typeof InputOTP>>;
+		},
+	};
+}
+
+type MetadataDefinition<FieldShape, ErrorShape> = ReturnType<
+	typeof defineCustomMetadata<FieldShape, ErrorShape>
+>;
+
+// Extend the CustomMetadata interface with our UI component props
+// This makes the custom metadata available on all field metadata objects
+declare module '@conform-to/react/future' {
+	interface CustomMetadata<FieldShape, ErrorShape>
+		extends MetadataDefinition<FieldShape, ErrorShape> {}
+}
 
 createRoot(document.getElementById('root')!).render(
 	<StrictMode>
-		<App />
+		<FormOptionsProvider
+			shouldValidate="onBlur"
+			shouldRevalidate="onInput"
+			defineCustomMetadata={defineCustomMetadata}
+		>
+			<App />
+		</FormOptionsProvider>
 	</StrictMode>,
 );

--- a/guide/app/layout.tsx
+++ b/guide/app/layout.tsx
@@ -63,6 +63,10 @@ const menus: { [code: string]: Menu[] } = {
 				{ title: 'report', to: '/api/react/future/report' },
 				{ title: 'isDirty', to: '/api/react/future/isDirty' },
 				{ title: 'FormProvider', to: '/api/react/future/FormProvider' },
+				{
+					title: 'FormOptionsProvider',
+					to: '/api/react/future/FormOptionsProvider',
+				},
 				{ title: 'memoize', to: '/api/react/future/memoize' },
 			],
 		},

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -39,6 +39,7 @@ import {
 	getField,
 	initializeState,
 	updateState,
+	defineDefaultMetadata,
 } from './state';
 import type {
 	FormContext,
@@ -46,6 +47,7 @@ import type {
 	FormMetadata,
 	Fieldset,
 	ValidateResult,
+	GlobalFormOptions,
 	FormOptions,
 	FieldName,
 	FieldMetadata,
@@ -77,13 +79,17 @@ import {
 // See: https://nextjs.org/docs/messages/next-prerender-current-time-client
 export const INITIAL_KEY = 'INITIAL_KEY';
 
-export const FormConfig = createContext({
+export const GlobalFormOptionsContext = createContext<
+	GlobalFormOptions & { observer: ReturnType<typeof createGlobalFormsObserver> }
+>({
 	intentName: DEFAULT_INTENT_NAME,
 	observer: createGlobalFormsObserver(),
 	serialize,
+	shouldValidate: 'onSubmit',
+	defineCustomMetadata: defineDefaultMetadata,
 });
 
-export const Form = createContext<FormContext[]>([]);
+export const FormContextContext = createContext<FormContext[]>([]);
 
 /**
  * Provides form context to child components.
@@ -93,18 +99,44 @@ export function FormProvider(props: {
 	context: FormContext;
 	children: React.ReactNode;
 }): React.ReactElement {
-	const stack = useContext(Form);
+	const stack = useContext(FormContextContext);
 	const value = useMemo(
 		// Put the latest form context first to ensure that to be the first one found
 		() => [props.context].concat(stack),
 		[stack, props.context],
 	);
 
-	return <Form.Provider value={value}>{props.children}</Form.Provider>;
+	return (
+		<FormContextContext.Provider value={value}>
+			{props.children}
+		</FormContextContext.Provider>
+	);
+}
+
+export function FormOptionsProvider(
+	props: Partial<GlobalFormOptions> & {
+		children: React.ReactNode;
+	},
+): React.ReactElement {
+	const { children, ...providedOptions } = props;
+	const defaultOptions = useContext(GlobalFormOptionsContext);
+	const options = useMemo(
+		() => ({
+			...defaultOptions,
+			...providedOptions,
+		}),
+		[defaultOptions, providedOptions],
+	);
+
+	return (
+		<GlobalFormOptionsContext.Provider value={options}>
+			{children}
+		</GlobalFormOptionsContext.Provider>
+	);
 }
 
 export function useFormContext(formId?: string): FormContext<any> {
-	const contexts = useContext(Form);
+	const contexts = useContext(FormContextContext);
 	const context = formId
 		? contexts.find((context) => formId === context.formId)
 		: contexts[0];
@@ -447,14 +479,15 @@ export function useForm<
 	intent: IntentDispatcher;
 } {
 	const { id, defaultValue, constraint } = options;
-	const config = useContext(FormConfig);
+	const globalOptions = useContext(GlobalFormOptionsContext);
 	const optionsRef = useLatest(options);
+	const globalOptionsRef = useLatest(globalOptions);
 	const fallbackId = useId();
 	const formId = id ?? `form-${fallbackId}`;
 	const [state, handleSubmit] = useConform<ErrorShape, Value>(formId, {
 		...options,
-		serialize: config.serialize,
-		intentName: config.intentName,
+		serialize: globalOptions.serialize,
+		intentName: globalOptions.intentName,
 		onError: optionsRef.current.onError ?? focusFirstInvalidField,
 		onValidate(ctx) {
 			if (options.schema) {
@@ -546,8 +579,9 @@ export function useForm<
 				}
 
 				const {
-					shouldValidate = 'onSubmit',
-					shouldRevalidate = shouldValidate,
+					shouldValidate = globalOptionsRef.current.shouldValidate,
+					shouldRevalidate = globalOptionsRef.current.shouldRevalidate ??
+						shouldValidate,
 				} = optionsRef.current;
 
 				if (
@@ -579,8 +613,9 @@ export function useForm<
 				}
 
 				const {
-					shouldValidate = 'onSubmit',
-					shouldRevalidate = shouldValidate,
+					shouldValidate = globalOptionsRef.current.shouldValidate,
+					shouldRevalidate = globalOptionsRef.current.shouldRevalidate ??
+						shouldValidate,
 				} = optionsRef.current;
 
 				if (
@@ -592,18 +627,32 @@ export function useForm<
 				}
 			},
 		}),
-		[formId, state, defaultValue, constraint, handleSubmit, intent, optionsRef],
+		[
+			formId,
+			state,
+			defaultValue,
+			constraint,
+			handleSubmit,
+			intent,
+			optionsRef,
+			globalOptionsRef,
+		],
 	);
 	const form = useMemo(
-		() => getFormMetadata(context, { serialize: config.serialize }),
-		[context, config.serialize],
+		() =>
+			getFormMetadata(context, {
+				serialize: globalOptions.serialize,
+				customize: globalOptions.defineCustomMetadata,
+			}),
+		[context, globalOptions.serialize, globalOptions.defineCustomMetadata],
 	);
 	const fields = useMemo(
 		() =>
 			getFieldset<FormShape, ErrorShape>(context, {
-				serialize: config.serialize,
+				serialize: globalOptions.serialize,
+				customize: globalOptions.defineCustomMetadata,
 			}),
-		[context, config.serialize],
+		[context, globalOptions.serialize, globalOptions.defineCustomMetadata],
 	);
 
 	return {
@@ -636,14 +685,15 @@ export function useFormMetadata<ErrorShape = string[]>(
 		formId?: string;
 	} = {},
 ): FormMetadata<ErrorShape> {
-	const config = useContext(FormConfig);
+	const globalOptions = useContext(GlobalFormOptionsContext);
 	const context = useFormContext(options.formId);
 	const formMetadata = useMemo(
 		() =>
 			getFormMetadata(context, {
-				serialize: config.serialize,
+				serialize: globalOptions.serialize,
+				customize: globalOptions.defineCustomMetadata,
 			}),
-		[context, config.serialize],
+		[context, globalOptions.serialize, globalOptions.defineCustomMetadata],
 	);
 
 	return formMetadata;
@@ -675,15 +725,21 @@ export function useField<FieldShape = any, ErrorShape = string>(
 		formId?: string;
 	} = {},
 ): FieldMetadata<FieldShape, ErrorShape> {
-	const config = useContext(FormConfig);
+	const globalOptions = useContext(GlobalFormOptionsContext);
 	const context = useFormContext(options.formId);
 	const field = useMemo(
 		() =>
 			getField(context, {
 				name,
-				serialize: config.serialize,
+				serialize: globalOptions.serialize,
+				customize: globalOptions.defineCustomMetadata,
 			}),
-		[context, name, config.serialize],
+		[
+			context,
+			name,
+			globalOptions.serialize,
+			globalOptions.defineCustomMetadata,
+		],
 	);
 
 	return field;
@@ -710,12 +766,15 @@ export function useField<FieldShape = any, ErrorShape = string>(
  * ```
  */
 export function useIntent(formRef: FormRef): IntentDispatcher {
-	const config = useContext(FormConfig);
+	const globalOptions = useContext(GlobalFormOptionsContext);
 
 	return useMemo(
 		() =>
-			createIntentDispatcher(() => getFormElement(formRef), config.intentName),
-		[formRef, config.intentName],
+			createIntentDispatcher(
+				() => getFormElement(formRef),
+				globalOptions.intentName,
+			),
+		[formRef, globalOptions.intentName],
 	);
 }
 
@@ -751,7 +810,7 @@ export function useControl(options?: {
 	 */
 	onFocus?: () => void;
 }): Control {
-	const { observer } = useContext(FormConfig);
+	const { observer } = useContext(GlobalFormOptionsContext);
 	const inputRef = useRef<
 		| HTMLInputElement
 		| HTMLSelectElement
@@ -1016,7 +1075,7 @@ export function useFormData<Value = any>(
 	select: Selector<FormData, Value> | Selector<URLSearchParams, Value>,
 	options?: UseFormDataOptions,
 ): Value {
-	const { observer } = useContext(FormConfig);
+	const { observer } = useContext(GlobalFormOptionsContext);
 	const valueRef = useRef<Value>();
 	const formDataRef = useRef<FormData | URLSearchParams | null>(null);
 	const value = useSyncExternalStore(

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -59,6 +59,8 @@ import type {
 	SubmitHandler,
 	FormState,
 	FormRef,
+	BaseErrorShape,
+	DefaultErrorShape,
 } from './types';
 import { actionHandlers, applyIntent, deserializeIntent } from './intent';
 import {
@@ -135,7 +137,7 @@ export function FormOptionsProvider(
 	);
 }
 
-export function useFormContext(formId?: string): FormContext<any> {
+export function useFormContext(formId?: string): FormContext {
 	const contexts = useContext(FormContextContext);
 	const context = formId
 		? contexts.find((context) => formId === context.formId)
@@ -469,7 +471,7 @@ export function useConform<ErrorShape, Value = undefined>(
  */
 export function useForm<
 	FormShape extends Record<string, any> = Record<string, any>,
-	ErrorShape = string,
+	ErrorShape extends BaseErrorShape = DefaultErrorShape,
 	Value = undefined,
 >(
 	options: FormOptions<FormShape, ErrorShape, Value>,
@@ -680,11 +682,11 @@ export function useForm<
  * }
  * ```
  */
-export function useFormMetadata<ErrorShape = string[]>(
+export function useFormMetadata(
 	options: {
 		formId?: string;
 	} = {},
-): FormMetadata<ErrorShape> {
+): FormMetadata {
 	const globalOptions = useContext(GlobalFormOptionsContext);
 	const context = useFormContext(options.formId);
 	const formMetadata = useMemo(
@@ -719,12 +721,12 @@ export function useFormMetadata<ErrorShape = string[]>(
  * }
  * ```
  */
-export function useField<FieldShape = any, ErrorShape = string>(
+export function useField<FieldShape = any>(
 	name: FieldName<FieldShape>,
 	options: {
 		formId?: string;
 	} = {},
-): FieldMetadata<FieldShape, ErrorShape> {
+): FieldMetadata<FieldShape> {
 	const globalOptions = useContext(GlobalFormOptionsContext);
 	const context = useFormContext(options.formId);
 	const field = useMemo(

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -39,7 +39,6 @@ import {
 	getField,
 	initializeState,
 	updateState,
-	defineDefaultMetadata,
 } from './state';
 import type {
 	FormContext,
@@ -88,7 +87,6 @@ export const GlobalFormOptionsContext = createContext<
 	observer: createGlobalFormsObserver(),
 	serialize,
 	shouldValidate: 'onSubmit',
-	defineCustomMetadata: defineDefaultMetadata,
 });
 
 export const FormContextContext = createContext<FormContext[]>([]);

--- a/packages/conform-react/future/index.ts
+++ b/packages/conform-react/future/index.ts
@@ -9,7 +9,6 @@ export type {
 	Control,
 	DefaultValue,
 	BaseMetadata,
-	DefaultMetadata,
 	CustomMetadata,
 	CustomMetadataDefinition,
 	BaseErrorShape,

--- a/packages/conform-react/future/index.ts
+++ b/packages/conform-react/future/index.ts
@@ -12,6 +12,8 @@ export type {
 	DefaultMetadata,
 	CustomMetadata,
 	CustomMetadataDefinition,
+	BaseErrorShape,
+	CustomTypes,
 	FormContext,
 	FormMetadata,
 	FormOptions,

--- a/packages/conform-react/future/index.ts
+++ b/packages/conform-react/future/index.ts
@@ -8,6 +8,10 @@ export { parseSubmission, report, isDirty } from '@conform-to/dom/future';
 export type {
 	Control,
 	DefaultValue,
+	BaseMetadata,
+	DefaultMetadata,
+	CustomMetadata,
+	CustomMetadataDefinition,
 	FormContext,
 	FormMetadata,
 	FormOptions,
@@ -19,6 +23,7 @@ export type {
 } from './types';
 export {
 	FormProvider,
+	FormOptionsProvider,
 	useControl,
 	useField,
 	useForm,

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -167,7 +167,7 @@ export type GlobalFormOptions = {
 	 * A function that defines custom metadata properties for form fields.
 	 * Useful for integrating with UI libraries or custom form components.
 	 */
-	defineCustomMetadata: CustomMetadataDefinition;
+	defineCustomMetadata?: CustomMetadataDefinition;
 };
 
 export type FormOptions<
@@ -458,14 +458,6 @@ export type SatisfyComponentProps<
 	CustomProps extends React.ComponentPropsWithoutRef<ElementType>,
 > = CustomProps;
 
-/** Default field metadata object */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type DefaultMetadata = {
-	inputProps: React.InputHTMLAttributes<HTMLInputElement>;
-	selectProps: React.SelectHTMLAttributes<HTMLSelectElement>;
-	textareaProps: React.TextareaHTMLAttributes<HTMLTextAreaElement>;
-};
-
 /**
  * Interface for extending field metadata with additional properties.
  */
@@ -484,7 +476,7 @@ export type CustomMetadataDefinition = <
 >(
 	metadata: BaseMetadata<FieldShape, ErrorShape>,
 ) => keyof CustomMetadata<FieldShape, ErrorShape> extends never
-	? DefaultMetadata
+	? {}
 	: CustomMetadata<any, any>;
 
 /** Field metadata object containing field state, validation attributes, and nested field access methods. */
@@ -493,7 +485,7 @@ export type FieldMetadata<
 	ErrorShape extends BaseErrorShape = DefaultErrorShape,
 > = Readonly<
 	(keyof CustomMetadata<FieldShape, ErrorShape> extends never
-		? DefaultMetadata
+		? {}
 		: CustomMetadata<FieldShape, ErrorShape>) &
 		// Base metadata properties take precedence over custom metadata
 		BaseMetadata<FieldShape, ErrorShape>

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -172,7 +172,9 @@ export type GlobalFormOptions = {
 
 export type FormOptions<
 	FormShape,
-	ErrorShape extends BaseErrorShape = DefaultErrorShape,
+	ErrorShape extends BaseErrorShape = string extends BaseErrorShape
+		? string
+		: BaseErrorShape,
 	Value = undefined,
 > = {
 	/** Optional form identifier. If not provided, a unique ID is automatically generated. */
@@ -351,7 +353,7 @@ export type ActionHandler<
 		value: Record<string, FormValue>,
 		...args: Parameters<Signature>
 	): Record<string, FormValue> | null;
-	onUpdate?<ErrorShape extends BaseErrorShape = DefaultErrorShape>(
+	onUpdate?<ErrorShape extends BaseErrorShape>(
 		state: FormState<ErrorShape>,
 		action: FormAction<
 			ErrorShape,
@@ -392,14 +394,14 @@ export type BaseErrorShape = CustomTypes extends { errorShape: infer Shape }
 	? Shape
 	: unknown;
 
-export type DefaultErrorShape = string extends BaseErrorShape
-	? string
-	: BaseErrorShape;
+export type DefaultErrorShape = CustomTypes extends { errorShape: infer Shape }
+	? Shape
+	: string;
 
 /** Base field metadata object containing field state, validation attributes, and accessibility IDs. */
 export type BaseMetadata<
 	FieldShape,
-	ErrorShape extends BaseErrorShape = DefaultErrorShape,
+	ErrorShape extends BaseErrorShape,
 > = ValidationAttributes & {
 	/** Unique key for React list rendering (for array fields). */
 	key: string | undefined;

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -141,10 +141,32 @@ export type FormAction<
 };
 
 export type GlobalFormOptions = {
+	/**
+	 * The name of the submit button field that indicates the submission intent.
+	 *
+	 * @default "__intent__"
+	 */
 	intentName: string;
+	/**
+	 * A custom serialization function for converting form data.
+	 */
 	serialize: Serialize;
+	/**
+	 * Determines when validation should run for the first time on a field.
+	 *
+	 * @default "onSubmit"
+	 */
 	shouldValidate: 'onSubmit' | 'onBlur' | 'onInput';
+	/**
+	 * Determines when validation should run again after the field has been validated once.
+	 *
+	 * @default Same as shouldValidate
+	 */
 	shouldRevalidate?: 'onSubmit' | 'onBlur' | 'onInput';
+	/**
+	 * A function that defines custom metadata properties for form fields.
+	 * Useful for integrating with UI libraries or custom form components.
+	 */
 	defineCustomMetadata: CustomMetadataDefinition;
 };
 
@@ -164,20 +186,19 @@ export interface FormOptions<
 	/** HTML validation attributes for fields (required, minLength, pattern, etc.). */
 	constraint?: Record<string, ValidationAttributes>;
 	/**
-	 * Define when conform should start validation.
-	 * Support "onSubmit", "onInput", "onBlur".
+	 * Determines when validation should run for the first time on a field.
+	 * Overrides the global default set by FormOptionsProvider if provided.
 	 *
-	 * @default "onSubmit"
+	 * @default Inherits from FormOptionsProvider, or "onSubmit" if not configured
 	 */
 	shouldValidate?: 'onSubmit' | 'onBlur' | 'onInput';
 	/**
-	 * Define when conform should revalidate again.
-	 * Support "onSubmit", "onInput", "onBlur".
+	 * Determines when validation should run again after the field has been validated once.
+	 * Overrides the global default set by FormOptionsProvider if provided.
 	 *
-	 * @default Same as shouldValidate, or "onSubmit" if shouldValidate is not provided.
+	 * @default Inherits from FormOptionsProvider, or same as shouldValidate
 	 */
 	shouldRevalidate?: 'onSubmit' | 'onBlur' | 'onInput';
-
 	/** Server-side submission result for form state synchronization. */
 	lastResult?: SubmissionResult<NoInfer<ErrorShape>> | null;
 	/** Custom validation handler. Can be skipped if using the schema property, or combined with schema to customize validation errors. */

--- a/packages/conform-react/tests/state.test.ts
+++ b/packages/conform-react/tests/state.test.ts
@@ -1388,6 +1388,15 @@ describe('form', () => {
 
 		const profileField = getField(context, {
 			name: 'profile',
+			customize: (metadata) => {
+				return {
+					get allErrors() {
+						return (metadata.errors ?? []).concat(
+							Object.values(metadata.fieldErrors).flat(),
+						);
+					},
+				};
+			},
 		});
 
 		// Profile field should be invalid due to child field error, even though it has no direct error
@@ -1401,6 +1410,15 @@ describe('form', () => {
 		// Test methods exist
 		expect(typeof usernameField.getFieldset).toBe('function');
 		expect(typeof usernameField.getFieldList).toBe('function');
+
+		// Test custom metadata
+		// @ts-expect-error allErrors is not set in CustomMetadata
+		expect(profileField.allErrors).toEqual([
+			'Address is incomplete',
+			'City is required',
+		]);
+		// @ts-expect-error Testing non existing property
+		expect(() => profileField.somethingNonExistent).toThrowError();
 	});
 
 	test('getFieldset', () => {

--- a/packages/conform-react/tests/state.test.ts
+++ b/packages/conform-react/tests/state.test.ts
@@ -1242,7 +1242,6 @@ describe('form', () => {
 		});
 		expect(metadata.touched).toBe(true);
 		expect(metadata.valid).toBe(false);
-		expect(metadata.invalid).toBe(true);
 
 		// Test props
 		expect(metadata.props.id).toBe('test-id');
@@ -1275,7 +1274,6 @@ describe('form', () => {
 
 		expect(metadata.errors).toEqual(['Something went wrong']);
 		expect(metadata.valid).toBe(false);
-		expect(metadata.invalid).toBe(true);
 		expect(metadata.fieldErrors).toEqual({});
 
 		// Test form with no errors
@@ -1296,7 +1294,6 @@ describe('form', () => {
 
 		expect(metadata.errors).toBe(undefined);
 		expect(metadata.valid).toBe(true);
-		expect(metadata.invalid).toBe(false);
 		expect(metadata.fieldErrors).toEqual({});
 	});
 
@@ -1317,7 +1314,11 @@ describe('form', () => {
 			context.state,
 			createAction({
 				type: 'client',
-				entries: [['username', 'test-user']],
+				entries: [
+					['username', 'test-user'],
+					['tags', 'react'],
+					['tags', 'typescript'],
+				],
 				error: {
 					fieldErrors: {
 						username: ['Username taken'],
@@ -1329,7 +1330,6 @@ describe('form', () => {
 		const usernameField = getField(context, {
 			name: 'username',
 			key: 'unique-key',
-			serialize: (value) => String(value),
 		});
 
 		// Test basic properties
@@ -1350,9 +1350,22 @@ describe('form', () => {
 		expect(usernameField.defaultValue).toBe('test-user');
 		expect(usernameField.touched).toBe(true);
 		expect(usernameField.valid).toBe(false);
-		expect(usernameField.invalid).toBe(true);
 		expect(usernameField.errors).toEqual(['Username taken']);
 		expect(usernameField.fieldErrors).toEqual({}); // No child fields, so empty
+		expect(usernameField.ariaInvalid).toBe(true);
+		expect(usernameField.ariaDescribedBy).toBe('test-id-field-username-error');
+
+		const tagsField = getField(context, {
+			name: 'tags',
+		});
+
+		expect(tagsField.defaultOptions).toEqual(['react', 'typescript']);
+		expect(tagsField.touched).toBe(true);
+		expect(tagsField.valid).toBe(true);
+		expect(tagsField.errors).toBe(undefined);
+		expect(tagsField.fieldErrors).toEqual({});
+		expect(tagsField.ariaInvalid).toBe(undefined);
+		expect(tagsField.ariaDescribedBy).toBe(undefined);
 
 		// Test mixed parent and child field errors
 		context.state = updateState(
@@ -1375,12 +1388,10 @@ describe('form', () => {
 
 		const profileField = getField(context, {
 			name: 'profile',
-			serialize: (value) => String(value),
 		});
 
 		// Profile field should be invalid due to child field error, even though it has no direct error
 		expect(profileField.valid).toBe(false);
-		expect(profileField.invalid).toBe(true);
 		expect(profileField.errors).toBe(undefined); // No direct error on profile
 		expect(profileField.fieldErrors).toEqual({
 			address: ['Address is incomplete'],

--- a/packages/conform-react/tests/useForm.browser.test.tsx
+++ b/packages/conform-react/tests/useForm.browser.test.tsx
@@ -7,6 +7,7 @@ import {
 	type FormError,
 	type FormOptions,
 	useForm,
+	FormOptionsProvider,
 } from '../future';
 import { expectErrorMessage, expectNoErrorMessages } from './helpers';
 
@@ -80,9 +81,7 @@ describe('future export: useForm', () => {
 					name={fields.title.name}
 					defaultValue={fields.title.defaultValue}
 					aria-label="Title"
-					aria-describedby={
-						!fields.title.valid ? fields.title.errorId : undefined
-					}
+					aria-describedby={fields.title.ariaDescribedBy}
 				/>
 				<div id={fields.title.errorId}>
 					{fields.title.errors?.join(', ') ?? 'n/a'}
@@ -91,9 +90,7 @@ describe('future export: useForm', () => {
 					name={fields.description.name}
 					defaultValue={fields.description.defaultValue}
 					aria-label="Description"
-					aria-describedby={
-						!fields.description.valid ? fields.description.errorId : undefined
-					}
+					aria-describedby={fields.description.ariaDescribedBy}
 				/>
 				<div id={fields.description.errorId}>
 					{fields.description.errors?.join(', ') ?? 'n/a'}
@@ -107,11 +104,7 @@ describe('future export: useForm', () => {
 								name={taskField.content.name}
 								defaultValue={taskField.content.defaultValue}
 								aria-label={`Task #${index + 1} Content`}
-								aria-describedby={
-									!taskField.content.valid
-										? taskField.content.errorId
-										: undefined
-								}
+								aria-describedby={taskField.content.ariaDescribedBy}
 							/>
 							<div id={taskField.content.errorId}>
 								{taskField.content.errors?.join(', ') ?? 'n/a'}
@@ -121,11 +114,7 @@ describe('future export: useForm', () => {
 								name={taskField.completed.name}
 								defaultChecked={taskField.completed.defaultChecked}
 								aria-label={`Task #${index + 1} Completed`}
-								aria-describedby={
-									!taskField.completed.valid
-										? taskField.completed.errorId
-										: undefined
-								}
+								aria-describedby={taskField.completed.ariaDescribedBy}
 							/>
 							<div id={taskField.completed.errorId}>
 								{taskField.completed.errors?.join(', ') ?? 'n/a'}
@@ -273,8 +262,29 @@ describe('future export: useForm', () => {
 		};
 	}
 
-	test('shouldValidate: onSubmit (default)', async () => {
-		const screen = render(<Form />);
+	test.each([
+		{
+			setup: 'Default behavior',
+			element: <Form />,
+		},
+		{
+			setup: 'Global Options',
+			element: (
+				<FormOptionsProvider shouldValidate="onSubmit">
+					<Form />
+				</FormOptionsProvider>
+			),
+		},
+		{
+			setup: 'Local Override',
+			element: (
+				<FormOptionsProvider shouldValidate="onInput">
+					<Form shouldValidate="onSubmit" />
+				</FormOptionsProvider>
+			),
+		},
+	])('$setup - shouldValidate: onSubmit (default)', async ({ element }) => {
+		const screen = render(element);
 		const form = getForm(screen);
 
 		await expectNoErrorMessages(form.title, form.description, form.confirmed);
@@ -342,8 +352,29 @@ describe('future export: useForm', () => {
 		await expectNoErrorMessages(form.title, form.description, form.confirmed);
 	});
 
-	test('shouldValidate: onBlur', async () => {
-		const screen = render(<Form shouldValidate="onBlur" />);
+	test.each([
+		{
+			setup: 'Direct Options',
+			element: <Form shouldValidate="onBlur" />,
+		},
+		{
+			setup: 'Global Options',
+			element: (
+				<FormOptionsProvider shouldValidate="onBlur">
+					<Form />
+				</FormOptionsProvider>
+			),
+		},
+		{
+			setup: 'Local Override',
+			element: (
+				<FormOptionsProvider shouldValidate="onInput">
+					<Form shouldValidate="onBlur" />
+				</FormOptionsProvider>
+			),
+		},
+	])('$setup - shouldValidate: onBlur', async ({ element }) => {
+		const screen = render(element);
 		const form = getForm(screen);
 
 		await expectNoErrorMessages(form.title, form.description, form.confirmed);
@@ -415,8 +446,29 @@ describe('future export: useForm', () => {
 		await expectNoErrorMessages(form.title, form.description, form.confirmed);
 	});
 
-	test('shouldValidate: onInput', async () => {
-		const screen = render(<Form shouldValidate="onInput" />);
+	test.each([
+		{
+			setup: 'Direct Options',
+			element: <Form shouldValidate="onInput" />,
+		},
+		{
+			setup: 'Global Options',
+			element: (
+				<FormOptionsProvider shouldValidate="onInput">
+					<Form />
+				</FormOptionsProvider>
+			),
+		},
+		{
+			setup: 'Local Override',
+			element: (
+				<FormOptionsProvider shouldValidate="onBlur">
+					<Form shouldValidate="onInput" />
+				</FormOptionsProvider>
+			),
+		},
+	])('$setup - shouldValidate: onInput', async ({ element }) => {
+		const screen = render(element);
 		const form = getForm(screen);
 
 		await expectNoErrorMessages(form.title, form.description, form.confirmed);


### PR DESCRIPTION
This PR adds metadata customization support to future `useForm` hook.

This update introduces a `<FormOptionsProvider />` component that allows users to define global form options, including custom metadata properties that match your form component types when integrating with UI libraries or any custom components:

```tsx
import {
  FormOptionsProvider,
  type BaseMetadata,
} from '@conform-to/react/future';
import { TextField } from './components/TextField';

// Define custom metadata properties that matches the type of our custom form components
function defineCustomMetadata<FieldShape, ErrorShape>(
  metadata: BaseMetadata<FieldShape, ErrorShape>,
) {
  return {
    get textFieldProps() {
      return {
        name: metadata.name,
        defaultValue: metadata.defaultValue,
        isInvalid: !metadata.valid,
      } satisfies Partial<React.ComponentProps<typeof TextField>>;
    },
  };
}

// Extend the CustomMetadata interface with our implementation
// This makes the custom metadata types available on all field metadata objects
declare module '@conform-to/react/future' {
  interface CustomMetadata<FieldShape, ErrorShape>
    extends ReturnType<typeof defineCustomMetadata<FieldShape, ErrorShape>> {}
}

// Wrap your app with FormOptionsProvider
<FormOptionsProvider
  shouldValidate="onBlur"
  defineCustomMetadata={defineCustomMetadata}
>
  <App />
</FormOptionsProvider>;

// Use custom metadata properties in your components
function Example() {
  const { form, fields } = useForm({
    // shouldValidate now defaults to "onBlur"
  });

  return (
    <form {...form.props}>
      <TextField {...fields.email.textFieldProps} />
    </form>
  );
}
```
