### PR TITLE
feat: better datetime-local support

### DIFF
--- a/.changeset/future-date-utc-without-z.md
+++ b/.changeset/future-date-utc-without-z.md
@@ -1,0 +1,11 @@
+---
+'@conform-to/dom': minor
+'@conform-to/zod': minor
+'@conform-to/valibot': minor
+---
+
+feat: improve `datetime-local` Date handling in future APIs
+
+Date values now serialize to datetime strings without a trailing `Z` (for example, `2026-01-01T12:00:00.000`). Our Zod and Valibot integration will also coerce timezone-less datetime strings as UTC by default.
+
+This applies to future APIs only. No changes were made to v1 APIs to avoid breaking changes.

--- a/docs/api/react/future/configureForms.md
+++ b/docs/api/react/future/configureForms.md
@@ -25,6 +25,18 @@ This is an advanced option. You typically don't need to change this unless you h
 
 A custom serialization function for converting form data.
 
+If not provided, Conform uses a default serializer with the following behavior:
+
+- boolean:
+  - true → 'on'
+  - false → undefined
+- Date:
+  - Converted to UTC datetime string without trailing `Z` (e.g. `2026-01-01T12:00:00.000`)
+- number / bigint:
+  - Converted to string using `.toString()`
+- string / File:
+  - Returned as-is
+
 This is an advanced option. You typically don't need to change this unless you have special serialization requirements.
 
 ### `shouldValidate?: 'onSubmit' | 'onBlur' | 'onInput'`

--- a/docs/api/react/future/isDirty.md
+++ b/docs/api/react/future/isDirty.md
@@ -24,7 +24,7 @@ The current form data to compare. It can be:
 
 An object representing the default values of the form to compare against. Defaults to an empty object if not provided.
 
-### `options.serialize?: (value: unknown) => string | File | undefined`
+### `options.serialize?: (value: unknown, defaultSerialize: Serialize) => string | string[] | File | File[] | null | undefined`
 
 A function to serialize values in defaultValue before comparing them to the form data. If not provided, a default serializer is used that behaves as follows:
 
@@ -32,7 +32,7 @@ A function to serialize values in defaultValue before comparing them to the form
   - true → 'on'
   - false → undefined
 - Date:
-  - Converted to ISO string (`.toISOString()`)
+  - Converted to UTC datetime string without trailing `Z` (e.g. `2026-01-01T12:00:00.000`)
 - number / bigint:
   - Converted to string using `.toString()`
 - string / File:

--- a/docs/api/react/future/useField.md
+++ b/docs/api/react/future/useField.md
@@ -51,6 +51,8 @@ The field's default value as a string. Returns an empty string `''` when:
 - No default value is set (field value is `null` or `undefined`)
 - The field value cannot be serialized to a string (e.g., objects or arrays)
 
+For Date values, Conform serializes to a UTC datetime string without trailing `Z` (for example, `2026-01-01T12:00:00.000`).
+
 ### `defaultOptions: string[]`
 
 Default selected options for multi-select fields or checkbox group. Returns an empty array `[]` when:

--- a/docs/api/valibot/future/coerceFormValue.md
+++ b/docs/api/valibot/future/coerceFormValue.md
@@ -15,7 +15,7 @@ The following rules are applied by default:
 1. If the value is an empty string / file, pass `undefined` to the schema
 2. If the schema is `v.number()`, trim the value and cast it with the `Number` constructor
 3. If the schema is `v.boolean()`, treat the value as `true` if it equals `on` (browser default `value` of a checkbox / radio button)
-4. If the schema is `v.date()`, cast the value with the `Date` constructor
+4. If the schema is `v.date()`, cast the value with the `Date` constructor. Timezone-less datetime strings (e.g. `2026-01-01T12:00:00.000`) are interpreted as UTC.
 5. If the schema is `v.bigint()`, trim the value and cast it with the `BigInt` constructor
 
 ## Parameters

--- a/docs/api/valibot/future/coerceFormValue.md
+++ b/docs/api/valibot/future/coerceFormValue.md
@@ -15,7 +15,7 @@ The following rules are applied by default:
 1. If the value is an empty string / file, pass `undefined` to the schema
 2. If the schema is `v.number()`, trim the value and cast it with the `Number` constructor
 3. If the schema is `v.boolean()`, treat the value as `true` if it equals `on` (browser default `value` of a checkbox / radio button)
