### PR TITLE
feat(conform-dom/future): strip empty values by default

### DIFF
--- a/.changeset/strip-empty-values.md
+++ b/.changeset/strip-empty-values.md
@@ -1,0 +1,19 @@
+---
+'@conform-to/dom': minor
+---
+
+`parseSubmission` now strips empty values by default. This makes it easier to work with schemas directly (without `coerceFormValue`) since you no longer need extra validation like `.min(1)` for required fields. You can set `stripEmptyValues: false` to preserve empty values if needed.
+
+```ts
+const formData = new FormData();
+// Empty text input
+formData.append('name', '');
+// Empty file input
+formData.append('files[]', new File([], ''));
+
+parseSubmission(formData);
+// { payload: {} }
+
+parseSubmission(formData, { stripEmptyValues: false });
+// { payload: { name: '', files: [new File([], '')] } }
+```

--- a/packages/conform-react/tests/useForm.browser.test.tsx
+++ b/packages/conform-react/tests/useForm.browser.test.tsx
@@ -12,6 +12,7 @@ import {
 	parseSubmission,
 } from '../future';
 import { expectErrorMessage, expectNoErrorMessages } from './helpers';
+import { isGlobalInstance } from '@conform-to/dom';
 
 describe('future export: useForm', () => {
 	type Schema = {
@@ -56,7 +57,12 @@ describe('future export: useForm', () => {
 			for (let i = 0; i < value.tasks.length; i++) {
 				const task = value.tasks[i];
 
-				if (task === null || typeof task !== 'object' || !('content' in task)) {
+				if (
+					task === null ||
+					typeof task !== 'object' ||
+					Array.isArray(task) ||
+					isGlobalInstance(task, 'File')
+				) {
 					error.fieldErrors[`tasks[${i}]`] = ['Task is invalid'];
 					continue;
 				}


### PR DESCRIPTION
I notice many people either forget or prefer not using the `coerceFormValue` helper. This is fine. But there is a huge gap in terms of how the schema is setup when you don't use this helper.

This should reduce the gap so the only difference would be type coercion, which matches exactly the name of this helper. I am also planning to simplify the implementation of `coerceFormValue` as it no longer have to strip empty values.