### PR TITLE
feat(conform-react/future): support custom default value on reset intent

### DIFF
--- a/.changeset/unlucky-seals-laugh.md
+++ b/.changeset/unlucky-seals-laugh.md
@@ -1,0 +1,22 @@
+---
+'@conform-to/react': minor
+'@conform-to/dom': minor
+---
+
+The `intent.reset()` method now accepts an optional `defaultValue` parameter to reset forms to a different value:
+
+```tsx
+// Clear all fields
+<button type="button" onClick={() => intent.reset({ defaultValue: null })}>
+  Clear
+</button>
+
+// Restore to a specific snapshot
+<button type="button" onClick={() => intent.reset({ defaultValue: savedValue })}>
+  Restore
+</button>
+```
+
+This is useful for filter forms where the initial `defaultValue` comes from URL parameters, but you want a "Clear" button that empties all fields.
+
+Additionally, `intent.update()` has been optimized to behave more consistently with `intent.reset()`, with improved type inference when updating multiple fields at once

--- a/docs/api/react/future/useField.md
+++ b/docs/api/react/future/useField.md
@@ -44,17 +44,23 @@ Auto-generated ID for associating field descriptions via `aria-describedby`.
 
 Auto-generated ID for associating field errors via `aria-describedby`.
 
-### `defaultValue: string | undefined`
+### `defaultValue: string`
 
-The field's default value as a string.
+The field's default value as a string. Returns an empty string `''` when:
 
-### `defaultOptions: string[] | undefined`
+- No default value is set (field value is `null` or `undefined`)
+- The field value cannot be serialized to a string (e.g., objects or arrays)
 
-Default selected options for multi-select fields or checkbox group.
+### `defaultOptions: string[]`
 
-### `defaultChecked: boolean | undefined`
+Default selected options for multi-select fields or checkbox group. Returns an empty array `[]` when:
 
-Default checked state for checkbox/radio inputs.
+- No default options are set (field value is `null` or `undefined`)
+- The field value cannot be serialized to a string array (e.g., nested objects or arrays of objects)
+
+### `defaultChecked: boolean`
+
+Default checked state for checkbox inputs. Returns `true` if the field value is `'on'`. For radio buttons, compare the field's `defaultValue` with the radio button's value attribute instead.
 
 ### `touched: boolean`
 

--- a/docs/api/react/future/useIntent.md
+++ b/docs/api/react/future/useIntent.md
@@ -29,9 +29,11 @@ Triggers validation for the entire form or a specific field. If you provide a na
 
 - **name** (optional): Field name to validate. If omitted, validates the entire form.
 
-### `reset(): void`
+### `reset(options?): void`
 
-Resets the form to its initial state, clearing all values and validation states.
+Resets the form to a specific default value.
+
+- **options.defaultValue** (optional): The value to reset the form to. If not provided, resets to the default value from `useForm`. Pass `null` to clear all fields, or pass a custom object to reset to a specific state.
 
 ### `update(options): void`
 