-4. If the schema is `v.date()`, cast the value with the `Date` constructor. Timezone-less datetime strings (e.g. `2026-01-01T12:00:00.000`) are interpreted as UTC.
+4. If the schema is `v.date()`, cast the value with the `Date` constructor. Timezone-less datetime strings (e.g. `2026-01-01T12:00:00.000`) are normalized to UTC by appending `Z` before parsing.
 5. If the schema is `v.bigint()`, trim the value and cast it with the `BigInt` constructor
 
 ## Parameters

--- a/docs/api/valibot/future/configureCoercion.md
+++ b/docs/api/valibot/future/configureCoercion.md
@@ -43,7 +43,7 @@ Optional. Type-specific string-to-typed-value conversion functions shared betwee
 
 - `number`: default uses `Number()` with empty-string guard (returns `NaN` for empty)
 - `boolean`: default returns `true` for `'on'`, rejects otherwise
-- `date`: default uses `new Date()` with invalid date check
+- `date`: default uses `new Date()` with invalid date check, and interprets timezone-less datetime strings (e.g. `2026-01-01T12:00:00.000`) as UTC
 
 ### `config.customize`
 

--- a/docs/api/zod/future/coerceFormValue.md
+++ b/docs/api/zod/future/coerceFormValue.md
@@ -15,7 +15,7 @@ The following rules are applied by default:
 1. If the value is an empty string / file, pass `undefined` to the schema
 2. If the schema is `z.number()`, trim the value and cast it with the `Number` constructor
 3. If the schema is `z.boolean()`, treat the value as `true` if it equals `on` (browser default `value` of a checkbox / radio button)
-4. If the schema is `z.date()`, cast the value with the `Date` constructor
+4. If the schema is `z.date()`, cast the value with the `Date` constructor. Timezone-less datetime strings (e.g. `2026-01-01T12:00:00.000`) are interpreted as UTC.
 5. If the schema is `z.bigint()`, trim the value and cast it with the `BigInt` constructor
 
 ## Parameters

--- a/docs/api/zod/future/coerceFormValue.md
+++ b/docs/api/zod/future/coerceFormValue.md
@@ -15,7 +15,7 @@ The following rules are applied by default:
 1. If the value is an empty string / file, pass `undefined` to the schema
 2. If the schema is `z.number()`, trim the value and cast it with the `Number` constructor
 3. If the schema is `z.boolean()`, treat the value as `true` if it equals `on` (browser default `value` of a checkbox / radio button)
-4. If the schema is `z.date()`, cast the value with the `Date` constructor. Timezone-less datetime strings (e.g. `2026-01-01T12:00:00.000`) are interpreted as UTC.
+4. If the schema is `z.date()`, cast the value with the `Date` constructor. Timezone-less datetime strings (e.g. `2026-01-01T12:00:00.000`) are normalized to UTC by appending `Z` before parsing.
 5. If the schema is `z.bigint()`, trim the value and cast it with the `BigInt` constructor
 
 ## Parameters

--- a/docs/api/zod/future/configureCoercion.md
+++ b/docs/api/zod/future/configureCoercion.md
@@ -43,7 +43,7 @@ Optional. Type-specific string-to-typed-value conversion functions shared betwee
 
 - `number`: default uses `Number()` with empty-string guard (returns `NaN` for empty)
 - `boolean`: default returns `true` for `'on'`, rejects otherwise
