### PR TITLE
Support JSON fields via `nameForJSON` and `defaultJSON`

### DIFF
--- a/examples/react-router/app/root.tsx
+++ b/examples/react-router/app/root.tsx
@@ -58,6 +58,9 @@ export default function App() {
 				<li>
 					<Link to="todos">Dynamic form with data persistence</Link>
 				</li>
+				<li>
+					<Link to="date">Json</Link>
+				</li>
 			</ul>
 
 			<hr />

--- a/examples/react-router/app/root.tsx
+++ b/examples/react-router/app/root.tsx
@@ -59,7 +59,7 @@ export default function App() {
 					<Link to="todos">Dynamic form with data persistence</Link>
 				</li>
 				<li>
-					<Link to="date">Json</Link>
+					<Link to="json">Json</Link>
 				</li>
 			</ul>
 

--- a/examples/react-router/app/routes.ts
+++ b/examples/react-router/app/routes.ts
@@ -8,5 +8,6 @@ export default [
 	route('signup-async-schema', 'routes/signup-async-schema.tsx'),
 	route('signup-server-validation', 'routes/signup-server-validation.tsx'),
 	route('todos', 'routes/todos.tsx'),
+	route('json', 'routes/json.tsx'),
 	route('file-upload', 'routes/file-upload.tsx'),
 ] satisfies RouteConfig;

--- a/examples/react-router/app/routes/json.tsx
+++ b/examples/react-router/app/routes/json.tsx
@@ -21,6 +21,10 @@ const userSchema = z.object({
 	media: mediaSchema,
 });
 
+// not ideal, performance issues ?
+const isMediaValue = (value: unknown): value is z.infer<typeof mediaSchema> =>
+	mediaSchema.safeParse(value).success;
+
 const { coerceFormValue } = configureCoercion({
 	customize(type) {
 		if (type === mediaSchema) {
@@ -91,11 +95,7 @@ export default function Component({
 			isDirty(formData, {
 				defaultValue: form.defaultValue,
 				serialize: (value, defaultSerialize) => {
-					if (
-						value instanceof Object &&
-						'type' in value &&
-						value.type === 'media'
-					) {
+					if (isMediaValue(value)) {
 						return JSON.stringify(value);
 					}
 					return defaultSerialize(value);

--- a/examples/react-router/app/routes/json.tsx
+++ b/examples/react-router/app/routes/json.tsx
@@ -1,0 +1,126 @@
+import {
+	isDirty,
+	parseSubmission,
+	report,
+	useForm,
+	useFormData,
+} from '@conform-to/react/future';
+import { configureCoercion } from '@conform-to/zod/v4/future';
+import { z } from 'zod/v4';
+import { createInMemoryStore } from '~/store';
+import type { Route } from './+types/json';
+import { Form } from 'react-router';
+
+const mediaSchema = z.object({
+	type: z.literal('media'),
+	path: z.string(),
+});
+
+const userSchema = z.object({
+	firstName: z.string(),
+	media: mediaSchema,
+});
+
+const { coerceFormValue } = configureCoercion({
+	customize(type) {
+		if (type === mediaSchema) {
+			return (value) => {
+				if (typeof value !== 'string') {
+					return value;
+				}
+				return JSON.parse(value);
+			};
+		}
+		return null;
+	},
+});
+
+const schema = coerceFormValue(userSchema);
+
+const store = createInMemoryStore<z.infer<typeof schema>>();
+
+export async function loader() {
+	const user = await store.getValue();
+	return {
+		user,
+	};
+}
+
+export async function action({ request }: Route.ActionArgs) {
+	const formData = await request.formData();
+	const submission = parseSubmission(formData);
+	const result = schema.safeParse(submission.payload);
+
+	if (!result.success) {
+		return {
+			result: report(submission, {
+				error: {
+					issues: result.error.issues,
+				},
+			}),
+		};
+	}
+
+	await store.setValue(result.data);
+
+	return {
+		result: report(submission, {
+			reset: true,
+			value: result.data,
+		}),
+	};
+}
+
+export default function Component({
+	loaderData,
+	actionData,
+}: Route.ComponentProps) {
+	const { form, fields } = useForm(schema, {
+		lastResult: actionData?.result,
+		defaultValue: loaderData.user,
+	});
+
+	const dirty = useFormData(
+		form.id,
+		(formData) =>
+			isDirty(formData, {
+				defaultValue: form.defaultValue,
+				serialize: (value, defaultSerialize) => {
+					if (
+						value instanceof Object &&
+						'type' in value &&
+						value.type === 'media'
+					) {
+						return JSON.stringify(value);
+					}
+					return defaultSerialize(value);
+				},
+			}) ?? false,
+	);
+
+	return (
+		<div>
+			<Form {...form.props} method="post">
+				<div>
+					<label>Title</label>
+					<input
+						type="text"
+						defaultValue={fields.firstName.defaultValue}
+						name={fields.firstName.name}
+					/>
+					<div>{fields.firstName.errors}</div>
+				</div>
+				<div>
+					<label>Media</label>
+					<input
+						type="text"
+						defaultValue={fields.media.defaultJSON}
+						name={fields.media.nameForJSON}
+					/>
+					<div>{fields.media.errors}</div>
+				</div>
+				<button disabled={!dirty}>Save</button>
+			</Form>
+		</div>
+	);
+}

--- a/examples/react-router/app/routes/json.tsx
+++ b/examples/react-router/app/routes/json.tsx
@@ -28,7 +28,12 @@ const { coerceFormValue } = configureCoercion({
 				if (typeof value !== 'string') {
 					return value;
 				}
-				return JSON.parse(value);
+				try {
+					return JSON.parse(value);
+				} catch (err) {
+					// Keep raw input so schema validation can surface a normal field error
+					return value;
+				}
 			};
 		}
 		return null;
@@ -102,8 +107,9 @@ export default function Component({
 		<div>
 			<Form {...form.props} method="post">
 				<div>
-					<label>Title</label>
+					<label htmlFor={fields.firstName.id}>Title</label>
 					<input
+						id={fields.firstName.id}
 						type="text"
 						defaultValue={fields.firstName.defaultValue}
 						name={fields.firstName.name}
@@ -111,15 +117,18 @@ export default function Component({
 					<div>{fields.firstName.errors}</div>
 				</div>
 				<div>
-					<label>Media</label>
+					<label htmlFor={fields.media.id}>Media</label>
 					<input
+						id={fields.media.id}
 						type="text"
 						defaultValue={fields.media.defaultJSON}
 						name={fields.media.nameForJSON}
 					/>
 					<div>{fields.media.errors}</div>
 				</div>
-				<button disabled={!dirty}>Save</button>
+				<button type="submit" disabled={!dirty}>
+					Save
+				</button>
 			</Form>
 		</div>
 	);

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -190,7 +190,11 @@ export function getDefaultJSON(
 		name,
 	);
 
-	return JSON.stringify(value) ?? 'null';
+	try {
+		return JSON.stringify(value) ?? '';
+	} catch (err) {
+		return '';
+	}
 }
 
 export function getDefaultOptions(

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -179,6 +179,20 @@ export function getDefaultValue(
 	return '';
 }
 
+export function getDefaultJSON(
+	context: FormContext<any>,
+	name: string,
+): string {
+	const value = getPathValue(
+		context.state.serverValue ??
+			context.state.targetValue ??
+			context.state.defaultValue,
+		name,
+	);
+
+	return JSON.stringify(value) ?? 'null';
+}
+
 export function getDefaultOptions(
 	context: FormContext<any>,
 	name: string,
@@ -468,6 +482,7 @@ export function getField<
 	const metadata: BaseFieldMetadata<FieldShape, ErrorShape> = {
 		key,
 		name,
+		nameForJSON: name as FieldName<string>,
 		id,
 		descriptionId: `${id}-description`,
 		errorId: `${id}-error`,
@@ -483,6 +498,9 @@ export function getField<
 		accept: constraint?.accept,
 		get defaultValue() {
 			return getDefaultValue(context, name, serialize);
+		},
+		get defaultJSON() {
+			return getDefaultJSON(context, name);
 		},
 		get defaultOptions() {
 			return getDefaultOptions(context, name, serialize);

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -760,6 +760,8 @@ export type FieldMetadata<
 			key: string | undefined;
 			/** The field name path exactly as provided. */
 			name: FieldName<FieldShape>;
+			/** The field name cast as a string */
+			nameForJSON: FieldName<string>;
 			/** The field's unique identifier, automatically generated as {formId}-field-{fieldName}. */
 			id: string;
 			/** Auto-generated ID for associating field descriptions via aria-describedby. */
@@ -776,6 +778,11 @@ export type FieldMetadata<
 			 * - The field value cannot be serialized to a string (e.g., objects or arrays)
 			 */
 			defaultValue: string;
+			/**
+			 * The field's default value as a string.
+			 * Return the object value serialized into a string
+			 */
+			defaultJSON: string;
 			/**
 			 * Default selected options for multi-select fields or checkbox group.
 			 *


### PR DESCRIPTION
**Closes #1137**

### Context

When using `coerceFormValue` / `configureCoercion` with custom object types (e.g. a media picker), developers face two friction points today:

1. **Data preparation** — the `defaultValue` passed to `useForm` must already be serialized as a string, requiring a manual `JSON.stringify` before passing loader data to the form.
2. **TypeScript error** — since the schema expects an object (e.g. `Media`) but the form receives a string, TypeScript rejects the `defaultValue` assignment.

This was surfaced in [#1135](https://github.com/edmundhung/conform/discussions/1135) and you suggested extending Conform's naming conventions to support automatic JSON serialisation via a dedicated name pattern.

### Solution

This PR implements that suggestion by adding two new fields to `FieldMetadata`:

- **`nameForJSON`** — same name as `name`, typed as `FieldName<string>` instead of `FieldName<FieldShape>`. Use it as the `name` attribute on your input when the value is a JSON-serialised object.
- **`defaultJSON`** — the field's default value serialised via `JSON.stringify`. Use it as the `defaultValue` attribute.

```tsx
<input
  name={fields.media.nameForJSON}
  defaultValue={fields.media.defaultJSON}
/>
```

This pair allows you to pass the original typed object directly to `defaultValue` in `useForm` no manual stringification needed. while still submitting the value as a flat JSON string in the `FormData`.

### Example

See `examples/react-router/app/routes/json.tsx` for a full working demo with a `mediaSchema`.

---

### Open question — dirty detection

The current example uses `isDirty` with a custom `serialize` option to compare the form's current state against the default value:

```tsx
const dirty = useFormData(
  form.id,
  (formData) =>
    isDirty(formData, {
      defaultValue: form.defaultValue,
      serialize: (value, defaultSerialize) => {
        if (
          value instanceof Object &&
          'type' in value &&
          value.type === 'media'
        ) {
          return JSON.stringify(value);
        }
        return defaultSerialize(value);
      },
    }) ?? false,
);
```

This works but feels **fragile**: the detection relies on duck-typing (`value.type === 'media'`) rather than on the schema definition itself. As soon as there are multiple custom JSON types, this serialize function grows and becomes a maintenance burden, with no guarantee that it stays in sync with the `customize` coercion config.


Happy to hear if there's a better direction for this, or if the current duck-typing approach is the intended pattern for now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

- Adds FieldMetadata.nameForJSON: FieldName<string> and FieldMetadata.defaultJSON: string (getter) in packages/conform-react/future/types.ts and initializes them in packages/conform-react/future/state.ts.
- Adds export getDefaultJSON(context, name) in packages/conform-react/future/state.ts which resolves the field's server/target/default value and returns JSON.stringify(value) (falls back to '').
- Example route examples/react-router/app/routes/json.tsx demonstrating Zod schema + custom coercion for media objects, usage of fields.media.nameForJSON and fields.media.defaultJSON in inputs, and a custom serialize-based dirty check.
- Adds navigation and route config entries to expose the new example route.

Example usage:
```jsx
<input name={fields.media.nameForJSON} defaultValue={fields.media.defaultJSON} />
```

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->