### PR TITLE
feat(conform-react/future): better type inference with custom schema support

### DIFF
--- a/.changeset/good-carpets-protect.md
+++ b/.changeset/good-carpets-protect.md
@@ -1,0 +1,85 @@
+---
+'@conform-to/react': minor
+'@conform-to/zod': minor
+'@conform-to/valibot': minor
+---
+
+## New `useForm` overload for schema-first forms
+
+You can now pass a schema directly as the first argument to `useForm`, with options as the second argument:
+
+```tsx
+const { form, fields } = useForm(schema, {
+  onSubmit(event, { value }) {
+    // value is fully typed based on your schema
+  },
+});
+```
+
+**Breaking changes:**
+
+- The manual (non-schema) setup `useForm({ onValidate, ... })` no longer accepts a `schema` option. Use the schema-first API `useForm(schema, options)` instead.
+- The options parameter now requires at least `lastResult` or `onSubmit` to be provided.
+
+## New `getConstraint` option for `FormOptionsProvider`
+
+Automatically derive HTML validation attributes from your schema. Set this once globally and you no longer need to configure the `constraint` option on every `useForm`:
+
+```tsx
+import { getZodConstraint } from '@conform-to/zod/v3/future';
+
+<FormOptionsProvider getConstraint={getZodConstraint}>
+  <App />
+</FormOptionsProvider>;
+```
+
+This automatically derives HTML attributes like `required`, `minLength`, `maxLength`, `min`, `max`, `pattern`, etc. from your schema for all forms.
+
+## New `validateSchema` option for `FormOptionsProvider`
+
+Customize how schemas are validated globally across your application. This is useful for advanced scenarios like custom error maps or non-StandardSchema libraries.
+
+To enable type inference with `validateSchema`, declare the `CustomSchema` interface for your schema library:
+
+```tsx
+// 1. Declare CustomSchema for type inference
+declare module '@conform-to/react/future' {
+  interface CustomSchema<Schema> {
+    baseType: z.ZodTypeAny;
+    input: Schema extends z.ZodTypeAny ? z.input<Schema> : unknown;
+    output: Schema extends z.ZodTypeAny ? z.output<Schema> : unknown;
+    options: Partial<z.ParseParams>;
+  }
+}
+
+// 2. Configure FormOptionsProvider with validateSchema options
+<FormOptionsProvider
+  validateSchema={(schema, { payload, schemaOptions }) => {
+    try {
+      const result = schema.safeParse(payload, schemaOptions);
+      return formatResult(result);
+    } catch {
+      return schema.safeParseAsync(payload, schemaOptions).then(formatResult);
+    }
+  }}
+>
+  <App />
+</FormOptionsProvider>;
+
+// 3. Setup your form with a schema
+function SignupForm() {
+  const schema = z.object({
+    username: z.string().min(3),
+    email: z.string().email(),
+  });
+
+  const { form, fields } = useForm(schema, {
+    schemaOptions: { errorMap: customErrorMap }, // Optional per-form customization
+    onSubmit(event, { value }) {
+      console.log(value); // Fully typed: { username: string; email: string }
+    },
+  });
+
+  return <form {...form.props}>...</form>;
+}
+```

--- a/docs/api/valibot/future/getValibotConstraint.md
+++ b/docs/api/valibot/future/getValibotConstraint.md
@@ -1,0 +1,82 @@
+# getValibotConstraint
+
+A helper that returns an object containing the validation attributes for each field by introspecting the valibot schema.
+
+```tsx
+import { getValibotConstraint } from '@conform-to/valibot/future';
+import * as v from 'valibot';
+
+const constraint = getValibotConstraint(
+  v.object({
+    title: v.pipe(v.string(), v.minLength(5), v.maxLength(20)),
+    description: v.optional(
+      v.pipe(v.string(), v.minLength(100), v.maxLength(1000)),
+    ),
+  }),
+);
+// Returns:
+// {
+//   title: { required: true, minLength: 5, maxLength: 20 },
+//   description: { required: false, minLength: 100, maxLength: 1000 }
+// }
+```
+
+## Parameters
+
+### `schema`
+
+The schema to be introspected.
+
+## Returns
+
+- `Record<string, Constraint>` - An object containing validation attributes for each field if the schema is a Valibot schema
+- `null` - If the schema is not a Valibot schema
+
+## Tips
+
+### Setup with useForm
+
+Pass `getValibotConstraint` to `useForm` to derive HTML validation attributes from your schema:
+
+```tsx
+import { getValibotConstraint } from '@conform-to/valibot/future';
+import { useForm } from '@conform-to/react';
+import * as v from 'valibot';
+
+const schema = v.object({
+  title: v.pipe(v.string(), v.minLength(5), v.maxLength(20)),
+  description: v.optional(
+    v.pipe(v.string(), v.minLength(100), v.maxLength(1000)),
+  ),
+});
+
+function Example() {
+  const [form, fields] = useForm({
+    constraint: getValibotConstraint(schema),
+  });
+
+  // fields.title.required === true
+  // fields.title.minLength === 5
+  // fields.title.maxLength === 20
+  // fields.description.required === false
+  // fields.description.minLength === 100
+  // fields.description.maxLength === 1000
+}
+```
+
+### Setup with FormOptionsProvider
+
+To avoid repeating the configuration across multiple forms, you can set `getValibotConstraint` globally with `FormOptionsProvider`:
+
+```tsx
+import { FormOptionsProvider } from '@conform-to/react/future';
+import { getValibotConstraint } from '@conform-to/valibot/future';
+
+function App() {
+  return (
+    <FormOptionsProvider getConstraint={getValibotConstraint}>
+      <Main />
+    </FormOptionsProvider>
+  );
+}
+```