-- `date`: default uses `new Date()` with invalid date check
+- `date`: default uses `new Date()` with invalid date check, and interprets timezone-less datetime strings (e.g. `2026-01-01T12:00:00.000`) as UTC
 
 `bigint` is not configurable here because it has no NaN-like sentinel for structural mode. Use `customize` for custom bigint coercion.
 

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -684,7 +684,7 @@ export function isDirty(
 		 * - number / bigint:
 		 *   - Converted to string using `.toString()`
 		 * - Date:
-		 *   - Converted to ISO string using `.toISOString()`
+		 *   - Converted to UTC datetime string without trailing `Z` (e.g. `2026-01-01T12:00:00.000`)
 		 */
 		serialize?: (
 			value: unknown,
@@ -800,7 +800,7 @@ export function isDirty(
  * - null -> '' (empty string)
  * - boolean -> 'on' | '' (checked semantics)
  * - number | bigint -> value.toString()
- * - Date -> value.toISOString()
+ * - Date -> value.toISOString() without trailing `Z`
  * - File -> File
  * - FileList -> File[]
  * - Array -> string[] or File[] if all items serialize to the same kind; otherwise undefined
@@ -823,7 +823,7 @@ export function serialize(value: unknown): SerializedValue | null | undefined {
 		}
 
 		if (value instanceof Date) {
-			return value.toISOString();
+			return value.toISOString().slice(0, -1);
 		}
 
 		if (isGlobalInstance(value, 'File')) {

--- a/packages/conform-dom/tests/formdata.test.ts
+++ b/packages/conform-dom/tests/formdata.test.ts
@@ -1468,7 +1468,7 @@ describe('isDirty', () => {
 			}),
 		).toBe(false);
 		expect(
-			isDirty(createFormData([['datetime', '1970-01-01T00:00:00.000Z']]), {
+			isDirty(createFormData([['datetime', '1970-01-01T00:00:00.000']]), {
 				defaultValue: {
 					datetime: new Date(0),
 				},
@@ -1515,7 +1515,9 @@ test('serialize', () => {
 	expect(serialize(false)).toBe('');
 	expect(serialize(123)).toBe('123');
 	expect(serialize(987654321n)).toBe('987654321');
-	expect(serialize(new Date(12345))).toBe(new Date(12345).toISOString());
+	expect(serialize(new Date(12345))).toBe(
+		new Date(12345).toISOString().slice(0, -1),
+	);
 	expect(serialize(new Map())).toBeUndefined();
 	expect(serialize(new Set())).toBeUndefined();
 	expect(serialize(txtFile)).toBe(txtFile);

--- a/packages/conform-react/tests/useForm.browser.test.tsx
+++ b/packages/conform-react/tests/useForm.browser.test.tsx
@@ -9,6 +9,7 @@ import {
 	useForm as useFormDefault,
 	report,
 	parseSubmission,
+	isDirty,
 	configureForms,
 } from '../future';
 import { expectErrorMessage, expectNoErrorMessages } from './helpers';
@@ -1327,6 +1328,53 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 			await expect.element(task2.content).toHaveValue('');
 			await expect.element(task3.content).not.toBeInTheDocument();
 		});
+	});
+
+	test('default value serialization', async () => {
+		const date = new Date('2026-01-01T12:34:56.789Z');
+
+		function DateForm() {
+			const { form, fields } = useForm<{
+				date: Date;
+			}>({
+				defaultValue: {
+					date,
+				},
+				onValidate() {
+					return { error: null };
+				},
+				onSubmit(event) {
+					event.preventDefault();
+				},
+			});
+
+			return (
+				<form {...form.props}>
+					<input
+						type="datetime-local"
+						name={fields.date.name}
+						defaultValue={fields.date.defaultValue}
+						aria-label="Date"
+					/>
+				</form>
+			);
+		}
+
+		const screen = render(<DateForm />);
+		const input = screen.getByLabelText('Date');
+
+		await expect.element(input).toHaveValue('2026-01-01T12:34:56.789');
+
+		const formElement = screen.container.querySelector('form');
+
+		if (!formElement) {
+			throw new Error('Form element not found');
+		}
+
+		const formData = new FormData(formElement);
+
+		expect(formData.get('date')).toBe('2026-01-01T12:34:56.789');
+		expect(isDirty(formData, { defaultValue: { date } })).toBe(false);
 	});
 
 	describe('async validation', () => {

--- a/packages/conform-valibot/future.ts
+++ b/packages/conform-valibot/future.ts
@@ -1,11 +1,52 @@
+import { configureCoercion as baseConfigureCoercion } from './coercion';
+
 /**
  * @deprecated Use `getConstraints` instead.
  */
 export { getValibotConstraint } from './constraint';
-export {
-	coerceFormValue,
-	coerceStructure,
-	configureCoercion,
-} from './coercion';
 export { formatResult } from './format';
 export { isSchema, getConstraints } from './schema';
+
+function defaultDate(text: string): Date {
+	const date = new Date(shouldAppendUtcSuffix(text) ? `${text}Z` : text);
+
+	if (isNaN(date.getTime())) {
+		throw new Error('Invalid date');
+	}
+
+	return date;
+}
+
+function shouldAppendUtcSuffix(datetimeString: string): boolean {
+	if (datetimeString.includes(' ')) {
+		return false;
+	}
+
+	const separatorIndex = datetimeString.indexOf('T');
+
+	if (separatorIndex < 0) {
+		return false;
+	}
+
+	const time = datetimeString.slice(separatorIndex + 1);
+
+	return !(
+		time.toUpperCase().endsWith('Z') ||
+		time.includes('+') ||
+		time.includes('-')
+	);
+}
+
+export function configureCoercion(
+	config?: Parameters<typeof baseConfigureCoercion>[0],
+): ReturnType<typeof baseConfigureCoercion> {
+	return baseConfigureCoercion({
+		...config,
+		type: {
+			...config?.type,
+			date: config?.type?.date ?? defaultDate,
+		},
+	});
+}
+
+export const { coerceFormValue, coerceStructure } = configureCoercion();

--- a/packages/conform-valibot/tests/coercion.test.ts
+++ b/packages/conform-valibot/tests/coercion.test.ts
@@ -5,6 +5,7 @@ import {
 	coerceStructure,
 	configureCoercion,
 } from '../coercion';
+import * as future from '../future';
 import { getResult } from './helpers/valibot';
 
 describe('coercion', () => {
@@ -550,5 +551,57 @@ describe('coercion', () => {
 				},
 			});
 		});
+	});
+});
+
+describe('future export: coercion', () => {
+	test('coerceFormValue parses timezone-less datetime as UTC by default', () => {
+		const schema = future.coerceFormValue(v.date());
+		const date = v.parse(schema, '2026-01-01T12:00:00.000');
+
+		expect(date.toISOString()).toBe('2026-01-01T12:00:00.000Z');
+	});
+
+	test('coerceFormValue preserves explicit timezone offsets', () => {
+		const schema = future.coerceFormValue(v.date());
+		const date = v.parse(schema, '2026-01-01T12:00:00+08:00');
+
+		expect(date.toISOString()).toBe('2026-01-01T04:00:00.000Z');
+	});
+
+	test.skipIf(typeof document === 'undefined')(
+		'coerceFormValue parses datetime-local input as UTC by default',
+		() => {
+			const form = document.createElement('form');
+			const input = document.createElement('input');
+
+			input.type = 'datetime-local';
+			input.name = 'startsAt';
+			input.value = '2026-01-01T12:34';
+			form.append(input);
+
+			const value = new FormData(form).get('startsAt');
+
+			expect(value).toBe('2026-01-01T12:34');
+			expect(v.parse(future.coerceFormValue(v.date()), value)).toEqual(
+				new Date('2026-01-01T12:34:00.000Z'),
+			);
+		},
+	);
+
+	test('configureCoercion supports overriding date coercion', () => {
+		const fixedDate = new Date('2020-01-02T03:04:05.006Z');
+		const { coerceFormValue, coerceStructure } = future.configureCoercion({
+			type: {
+				date: () => fixedDate,
+			},
+		});
+
+		expect(
+			v.parse(coerceFormValue(v.date()), '2026-01-01T12:00:00.000'),
+		).toEqual(fixedDate);
+		expect(
+			v.parse(coerceStructure(v.date()), '2026-01-01T12:00:00.000'),
+		).toEqual(fixedDate);
 	});
 });

--- a/packages/conform-zod/v3/future.ts
+++ b/packages/conform-zod/v3/future.ts
@@ -1,11 +1,52 @@
+import { configureCoercion as baseConfigureCoercion } from './coercion';
+
 /**
  * @deprecated Use `getConstraints` instead.
  */
 export { getZodConstraint } from './constraint';
-export {
-	coerceFormValue,
-	coerceStructure,
-	configureCoercion,
-} from './coercion';
 export { formatResult } from './format';
 export { isSchema, getConstraints } from './schema';
+
+function defaultDate(text: string): Date {
+	const date = new Date(shouldAppendUtcSuffix(text) ? `${text}Z` : text);
+
+	if (isNaN(date.getTime())) {
+		throw new Error('Invalid date');
+	}
+
+	return date;
+}
+
+function shouldAppendUtcSuffix(datetimeString: string): boolean {
+	if (datetimeString.includes(' ')) {
+		return false;
+	}
+
+	const separatorIndex = datetimeString.indexOf('T');
+
+	if (separatorIndex < 0) {
+		return false;
+	}
+
+	const time = datetimeString.slice(separatorIndex + 1);
+
+	return !(
+		time.toUpperCase().endsWith('Z') ||
+		time.includes('+') ||
+		time.includes('-')
+	);
+}
+
+export function configureCoercion(
+	config?: Parameters<typeof baseConfigureCoercion>[0],
+): ReturnType<typeof baseConfigureCoercion> {
+	return baseConfigureCoercion({
+		...config,
+		type: {
+			...config?.type,
+			date: config?.type?.date ?? defaultDate,
+		},
+	});
+}
+
+export const { coerceFormValue, coerceStructure } = configureCoercion();

--- a/packages/conform-zod/v3/tests/coercion/coercion.test.ts
+++ b/packages/conform-zod/v3/tests/coercion/coercion.test.ts
@@ -4,6 +4,7 @@ import {
 	coerceStructure,
 	configureCoercion,
 } from '../../coercion';
+import * as future from '../../future';
 import { z } from 'zod/v3';
 import { getResult } from '../../../tests/helpers/zod';
 
@@ -591,5 +592,57 @@ describe('coercion', () => {
 				},
 			});
 		});
