### PR TITLE
fix(conform-zod/v3): zod default schema behavior when coercion is enabled

### DIFF
--- a/packages/conform-zod/v3/coercion.ts
+++ b/packages/conform-zod/v3/coercion.ts
@@ -13,6 +13,7 @@ import {
 	any,
 	ZodCatch,
 	ZodBranded,
+	ZodDefault,
 } from 'zod';
 import type {
 	ZodDiscriminatedUnionOption,
@@ -288,9 +289,15 @@ export function enableTypeCoercion<Schema extends ZodTypeAny>(
 		const defaultValue = def.defaultValue();
 		schema = any()
 			.transform(options.stripEmptyValue)
-			// Reconstruct `.default()` as `.optional().transform(value => value ?? defaultValue)`
-			.pipe(enableTypeCoercion(def.innerType, options).optional())
-			.transform((value) => value ?? defaultValue);
+			.pipe(
+				new ZodDefault({
+					...def,
+					innerType:
+						defaultValue !== ''
+							? enableTypeCoercion(def.innerType, options)
+							: def.innerType,
+				}),
+			);
 	} else if (def.typeName === 'ZodCatch') {
 		schema = new ZodCatch({
 			...def,

--- a/packages/conform-zod/v3/tests/coercion/schema/default.test.ts
+++ b/packages/conform-zod/v3/tests/coercion/schema/default.test.ts
@@ -47,17 +47,11 @@ describe('coercion', () => {
 
 			const today = new Date();
 			const schema2 = z.object({
-				a: z.string().email('invalid').default(''),
-				b: z.number().gt(10, 'invalid').default(0),
-				c: z
-					.boolean()
-					.refine((value) => !!value, 'invalid')
-					.default(false),
-				d: z.date().min(today, 'invalid').default(defaultDate),
-				e: z
-					.instanceof(File)
-					.refine((file) => file.size > 100, 'invalid')
-					.default(defaultFile),
+				a: z.string().default(''),
+				b: z.number().default(0),
+				c: z.boolean().default(false),
+				d: z.date().default(defaultDate),
+				e: z.instanceof(File).default(defaultFile),
 			});
 
 			expect(getResult(coerceFormValue(schema2).safeParse({}))).toEqual({
@@ -68,6 +62,33 @@ describe('coercion', () => {
 					c: false,
 					d: defaultDate,
 					e: defaultFile,
+				},
+			});
+
+			const schema3 = z
+				.object({
+					a: z.string().email('invalid').default(''),
+					b: z.number().gt(10, 'invalid').default(0),
+					c: z
+						.boolean()
+						.refine((value) => !!value, 'invalid')
+						.default(false),
+					d: z.date().min(today, 'invalid').default(defaultDate),
+					e: z
+						.instanceof(File)
+						.refine((file) => file.size > 100, 'invalid')
+						.default(defaultFile),
+				})
+				.default({});
+
+			expect(getResult(coerceFormValue(schema3).safeParse({}))).toEqual({
+				success: false,
+				error: {
+					a: ['invalid'],
+					b: ['invalid'],
+					c: ['invalid'],
+					d: ['invalid'],
+					e: ['invalid'],
 				},
 			});
 		});


### PR DESCRIPTION
Fix #1049

I am a little bit confused what is the right behavior here. As Zod 3 seems to validate against the default value, but zod 4 doesn't 🤔 

I also can't find anything related in Zod's migration docs: https://zod.dev/v4/changelog#default-updates

cc: @chimame 