--- a/examples/react-router/app/routes/todos.tsx
+++ b/examples/react-router/app/routes/todos.tsx
@@ -82,7 +82,7 @@ export default function Example({
 				<input
 					className={!fields.title.valid ? 'error' : ''}
 					name={fields.title.name}
-					defaultValue={fields.title.defaultValue ?? ''}
+					defaultValue={fields.title.defaultValue}
 				/>
 				<div>{fields.title.errors}</div>
 			</div>
@@ -159,6 +159,18 @@ export default function Example({
 			</button>
 			<hr />
 			<button disabled={!dirty}>Save</button>
+			<button type="button" onClick={() => intent.update({ value: null })}>
+				Update
+			</button>
+			<button type="button" onClick={() => intent.reset()}>
+				Reset
+			</button>
+			<button
+				type="button"
+				onClick={() => intent.reset({ defaultValue: null })}
+			>
+				Clear
+			</button>
 		</Form>
 	);
 }

--- a/examples/react-spa/src/routes/signup.tsx
+++ b/examples/react-spa/src/routes/signup.tsx
@@ -1,5 +1,5 @@
-import { useForm } from '@conform-to/react/future';
-import { coerceFormValue, memoize } from '@conform-to/zod/v3/future';
+import { useForm, memoize } from '@conform-to/react/future';
+import { coerceFormValue } from '@conform-to/zod/v3/future';
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router';
 import { z } from 'zod';

--- a/packages/conform-dom/dom.ts
+++ b/packages/conform-dom/dom.ts
@@ -503,6 +503,46 @@ export function normalizeFileValues(value: unknown): FileList | undefined {
 }
 
 /**
+ * Retrieves the default value of a form field element by reading the DOM's
+ * defaultValue, defaultChecked, or defaultSelected properties.
+ */
+export function getFieldDefaultValue(
+	element: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement,
+): string | string[] | File | File[] | FileList | null {
+	if (isInputElement(element)) {
+		switch (element.type) {
+			case 'file': {
+				return null;
+			}
+			case 'checkbox':
+			case 'radio': {
+				if (element.defaultChecked) {
+					return element.value;
+				}
+				return null;
+			}
+		}
+	} else if (isSelectElement(element)) {
+		if (element.multiple) {
+			const values: string[] = [];
+			for (const option of element.options) {
+				if (option.defaultSelected) {
+					values.push(option.value);
+				}
+			}
+			return values;
+		} else {
+			const selectedOption = Array.from(element.options).find(
+				(option) => option.defaultSelected,
+			);
+			return selectedOption ? selectedOption.value : null;
+		}
+	}
+
+	return element.defaultValue;
+}
+
+/**
  * Updates the DOM element with the provided value and defaultValue.
  * If the value or defaultValue is undefined, it will keep the current value instead
  */

--- a/packages/conform-dom/future/index.ts
+++ b/packages/conform-dom/future/index.ts
@@ -31,6 +31,7 @@ export {
 	focus,
 	change,
 	blur,
+	getFieldDefaultValue,
 	getFormAction,
 	getFormEncType,
 	getFormMethod,

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -476,7 +476,7 @@ export function useForm<
 ): {
 	form: FormMetadata<ErrorShape>;
 	fields: Fieldset<FormShape, ErrorShape>;
-	intent: IntentDispatcher;
+	intent: IntentDispatcher<FormShape>;
 } {
 	const { id, defaultValue, constraint } = options;
 	const globalOptions = useContext(GlobalFormOptionsContext);
@@ -550,7 +550,7 @@ export function useForm<
 			);
 		},
 	});