+	});
+});
+
+describe('future export: coercion', () => {
+	test('coerceFormValue parses timezone-less datetime as UTC by default', () => {
+		const schema = future.coerceFormValue(z.date());
+		const date = schema.parse('2026-01-01T12:00:00.000');
+
+		expect(date.toISOString()).toBe('2026-01-01T12:00:00.000Z');
+	});
+
+	test('coerceFormValue preserves explicit timezone offsets', () => {
+		const schema = future.coerceFormValue(z.date());
+		const date = schema.parse('2026-01-01T12:00:00+08:00');
+
+		expect(date.toISOString()).toBe('2026-01-01T04:00:00.000Z');
+	});
+
+	test.skipIf(typeof document === 'undefined')(
+		'coerceFormValue parses datetime-local input as UTC by default',
+		() => {
+			const form = document.createElement('form');
+			const input = document.createElement('input');
+
+			input.type = 'datetime-local';
+			input.name = 'startsAt';
+			input.value = '2026-01-01T12:34';
+			form.append(input);
+
+			const value = new FormData(form).get('startsAt');
+
+			expect(value).toBe('2026-01-01T12:34');
+			expect(future.coerceFormValue(z.date()).parse(value)).toEqual(
+				new Date('2026-01-01T12:34:00.000Z'),
+			);
+		},
+	);
+
+	test('configureCoercion supports overriding date coercion', () => {
+		const fixedDate = new Date('2020-01-02T03:04:05.006Z');
+		const { coerceFormValue, coerceStructure } = future.configureCoercion({
+			type: {
+				date: () => fixedDate,
+			},
+		});
+
+		expect(coerceFormValue(z.date()).parse('2026-01-01T12:00:00.000')).toEqual(
+			fixedDate,
+		);
+		expect(coerceStructure(z.date()).parse('2026-01-01T12:00:00.000')).toEqual(
+			fixedDate,
+		);
 	});
 });

