### PR TITLE
docs(conform-zod,conform-valibot): improve jsdocs on coercion APIs

### DIFF
--- a/packages/conform-valibot/coercion.ts
+++ b/packages/conform-valibot/coercion.ts
@@ -709,20 +709,25 @@ export function configureCoercion(config?: {
 
 	return {
 		/**
-		 * A helper that enhances the valibot schema to strip empty values and
-		 * coerce form values to the expected type.
+		 * Enhances a schema to coerce form values and strip empty values before validation.
+		 * This configured helper uses the options passed to `configureCoercion`.
+		 *
+		 * Results are cached per schema, so this can be called inline.
 		 *
 		 * @example
 		 *
 		 * ```tsx
-		 * import { coerceFormValue } from '@conform-to/valibot/future';
+		 * import { configureCoercion } from '@conform-to/valibot/future';
 		 * import * as v from 'valibot';
 		 *
-		 * const schema = coerceFormValue(
-		 *   v.object({
-		 *     // ...
-		 *   })
-		 * );
+		 * const { coerceFormValue } = configureCoercion();
+		 * const schema = coerceFormValue(v.object({
+		 *   age: v.optional(v.number()),
+		 *   subscribe: v.boolean(),
+		 * }));
+		 *
+		 * v.parse(schema, { age: '', subscribe: 'on' });
+		 * // { age: undefined, subscribe: true }
 		 * ```
 		 */
 		coerceFormValue<Schema extends GenericSchema | GenericSchemaAsync>(
@@ -751,14 +756,28 @@ export function configureCoercion(config?: {
 		},
 
 		/**
-		 * Enhances a schema to convert form string values to their typed
-		 * equivalents without validation. Useful for reading current form values
-		 * as typed data.
+		 * Enhances a schema to coerce form values without running validation.
+		 * This configured helper is useful for reading current form values as typed data.
 		 *
-		 * Skips schema validation (min/max/regex/etc.), defaults, transforms,
-		 * and refinements. Empty strings are preserved (not stripped).
+		 * It skips validation, defaults, transforms, and refinements, and preserves
+		 * empty strings.
 		 *
 		 * Results are cached per schema, so this can be called inline.
+		 *
+		 * @example
+		 *
+		 * ```tsx
+		 * import { configureCoercion } from '@conform-to/valibot/future';
+		 * import * as v from 'valibot';
+		 *
+		 * const { coerceStructure } = configureCoercion();
+		 * const schema = coerceStructure(v.object({
+		 *   age: v.pipe(v.number(), v.minValue(10)),
+		 * }));
+		 *
+		 * v.parse(schema, { age: '3' });
+		 * // { age: 3 }
+		 * ```
 		 */
 		coerceStructure<Schema extends GenericSchema | GenericSchemaAsync>(
 			type: Schema,

--- a/packages/conform-valibot/coercion.ts
+++ b/packages/conform-valibot/coercion.ts
@@ -717,10 +717,6 @@ export function configureCoercion(config?: {
 		 * @example
 		 *
 		 * ```tsx
-		 * import { configureCoercion } from '@conform-to/valibot/future';
-		 * import * as v from 'valibot';
-		 *
-		 * const { coerceFormValue } = configureCoercion();
 		 * const schema = coerceFormValue(v.object({
 		 *   age: v.optional(v.number()),
 		 *   subscribe: v.boolean(),
@@ -767,10 +763,6 @@ export function configureCoercion(config?: {
 		 * @example
 		 *
 		 * ```tsx
-		 * import { configureCoercion } from '@conform-to/valibot/future';
-		 * import * as v from 'valibot';
-		 *
-		 * const { coerceStructure } = configureCoercion();
 		 * const schema = coerceStructure(v.object({
 		 *   age: v.pipe(v.number(), v.minValue(10)),
 		 * }));

--- a/packages/conform-valibot/coercion.ts
+++ b/packages/conform-valibot/coercion.ts
@@ -755,8 +755,16 @@ export function configureCoercion(config?: {
 		 * Enhances a schema to coerce form values without running validation.
 		 * This configured helper is useful for reading current form values as typed data.
 		 *
-		 * It skips validation, defaults, transforms, and refinements, and preserves
-		 * empty strings.
+		 * It skips validation, defaults, transforms, and refinements, and does not strip
+		 * empty strings to `undefined`.
+		 *
+		 * For number, boolean, date, and bigint schemas, empty strings and other failed
+		 * string coercions still become fallback values:
+		 *
+		 * - `v.number()` -> `NaN`
+		 * - `v.boolean()` -> `false`
+		 * - `v.date()` -> `Invalid Date`
+		 * - `v.bigint()` -> `0n`
 		 *
 		 * Results are cached per schema, so this can be called inline.
 		 *

--- a/packages/conform-valibot/future.ts
+++ b/packages/conform-valibot/future.ts
@@ -78,8 +78,18 @@ export const coerceFormValue = defaultCoercion.coerceFormValue;
  * Enhances a schema to coerce form values without running validation.
  * This is useful for reading current form values as typed data.
  *
- * It skips validation, defaults, transforms, and refinements, and preserves
- * empty strings. Use `configureCoercion` to override type-specific coercion.
+ * It skips validation, defaults, transforms, and refinements, and does not strip
+ * empty strings to `undefined`.
+ *
+ * For number, boolean, date, and bigint schemas, empty strings and other failed
+ * string coercions still become fallback values:
+ *
+ * - `v.number()` -> `NaN`
+ * - `v.boolean()` -> `false`
+ * - `v.date()` -> `Invalid Date`
+ * - `v.bigint()` -> `0n`
+ *
+ * Use `configureCoercion` to override type-specific coercion.
  *
  * Results are cached per schema, so this can be called inline.
  *

--- a/packages/conform-valibot/future.ts
+++ b/packages/conform-valibot/future.ts
@@ -49,4 +49,52 @@ export function configureCoercion(
 	});
 }
 
-export const { coerceFormValue, coerceStructure } = configureCoercion();
+const defaultCoercion = configureCoercion();
+
+/**
+ * Enhances a schema to coerce form values and strip empty values before validation.
+ * Use `configureCoercion` to override empty-string handling and type-specific coercion.
+ *
+ * Results are cached per schema, so this can be called inline.
+ *
+ * @example
+ *
+ * ```tsx
+ * import { coerceFormValue } from '@conform-to/valibot/future';
+ * import * as v from 'valibot';
+ *
+ * const schema = coerceFormValue(v.object({
+ *   age: v.optional(v.number()),
+ *   subscribe: v.boolean(),
+ * }));
+ *
+ * v.parse(schema, { age: '', subscribe: 'on' });
+ * // { age: undefined, subscribe: true }
+ * ```
+ */
+export const coerceFormValue = defaultCoercion.coerceFormValue;
+
+/**
+ * Enhances a schema to coerce form values without running validation.
+ * This is useful for reading current form values as typed data.
+ *
+ * It skips validation, defaults, transforms, and refinements, and preserves
+ * empty strings. Use `configureCoercion` to override type-specific coercion.
+ *
+ * Results are cached per schema, so this can be called inline.
+ *
+ * @example
+ *
+ * ```tsx
+ * import { coerceStructure } from '@conform-to/valibot/future';
+ * import * as v from 'valibot';
+ *
+ * const schema = coerceStructure(v.object({
+ *   age: v.pipe(v.number(), v.minValue(10)),
+ * }));
+ *
+ * v.parse(schema, { age: '3' });
+ * // { age: 3 }
+ * ```
+ */
+export const coerceStructure = defaultCoercion.coerceStructure;

--- a/packages/conform-zod/v3/coercion.ts
+++ b/packages/conform-zod/v3/coercion.ts
@@ -561,10 +561,6 @@ export function configureCoercion(config?: {
 		 * @example
 		 *
 		 * ```tsx
-		 * import { configureCoercion } from '@conform-to/zod/v3/future';
-		 * import { z } from 'zod';
-		 *
-		 * const { coerceFormValue } = configureCoercion();
 		 * const schema = coerceFormValue(z.object({
 		 *   age: z.number().optional(),
 		 *   subscribe: z.boolean(),
@@ -607,10 +603,6 @@ export function configureCoercion(config?: {
 		 * @example
 		 *
 		 * ```tsx
-		 * import { configureCoercion } from '@conform-to/zod/v3/future';
-		 * import { z } from 'zod';
-		 *
-		 * const { coerceStructure } = configureCoercion();
 		 * const schema = coerceStructure(z.object({
 		 *   age: z.number().min(10),
 		 * }));

--- a/packages/conform-zod/v3/coercion.ts
+++ b/packages/conform-zod/v3/coercion.ts
@@ -553,20 +553,25 @@ export function configureCoercion(config?: {
 
 	return {
 		/**
-		 * A helper that enhance the zod schema to strip empty value and coerce
-		 * form value to the expected type with option to customize type coercion.
+		 * Enhances a schema to coerce form values and strip empty values before validation.
+		 * This configured helper uses the options passed to `configureCoercion`.
+		 *
+		 * Results are cached per schema, so this can be called inline.
 		 *
 		 * @example
 		 *
 		 * ```tsx
-		 * import { coerceFormValue } from '@conform-to/zod/v3/future';
+		 * import { configureCoercion } from '@conform-to/zod/v3/future';
 		 * import { z } from 'zod';
 		 *
-		 * const schema = coerceFormValue(
-		 *   z.object({
-		 *     // ...
-		 *   })
-		 * );
+		 * const { coerceFormValue } = configureCoercion();
+		 * const schema = coerceFormValue(z.object({
+		 *   age: z.number().optional(),
+		 *   subscribe: z.boolean(),
+		 * }));
+		 *
+		 * schema.parse({ age: '', subscribe: 'on' });
+		 * // { age: undefined, subscribe: true }
 		 * ```
 		 */
 		coerceFormValue<Schema extends ZodTypeAny>(
@@ -591,14 +596,28 @@ export function configureCoercion(config?: {
 		},
 
 		/**
-		 * Enhances a schema to convert form string values to their typed
-		 * equivalents without validation. Useful for reading current form values
-		 * as typed data.
+		 * Enhances a schema to coerce form values without running validation.
+		 * This configured helper is useful for reading current form values as typed data.
 		 *
-		 * Skips schema validation (min/max/regex/etc.), defaults, transforms,
-		 * and refinements. Empty strings are preserved (not stripped).
+		 * It skips validation, defaults, transforms, and refinements, and preserves
+		 * empty strings.
 		 *
 		 * Results are cached per schema, so this can be called inline.
+		 *
+		 * @example
+		 *
+		 * ```tsx
+		 * import { configureCoercion } from '@conform-to/zod/v3/future';
+		 * import { z } from 'zod';
+		 *
+		 * const { coerceStructure } = configureCoercion();
+		 * const schema = coerceStructure(z.object({
+		 *   age: z.number().min(10),
+		 * }));
+		 *
+		 * schema.parse({ age: '3' });
+		 * // { age: 3 }
+		 * ```
 		 */
 		coerceStructure<Schema extends ZodTypeAny>(
 			type: Schema,

--- a/packages/conform-zod/v3/coercion.ts
+++ b/packages/conform-zod/v3/coercion.ts
@@ -595,8 +595,16 @@ export function configureCoercion(config?: {
 		 * Enhances a schema to coerce form values without running validation.
 		 * This configured helper is useful for reading current form values as typed data.
 		 *
-		 * It skips validation, defaults, transforms, and refinements, and preserves
-		 * empty strings.
+		 * It skips validation, defaults, transforms, and refinements, and does not strip
+		 * empty strings to `undefined`.
+		 *
+		 * For number, boolean, date, and bigint schemas, empty strings and other failed
+		 * string coercions still become fallback values:
+		 *
+		 * - `z.number()` -> `NaN`
+		 * - `z.boolean()` -> `false`
+		 * - `z.date()` -> `Invalid Date`
+		 * - `z.bigint()` -> `0n`
 		 *
 		 * Results are cached per schema, so this can be called inline.
 		 *

--- a/packages/conform-zod/v3/future.ts
+++ b/packages/conform-zod/v3/future.ts
@@ -49,4 +49,52 @@ export function configureCoercion(
 	});
 }
 
-export const { coerceFormValue, coerceStructure } = configureCoercion();
+const defaultCoercion = configureCoercion();
+
+/**
+ * Enhances a schema to coerce form values and strip empty values before validation.
+ * Use `configureCoercion` to override empty-string handling and type-specific coercion.
+ *
+ * Results are cached per schema, so this can be called inline.
+ *
+ * @example
+ *
+ * ```tsx
+ * import { coerceFormValue } from '@conform-to/zod/v3/future';
+ * import { z } from 'zod';
+ *
+ * const schema = coerceFormValue(z.object({
+ *   age: z.number().optional(),
+ *   subscribe: z.boolean(),
+ * }));
+ *
+ * schema.parse({ age: '', subscribe: 'on' });
+ * // { age: undefined, subscribe: true }
+ * ```
+ */
+export const coerceFormValue = defaultCoercion.coerceFormValue;
+
+/**
+ * Enhances a schema to coerce form values without running validation.
+ * This is useful for reading current form values as typed data.
+ *
+ * It skips validation, defaults, transforms, and refinements, and preserves
+ * empty strings. Use `configureCoercion` to override type-specific coercion.
+ *
+ * Results are cached per schema, so this can be called inline.
+ *
+ * @example
+ *
+ * ```tsx
+ * import { coerceStructure } from '@conform-to/zod/v3/future';
+ * import { z } from 'zod';
+ *
+ * const schema = coerceStructure(z.object({
+ *   age: z.number().min(10),
+ * }));
+ *
+ * schema.parse({ age: '3' });
+ * // { age: 3 }
+ * ```
+ */
+export const coerceStructure = defaultCoercion.coerceStructure;

--- a/packages/conform-zod/v3/future.ts
+++ b/packages/conform-zod/v3/future.ts
@@ -78,8 +78,18 @@ export const coerceFormValue = defaultCoercion.coerceFormValue;
  * Enhances a schema to coerce form values without running validation.
  * This is useful for reading current form values as typed data.
  *
- * It skips validation, defaults, transforms, and refinements, and preserves
- * empty strings. Use `configureCoercion` to override type-specific coercion.
+ * It skips validation, defaults, transforms, and refinements, and does not strip
+ * empty strings to `undefined`.
+ *
+ * For number, boolean, date, and bigint schemas, empty strings and other failed
+ * string coercions still become fallback values:
+ *
+ * - `z.number()` -> `NaN`
+ * - `z.boolean()` -> `false`
+ * - `z.date()` -> `Invalid Date`
+ * - `z.bigint()` -> `0n`
+ *
+ * Use `configureCoercion` to override type-specific coercion.
  *
  * Results are cached per schema, so this can be called inline.
  *

--- a/packages/conform-zod/v4/coercion.ts
+++ b/packages/conform-zod/v4/coercion.ts
@@ -525,10 +525,6 @@ export function configureCoercion(config?: {
 		 * @example
 		 *
 		 * ```tsx
-		 * import { configureCoercion } from '@conform-to/zod/v4/future';
-		 * import { z } from 'zod';
-		 *
-		 * const { coerceFormValue } = configureCoercion();
 		 * const schema = coerceFormValue(z.object({
 		 *   age: z.number().optional(),
 		 *   subscribe: z.boolean(),
@@ -572,10 +568,6 @@ export function configureCoercion(config?: {
 		 * @example
 		 *
 		 * ```tsx
-		 * import { configureCoercion } from '@conform-to/zod/v4/future';
-		 * import { z } from 'zod';
-		 *
-		 * const { coerceStructure } = configureCoercion();
 		 * const schema = coerceStructure(z.object({
 		 *   age: z.number().min(10),
 		 * }));

--- a/packages/conform-zod/v4/coercion.ts
+++ b/packages/conform-zod/v4/coercion.ts
@@ -560,8 +560,16 @@ export function configureCoercion(config?: {
 		 * Enhances a schema to coerce form values without running validation.
 		 * This configured helper is useful for reading current form values as typed data.
 		 *
-		 * It skips validation, defaults, transforms, and refinements, and preserves
-		 * empty strings.
+		 * It skips validation, defaults, transforms, and refinements, and does not strip
+		 * empty strings to `undefined`.
+		 *
+		 * For number, boolean, date, and bigint schemas, empty strings and other failed
+		 * string coercions still become fallback values:
+		 *
+		 * - `z.number()` -> `NaN`
+		 * - `z.boolean()` -> `false`
+		 * - `z.date()` -> `Invalid Date`
+		 * - `z.bigint()` -> `0n`
 		 *
 		 * Results are cached per schema, so this can be called inline.
 		 *

--- a/packages/conform-zod/v4/coercion.ts
+++ b/packages/conform-zod/v4/coercion.ts
@@ -517,21 +517,25 @@ export function configureCoercion(config?: {
 
 	return {
 		/**
-		 * A helper that enhance the zod schema to strip empty value and coerce
-		 * form value to the expected type with option to customize type coercion.
+		 * Enhances a schema to coerce form values and strip empty values before validation.
+		 * This configured helper uses the options passed to `configureCoercion`.
+		 *
+		 * Results are cached per schema, so this can be called inline.
 		 *
 		 * @example
 		 *
 		 * ```tsx
-		 * import { coerceFormValue } from '@conform-to/zod/v4/future';
+		 * import { configureCoercion } from '@conform-to/zod/v4/future';
 		 * import { z } from 'zod';
 		 *
-		 * // Coerce the form value
-		 * const schema = coerceFormValue(
-		 *   z.object({
-		 *     // ...
-		 *   })
-		 * );
+		 * const { coerceFormValue } = configureCoercion();
+		 * const schema = coerceFormValue(z.object({
+		 *   age: z.number().optional(),
+		 *   subscribe: z.boolean(),
+		 * }));
+		 *
+		 * schema.parse({ age: '', subscribe: 'on' });
+		 * // { age: undefined, subscribe: true }
 		 * ```
 		 */
 		coerceFormValue<Schema extends $ZodType>(
@@ -557,14 +561,28 @@ export function configureCoercion(config?: {
 		},
 
 		/**
-		 * Enhances a schema to convert form string values to their typed
-		 * equivalents without validation. Useful for reading current form values
-		 * as typed data.
+		 * Enhances a schema to coerce form values without running validation.
+		 * This configured helper is useful for reading current form values as typed data.
 		 *
-		 * Skips schema validation (min/max/regex/etc.), defaults, transforms,
-		 * and refinements. Empty strings are preserved (not stripped).
+		 * It skips validation, defaults, transforms, and refinements, and preserves
+		 * empty strings.
 		 *
 		 * Results are cached per schema, so this can be called inline.
+		 *
+		 * @example
+		 *
+		 * ```tsx
+		 * import { configureCoercion } from '@conform-to/zod/v4/future';
+		 * import { z } from 'zod';
+		 *
+		 * const { coerceStructure } = configureCoercion();
+		 * const schema = coerceStructure(z.object({
+		 *   age: z.number().min(10),
+		 * }));
+		 *
+		 * schema.parse({ age: '3' });
+		 * // { age: 3 }
+		 * ```
 		 */
 		coerceStructure<Schema extends $ZodType>(
 			type: Schema,

--- a/packages/conform-zod/v4/future.ts
+++ b/packages/conform-zod/v4/future.ts
@@ -49,4 +49,52 @@ export function configureCoercion(
 	});
 }
 
-export const { coerceFormValue, coerceStructure } = configureCoercion();
+const defaultCoercion = configureCoercion();
+
+/**
+ * Enhances a schema to coerce form values and strip empty values before validation.
+ * Use `configureCoercion` to override empty-string handling and type-specific coercion.
+ *
+ * Results are cached per schema, so this can be called inline.
+ *
+ * @example
+ *
+ * ```tsx
+ * import { coerceFormValue } from '@conform-to/zod/v4/future';
+ * import { z } from 'zod';
+ *
+ * const schema = coerceFormValue(z.object({
+ *   age: z.number().optional(),
+ *   subscribe: z.boolean(),
+ * }));
+ *
+ * schema.parse({ age: '', subscribe: 'on' });
+ * // { age: undefined, subscribe: true }
+ * ```
+ */
+export const coerceFormValue = defaultCoercion.coerceFormValue;
+
+/**
+ * Enhances a schema to coerce form values without running validation.
+ * This is useful for reading current form values as typed data.
+ *
+ * It skips validation, defaults, transforms, and refinements, and preserves
+ * empty strings. Use `configureCoercion` to override type-specific coercion.
+ *
+ * Results are cached per schema, so this can be called inline.
+ *
+ * @example
+ *
+ * ```tsx
+ * import { coerceStructure } from '@conform-to/zod/v4/future';
+ * import { z } from 'zod';
+ *
+ * const schema = coerceStructure(z.object({
+ *   age: z.number().min(10),
+ * }));
+ *
+ * schema.parse({ age: '3' });
+ * // { age: 3 }
+ * ```
+ */
+export const coerceStructure = defaultCoercion.coerceStructure;

--- a/packages/conform-zod/v4/future.ts
+++ b/packages/conform-zod/v4/future.ts
@@ -78,8 +78,18 @@ export const coerceFormValue = defaultCoercion.coerceFormValue;
  * Enhances a schema to coerce form values without running validation.
  * This is useful for reading current form values as typed data.
  *
- * It skips validation, defaults, transforms, and refinements, and preserves
- * empty strings. Use `configureCoercion` to override type-specific coercion.
+ * It skips validation, defaults, transforms, and refinements, and does not strip
+ * empty strings to `undefined`.
+ *
+ * For number, boolean, date, and bigint schemas, empty strings and other failed
+ * string coercions still become fallback values:
+ *
+ * - `z.number()` -> `NaN`
+ * - `z.boolean()` -> `false`
+ * - `z.date()` -> `Invalid Date`
+ * - `z.bigint()` -> `0n`
+ *
+ * Use `configureCoercion` to override type-specific coercion.
  *
  * Results are cached per schema, so this can be called inline.
  *


### PR DESCRIPTION
Improve the hover docs for the future coercion APIs in zod and valibot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

This PR improves JSDoc for the "future" coercion APIs across conform-zod (v3 & v4) and conform-valibot to provide richer IDE/hover documentation and clearer examples.

Key points:
- Expanded JSDoc for configureCoercion helpers (coerceFormValue, coerceStructure):
  - coerceFormValue: documents stripping of empty values before validation, coercion using configureCoercion options, and caching per schema.
  - coerceStructure: documents coercion without running validation (skips defaults/transforms/refinements), preserves empty strings (no empty→undefined stripping), and states fallback/sentinel outcomes for failed number/boolean/date/bigint coercions.
- future.ts modules: changed exports to create a single cached defaultCoercion instance and export its methods (exported as references to defaultCoercion.coerceFormValue / .coerceStructure) instead of destructuring from configureCoercion() inline — done to improve hover docs.
- No changes to runtime logic, function signatures, exported types, or coercion implementation — only documentation/examples and export wiring were modified.

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->