-	const intent = useIntent(formId);
+	const intent = useIntent<FormShape>(formId);
 	const context = useMemo<FormContext<ErrorShape>>(
 		() => ({
 			formId,
@@ -765,7 +765,9 @@ export function useField<FieldShape = any>(
  * }
  * ```
  */
-export function useIntent(formRef: FormRef): IntentDispatcher {
+export function useIntent<FormShape extends Record<string, any>>(
+	formRef: FormRef,
+): IntentDispatcher<FormShape> {
 	const globalOptions = useContext(GlobalFormOptionsContext);
 
 	return useMemo(

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -120,7 +120,7 @@ export function getDefaultValue(
 	context: FormContext<any>,
 	name: string,
 	serialize: Serialize = defaultSerialize,
-): string | undefined {
+): string {
 	const value = getValueAtPath(
 		context.state.serverIntendedValue ??
 			context.state.clientIntendedValue ??
@@ -132,13 +132,15 @@ export function getDefaultValue(
 	if (typeof serializedValue === 'string') {
 		return serializedValue;
 	}
+
+	return '';
 }
 
 export function getDefaultOptions(
 	context: FormContext<any>,
 	name: string,
 	serialize: Serialize = defaultSerialize,
-): string[] | undefined {
+): string[] {
 	const value = getValueAtPath(
 		context.state.serverIntendedValue ??
 			context.state.clientIntendedValue ??
@@ -157,6 +159,8 @@ export function getDefaultOptions(
 	if (typeof serializedValue === 'string') {
 		return [serializedValue];
 	}
+
+	return [];
 }
 
 export function isDefaultChecked(
@@ -172,7 +176,11 @@ export function isDefaultChecked(
 	);
 	const serializedValue = serialize(value);
 
-	return serializedValue === 'on';
+	if (typeof serializedValue === 'string') {
+		return serializedValue === 'on';
+	}
+
+	return false;
 }
 
 /**

--- a/packages/conform-react/future/util.ts
+++ b/packages/conform-react/future/util.ts
@@ -22,6 +22,13 @@ export function isNumber(value: unknown): value is number {
 	return typeof value === 'number';
 }
 
+export function isNullable<T>(
+	value: unknown,
+	typeGuard: (value: unknown) => value is T,
+): value is T | null {
+	return value === null || typeGuard(value);
+}
+
 export function isOptional<T>(
 	value: unknown,
 	typeGuard: (value: unknown) => value is T,

--- a/packages/conform-react/package.json
+++ b/packages/conform-react/package.json
@@ -67,7 +67,7 @@
 		"rollup-plugin-copy": "^3.4.0",
 		"rollup": "^2.79.1",
 		"typescript": "^5.8.3",
-		"vitest-browser-react": "^0.3.0"
+		"vitest-browser-react": "^1.0.1"
 	},
 	"peerDependencies": {
 		"react": ">=18"

--- a/packages/conform-react/tests/state.test.ts
+++ b/packages/conform-react/tests/state.test.ts
@@ -67,8 +67,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('');
+		expect(getDefaultValue(context, 'password')).toBe('');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
@@ -97,8 +97,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('');
+		expect(getDefaultValue(context, 'password')).toBe('');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
@@ -121,8 +121,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('');
+		expect(getDefaultValue(context, 'password')).toBe('');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
@@ -211,8 +211,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('');
+		expect(getDefaultValue(context, 'password')).toBe('');
 		expect(isTouched(context.state)).toBe(false);
 		expect(isTouched(context.state, 'username')).toBe(false);
 		expect(isTouched(context.state, 'password')).toBe(false);
@@ -245,8 +245,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('');
+		expect(getDefaultValue(context, 'password')).toBe('');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(false);
@@ -268,8 +268,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('');
+		expect(getDefaultValue(context, 'password')).toBe('');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
@@ -334,8 +334,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('');
+		expect(getDefaultValue(context, 'password')).toBe('');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(false);
@@ -370,8 +370,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('');
+		expect(getDefaultValue(context, 'password')).toBe('');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
@@ -401,8 +401,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('');
+		expect(getDefaultValue(context, 'password')).toBe('');
 		expect(isTouched(context.state)).toBe(false);
 		expect(isTouched(context.state, 'username')).toBe(false);
 		expect(isTouched(context.state, 'password')).toBe(false);
@@ -423,8 +423,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('');
+		expect(getDefaultValue(context, 'password')).toBe('');
 		expect(isTouched(context.state)).toBe(false);
 		expect(isTouched(context.state, 'username')).toBe(false);
 		expect(isTouched(context.state, 'password')).toBe(false);
@@ -457,8 +457,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('');
+		expect(getDefaultValue(context, 'password')).toBe('');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(false);
@@ -486,8 +486,8 @@ describe('form', () => {
 			}),
 		);
 
-		expect(getDefaultValue(context, 'username')).toBe(undefined);
-		expect(getDefaultValue(context, 'password')).toBe(undefined);
+		expect(getDefaultValue(context, 'username')).toBe('');
+		expect(getDefaultValue(context, 'password')).toBe('');
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'username')).toBe(true);
 		expect(isTouched(context.state, 'password')).toBe(true);
@@ -686,9 +686,9 @@ describe('form', () => {
 		);
 
 		expect(getListKey(context, 'tasks')).toEqual([]);
-		expect(getDefaultValue(context, 'title')).toBe(undefined);
-		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
-		expect(getDefaultOptions(context, 'tasks')).toEqual(undefined);
+		expect(getDefaultValue(context, 'title')).toBe('');
+		expect(getDefaultValue(context, 'tasks')).toBe('');
+		expect(getDefaultOptions(context, 'tasks')).toEqual([]);
 		expect(isTouched(context.state)).toBe(true);
 		expect(isTouched(context.state, 'title')).toBe(true);
 		expect(isTouched(context.state, 'tasks')).toBe(true);
@@ -708,7 +708,7 @@ describe('form', () => {
 
 		expect(getListKey(context, 'tasks')).toEqual(['0-tasks[0]', '0-tasks[1]']);
 		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
-		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultValue(context, 'tasks')).toBe('');
 		expect(getDefaultOptions(context, 'tasks')).toEqual([
 			'Default task 1',
 			'Default task 2',
@@ -750,7 +750,7 @@ describe('form', () => {
 			'0',
 		]);
 		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
-		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultValue(context, 'tasks')).toBe('');
 		expect(getDefaultOptions(context, 'tasks')).toEqual([
 			'Default task 1',
 			'Default task 2',
@@ -793,7 +793,7 @@ describe('form', () => {
 			'0',
 		]);
 		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
-		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultValue(context, 'tasks')).toBe('');
 		expect(getDefaultOptions(context, 'tasks')).toEqual([
 			'Default task 1',
 			'Default task 2',
@@ -842,7 +842,7 @@ describe('form', () => {
 			'0',
 		]);
 		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
-		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultValue(context, 'tasks')).toBe('');
 		expect(getDefaultOptions(context, 'tasks')).toEqual([
 			'Urgent task',
 			'Default task 1',
@@ -894,7 +894,7 @@ describe('form', () => {
 			'0-tasks[1]',
 		]);
 		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
-		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultValue(context, 'tasks')).toBe('');
 		expect(getDefaultOptions(context, 'tasks')).toEqual([
 			'Urgent task',
 			'New task',
@@ -952,7 +952,7 @@ describe('form', () => {
 			'0-tasks[1]',
 		]);
 		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
-		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultValue(context, 'tasks')).toBe('');
 		expect(getDefaultOptions(context, 'tasks')).toEqual([
 			'Urgent task',
 			'New task',
@@ -1004,7 +1004,7 @@ describe('form', () => {
 
 		expect(getListKey(context, 'tasks')).toEqual(['1', '0', '0-tasks[1]']);
 		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
-		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultValue(context, 'tasks')).toBe('');
 		expect(getDefaultOptions(context, 'tasks')).toEqual([
 			'Urgent task',
 			'New task',
@@ -1053,7 +1053,7 @@ describe('form', () => {
 
 		expect(getListKey(context, 'tasks')).toEqual(['1', '0', '0-tasks[1]']);
 		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
-		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultValue(context, 'tasks')).toBe('');
 		expect(getDefaultOptions(context, 'tasks')).toEqual([
 			'Urgent task',
 			'New task',
@@ -1097,7 +1097,7 @@ describe('form', () => {
 
 		expect(getListKey(context, 'tasks')).toEqual(['1-tasks[0]', '1-tasks[1]']);
 		expect(getDefaultValue(context, 'title')).toBe('My Tasks');
-		expect(getDefaultValue(context, 'tasks')).toBe(undefined);
+		expect(getDefaultValue(context, 'tasks')).toBe('');
 		expect(getDefaultOptions(context, 'tasks')).toEqual([
 			'Default task 1',
 			'Default task 2',

--- a/packages/conform-react/tests/useForm.node.test.tsx
+++ b/packages/conform-react/tests/useForm.node.test.tsx
@@ -13,9 +13,9 @@ describe('future export: useForm', () => {
 		);
 
 		expect(form.errors).toBe(undefined);
-		expect(fields.title.defaultValue).toBe(undefined);
+		expect(fields.title.defaultValue).toBe('');
 		expect(fields.title.errors).toBe(undefined);
-		expect(fields.description.defaultValue).toBe(undefined);
+		expect(fields.description.defaultValue).toBe('');
 		expect(fields.description.errors).toBe(undefined);
 
 		// Test if the form state is stable
@@ -181,7 +181,7 @@ describe('future export: useForm', () => {
 		expect(form.errors).toBe(undefined);
 		expect(fields.title.defaultValue).toBe('Default Title');
 		expect(fields.title.errors).toBe(undefined);
-		expect(fields.description.defaultValue).toBe(undefined);
+		expect(fields.description.defaultValue).toBe('');
 		expect(fields.description.errors).toBe(undefined);
 	});
 
@@ -224,7 +224,7 @@ describe('future export: useForm', () => {
 		expect(form.errors).toEqual(['Form error']);
 		expect(fields.title.defaultValue).toBe('Example');
 		expect(fields.title.errors).toBe(undefined);
-		expect(fields.notes.defaultValue).toBe(undefined);
+		expect(fields.notes.defaultValue).toBe('');
 		expect(fields.notes.defaultOptions).toEqual(['Foo']);
 		expect(fields.notes.errors).toEqual(['Notes error']);
 		expect(notes[0]?.defaultValue).toBe('Foo');
@@ -273,7 +273,7 @@ describe('future export: useForm', () => {
 		expect(form.errors).toEqual(['Form error']);
 		expect(fields.title.defaultValue).toBe('Example');
 		expect(fields.title.errors).toBe(undefined);
-		expect(fields.notes.defaultValue).toBe(undefined);
+		expect(fields.notes.defaultValue).toBe('');
 		expect(fields.notes.defaultOptions).toEqual([
 			'Second note',
 			'First note',
@@ -328,7 +328,7 @@ describe('future export: useForm', () => {
 		expect(form.errors).toEqual(['Form error']);
 		expect(fields.title.defaultValue).toBe('Example');
 		expect(fields.title.errors).toBe(undefined);
-		expect(fields.notes.defaultValue).toBe(undefined);
+		expect(fields.notes.defaultValue).toBe('');
 		expect(fields.notes.defaultOptions).toEqual(['First note', 'Third note']);
 		expect(fields.notes.errors).toEqual(['Notes error']);
 		expect(notes[0]?.defaultValue).toBe('First note');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,13 +506,13 @@ importers:
         version: link:../../packages/conform-zod
       react:
         specifier: ^19.1.1
-        version: 19.1.1
+        version: 19.2.0
       react-dom:
         specifier: ^19.1.1
-        version: 19.1.1(react@19.1.1)
+        version: 19.2.0(react@19.2.0)
       react-router:
         specifier: ^7.8.2
-        version: 7.8.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 7.8.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       zod:
         specifier: ^3.25.75
         version: 3.25.76
@@ -870,8 +870,8 @@ importers:
         specifier: ^5.8.3
         version: 5.9.2
       vitest-browser-react:
-        specifier: ^0.3.0
-        version: 0.3.0(@types/react-dom@18.3.7(@types/react@18.3.1))(@types/react@18.3.1)(@vitest/browser@3.2.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4)
+        specifier: ^1.0.1
+        version: 1.0.1(@types/react-dom@18.3.7(@types/react@18.3.1))(@types/react@18.3.1)(@vitest/browser@3.2.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4)
 
   packages/conform-valibot:
     dependencies:
@@ -9924,6 +9924,11 @@ packages:
     peerDependencies:
       react: ^19.1.1
 
+  react-dom@19.2.0:
+    resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
+    peerDependencies:
+      react: ^19.2.0
+
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
 
@@ -10081,6 +10086,10 @@ packages:
 
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.0:
+    resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
     engines: {node: '>=0.10.0'}
 
   read-cache@1.0.0:
@@ -10331,6 +10340,9 @@ packages:
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   selfsigned@2.4.1:
     resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
@@ -11328,16 +11340,16 @@ packages:
       vite:
         optional: true
 
-  vitest-browser-react@0.3.0:
-    resolution: {integrity: sha512-dk8T3GHhwrmCJLqDer1A2NB8MlIGsUb9Wr4/iMpbrwz4sBCh1PjV0SkZ9BYmoBrJ4j/Tx8qxzCXFXnbE2IbWzg==}
+  vitest-browser-react@1.0.1:
+    resolution: {integrity: sha512-LqiGFCdknrbMoSDWXTCTrPsED3SvdIXIgYOOZyYUNj2dkJusW2eF6NENOlBlxwq+FBQqzNK1X59b+b03pXFpAQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     peerDependencies:
       '@types/react': ^18.0.0 || ^19.0.0
       '@types/react-dom': ^18.0.0 || ^19.0.0
-      '@vitest/browser': ^2.1.0 || ^3.0.0
+      '@vitest/browser': ^2.1.0 || ^3.0.0 || ^4.0.0-0
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
-      vitest: ^2.1.0 || ^3.0.0
+      vitest: ^2.1.0 || ^3.0.0 || ^4.0.0-0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -22983,6 +22995,11 @@ snapshots:
       react: 19.1.1
       scheduler: 0.26.0
 
+  react-dom@19.2.0(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      scheduler: 0.27.0
+
   react-fast-compare@3.2.2: {}
 
   react-focus-lock@2.9.6(@types/react@18.3.23)(react@18.3.1):
@@ -23088,6 +23105,14 @@ snapshots:
     optionalDependencies:
       react-dom: 19.1.1(react@19.1.1)
 
+  react-router@7.8.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      cookie: 1.0.2
+      react: 19.2.0
+      set-cookie-parser: 2.6.0
+    optionalDependencies:
+      react-dom: 19.2.0(react@19.2.0)
+
   react-stately@3.38.0(react@18.3.1):
     dependencies:
       '@react-stately/calendar': 3.8.1(react@18.3.1)
@@ -23158,6 +23183,8 @@ snapshots:
       loose-envify: 1.4.0
 
   react@19.1.1: {}
+
+  react@19.2.0: {}
 
   read-cache@1.0.0:
     dependencies:
@@ -23490,6 +23517,8 @@ snapshots:
       loose-envify: 1.4.0
 
   scheduler@0.26.0: {}
+
+  scheduler@0.27.0: {}
 
   selfsigned@2.4.1:
     dependencies:
@@ -24587,7 +24616,7 @@ snapshots:
     optionalDependencies:
       vite: 6.3.5(@types/node@20.11.20)(jiti@1.21.0)(terser@5.26.0)
 
-  vitest-browser-react@0.3.0(@types/react-dom@18.3.7(@types/react@18.3.1))(@types/react@18.3.1)(@vitest/browser@3.2.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4):
+  vitest-browser-react@1.0.1(@types/react-dom@18.3.7(@types/react@18.3.1))(@types/react@18.3.1)(@vitest/browser@3.2.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.2.4):
     dependencies:
       '@vitest/browser': 3.2.4(msw@2.7.0(@types/node@20.11.20)(typescript@5.9.2))(playwright@1.49.1)(vite@6.3.5(@types/node@20.11.20)(jiti@1.21.0)(terser@5.26.0))(vitest@3.2.4)
       react: 18.3.1


### PR DESCRIPTION
Fix https://github.com/edmundhung/conform/discussions/1014#discussioncomment-14716376

This PR adds support for resetting forms with custom default values:

```tsx
// Clear all fields
intent.reset({ defaultValue: null })

// Restore to a specific snapshot
intent.reset({ defaultValue: savedValue })
```

Meanwhile, I have also improved type inference for `intent.update()` when updating form `value`  which defaults to the form shape when no `name` is specified. 

Another subtle but important change is that this also adjusted how DOM values are synced in Conform so that update intent behaves more consistently with reset intent:

Both `reset` and `update` intents work in two phases:
1. Update form state with new default value, triggering React to re-render and update DOM's defaultValue/defaultChecked/defaultSelected properties
2. Sync DOM by either calling `formElement.reset()` for reset intent or looping through elements for update intent

Previously, `intent.update()` skipped fields with `undefined` values to avoid touching unmanaged inputs. Now it falls back to element's default value (except for file inputs which are explicitly skipped). This makes both `intent.update({ value: {} })` and `intent.reset({ defaultValue: {} })` clear all fields. Unmanaged inputs remain safe with the new setup since they are reset to their default value, which typically hasn't changed as these fields aren't meant to be modified by users.