--- a/docs/api/zod/future/getZodConstraint.md
+++ b/docs/api/zod/future/getZodConstraint.md
@@ -1,0 +1,78 @@
+# getZodConstraint
+
+A helper that returns an object containing the validation attributes for each field by introspecting the zod schema.
+
+```tsx
+import { getZodConstraint } from '@conform-to/zod/v3/future'; // Or '@conform-to/zod/v4/future'
+import { z } from 'zod';
+
+const constraint = getZodConstraint(
+  z.object({
+    title: z.string().min(5).max(20),
+    description: z.string().min(100).max(1000).optional(),
+  }),
+);
+// Returns:
+// {
+//   title: { required: true, minLength: 5, maxLength: 20 },
+//   description: { required: false, minLength: 100, maxLength: 1000 }
+// }
+```
+
+## Parameters
+
+### `schema`
+
+The schema to be introspected.
+
+## Returns
+
+- `Record<string, Constraint>` - An object containing validation attributes for each field if the schema is a Zod schema
+- `null` - If the schema is not a Zod schema
+
+## Tips
+
+### Setup with useForm
+
+Pass `getZodConstraint` to `useForm` to derive HTML validation attributes from your schema:
+
+```tsx
+import { getZodConstraint } from '@conform-to/zod/v3/future';
+import { useForm } from '@conform-to/react';
+import { z } from 'zod';
+
+const schema = z.object({
+  title: z.string().min(5).max(20),
+  description: z.string().min(100).max(1000).optional(),
+});
+
+function Example() {
+  const [form, fields] = useForm({
+    constraint: getZodConstraint(schema),
+  });
+
+  // fields.title.required === true
+  // fields.title.minLength === 5
+  // fields.title.maxLength === 20
+  // fields.description.required === false
+  // fields.description.minLength === 100
+  // fields.description.maxLength === 1000
+}
+```
+
+### Setup with FormOptionsProvider
+
+To avoid repeating the configuration across multiple forms, you can set `getZodConstraint` globally with `FormOptionsProvider`:
+
+```tsx
+import { FormOptionsProvider } from '@conform-to/react/future';
+import { getZodConstraint } from '@conform-to/zod/v3/future';
+
+function App() {
+  return (
+    <FormOptionsProvider getConstraint={getZodConstraint}>
+      <Main />
+    </FormOptionsProvider>
+  );
+}
+```

