### PR TITLE
fix: useControl should preserve DOM defaultValue when no options are provided

### DIFF
--- a/.changeset/fix-usecontrol-defaultvalue.md
+++ b/.changeset/fix-usecontrol-defaultvalue.md
@@ -1,5 +1,5 @@
 ---
-'@conform-to/react': patch
+'@conform-to/dom': patch
 ---
 
-fix(conform-react/future): useControl should preserve DOM defaultValue when no options are provided
+fix(conform-dom): updateField should preserve DOM value when no value is provided

--- a/packages/conform-dom/dom.ts
+++ b/packages/conform-dom/dom.ts
@@ -621,31 +621,35 @@ export function updateField(
 
 	const value = normalizeStringValues(options.value);
 	const defaultValue = normalizeStringValues(options.defaultValue);
-	const inputValue = value?.[0] ?? '';
 
-	if (element.value !== inputValue) {
-		/**
-		 * Triggering react custom change event
-		 * Solution based on dom-testing-library
-		 * @see https://github.com/facebook/react/issues/10135#issuecomment-401496776
-		 * @see https://github.com/testing-library/dom-testing-library/blob/main/src/events.js#L104-L123
-		 */
-		const { set: valueSetter } =
-			Object.getOwnPropertyDescriptor(element, 'value') || {};
-		const prototype = Object.getPrototypeOf(element);
-		const { set: prototypeValueSetter } =
-			Object.getOwnPropertyDescriptor(prototype, 'value') || {};
+	if (value) {
+		const inputValue = value[0] ?? '';
 
-		if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
-			prototypeValueSetter.call(element, inputValue);
-		} else if (valueSetter) {
-			valueSetter.call(element, inputValue);
-		} else {
-			throw new Error('The given element does not have a value setter');
+		if (element.value !== inputValue) {
+			/**
+			 * Triggering react custom change event
+			 * Solution based on dom-testing-library
+			 * @see https://github.com/facebook/react/issues/10135#issuecomment-401496776
+			 * @see https://github.com/testing-library/dom-testing-library/blob/main/src/events.js#L104-L123
+			 */
+			const { set: valueSetter } =
+				Object.getOwnPropertyDescriptor(element, 'value') || {};
+			const prototype = Object.getPrototypeOf(element);
+			const { set: prototypeValueSetter } =
+				Object.getOwnPropertyDescriptor(prototype, 'value') || {};
+
+			if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
+				prototypeValueSetter.call(element, inputValue);
+			} else if (valueSetter) {
+				valueSetter.call(element, inputValue);
+			} else {
+				throw new Error('The given element does not have a value setter');
+			}
+
+			isChanged = true;
 		}
-
-		isChanged = true;
 	}
+
 	if (defaultValue) {
 		element.defaultValue = defaultValue[0] ?? '';
 	}

--- a/packages/conform-dom/tests/dom.browser.test.ts
+++ b/packages/conform-dom/tests/dom.browser.test.ts
@@ -46,6 +46,29 @@ describe('updateField', () => {
 		expect(changed4).toBe(false);
 	});
 
+	it('preserves existing value when value option is undefined', () => {
+		const input = document.createElement('input');
+		input.type = 'text';
+		input.value = 'existing value';
+		input.defaultValue = 'existing default';
+
+		// Only pass defaultValue, not value - should preserve input.value
+		const changed = updateField(input, {
+			defaultValue: 'new default',
+		});
+
+		expect(input.value).toBe('existing value');
+		expect(input.defaultValue).toBe('new default');
+		expect(changed).toBe(false);
+
+		// Passing no options should preserve both
+		const changed2 = updateField(input, {});
+
+		expect(input.value).toBe('existing value');
+		expect(input.defaultValue).toBe('new default');
+		expect(changed2).toBe(false);
+	});
+
 	it('supports checkbox', () => {
 		const input = document.createElement('input');
 		input.type = 'checkbox';

--- a/packages/conform-react/future/dom.ts
+++ b/packages/conform-react/future/dom.ts
@@ -63,10 +63,8 @@ export function initializeField(
 				: null
 			: options?.defaultValue;
 
-	// Preserve the element's existing default value from the DOM unless a value is provided
-	if (defaultValue !== undefined) {
-		updateField(element, { value: defaultValue, defaultValue });
-	}
+	// Update the value of the element, including the default value
+	updateField(element, { value: defaultValue, defaultValue });
 
 	element.dataset.conform = 'initialized';
 }


### PR DESCRIPTION
Fix #1120