### PR TITLE
refactor(conform-react/future): ensure missing fields are properly touched

### DIFF
--- a/packages/conform-react/future/intent.ts
+++ b/packages/conform-react/future/intent.ts
@@ -156,22 +156,17 @@ export const actionHandlers: {
 		onUpdate(state, { submission, intent, error }) {
 			const name = intent.payload ?? '';
 			const basePath = getPathSegments(name);
+			const allFields = error
+				? // Consider fields / fieldset with errors as touched too
+					submission.fields.concat(Object.keys(error.fieldErrors))
+				: submission.fields;
 
 			let touchedFields = appendUniqueItem(state.touchedFields, name);
 
-			for (const field of submission.fields) {
+			for (const field of allFields) {
 				// Add all child fields to the touched fields too
 				if (getRelativePath(field, basePath) !== null) {
 					touchedFields = appendUniqueItem(touchedFields, field);
-				}
-			}
-
-			// We couldn't find out all the fields from the FormData, e.g. unchecked checkboxes.
-			// or fieldsets without any fields, but we can at least include missing
-			// required fields based on the form error
-			if (name === '' && error) {
-				for (const name of Object.keys(error.fieldErrors)) {
-					touchedFields = appendUniqueItem(touchedFields, name);
 				}
 			}
 
@@ -197,6 +192,10 @@ export const actionHandlers: {
 			);
 		},
 		onUpdate(state, { type, submission, intent }) {
+			if (type === 'server') {
+				return state;
+			}
+
 			let listKeys = state.listKeys;
 
 			// Update the keys only for client updates to avoid double updates if there is no client validation
@@ -243,6 +242,10 @@ export const actionHandlers: {
 			return updateValueAtPath(value, options.name, list);
 		},
 		onUpdate(state, { type, submission, intent }) {
+			if (type === 'server') {
+				return state;
+			}
+
 			const currentValue = submission.payload;
 			const list = getArrayAtPath(currentValue, intent.payload.name);
 			const index = intent.payload.index ?? list.length;
@@ -304,6 +307,10 @@ export const actionHandlers: {
 			return updateValueAtPath(value, options.name, list);
 		},
 		onUpdate(state, { type, submission, intent }) {
+			if (type === 'server') {
+				return state;
+			}
+
 			const currentValue = submission.payload;
 			const updateListIndex = createPathIndexUpdater(
 				intent.payload.name,
@@ -371,6 +378,10 @@ export const actionHandlers: {
 			return updateValueAtPath(value, options.name, list);
 		},
 		onUpdate(state, { type, submission, intent }) {
+			if (type === 'server') {
+				return state;
+			}
+
 			const currentValue = submission.payload;
 			const updateListIndex = createPathIndexUpdater(
 				intent.payload.name,

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -96,22 +96,19 @@ export function updateState<ErrorShape>(
 						? value
 						: state.serverIntendedValue,
 				});
+	// Validate the whole form if no intent is provided (default submission)
+	const intent = action.intent ?? { type: 'validate' };
+	const handler = action.ctx.handlers?.[intent.type];
 
-	if (action.type !== 'server' && typeof action.intent !== 'undefined') {
-		// Validate the whole form if no intent is provided (default submission)
-		const intent = action.intent ?? { type: 'validate' };
-		const handler = action.ctx.handlers?.[intent.type];
-
-		if (typeof handler?.onUpdate === 'function') {
-			if (handler.validatePayload?.(intent.payload) ?? true) {
-				return handler.onUpdate(state, {
-					...action,
-					intent: {
-						type: intent.type,
-						payload: intent.payload,
-					},
-				});
-			}
+	if (typeof handler?.onUpdate === 'function') {
+		if (handler.validatePayload?.(intent.payload) ?? true) {
+			return handler.onUpdate(state, {
+				...action,
+				intent: {
+					type: intent.type,
+					payload: intent.payload,
+				},
+			});
 		}
 	}
 


### PR DESCRIPTION
Fix https://github.com/edmundhung/conform/discussions/1014#discussioncomment-14528071

This fix two things:

- Conform were patching `submission.fields` with form elements found in the DOM, but it creates a new array instead of modifying the list directly. This is now updated correctly.
- Make sure Conform updates the touched state on both client and server result.