--- a/packages/conform-zod/v4/future.ts
+++ b/packages/conform-zod/v4/future.ts
@@ -1,11 +1,52 @@
+import { configureCoercion as baseConfigureCoercion } from './coercion';
+
 /**
  * @deprecated Use `getConstraints` instead.
  */
 export { getZodConstraint } from './constraint';
-export {
-	coerceFormValue,
-	coerceStructure,
-	configureCoercion,
-} from './coercion';
 export { formatResult } from './format';
 export { isSchema, getConstraints } from './schema';
+
+function defaultDate(text: string): Date {
+	const date = new Date(shouldAppendUtcSuffix(text) ? `${text}Z` : text);
+
+	if (isNaN(date.getTime())) {
+		throw new Error('Invalid date');
+	}
+
+	return date;
+}
+
+function shouldAppendUtcSuffix(datetimeString: string): boolean {
+	if (datetimeString.includes(' ')) {
+		return false;
+	}
+
+	const separatorIndex = datetimeString.indexOf('T');
+
+	if (separatorIndex < 0) {
+		return false;
+	}
+
+	const time = datetimeString.slice(separatorIndex + 1);
+
+	return !(
+		time.toUpperCase().endsWith('Z') ||
+		time.includes('+') ||
+		time.includes('-')
+	);
+}
+
+export function configureCoercion(
+	config?: Parameters<typeof baseConfigureCoercion>[0],
+): ReturnType<typeof baseConfigureCoercion> {
+	return baseConfigureCoercion({
+		...config,
+		type: {
+			...config?.type,
+			date: config?.type?.date ?? defaultDate,
+		},
+	});
+}
+
+export const { coerceFormValue, coerceStructure } = configureCoercion();

