### PR TITLE
fix(conform-dom): empty bracket support

### DIFF
--- a/.changeset/fix-array-push-notation.md
+++ b/.changeset/fix-array-push-notation.md
@@ -1,0 +1,16 @@
+---
+'@conform-to/dom': patch
+---
+
+Fix `parseSubmission` array handling for entries ending with `[]`. Previously, when multiple form entries had the same name ending with `[]` (e.g., `todos[]`), all items were incorrectly pushed as a single nested array element. Now they are correctly spread as individual array items.
+
+```ts
+const formData = new FormData();
+formData.append('todos[]', 'Buy milk');
+formData.append('todos[]', 'Walk dog');
+formData.append('todos[]', 'Write tests');
+
+parseSubmission(formData);
+// Before: { todos: [['Buy milk', 'Walk dog', 'Write tests']] }
+// After:  { todos: ['Buy milk', 'Walk dog', 'Write tests'] }
+```

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -369,15 +369,21 @@ export function parseSubmission(
 
 	for (const name of new Set(formData.keys())) {
 		if (name !== intentName && !options?.skipEntry?.(name)) {
-			const value = formData.getAll(name);
-			setValueAtPath(
-				submission.payload,
-				name,
-				value.length > 1 ? value : value[0],
-				{
-					silent: true, // Avoid errors if the path is invalid
-				},
-			);
+			let value: FormDataEntryValue | FormDataEntryValue[] | undefined =
+				formData.getAll(name);
+			const segments = getPathSegments(name);
+
+			// If the name ends with [], remove the empty segment and keep the full array
+			// Otherwise, unwrap single values
+			if (segments.length > 0 && segments[segments.length - 1] === '') {
+				segments.pop();
+			} else {
+				value = value.length > 1 ? value : value[0];
+			}
+
+			setValueAtPath(submission.payload, segments, value, {
+				silent: true, // Avoid errors if the path is invalid
+			});
 			submission.fields.push(name);
 		}
 	}

--- a/packages/conform-dom/tests/formdata.test.ts
+++ b/packages/conform-dom/tests/formdata.test.ts
@@ -547,6 +547,145 @@ describe('parseSubmission', () => {
 			intent: 'login',
 		});
 	});
+
+	it('handles array push notation with [] correctly', () => {
+		// Single entry with [] notation
+		expect(parseSubmission(createFormData([['todos[]', 'Buy milk']]))).toEqual({
+			payload: {
+				todos: ['Buy milk'],
+			},
+			fields: ['todos[]'],
+			intent: null,
+		});
+
+		// Multiple entries with [] notation
+		expect(
+			parseSubmission(
+				createFormData([
+					['todos[]', 'Buy milk'],
+					['todos[]', 'Walk the dog'],
+					['todos[]', 'Write tests'],
+				]),
+			),
+		).toEqual({
+			payload: {
+				todos: ['Buy milk', 'Walk the dog', 'Write tests'],
+			},
+			fields: ['todos[]'],
+			intent: null,
+		});
+
+		// Multiple array fields with [] notation
+		expect(
+			parseSubmission(
+				createFormData([
+					['tags[]', 'javascript'],
+					['tags[]', 'typescript'],
+					['categories[]', 'frontend'],
+					['categories[]', 'backend'],
+				]),
+			),
+		).toEqual({
+			payload: {
+				tags: ['javascript', 'typescript'],
+				categories: ['frontend', 'backend'],
+			},
+			fields: ['tags[]', 'categories[]'],
+			intent: null,
+		});
+
+		// Array with primitive values using different approach
+		expect(
+			parseSubmission(
+				createFormData([
+					['numbers[]', '1'],
+					['numbers[]', '2'],
+					['numbers[]', '3'],
+					['numbers[]', '4'],
+				]),
+			),
+		).toEqual({
+			payload: {
+				numbers: ['1', '2', '3', '4'],
+			},
+			fields: ['numbers[]'],
+			intent: null,
+		});
+
+		// Complex nested structure with mixed notation
+		expect(
+			parseSubmission(
+				createFormData([
+					['title', 'My Form'],
+					['users[0].name', 'Alice'],
+					['users[0].roles[]', 'admin'],
+					['users[0].roles[]', 'editor'],
+					['users[1].name', 'Bob'],
+					['users[1].roles[]', 'viewer'],
+				]),
+			),
+		).toEqual({
+			payload: {
+				title: 'My Form',
+				users: [
+					{
+						name: 'Alice',
+						roles: ['admin', 'editor'],
+					},
+					{
+						name: 'Bob',
+						roles: ['viewer'],
+					},
+				],
+			},
+			fields: [
+				'title',
+				'users[0].name',
+				'users[0].roles[]',
+				'users[1].name',
+				'users[1].roles[]',
+			],
+			intent: null,
+		});
+
+		// File inputs with [] notation
+		const file1 = new File(['content1'], 'file1.txt');
+		const file2 = new File(['content2'], 'file2.txt');
+		const file3 = new File(['content3'], 'file3.txt');
+
+		expect(
+			parseSubmission(
+				createFormData([
+					['attachments[]', file1],
+					['attachments[]', file2],
+					['attachments[]', file3],
+				]),
+			),
+		).toEqual({
+			payload: {
+				attachments: [file1, file2, file3],
+			},
+			fields: ['attachments[]'],
+			intent: null,
+		});
+
+		// Empty array field (no entries)
+		expect(
+			parseSubmission(
+				createFormData([
+					['name', 'Test'],
+					['description', 'Description'],
+				]),
+			),
+		).toEqual({
+			payload: {
+				name: 'Test',
+				description: 'Description',
+			},
+			fields: ['name', 'description'],
+			intent: null,
+		});
+	});
 });
 
 describe('report', () => {


### PR DESCRIPTION
Fix `parseSubmission` array handling for entries ending with `[]`. Previously, when multiple form entries had the same name ending with `[]` (e.g., `todos[]`), all items were incorrectly pushed as a single nested array element. Now they are correctly spread as individual array items.

```ts
const formData = new FormData();
formData.append('todos[]', 'Buy milk');
formData.append('todos[]', 'Walk dog');
formData.append('todos[]', 'Write tests');

parseSubmission(formData);
// Before: { todos: [['Buy milk', 'Walk dog', 'Write tests']] }
// After:  { todos: ['Buy milk', 'Walk dog', 'Write tests'] }
```
