### PR TITLE
fix(conform-react/future): loosen FormConfig type

### DIFF
--- a/.changeset/rotten-pugs-brush.md
+++ b/.changeset/rotten-pugs-brush.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/react': patch
+---
+
+fix: loosen FormOptions type to not require either onSubmit or lastResult

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -182,12 +182,6 @@ export type RequireKey<T, K extends keyof T> = Prettify<
 	T & Pick<NonPartial<T>, K>
 >;
 
-export type RequireOneOf<T, K extends keyof T> = Prettify<
-	{
-		[K in keyof T]-?: RequireKey<T, K>;
-	}[K]
->;
-
 export type BaseSchemaType = StandardSchemaV1<any, any>;
 
 export type InferInput<Schema> =
@@ -257,12 +251,9 @@ export type FormOptions<
 		Value,
 		Schema
 	> = never,
-> = RequireOneOf<
-	RequireKey<
-		BaseFormOptions<FormShape, ErrorShape, Value, Schema>,
-		RequiredKeys
-	>,
-	'onSubmit' | 'lastResult'
+> = RequireKey<
+	BaseFormOptions<FormShape, ErrorShape, Value, Schema>,
+	RequiredKeys
 >;
 
 export interface FormContext<


### PR DESCRIPTION
Let's not require either `onSubmit` or `lastResult` option on the future `useForm` hook.