--- a/packages/conform-zod/v4/tests/coercion/coercion.test.ts
+++ b/packages/conform-zod/v4/tests/coercion/coercion.test.ts
@@ -4,6 +4,7 @@ import {
 	coerceStructure,
 	configureCoercion,
 } from '../../coercion';
+import * as future from '../../future';
 import { z } from 'zod-v4';
 import { getResult } from '../../../tests/helpers/zod';
 
@@ -643,5 +644,57 @@ describe('coercion', () => {
 				},
 			});
 		});
+	});
+});
+
+describe('future export: coercion', () => {
+	test('coerceFormValue parses timezone-less datetime as UTC by default', () => {
+		const schema = future.coerceFormValue(z.date());
+		const date = schema.parse('2026-01-01T12:00:00.000');
+
+		expect(date.toISOString()).toBe('2026-01-01T12:00:00.000Z');
+	});
+
+	test('coerceFormValue preserves explicit timezone offsets', () => {
+		const schema = future.coerceFormValue(z.date());
+		const date = schema.parse('2026-01-01T12:00:00+08:00');
+
+		expect(date.toISOString()).toBe('2026-01-01T04:00:00.000Z');
+	});
+
+	test.skipIf(typeof document === 'undefined')(
+		'coerceFormValue parses datetime-local input as UTC by default',
+		() => {
+			const form = document.createElement('form');
+			const input = document.createElement('input');
+
+			input.type = 'datetime-local';
+			input.name = 'startsAt';
+			input.value = '2026-01-01T12:34';
+			form.append(input);
+
+			const value = new FormData(form).get('startsAt');
+
+			expect(value).toBe('2026-01-01T12:34');
+			expect(future.coerceFormValue(z.date()).parse(value)).toEqual(
+				new Date('2026-01-01T12:34:00.000Z'),
+			);
+		},
+	);
+
+	test('configureCoercion supports overriding date coercion', () => {
+		const fixedDate = new Date('2020-01-02T03:04:05.006Z');
+		const { coerceFormValue, coerceStructure } = future.configureCoercion({
+			type: {
+				date: () => fixedDate,
+			},
+		});
+
+		expect(coerceFormValue(z.date()).parse('2026-01-01T12:00:00.000')).toEqual(
+			fixedDate,
+		);
+		expect(coerceStructure(z.date()).parse('2026-01-01T12:00:00.000')).toEqual(
+			fixedDate,
+		);
 	});
 });


### PR DESCRIPTION
Fix https://github.com/edmundhung/conform/discussions/1135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

This PR updates future APIs to improve datetime-local handling:

- Serialize Date values as UTC datetime strings without a trailing Z (e.g. `2026-01-01T12:00:00.000`) in conform-dom (default serializer and isDirty).
- Interpret timezone-less datetime strings as UTC when coercing form values for Zod and Valibot.
- Add local default-date coercion helpers and a wrapper `configureCoercion()` in conform-zod and conform-valibot; `coerceFormValue`/`coerceStructure` are exported via `configureCoercion()` and can be overridden.
- Update docs (configureForms, isDirty, useField, and coercion docs) to reflect new serialization/coercion behavior.
- Add and adjust tests verifying default value serialization, parsing timezone-less datetimes as UTC, preserving explicit offsets, and export availability (including isDirty).

Scope: future APIs only; no changes to v1 APIs.
</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->