### PR TITLE
docs: fix number of properties returned by useForm hook

### DIFF
--- a/docs/api/react/future/useForm.md
+++ b/docs/api/react/future/useForm.md
@@ -68,7 +68,7 @@ Blur event handler for custom focus handling logic.
 
 ## Returns
 
-The hook returns an object with four properties:
+The hook returns an object with three properties:
 
 ### `form: FormMetadata<ErrorShape>`
 


### PR DESCRIPTION
Corrected the number of properties returned by the `useForm` hook from four to three.

From what I can see the `useForm` from the future export only returns 3 properties. Not 4 as the docs said. Thought I would fix it and do a PR since it's only word, instead of mentioning it in an issue.