--- a/examples/chakra-ui/src/App.tsx
+++ b/examples/chakra-ui/src/App.tsx
@@ -48,8 +48,7 @@ export default function App() {
 	const [searchParams, setSearchParams] = useState(
 		() => new URLSearchParams(window.location.search),
 	);
-	const { form, fields, intent } = useForm({
-		schema,
+	const { form, fields, intent } = useForm(schema, {
 		defaultValue: {
 			email: searchParams.get('email'),
 			language: searchParams.get('language'),

--- a/examples/headless-ui/src/App.tsx
+++ b/examples/headless-ui/src/App.tsx
@@ -33,8 +33,7 @@ export default function App() {
 	const [searchParams, setSearchParams] = useState(
 		() => new URLSearchParams(window.location.search),
 	);
-	const { form, fields, intent } = useForm({
-		schema,
+	const { form, fields, intent } = useForm(schema, {
 		defaultValue: {
 			owner: searchParams.getAll('owner'),
 			assignee: searchParams.get('assignee'),

--- a/examples/material-ui/src/App.tsx
+++ b/examples/material-ui/src/App.tsx
@@ -46,8 +46,7 @@ export default function App() {
 	const [searchParams, setSearchParams] = useState(
 		() => new URLSearchParams(window.location.search),
 	);
-	const { form, fields, intent } = useForm({
-		schema,
+	const { form, fields, intent } = useForm(schema, {
 		defaultValue: {
 			email: searchParams.get('email'),
 			description: searchParams.get('description'),

--- a/examples/nextjs/app/signup-async-schema/_form.tsx
+++ b/examples/nextjs/app/signup-async-schema/_form.tsx
@@ -20,11 +20,10 @@ export function SignupAsyncSchemaForm() {
 			}),
 		[],
 	);
-	const { form, fields } = useForm({
+	const { form, fields } = useForm(schema, {
 		lastResult,
 		shouldValidate: 'onBlur',
 		shouldRevalidate: 'onInput',
-		schema,
 	});
 
 	return (

--- a/examples/nextjs/app/signup/_form.tsx
+++ b/examples/nextjs/app/signup/_form.tsx
@@ -22,11 +22,10 @@ export function SignupForm() {
 			}),
 		[],
 	);
-	const { form, fields } = useForm({
+	const { form, fields } = useForm(signupSchema, {
 		lastResult,
 		shouldValidate: 'onBlur',
 		shouldRevalidate: 'onInput',
-		schema: signupSchema,
 		async onValidate({ payload, error }) {
 			if (typeof payload.username === 'string' && !error.fieldErrors.username) {
 				const messages = await validateUsername(payload.username);

--- a/examples/nextjs/app/todos/_form.tsx
+++ b/examples/nextjs/app/todos/_form.tsx
@@ -12,11 +12,10 @@ export function TodoForm({
 	defaultValue?: z.infer<typeof schema> | null;
 }) {
 	const [lastResult, action] = useActionState(createTodos, null);
-	const { form, fields, intent } = useForm({
+	const { form, fields, intent } = useForm(schema, {
 		lastResult,
 		shouldValidate: 'onBlur',
 		defaultValue,
-		schema,
 	});
 	const dirty = useFormData(form.id, (formData) =>
 		isDirty(formData, {

--- a/examples/radix-ui/src/App.tsx
+++ b/examples/radix-ui/src/App.tsx
@@ -29,8 +29,7 @@ export default function App() {
 	const [searchParams, setSearchParams] = useState(
 		() => new URLSearchParams(window.location.search),
 	);
-	const { form, fields, intent } = useForm({
-		schema,
+	const { form, fields, intent } = useForm(schema, {
 		defaultValue: {
 			isTermsAgreed: searchParams.get('isTermsAgreed'),
 			carType: searchParams.get('carType'),

--- a/examples/react-aria/src/App.tsx
+++ b/examples/react-aria/src/App.tsx
@@ -39,8 +39,7 @@ export default function App() {
 	const [searchParams, setSearchParams] = useState(
 		() => new URLSearchParams(window.location.search),
 	);
-	const { form, fields, intent } = useForm({
-		schema,
+	const { form, fields, intent } = useForm(schema, {
 		defaultValue: {
 			email: searchParams.get('email'),
 			price: searchParams.get('price'),

--- a/examples/react-router/app/routes/file-upload.tsx
+++ b/examples/react-router/app/routes/file-upload.tsx
@@ -30,10 +30,9 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 export default function Login({ actionData }: Route.ComponentProps) {
-	const { form, fields } = useForm({
+	const { form, fields } = useForm(schema, {
 		lastResult: actionData?.result,
 		shouldValidate: 'onBlur',
-		schema,
 	});
 
 	return (

--- a/examples/react-router/app/routes/login-fetcher.tsx
+++ b/examples/react-router/app/routes/login-fetcher.tsx
@@ -32,12 +32,10 @@ export async function action({ request }: Route.ActionArgs) {
 
 export default function LoginWithFetcher() {
 	const fetcher = useFetcher<Route.ComponentProps['actionData']>();
-	const { form, fields } = useForm({
+	const { form, fields } = useForm(schema, {
 		// Sync the result of last submission
 		lastResult: fetcher.data?.result,
 		shouldValidate: 'onBlur',
-		// Reuse the validation logic on the client
-		schema,
 	});
 
 	return (

--- a/examples/react-router/app/routes/signup-async-schema.tsx
+++ b/examples/react-router/app/routes/signup-async-schema.tsx
@@ -96,11 +96,10 @@ export default function Signup({ actionData }: Route.ComponentProps) {
 			}),
 		[],
 	);
-	const { form, fields } = useForm({
+	const { form, fields } = useForm(schema, {
 		lastResult: actionData?.result,
 		shouldValidate: 'onBlur',
 		shouldRevalidate: 'onInput',
-		schema,
 	});
 
 	return (

--- a/examples/react-router/app/routes/signup-server-validation.tsx
+++ b/examples/react-router/app/routes/signup-server-validation.tsx
@@ -34,7 +34,7 @@ export async function action({ request }: Route.ActionArgs) {
 	const submission = parseSubmission(formData);
 	const result = schema.safeParse(submission.payload);
 
-	let error = formatResult(result);
+	let { error } = formatResult(result);
 
 	if (!error?.fieldErrors.username) {
 		const isUsernameUnique = await new Promise<boolean>((resolve) => {
@@ -73,11 +73,10 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 export default function Signup({ actionData }: Route.ComponentProps) {
-	const { form, fields } = useForm({
+	const { form, fields } = useForm(schema, {
 		lastResult: actionData?.result,
 		shouldValidate: 'onBlur',
 		shouldRevalidate: 'onInput',
-		schema,
 		onValidate({ error, intent }) {
 			// If there is client error, use it
 			if (error.fieldErrors.username) {

--- a/examples/react-router/app/routes/signup.tsx
+++ b/examples/react-router/app/routes/signup.tsx
@@ -97,11 +97,10 @@ export default function Signup({ actionData }: Route.ComponentProps) {
 			}),
 		[],
 	);
-	const { form, fields } = useForm({
+	const { form, fields } = useForm(schema, {
 		lastResult: actionData?.result,
 		shouldValidate: 'onBlur',
 		shouldRevalidate: 'onInput',
-		schema,
 		async onValidate({ payload, error }) {
 			if (typeof payload.username === 'string' && !error.fieldErrors.username) {
 				const messages = await validateUsername(payload.username);

--- a/examples/react-router/app/routes/todos.tsx
+++ b/examples/react-router/app/routes/todos.tsx
@@ -57,7 +57,7 @@ export default function Example({
 	actionData,
 }: Route.ComponentProps) {
 	const navigation = useNavigation();
-	const { form, fields, intent } = useForm({
+	const { form, fields, intent } = useForm(schema, {
 		// If we reset the form after a successful submission, we need to
 		// keep in mind that the default value (loader) will be updated
 		// only after the submsionn result (action) is received. We need to
@@ -66,7 +66,6 @@ export default function Example({
 		lastResult: navigation.state === 'idle' ? actionData?.result : null,
 		defaultValue: loaderData.todos,
 		shouldValidate: 'onBlur',
-		schema,
 	});
 	const dirty = useFormData(
 		form.id,

--- a/examples/react-spa/src/routes/login.tsx
+++ b/examples/react-spa/src/routes/login.tsx
@@ -18,20 +18,19 @@ export default function Login() {
 	const { form, fields } = useForm({
 		shouldValidate: 'onBlur',
 		onValidate({ payload, error }) {
-			if (!payload.email) {
+			const { email, password } = payload;
+
+			if (!email) {
 				error.fieldErrors.email = ['Email is required'];
-			} else if (
-				typeof payload.email !== 'string' ||
-				!payload.email.includes('@')
-			) {
+			} else if (typeof email !== 'string' || !email.includes('@')) {
 				error.fieldErrors.email = ['Email is invalid'];
 			}
 
-			if (!payload.password) {
+			if (!password) {
 				error.fieldErrors.password = ['Password is required'];
 			}
 
-			return { error, value: payload };
+			return { error, value: { email, password } };
 		},
 		async onSubmit(event, { value, update }) {
 			event.preventDefault();

--- a/examples/react-spa/src/routes/signup-async-schema.tsx
+++ b/examples/react-spa/src/routes/signup-async-schema.tsx
@@ -68,8 +68,7 @@ export default function SignupAsyncSchema() {
 			}),
 		[],
 	);
-	const { form, fields } = useForm({
-		schema,
+	const { form, fields } = useForm(schema, {
 		shouldValidate: 'onBlur',
 		shouldRevalidate: 'onInput',
 		async onSubmit(event, { value, update }) {

--- a/examples/react-spa/src/routes/signup.tsx
+++ b/examples/react-spa/src/routes/signup.tsx
@@ -58,10 +58,9 @@ export default function Signup() {
 			}),
 		[],
 	);
-	const { form, fields } = useForm({
+	const { form, fields } = useForm(schema, {
 		shouldValidate: 'onBlur',
 		shouldRevalidate: 'onInput',
-		schema,
 		async onValidate({ payload, error }) {
 			if (typeof payload.username === 'string' && !error.fieldErrors.username) {
 				const messages = await validateUsername(payload.username);

--- a/examples/react-spa/src/routes/todos.tsx
+++ b/examples/react-spa/src/routes/todos.tsx
@@ -33,9 +33,8 @@ export default function Todos() {
 	const [defaultValue, setDefaultValue] = useState<z.infer<
 		typeof todosSchema
 	> | null>(null);
-	const { form, fields, intent } = useForm({
+	const { form, fields, intent } = useForm(todosSchema, {
 		defaultValue,
-		schema: todosSchema,
 		async onSubmit(event, { value, update }) {
 			event.preventDefault();
 

--- a/examples/shadcn-ui/src/App.tsx
+++ b/examples/shadcn-ui/src/App.tsx
@@ -46,8 +46,7 @@ export default function App() {
 	const [searchParams, setSearchParams] = useState(
 		() => new URLSearchParams(window.location.search),
 	);
-	const { form, fields, intent } = useForm({
-		schema,
+	const { form, fields, intent } = useForm(schema, {
 		defaultValue: {
 			name: searchParams.get('name'),
 			dateOfBirth: searchParams.get('dateOfBirth'),

--- a/packages/conform-react/future/index.ts
+++ b/packages/conform-react/future/index.ts
@@ -9,6 +9,7 @@ export type {
 	Control,
 	DefaultValue,
 	BaseMetadata,
+	CustomSchema,
 	CustomMetadata,
 	CustomMetadataDefinition,
 	BaseErrorShape,

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -142,6 +142,46 @@ export type FormAction<
 	ctx: Context;
 };
 
+export type SchemaValidationContext<Schema> = {
+	/**
+	 * TODO
+	 */
+	schemaOptions: InferOptions<Schema>;
+	/**
+	 * The submitted values mapped by field name.
+	 * Supports nested names like `user.email` and indexed names like `items[0].id`.
+	 */
+	payload: Record<string, FormValue>;
+	/**
+	 * The submission intent derived from the button that triggered the form submission.
+	 */
+	intent: UnknownIntent | null;
+	/**
+	 * The raw FormData object of the submission.
+	 */
+	formData: FormData;
+	/**
+	 * Reference to the HTML form element that triggered the submission.
+	 */
+	formElement: HTMLFormElement;
+	/**
+	 * The specific element (button/input) that triggered the form submission.
+	 */
+	submitter: HTMLElement | null;
+};
+
+export type SchemaValidationResult<ErrorShape, Value> = {
+	error: FormError<ErrorShape> | null;
+	value?: Value;
+};
+
+export type SchemaValidationHandler = <Schema extends BaseSchemaType>(
+	schema: Schema,
+	context: SchemaValidationContext<Schema>,
+) =>
+	| SchemaValidationResult<string, InferOutput<Schema>>
+	| Promise<SchemaValidationResult<string, InferOutput<Schema>>>;
+
 export type GlobalFormOptions = {
 	/**
 	 * The name of the submit button field that indicates the submission intent.
@@ -170,7 +210,52 @@ export type GlobalFormOptions = {
 	 * Useful for integrating with UI libraries or custom form components.
 	 */
 	defineCustomMetadata?: CustomMetadataDefinition;
+	/**
+	 * A custom schema validation handler that processes schema validation globally.
+	 * Allows you to configure how schemas are validated across your entire application.
+	 *
+	 * @example
+	 * ```tsx
+	 * <FormOptionsProvider
+	 *   validateSchema={(schema, { payload, schemaOptions }) => {
+	 *     const result = schema.safeParse(payload, schemaOptions);
+	 *     return formatResult(result);
+	 *   }}
+	 * >
+	 *   <App />
+	 * </FormOptionsProvider>
+	 * ```
+	 */
+	validateSchema: SchemaValidationHandler;
+	/**
+	 * A function that derives HTML validation constraints from the schema.
+	 * Useful for progressive enhancement and providing instant feedback.
+	 *
+	 * @example
+	 * ```tsx
+	 * import { getZodConstraint } from '@conform-to/zod/future';
+	 *
+	 * <FormOptionsProvider
+	 *   getConstraint={(schema) => getZodConstraint(schema)}
+	 * >
+	 *   <App />
+	 * </FormOptionsProvider>
+	 * ```
+	 */
+	getConstraint?: (
+		schema: BaseSchemaType,
+	) => Record<string, ValidationAttributes> | null;
 };
+
+export type RequireKey<T, K extends keyof T> = Prettify<
+	T & { [P in K]-?: T[P] }
+>;
+
+export type RequireOneOf<T, K extends keyof T> = Prettify<
+	{
+		[K in keyof T]-?: RequireKey<T, K>;
+	}[K]
+>;
 
 export type FormOptions<
 	FormShape extends Record<string, any> = Record<string, any>,
@@ -178,50 +263,62 @@ export type FormOptions<
 		? string
 		: BaseErrorShape,
 	Value = undefined,
-> = {
-	/** Optional form identifier. If not provided, a unique ID is automatically generated. */
-	id?: string;
-	/** Optional key for form state reset. When the key changes, the form resets to its initial state. */
-	key?: string;
-	/** Optional standard schema for validation (e.g., Zod, Valibot, Yup). Removes the need for manual onValidate setup. */
-	schema?: StandardSchemaV1<FormShape, Value>;
-	/** Initial form values. Can be a partial object matching your form structure. */
-	defaultValue?: NoInfer<DefaultValue<FormShape>>;
-	/** HTML validation attributes for fields (required, minLength, pattern, etc.). */
-	constraint?: Record<string, ValidationAttributes>;
-	/**
-	 * Determines when validation should run for the first time on a field.
-	 * Overrides the global default set by FormOptionsProvider if provided.
-	 *
-	 * @default Inherits from FormOptionsProvider, or "onSubmit" if not configured
-	 */
-	shouldValidate?: 'onSubmit' | 'onBlur' | 'onInput';
-	/**
-	 * Determines when validation should run again after the field has been validated once.
-	 * Overrides the global default set by FormOptionsProvider if provided.
-	 *
-	 * @default Inherits from FormOptionsProvider, or same as shouldValidate
-	 */
-	shouldRevalidate?: 'onSubmit' | 'onBlur' | 'onInput';
-	/** Server-side submission result for form state synchronization. */
-	lastResult?: SubmissionResult<NoInfer<ErrorShape>> | null;
-	/** Error handling callback triggered when validation errors occur. By default, it focuses the first invalid field. */
-	onError?: ErrorHandler<ErrorShape>;
-	/** Form submission handler called when the form is submitted with no validation errors. */
-	onSubmit?: SubmitHandler<NoInfer<ErrorShape>, NoInfer<Value>>;
-	/** Input event handler for custom input event logic. */
-	onInput?: InputHandler;
-	/** Blur event handler for custom focus handling logic. */
-	onBlur?: BlurHandler;
-} & (string extends ErrorShape
-	? {
+	Schema = undefined,
+	RequireValidateHandler extends boolean = false,
+> = RequireOneOf<
+	RequireKey<
+		{
+			/** Optional form identifier. If not provided, a unique ID is automatically generated. */
+			id?: string;
+			/** Optional key for form state reset. When the key changes, the form resets to its initial state. */
+			key?: string;
+			/** Server-side submission result for form state synchronization. */
+			lastResult?: SubmissionResult<ErrorShape> | null | undefined;
+			/** Form submission handler called when the form is submitted with no validation errors. */
+			onSubmit?: SubmitHandler<NoInfer<ErrorShape>, NoInfer<Value>>;
+			/** Initial form values. Can be a partial object matching your form structure. */
+			defaultValue?: DefaultValue<FormShape>;
+			/** HTML validation attributes for fields (required, minLength, pattern, etc.). */
+			constraint?: Record<string, ValidationAttributes>;
+			/**
+			 * Options to pass to the schema validation handler configured in FormOptionsProvider.
+			 * Only used when a schema is provided and validateSchema is configured globally.
+			 *
+			 * @example
+			 * ```tsx
+			 * useForm(zodSchema, {
+			 *   schemaOptions: { errorMap: customErrorMap }
+			 * });
+			 * ```
+			 */
+			schemaOptions?: InferOptions<Schema>;
+			/**
+			 * Determines when validation should run for the first time on a field.
+			 * Overrides the global default set by FormOptionsProvider if provided.
+			 *
+			 * @default Inherits from FormOptionsProvider, or "onSubmit" if not configured
+			 */
+			shouldValidate?: 'onSubmit' | 'onBlur' | 'onInput';
+			/**
+			 * Determines when validation should run again after the field has been validated once.
+			 * Overrides the global default set by FormOptionsProvider if provided.
+			 *
+			 * @default Inherits from FormOptionsProvider, or same as shouldValidate
+			 */
+			shouldRevalidate?: 'onSubmit' | 'onBlur' | 'onInput';
+			/** Error handling callback triggered when validation errors occur. By default, it focuses the first invalid field. */
+			onError?: ErrorHandler<NoInfer<ErrorShape>>;
+			/** Input event handler for custom input event logic. */
+			onInput?: InputHandler;
+			/** Blur event handler for custom focus handling logic. */
+			onBlur?: BlurHandler;
 			/** Custom validation handler. Can be skipped if using the schema property, or combined with schema to customize validation errors. */
-			onValidate?: ValidateHandler<ErrorShape, Value>;
-		}
-	: {
-			/** Custom validation handler. Can be skipped if using the schema property, or combined with schema to customize validation errors. */
-			onValidate: ValidateHandler<ErrorShape, Value>;
-		});
+			onValidate?: ValidateHandler<ErrorShape, Value, InferOutput<Schema>>;
+		},
+		RequireValidateHandler extends true ? 'onValidate' : never
+	>,
+	'onSubmit' | 'lastResult'
+>;
 
 export interface FormContext<
 	ErrorShape extends BaseErrorShape = DefaultErrorShape,
@@ -500,6 +597,38 @@ export type SatisfyComponentProps<
 /**
  * Interface for extending field metadata with additional properties.
  */
+export interface CustomSchema<
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	Schema,
+> {
+	// input, output, options, etc.
+}
+
+export type BaseSchemaType =
+	CustomSchema<any> extends { baseType: infer BaseSchema }
+		? BaseSchema
+		: StandardSchemaV1<any, any>;
+
+export type InferInput<Schema> =
+	CustomSchema<Schema> extends { input: infer Input }
+		? Input
+		: Schema extends StandardSchemaV1<infer input, any>
+			? input
+			: unknown;
+
+export type InferOutput<Schema> =
+	CustomSchema<Schema> extends { output: infer Output }
+		? Output
+		: Schema extends StandardSchemaV1<any, infer output>
+			? output
+			: undefined;
+
+export type InferOptions<Schema> =
+	CustomSchema<Schema> extends { options: infer Options } ? Options : undefined;
+
+/**
+ * Interface for extending field metadata with additional properties.
+ */
 export interface CustomMetadata<
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	FieldShape = any,
@@ -607,7 +736,7 @@ export type ValidateResult<ErrorShape, Value> =
 			value?: Value;
 	  };
 
-export type ValidateContext<Value> = {
+export type ValidateContext<SchemaValue> = {
 	/**
 	 * The submitted values mapped by field name.
 	 * Supports nested names like `user.email` and indexed names like `items[0].id`.
@@ -638,11 +767,11 @@ export type ValidateContext<Value> = {
 	 * The validated value from schema validation. Only defined when a schema is provided
 	 * and the validation succeeds. Undefined if no schema is provided or validation fails.
 	 */
-	schemaValue: Value | undefined;
+	schemaValue: SchemaValue;
 };
 
-export type ValidateHandler<ErrorShape, Value> = (
-	ctx: ValidateContext<Value>,
+export type ValidateHandler<ErrorShape, Value, SchemaValue = undefined> = (
+	ctx: ValidateContext<SchemaValue>,
 ) =>
 	| ValidateResult<ErrorShape, Value>
 	| Promise<ValidateResult<ErrorShape, Value>>

--- a/packages/conform-react/tests/useForm.node.test.tsx
+++ b/packages/conform-react/tests/useForm.node.test.tsx
@@ -8,6 +8,7 @@ describe('future export: useForm', () => {
 	test('default state', () => {
 		const { form, fields } = serverRenderHook(() =>
 			useForm<{ title: string; description: string }, string>({
+				lastResult: null,
 				onValidate: () => undefined,
 			}),
 		);
@@ -21,6 +22,7 @@ describe('future export: useForm', () => {
 		// Test if the form state is stable
 		const secondUseFormResult = serverRenderHook(() =>
 			useForm<{ title: string; description: string }, string>({
+				lastResult: null,
 				onValidate: () => undefined,
 			}),
 		);
@@ -31,6 +33,7 @@ describe('future export: useForm', () => {
 	test('default value', () => {
 		const { form, fields } = serverRenderHook(() =>
 			useForm<{ title: string; description: string }, string>({
+				lastResult: null,
 				defaultValue: { title: 'Example', description: 'Hello World' },
 				onValidate: () => undefined,
 			}),

--- a/packages/conform-valibot/constraint.ts
+++ b/packages/conform-valibot/constraint.ts
@@ -12,12 +12,25 @@ const keys: Array<keyof Constraint> = [
 	'pattern',
 ];
 
+export function isValibotSchema(
+	schema: unknown,
+): schema is GenericSchema | GenericSchemaAsync {
+	return (
+		typeof schema === 'object' &&
+		schema !== null &&
+		'~standard' in schema &&
+		typeof schema['~standard'] === 'object' &&
+		schema['~standard'] !== null &&
+		'vendor' in schema['~standard'] &&
+		schema['~standard'].vendor === 'valibot'
+	);
+}
+
 export function getValibotConstraint<
 	T extends GenericSchema | GenericSchemaAsync,
 >(schema: T): Record<string, Constraint> {
 	function updateConstraint(
 		schema: T,
-
 		data: Record<string, Constraint>,
 		name = '',
 	): void {
@@ -174,4 +187,20 @@ export function getValibotConstraint<
 	updateConstraint(schema, result);
 
 	return result;
+}
+
+export function getConstraint<T extends GenericSchema | GenericSchemaAsync>(
+	schema: T,
+): Record<string, Constraint>;
+export function getConstraint(
+	schema: unknown,
+): Record<string, Constraint> | null;
+export function getConstraint(
+	schema: unknown,
+): Record<string, Constraint> | null {
+	if (!isValibotSchema(schema)) {
+		return null;
+	}
+
+	return getValibotConstraint(schema);
 }

--- a/packages/conform-valibot/future.ts
+++ b/packages/conform-valibot/future.ts
@@ -1,3 +1,3 @@
-export { getValibotConstraint } from './constraint';
+export { getConstraint as getValibotConstraint } from './constraint';
 export { coerceFormValue } from './coercion';
 export { formatResult } from './format';

--- a/packages/conform-valibot/tests/constraint.test.ts
+++ b/packages/conform-valibot/tests/constraint.test.ts
@@ -28,7 +28,7 @@ import {
 	variant,
 } from 'valibot';
 import { describe, expect, test } from 'vitest';
-import { getValibotConstraint } from '../constraint';
+import { getConstraint as getValibotConstraint } from '../constraint';
 
 enum TestEnum {
 	a = 'a',
@@ -203,6 +203,14 @@ describe('constraint', () => {
 		// Non-object schemas will throw an error
 		expect(() => getValibotConstraint(string())).toThrow();
 		expect(() => getValibotConstraint(array(string()))).toThrow();
+
+		// Non-Valibot schemas return null
+		expect(getValibotConstraint(null)).toBe(null);
+		expect(getValibotConstraint(undefined)).toBe(null);
+		expect(getValibotConstraint({})).toBe(null);
+		expect(getValibotConstraint({ foo: 'bar' })).toBe(null);
+		expect(getValibotConstraint('string')).toBe(null);
+		expect(getValibotConstraint(123)).toBe(null);
 
 		// Intersection is supported
 		expect(

--- a/packages/conform-zod/v3/constraint.ts
+++ b/packages/conform-zod/v3/constraint.ts
@@ -18,6 +18,18 @@ const keys: Array<keyof Constraint> = [
 	'pattern',
 ];
 
+export function isZodSchema(schema: unknown): schema is ZodTypeAny {
+	return (
+		typeof schema === 'object' &&
+		schema !== null &&
+		'~standard' in schema &&
+		typeof schema['~standard'] === 'object' &&
+		schema['~standard'] !== null &&
+		'vendor' in schema['~standard'] &&
+		schema['~standard'].vendor === 'zod'
+	);
+}
+
 export function getZodConstraint(
 	schema: ZodTypeAny,
 ): Record<string, Constraint> {
@@ -144,4 +156,18 @@ export function getZodConstraint(
 	updateConstraint(schema, result);
 
 	return result;
+}
+
+export function getConstraint(schema: ZodTypeAny): Record<string, Constraint>;
+export function getConstraint(
+	schema: unknown,
+): Record<string, Constraint> | null;
+export function getConstraint(
+	schema: unknown,
+): Record<string, Constraint> | null {
+	if (!isZodSchema(schema)) {
+		return null;
+	}
+
+	return getZodConstraint(schema);
 }

--- a/packages/conform-zod/v3/format.ts
+++ b/packages/conform-zod/v3/format.ts
@@ -11,27 +11,8 @@ import { formatPathSegments } from '@conform-to/dom/future';
  * const error = formatResult(result);
  * ```
  */
-export function formatResult(
-	result: SafeParseReturnType<any, any>,
-): FormError<string> | null;
-export function formatResult<Output, ErrorShape>(
-	result: SafeParseReturnType<any, Output>,
-	options: {
-		/** Whether to include the parsed value in the returned object */
-		includeValue: true;
-		/** Custom function to format validation issues for each field */
-		formatIssues: (issue: ZodIssue[], name: string) => ErrorShape[];
-	},
-): {
-	error: FormError<ErrorShape> | null;
-	value: Output | undefined;
-};
 export function formatResult<Output>(
 	result: SafeParseReturnType<any, Output>,
-	options: {
-		includeValue: true;
-		formatIssues?: undefined;
-	},
 ): {
 	error: FormError<string> | null;
 	value: Output | undefined;
@@ -39,23 +20,22 @@ export function formatResult<Output>(
 export function formatResult<Output, ErrorShape>(
 	result: SafeParseReturnType<any, Output>,
 	options: {
-		includeValue?: false;
+		/** Custom function to format validation issues for each field */
 		formatIssues: (issue: ZodIssue[], name: string) => ErrorShape[];
 	},
-): FormError<ErrorShape> | null;
+): {
+	error: FormError<ErrorShape> | null;
+	value: Output | undefined;
+};
 export function formatResult<Output, Input, ErrorShape>(
 	result: SafeParseReturnType<Input, Output>,
 	options?: {
-		includeValue?: boolean;
 		formatIssues?: (issue: ZodIssue[], name: string) => ErrorShape[];
 	},
-):
-	| FormError<string | ErrorShape>
-	| null
-	| {
-			error: FormError<string | ErrorShape> | null;
-			value: Output | undefined;
-	  } {
+): {
+	error: FormError<string | ErrorShape> | null;
+	value: Output | undefined;
+} {
 	let error: FormError<string | ErrorShape> | null = null;
 	let value: Output | undefined = undefined;
 
@@ -88,10 +68,6 @@ export function formatResult<Output, Input, ErrorShape>(
 		};
 	} else {
 		value = result.data;
-	}
-
-	if (!options?.includeValue) {
-		return error;
 	}
 
 	return {

--- a/packages/conform-zod/v3/future.ts
+++ b/packages/conform-zod/v3/future.ts
@@ -1,3 +1,3 @@
-export { getZodConstraint } from './constraint';
+export { getConstraint as getZodConstraint } from './constraint';
 export { coerceFormValue } from './coercion';
 export { formatResult } from './format';

--- a/packages/conform-zod/v3/tests/constraint.test.ts
+++ b/packages/conform-zod/v3/tests/constraint.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { getZodConstraint } from '../constraint';
+import { getConstraint as getZodConstraint } from '../constraint';
 import { z } from 'zod';
 
 describe('constraint', () => {
@@ -162,6 +162,14 @@ describe('constraint', () => {
 		// Non-object schemas will throw an error
 		expect(() => getZodConstraint(z.string())).toThrow();
 		expect(() => getZodConstraint(z.array(z.string()))).toThrow();
+
+		// Non-Zod schemas return null
+		expect(getZodConstraint(null)).toBe(null);
+		expect(getZodConstraint(undefined)).toBe(null);
+		expect(getZodConstraint({})).toBe(null);
+		expect(getZodConstraint({ foo: 'bar' })).toBe(null);
+		expect(getZodConstraint('string')).toBe(null);
+		expect(getZodConstraint(123)).toBe(null);
 
 		// Intersection is supported
 		expect(

--- a/packages/conform-zod/v4/constraint.ts
+++ b/packages/conform-zod/v4/constraint.ts
@@ -13,6 +13,18 @@ const keys: Array<keyof Constraint> = [
 	'pattern',
 ];
 
+export function isZodSchema(schema: unknown): schema is $ZodType {
+	return (
+		typeof schema === 'object' &&
+		schema !== null &&
+		'~standard' in schema &&
+		typeof schema['~standard'] === 'object' &&
+		schema['~standard'] !== null &&
+		'vendor' in schema['~standard'] &&
+		schema['~standard'].vendor === 'zod'
+	);
+}
+
 export function getZodConstraint(schema: $ZodType): Record<string, Constraint> {
 	function updateConstraint(
 		schema: $ZodType,
@@ -139,4 +151,18 @@ export function getZodConstraint(schema: $ZodType): Record<string, Constraint> {
 	updateConstraint(schema, result);
 
 	return result;
+}
+
+export function getConstraint(schema: $ZodType): Record<string, Constraint>;
+export function getConstraint(
+	schema: unknown,
+): Record<string, Constraint> | null;
+export function getConstraint(
+	schema: unknown,
+): Record<string, Constraint> | null {
+	if (!isZodSchema(schema)) {
+		return null;
+	}
+
+	return getZodConstraint(schema);
 }

--- a/packages/conform-zod/v4/future.ts
+++ b/packages/conform-zod/v4/future.ts
@@ -1,3 +1,3 @@
-export { getZodConstraint } from './constraint';
+export { getConstraint as getZodConstraint } from './constraint';
 export { coerceFormValue } from './coercion';
 export { formatResult } from './format';

--- a/packages/conform-zod/v4/tests/constraint.test.ts
+++ b/packages/conform-zod/v4/tests/constraint.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { getZodConstraint } from '../constraint';
+import { getConstraint as getZodConstraint } from '../constraint';
 import { z } from 'zod-v4';
 
 describe('constraint', () => {
@@ -164,6 +164,14 @@ describe('constraint', () => {
 		// Non-object schemas will throw an error
 		expect(() => getZodConstraint(z.string())).toThrow();
 		expect(() => getZodConstraint(z.array(z.string()))).toThrow();
+
+		// Non-Zod schemas return null
+		expect(getZodConstraint(null)).toBe(null);
+		expect(getZodConstraint(undefined)).toBe(null);
+		expect(getZodConstraint({})).toBe(null);
+		expect(getZodConstraint({ foo: 'bar' })).toBe(null);
+		expect(getZodConstraint('string')).toBe(null);
+		expect(getZodConstraint(123)).toBe(null);
 
 		// Intersection is supported
 		expect(


### PR DESCRIPTION
This PR refactors the type inference setup in `useForm` by promoting the `schema` option as the first argument instead:

```tsx
// Infers both the fields and value from the schema
const { form, fields } = useForm(schema, {
  onSubmit(event, { value }) {
    // value is fully typed based on your schema
  },
});
```

If you want to validate your form without a schema, you can skip the schema argument and provide an option just like before:

```tsx
// Infer the fields from your default value and value from the onValidate method
const { form, fields } = useForm({
  defaultValue: {
    email: '',
    password: '',
  },
  onValidate({ formData }) {
    // ...
  },
});
```

**Breaking Change**: The options no longer accept a `schema` property. Please move it to the first argument when updating.

I have also tightened up the types to make sure you won't miss the important options:
- `onValidate` is now required if you didn't provide a schema
- Either `onSubmit` or `lastResult` is required

Besides this, I have also introduced two new options to `<FormOptionsProvider />`:

1. `getConstraint`

Conform can now automatically derive HTML validation attributes from your schema. Set this once globally and you no longer need to configure the constraint option on every useForm:

```tsx
<FormOptionsProvider getConstraint={getZodConstraint}>
  <App />
</FormOptionsProvider>
```

2. `validateSchema`

Customize how schemas are validated globally across your application. This is useful if you need to pass addtional options to your schema validation library, or to support other schema libraries that don't implement standard schema.

```ts
// 1. Declare CustomSchema for type inference
declare module '@conform-to/react/future' {
  interface CustomSchema<Schema> {
    baseType: z.ZodTypeAny;
    input: Schema extends z.ZodTypeAny ? z.input<Schema> : unknown;
    output: Schema extends z.ZodTypeAny ? z.output<Schema> : unknown;
    options: Partial<z.ParseParams>;
  }
}

// 2. Configure FormOptionsProvider with validateSchema options
<FormOptionsProvider
  validateSchema={(schema, { payload, schemaOptions }) => {
    try {
      const result = schema.safeParse(payload, schemaOptions);
      return formatResult(result);
    } catch {
      return schema.safeParseAsync(payload, schemaOptions).then(formatResult);
    }
  }}
>
  <App />
</FormOptionsProvider>;

// 3. Setup your form with a schema
function SignupForm() {
  const schema = z.object({
    username: z.string().min(3),
    email: z.string().email(),
  });

  const { form, fields } = useForm(schema, {
    schemaOptions: { errorMap: customErrorMap }, // Optional per-form customization
    onSubmit(event, { value }) {
      console.log(value); // Fully typed: { username: string; email: string }
    },
  });

  return <form {...form.props}>...</form>;
}
```