### PR TITLE
feat: customize serializer based on field name

### DIFF
--- a/.changeset/field-aware-serialize.md
+++ b/.changeset/field-aware-serialize.md
@@ -1,0 +1,22 @@
+---
+'@conform-to/dom': minor
+'@conform-to/react': minor
+---
+
+feat: customize serializer based on field name
+
+The `serialize` options now let you customize serialization based on `ctx.name`, both globally through `configureForms()` and per form through `useForm()`, while delegating everything else back to Conform's default serializer with `ctx.defaultSerialize`.
+
+This changes the serializer callback signature to:
+
+```ts
+serialize(value, ctx) {
+  // Custom serialization for a specific field name
+  if (ctx.name === 'metadata') {
+    return typeof value === 'string' || value == null
+      ? value
+      : JSON.stringify(value);
+  }
+  return ctx.defaultSerialize(value, ctx);
+}
+```

--- a/docs/api/react/future/configureForms.md
+++ b/docs/api/react/future/configureForms.md
@@ -21,9 +21,12 @@ The name of the submit button field that indicates the submission intent. Defaul
 
 This is an advanced option. You typically don't need to change this unless you have conflicts with existing field names.
 
-### `serialize?: Serialize`
+### `serialize?: (value, ctx) => string | string[] | File | File[] | null | undefined`
 
-A custom serialization function for converting form data.
+A custom serializer for converting form values.
+
+- `ctx.name` is the field name being serialized when available.
+- `ctx.defaultSerialize` lets you delegate values you are not customizing to the default serializer.
 
 If not provided, Conform uses a default serializer with the following behavior:
 

--- a/docs/api/react/future/configureForms.md
+++ b/docs/api/react/future/configureForms.md
@@ -26,7 +26,7 @@ This is an advanced option. You typically don't need to change this unless you h
 A custom serializer for converting form values.
 
 - `ctx.name` is the field name being serialized when available.
-- `ctx.defaultSerialize` lets you delegate values you are not customizing to the default serializer.
+- `ctx.defaultSerialize(value)` lets you delegate values you are not customizing to the default serializer.
 
 If not provided, Conform uses a default serializer with the following behavior:
 

--- a/docs/api/react/future/configureForms.md
+++ b/docs/api/react/future/configureForms.md
@@ -21,7 +21,7 @@ The name of the submit button field that indicates the submission intent. Defaul
 
 This is an advanced option. You typically don't need to change this unless you have conflicts with existing field names.
 
-### `serialize?: (value, ctx) => string | string[] | File | File[] | null | undefined`
+### `serialize?: (value, ctx) => FormValue | null | undefined`
 
 A custom serializer for converting form values.
 
@@ -32,7 +32,7 @@ If not provided, Conform uses a default serializer with the following behavior:
 
 - boolean:
   - true → 'on'
-  - false → undefined
+  - false → null
 - Date:
   - Converted to UTC datetime string without trailing `Z` (e.g. `2026-01-01T12:00:00.000`)
 - number / bigint:

--- a/docs/api/react/future/isDirty.md
+++ b/docs/api/react/future/isDirty.md
@@ -24,7 +24,7 @@ The current form data to compare. It can be:
 
 An object representing the default values of the form to compare against. Defaults to an empty object if not provided.
 
-### `options.serialize?: (value: unknown, defaultSerialize: Serialize) => string | string[] | File | File[] | null | undefined`
+### `options.serialize?: (value, ctx) => string | string[] | File | File[] | null | undefined`
 
 A function to serialize values in defaultValue before comparing them to the form data. If not provided, a default serializer is used that behaves as follows:
 

--- a/docs/api/react/future/isDirty.md
+++ b/docs/api/react/future/isDirty.md
@@ -24,13 +24,16 @@ The current form data to compare. It can be:
 
 An object representing the default values of the form to compare against. Defaults to an empty object if not provided.
 
-### `options.serialize?: (value, ctx) => string | string[] | File | File[] | null | undefined`
+### `options.serialize?: (value, ctx) => FormValue | null | undefined`
 
 A function to serialize values in defaultValue before comparing them to the form data. If not provided, a default serializer is used that behaves as follows:
 
+- `ctx.name` is the field name being serialized when available.
+- `ctx.defaultSerialize` lets you delegate values you are not customizing to the default serializer.
+
 - boolean:
   - true → 'on'
-  - false → undefined
+  - false → null
 - Date:
   - Converted to UTC datetime string without trailing `Z` (e.g. `2026-01-01T12:00:00.000`)
 - number / bigint:

--- a/docs/api/react/future/isDirty.md
+++ b/docs/api/react/future/isDirty.md
@@ -29,7 +29,7 @@ An object representing the default values of the form to compare against. Defaul
 A function to serialize values in defaultValue before comparing them to the form data. If not provided, a default serializer is used that behaves as follows:
 
 - `ctx.name` is the field name being serialized when available.
-- `ctx.defaultSerialize` lets you delegate values you are not customizing to the default serializer.
+- `ctx.defaultSerialize(value)` lets you delegate values you are not customizing to the default serializer.
 
 - boolean:
   - true → 'on'
@@ -40,6 +40,8 @@ A function to serialize values in defaultValue before comparing them to the form
   - Converted to string using `.toString()`
 - string / File:
   - Returned as-is
+
+If you use a custom serializer through [useForm()](./useForm.md) or [configureForms()](./configureForms.md), pass `form.context.serialize` to `isDirty()` so it matches the form's actual serialization behavior.
 
 ### `options.skipEntry?: (name: string) => boolean`
 

--- a/docs/api/react/future/useControl.md
+++ b/docs/api/react/future/useControl.md
@@ -376,7 +376,7 @@ const { form, fields } = useForm({
         : JSON.stringify(value);
     }
 
-    return context.defaultSerialize(value, context);
+    return context.defaultSerialize(value);
   },
 });
 

--- a/docs/api/react/future/useControl.md
+++ b/docs/api/react/future/useControl.md
@@ -357,3 +357,40 @@ You can register multiple checkbox or radio inputs as a group by passing an arra
 ```
 
 If you don't need to re-use the existing native inputs, you can always represent the group with a single hidden multi-select or text input. For complete examples, see the checkbox and radio group implementations in the [React Aria example](../../../../examples/react-aria/).
+
+### Unknown value shape
+
+If your custom control has a known shape, reach for a fieldset. But, if the shape is not known upfront, serializing the payload as a JSON string is often the simpler option.
+
+Just parse or coerce that JSON string back to the original shape with `JSON.parse()` on the server.
+
+```tsx
+const { form, fields } = useForm({
+  defaultValue: {
+    metadata: { foo: 'bar' },
+  },
+  serialize(value, context) {
+    if (context.name === 'metadata') {
+      return typeof value === 'string' || value == null
+        ? value
+        : JSON.stringify(value);
+    }
+
+    return context.defaultSerialize(value, context);
+  },
+});
+
+const control = useControl({
+  defaultValue: fields.metadata.defaultValue,
+  parse(payload) {
+    if (typeof payload !== 'string') {
+      throw new Error('Expected a string payload');
+    }
+
+    return JSON.parse(payload);
+  },
+  serialize(value) {
+    return JSON.stringify(value);
+  },
+});
+```

--- a/docs/api/react/future/useForm.md
+++ b/docs/api/react/future/useForm.md
@@ -35,7 +35,7 @@ Initial form values. Can be a partial object matching your form structure.
 A custom serialization function for converting form values.
 
 - `ctx.name` is the field name being serialized when available.
-- `ctx.defaultSerialize` lets you delegate values you are not customizing to the default serializer.
+- `ctx.defaultSerialize(value)` lets you delegate values you are not customizing to the resolved default serializer.
 
 The default serializer can be configured via [configureForms](./configureForms.md).
 

--- a/docs/api/react/future/useForm.md
+++ b/docs/api/react/future/useForm.md
@@ -30,7 +30,7 @@ Optional [standard schema](https://standardschema.dev/) for validation (e.g., Zo
 
 Initial form values. Can be a partial object matching your form structure.
 
-### `serialize?: (value, ctx) => string | string[] | File | File[] | null | undefined`
+### `serialize?: (value, ctx) => FormValue | null | undefined`
 
 A custom serialization function for converting form values.
 

--- a/docs/api/react/future/useForm.md
+++ b/docs/api/react/future/useForm.md
@@ -30,6 +30,15 @@ Optional [standard schema](https://standardschema.dev/) for validation (e.g., Zo
 
 Initial form values. Can be a partial object matching your form structure.
 
+### `serialize?: (value, ctx) => string | string[] | File | File[] | null | undefined`
+
+A custom serialization function for converting form values.
+
+- `ctx.name` is the field name being serialized when available.
+- `ctx.defaultSerialize` lets you delegate values you are not customizing to the default serializer.
+
+The default serializer can be configured via [configureForms](./configureForms.md).
+
 ### `constraint?: Record<string, ValidationAttributes>`
 
 HTML validation attributes for fields (`required`, `minLength`, `pattern`, etc.).

--- a/examples/react-aria/src/components/DateRangePicker.tsx
+++ b/examples/react-aria/src/components/DateRangePicker.tsx
@@ -63,7 +63,7 @@ export function DateRangePicker({
 					end: parseDate(range.end),
 				};
 			} catch {
-				return;
+				return null;
 			}
 		},
 		serialize(value) {

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -3,11 +3,11 @@ import type {
 	FormValue,
 	FieldName,
 	JsonPrimitive,
-	Serialize,
-	SerializedValue,
+	CustomSerialize,
 	Submission,
 	SubmissionResult,
 	UnknownObject,
+	Serialize,
 } from './types';
 import { isGlobalInstance, isSubmitter } from './dom';
 import { deepEqual, getTypeName, isPlainObject, stripFiles } from './util';
@@ -686,10 +686,7 @@ export function isDirty(
 		 * - Date:
 		 *   - Converted to UTC datetime string without trailing `Z` (e.g. `2026-01-01T12:00:00.000`)
 		 */
-		serialize?: (
-			value: unknown,
-			defaultSerialize: Serialize,
-		) => SerializedValue | null | undefined;
+		serialize?: CustomSerialize;
 		/**
 		 * A function to exclude specific fields from the comparison.
 		 * Useful for ignoring hidden inputs like CSRF tokens or internal fields added by frameworks
@@ -716,14 +713,20 @@ export function isDirty(
 					skipEntry: options?.skipEntry,
 				}).payload
 			: formData;
-	const defaultValue = options?.defaultValue;
-	const serializeValue: Serialize = options?.serialize
-		? (value) => options.serialize!(value, serialize)
-		: serialize;
+	const serialize: Serialize = (value, context) => {
+		if (options?.serialize) {
+			return options.serialize(value, {
+				name: context.name,
+				defaultSerialize: defaultSerialize,
+			});
+		}
+
+		return defaultSerialize(value);
+	};
 
 	return !deepEqual(
-		normalize(formValue, serializeValue),
-		normalize(defaultValue, serializeValue),
+		normalize(formValue, serialize),
+		normalize(options?.defaultValue, serialize),
 	);
 }
 
@@ -742,7 +745,7 @@ export function isDirty(
  * - Array -> string[] or File[] if all items serialize to the same kind; otherwise undefined
  * - anything else -> undefined
  */
-export function serialize(value: unknown): SerializedValue | null | undefined {
+export function defaultSerialize(value: unknown): ReturnType<Serialize> {
 	function serializePrimitive(
 		value: unknown,
 	): string | File | null | undefined {
@@ -825,9 +828,12 @@ export function serialize(value: unknown): SerializedValue | null | undefined {
  */
 export function normalize(
 	value: unknown,
-	serializeValue: Serialize = serialize,
+	serialize: Serialize = defaultSerialize,
+	name?: string,
 ): unknown {
-	let data: unknown = serializeValue(value);
+	let data: unknown = serialize(value, {
+		name,
+	});
 
 	if (typeof data === 'undefined') {
 		data = value;
@@ -850,7 +856,9 @@ export function normalize(
 			return undefined;
 		}
 
-		const array = data.map((item) => normalize(item, serializeValue));
+		const array = data.map((item, index) =>
+			normalize(item, serialize, appendPath(name, index)),
+		);
 
 		if (
 			array.length === 1 &&
@@ -865,7 +873,11 @@ export function normalize(
 	if (isPlainObject(data)) {
 		const entries = Object.entries(data).reduce<Array<[string, unknown]>>(
 			(list, [key, value]) => {
-				const normalizedValue = normalize(value, serializeValue);
+				const normalizedValue = normalize(
+					value,
+					serialize,
+					appendPath(name, key),
+				);
 
 				if (typeof normalizedValue !== 'undefined') {
 					list.push([key, normalizedValue]);

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -137,24 +137,26 @@ export function appendPath(
 	path: string | undefined,
 	segment: string | number | undefined,
 ): string {
+	const base = path ?? '';
+
 	// 1) nothing to append
 	if (typeof segment === 'undefined') {
-		return path ?? '';
+		return base;
 	}
 
 	// 2) explicit empty-segment => empty bracket
 	if (segment === '') {
 		// even as first segment, "[]" is valid
-		return `${path}[]`;
+		return `${base}[]`;
 	}
 
 	// 3) numeric index => [n]
 	if (typeof segment === 'number') {
-		return `${path}[${segment}]`;
+		return `${base}[${segment}]`;
 	}
 
 	// 4) non-empty string => .prop (no leading dot if no base)
-	return path ? `${path}.${segment}` : segment;
+	return base ? `${base}.${segment}` : segment;
 }
 
 /**
@@ -717,7 +719,7 @@ export function isDirty(
 		if (options?.serialize) {
 			return options.serialize(value, {
 				name: context.name,
-				defaultSerialize: defaultSerialize,
+				defaultSerialize,
 			});
 		}
 

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -680,7 +680,7 @@ export function isDirty(
 		 *   - Returned as-is
 		 * - boolean:
 		 *   - true → 'on'
-		 *   - false → undefined
+		 *   - false → null
 		 * - number / bigint:
 		 *   - Converted to string using `.toString()`
 		 * - Date:
@@ -754,7 +754,7 @@ export function defaultSerialize(value: unknown): ReturnType<Serialize> {
 		}
 
 		if (typeof value === 'boolean') {
-			return value ? 'on' : '';
+			return value ? 'on' : null;
 		}
 
 		if (typeof value === 'number' || typeof value === 'bigint') {

--- a/packages/conform-dom/future/index.ts
+++ b/packages/conform-dom/future/index.ts
@@ -1,5 +1,6 @@
 export type {
 	Serialize,
+	CustomSerialize,
 	FieldName,
 	FormValue,
 	FormError,
@@ -20,7 +21,7 @@ export {
 	getPathValue,
 	setPathValue,
 	report,
-	serialize,
+	defaultSerialize,
 	getFieldValue,
 } from '../formdata';
 export { isPlainObject, deepEqual } from '../util';

--- a/packages/conform-dom/tests/formdata.test.ts
+++ b/packages/conform-dom/tests/formdata.test.ts
@@ -10,7 +10,7 @@ import {
 	parseSubmission,
 	report,
 	DEFAULT_INTENT_NAME,
-	serialize,
+	defaultSerialize,
 	getFieldValue,
 } from '../formdata';
 
@@ -1481,12 +1481,30 @@ describe('isDirty', () => {
 				defaultValue: {
 					datetime: new Date(0),
 				},
-				serialize(value, defaultSerialize) {
+				serialize(value, context) {
 					if (value instanceof Date && value.valueOf() === 0) {
 						return '';
 					}
 
-					return defaultSerialize(value);
+					return context.defaultSerialize(value, context);
+				},
+			}),
+		).toBe(false);
+		expect(
+			isDirty(createFormData([['json', '{"foo":"bar"}']]), {
+				defaultValue: {
+					json: {
+						foo: 'bar',
+					},
+				},
+				serialize(value, context) {
+					if (context.name === 'json') {
+						return typeof value === 'string' || value == null
+							? value
+							: JSON.stringify(value);
+					}
+
+					return context.defaultSerialize(value, context);
 				},
 			}),
 		).toBe(false);
@@ -1510,23 +1528,23 @@ test('serialize', () => {
 		type: 'image/svg+xml',
 	});
 
-	expect(serialize('test')).toBe('test');
-	expect(serialize(true)).toBe('on');
-	expect(serialize(false)).toBe('');
-	expect(serialize(123)).toBe('123');
-	expect(serialize(987654321n)).toBe('987654321');
-	expect(serialize(new Date(12345))).toBe(
+	expect(defaultSerialize('test')).toBe('test');
+	expect(defaultSerialize(true)).toBe('on');
+	expect(defaultSerialize(false)).toBe('');
+	expect(defaultSerialize(123)).toBe('123');
+	expect(defaultSerialize(987654321n)).toBe('987654321');
+	expect(defaultSerialize(new Date(12345))).toBe(
 		new Date(12345).toISOString().slice(0, -1),
 	);
-	expect(serialize(new Map())).toBeUndefined();
-	expect(serialize(new Set())).toBeUndefined();
-	expect(serialize(txtFile)).toBe(txtFile);
-	expect(serialize([txtFile, svgFile])).toEqual([txtFile, svgFile]);
-	expect(serialize(null)).toBe(null);
-	expect(serialize(undefined)).toBeUndefined();
-	expect(serialize({ a: 1, b: 2, c: 3 })).toBeUndefined();
-	expect(serialize(['foo', 'bar'])).toEqual(['foo', 'bar']);
-	expect(serialize([{ foo: 'bar' }])).toBeUndefined();
+	expect(defaultSerialize(new Map())).toBeUndefined();
+	expect(defaultSerialize(new Set())).toBeUndefined();
+	expect(defaultSerialize(txtFile)).toBe(txtFile);
+	expect(defaultSerialize([txtFile, svgFile])).toEqual([txtFile, svgFile]);
+	expect(defaultSerialize(null)).toBe(null);
+	expect(defaultSerialize(undefined)).toBeUndefined();
+	expect(defaultSerialize({ a: 1, b: 2, c: 3 })).toBeUndefined();
+	expect(defaultSerialize(['foo', 'bar'])).toEqual(['foo', 'bar']);
+	expect(defaultSerialize([{ foo: 'bar' }])).toBeUndefined();
 });
 
 describe('getFieldValue', () => {

--- a/packages/conform-dom/tests/formdata.test.ts
+++ b/packages/conform-dom/tests/formdata.test.ts
@@ -5,6 +5,7 @@ import {
 	getRelativePath,
 	parsePath,
 	formatPath,
+	appendPath,
 	isDirty,
 	isPathPrefix,
 	parseSubmission,
@@ -74,6 +75,24 @@ test('formatPath', () => {
 	expect(formatPath(['array', ''])).toEqual('array[]');
 	expect(formatPath(['a', 'b', 2, 'c', '', 'd'])).toEqual('a.b[2].c[].d');
 	expect(formatPath(['', '', ''])).toEqual('[][][]');
+});
+
+test('appendPath', () => {
+	expect(appendPath('', undefined)).toBe('');
+	expect(appendPath('tasks', undefined)).toBe('tasks');
+
+	expect(appendPath(undefined, undefined)).toBe('');
+	expect(appendPath('', '')).toBe('[]');
+	expect(appendPath(undefined, '')).toBe('[]');
+	expect(appendPath('tasks', '')).toBe('tasks[]');
+
+	expect(appendPath('', 0)).toBe('[0]');
+	expect(appendPath(undefined, 0)).toBe('[0]');
+	expect(appendPath('tasks', 0)).toBe('tasks[0]');
+
+	expect(appendPath('', 'foo')).toBe('foo');
+	expect(appendPath(undefined, 'foo')).toBe('foo');
+	expect(appendPath('tasks', 'content')).toBe('tasks.content');
 });
 
 test('isPathPrefix', () => {
@@ -1486,7 +1505,7 @@ describe('isDirty', () => {
 						return '';
 					}
 
-					return context.defaultSerialize(value, context);
+					return context.defaultSerialize(value);
 				},
 			}),
 		).toBe(false);
@@ -1504,7 +1523,7 @@ describe('isDirty', () => {
 							: JSON.stringify(value);
 					}
 
-					return context.defaultSerialize(value, context);
+					return context.defaultSerialize(value);
 				},
 			}),
 		).toBe(false);

--- a/packages/conform-dom/tests/formdata.test.ts
+++ b/packages/conform-dom/tests/formdata.test.ts
@@ -1530,7 +1530,7 @@ test('serialize', () => {
 
 	expect(defaultSerialize('test')).toBe('test');
 	expect(defaultSerialize(true)).toBe('on');
-	expect(defaultSerialize(false)).toBe('');
+	expect(defaultSerialize(false)).toBe(null);
 	expect(defaultSerialize(123)).toBe('123');
 	expect(defaultSerialize(987654321n)).toBe('987654321');
 	expect(defaultSerialize(new Date(12345))).toBe(

--- a/packages/conform-dom/types.ts
+++ b/packages/conform-dom/types.ts
@@ -146,7 +146,7 @@ export type CustomSerialize = (
 	value: unknown,
 	ctx: {
 		name: string | undefined;
-		defaultSerialize: Serialize;
+		defaultSerialize: (value: unknown) => ReturnType<Serialize>;
 	},
 ) => FormValue<FormDataEntryValue> | null | undefined;
 

--- a/packages/conform-dom/types.ts
+++ b/packages/conform-dom/types.ts
@@ -126,24 +126,29 @@ export type Serializable<T> = T extends File
 			: T;
 
 /**
- * Converts an arbitrary value into a {@link SerializedValue}.
+ * Converts an arbitrary value into a form value.
  *
  * This function is used to prepare field values for submission,
  * ensuring they are compatible with the browser's `FormData` API.
- *
- * @param value - The original value to serialize.
- * @returns A `SerializedValue` if the input can be represented in `FormData`,
- *          or `undefined` if it cannot be serialized.
  */
-export type Serialize = (value: unknown) => SerializedValue | null | undefined;
+export type Serialize = (
+	value: unknown,
+	ctx: {
+		name: string | undefined;
+	},
+) => FormValue<FormDataEntryValue> | null | undefined;
 
 /**
- * A value that can be serialized into `FormData`.
- *
- * - `string` and `File` are supported natively by `FormData`.
- * - Arrays allow representing multi-value fields.
+ * A custom serializer that can override specific values and delegate everything
+ * else back to the default serializer.
  */
-export type SerializedValue = string | string[] | File | File[];
+export type CustomSerialize = (
+	value: unknown,
+	ctx: {
+		name: string | undefined;
+		defaultSerialize: CustomSerialize;
+	},
+) => FormValue<FormDataEntryValue> | null | undefined;
 
 /**
  * Flatten a discriminated union into a single type with all properties.

--- a/packages/conform-dom/types.ts
+++ b/packages/conform-dom/types.ts
@@ -146,7 +146,7 @@ export type CustomSerialize = (
 	value: unknown,
 	ctx: {
 		name: string | undefined;
-		defaultSerialize: CustomSerialize;
+		defaultSerialize: Serialize;
 	},
 ) => FormValue<FormDataEntryValue> | null | undefined;
 

--- a/packages/conform-react/future/dom.ts
+++ b/packages/conform-react/future/dom.ts
@@ -242,7 +242,7 @@ export function updateFormValue(
 				continue;
 			}
 
-			const value = serialize(fieldValue);
+			const value = serialize(fieldValue, { name: element.name });
 
 			// Treat undefined as null to clear the field value
 			change(element, value !== undefined ? value : null, {
@@ -265,7 +265,7 @@ export function resetFormValue(
 			element.type !== 'file'
 		) {
 			const fieldValue = getPathValue(defaultValue, element.name);
-			const value = serialize(fieldValue);
+			const value = serialize(fieldValue, { name: element.name });
 
 			updateField(element, {
 				defaultValue: value !== undefined ? value : null,

--- a/packages/conform-react/future/forms.tsx
+++ b/packages/conform-react/future/forms.tsx
@@ -1,5 +1,5 @@
 import { isFieldElement, FieldName } from '@conform-to/dom';
-import { DEFAULT_INTENT_NAME, serialize } from '@conform-to/dom/future';
+import { DEFAULT_INTENT_NAME, defaultSerialize } from '@conform-to/dom/future';
 import { useContext, useMemo, useId, createContext } from 'react';
 import {
 	focusFirstInvalidField,
@@ -25,6 +25,7 @@ import {
 import {
 	isStandardSchemaV1,
 	resolveValidateResult,
+	resolveSerialize,
 	validateStandardSchemaV1,
 } from './util';
 
@@ -44,6 +45,11 @@ export function configureForms<
 	> = {},
 ) {
 	/**
+	 * Global serializer that composes the user-provided serializer with the default serializer.
+	 */
+	const globalSerialize = resolveSerialize(config.serialize, defaultSerialize);
+
+	/**
 	 * Global configuration with defaults applied
 	 */
 	const globalConfig: FormsConfig<
@@ -54,7 +60,7 @@ export function configureForms<
 	> = {
 		...config,
 		intentName: config.intentName ?? DEFAULT_INTENT_NAME,
-		serialize: config.serialize ?? serialize,
+		serialize: globalSerialize,
 		shouldValidate: config.shouldValidate ?? 'onSubmit',
 		shouldRevalidate:
 			config.shouldRevalidate ?? config.shouldValidate ?? 'onSubmit',
@@ -257,13 +263,17 @@ export function configureForms<
 			options.constraint ??
 			(schema ? globalConfig.getConstraints?.(schema) : undefined);
 		const optionsRef = useLatest(options);
+		const serialize = useMemo(
+			() => resolveSerialize(options.serialize, globalSerialize),
+			[options.serialize],
+		);
 		const fallbackId = useId();
 		const formId = options.id ?? `form-${fallbackId}`;
 		const [state, handleSubmit] = useConform<FormShape, ErrorShape, Value, any>(
 			formId,
 			{
 				...options,
-				serialize: globalConfig.serialize,
+				serialize,
 				intentName: globalConfig.intentName,
 				onError: options.onError ?? focusFirstInvalidField,
 				onValidate(ctx) {
@@ -335,6 +345,7 @@ export function configureForms<
 			() => ({
 				formId,
 				state,
+				serialize,
 				constraint: constraint ?? null,
 				handleSubmit,
 				handleInput(event) {
@@ -414,12 +425,11 @@ export function configureForms<
 					}
 				},
 			}),
-			[formId, state, constraint, handleSubmit, intent, optionsRef],
+			[formId, state, serialize, constraint, handleSubmit, intent, optionsRef],
 		);
 		const form = useMemo(
 			() =>
 				getFormMetadata(context, {
-					serialize: globalConfig.serialize,
 					extendFormMetadata: globalConfig.extendFormMetadata,
 					extendFieldMetadata: globalConfig.extendFieldMetadata,
 				}),
@@ -428,7 +438,6 @@ export function configureForms<
 		const fields = useMemo(
 			() =>
 				getFieldset(context, {
-					serialize: globalConfig.serialize,
 					extendFieldMetadata: globalConfig.extendFieldMetadata,
 				}),
 			[context],
@@ -468,7 +477,6 @@ export function configureForms<
 		const formMetadata = useMemo(
 			() =>
 				getFormMetadata(context, {
-					serialize: globalConfig.serialize,
 					extendFormMetadata: globalConfig.extendFormMetadata,
 					extendFieldMetadata: globalConfig.extendFieldMetadata,
 				}),
@@ -513,7 +521,6 @@ export function configureForms<
 			() =>
 				getField(context, {
 					name,
-					serialize: globalConfig.serialize,
 					extendFieldMetadata: globalConfig.extendFieldMetadata,
 				}),
 			[context, name],

--- a/packages/conform-react/future/forms.tsx
+++ b/packages/conform-react/future/forms.tsx
@@ -60,7 +60,6 @@ export function configureForms<
 	> = {
 		...config,
 		intentName: config.intentName ?? DEFAULT_INTENT_NAME,
-		serialize: globalSerialize,
 		shouldValidate: config.shouldValidate ?? 'onSubmit',
 		shouldRevalidate:
 			config.shouldRevalidate ?? config.shouldValidate ?? 'onSubmit',

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -14,7 +14,7 @@ import {
 	parseSubmission,
 	requestSubmit,
 	report,
-	serialize,
+	defaultSerialize,
 	isPlainObject,
 	isGlobalInstance,
 	dispatchInternalUpdateEvent,
@@ -34,6 +34,7 @@ import {
 } from 'react';
 import {
 	appendUniqueItem,
+	resolveSerialize,
 	resolveStandardSchemaResult,
 	resolveValidateResult,
 } from './util';
@@ -105,7 +106,7 @@ export const GlobalFormOptionsContext = createContext<
 >({
 	intentName: DEFAULT_INTENT_NAME,
 	observer: createGlobalFormsObserver(),
-	serialize,
+	serialize: defaultSerialize,
 	shouldValidate: 'onSubmit',
 });
 
@@ -730,6 +731,10 @@ export function useForm<
 	const globalOptions = useContext(GlobalFormOptionsContext);
 	const optionsRef = useLatest(options);
 	const globalOptionsRef = useLatest(globalOptions);
+	const serialize = useMemo(
+		() => resolveSerialize(options.serialize, globalOptions.serialize),
+		[options.serialize, globalOptions.serialize],
+	);
 	const fallbackId = useId();
 	const formId = id ?? `form-${fallbackId}`;
 	const [state, handleSubmit] = useConform<
@@ -739,7 +744,7 @@ export function useForm<
 		InferOutput<Schema>
 	>(formId, {
 		...options,
-		serialize: globalOptions.serialize,
+		serialize,
 		intentName: globalOptions.intentName,
 		onError: options.onError ?? focusFirstInvalidField,
 		onValidate(ctx) {
@@ -806,6 +811,7 @@ export function useForm<
 		() => ({
 			formId,
 			state,
+			serialize,
 			constraint: constraint ?? null,
 			handleSubmit,
 			handleInput(event) {
@@ -880,6 +886,7 @@ export function useForm<
 		[
 			formId,
 			state,
+			serialize,
 			constraint,
 			handleSubmit,
 			intent,
@@ -890,18 +897,16 @@ export function useForm<
 	const form = useMemo(
 		() =>
 			getFormMetadata(context, {
-				serialize: globalOptions.serialize,
 				extendFieldMetadata: globalOptions.defineCustomMetadata,
 			}),
-		[context, globalOptions.serialize, globalOptions.defineCustomMetadata],
+		[context, globalOptions.defineCustomMetadata],
 	);
 	const fields = useMemo(
 		() =>
 			getFieldset<FormShape, ErrorShape>(context, {
-				serialize: globalOptions.serialize,
 				extendFieldMetadata: globalOptions.defineCustomMetadata,
 			}),
-		[context, globalOptions.serialize, globalOptions.defineCustomMetadata],
+		[context, globalOptions.defineCustomMetadata],
 	);
 
 	return {
@@ -939,10 +944,9 @@ export function useFormMetadata(
 	const formMetadata = useMemo(
 		() =>
 			getFormMetadata(context, {
-				serialize: globalOptions.serialize,
 				extendFieldMetadata: globalOptions.defineCustomMetadata,
 			}),
-		[context, globalOptions.serialize, globalOptions.defineCustomMetadata],
+		[context, globalOptions.defineCustomMetadata],
 	);
 
 	return formMetadata;
@@ -980,15 +984,9 @@ export function useField<FieldShape = any>(
 		() =>
 			getField(context, {
 				name,
-				serialize: globalOptions.serialize,
 				extendFieldMetadata: globalOptions.defineCustomMetadata,
 			}),
-		[
-			context,
-			name,
-			globalOptions.serialize,
-			globalOptions.defineCustomMetadata,
-		],
+		[context, name, globalOptions.defineCustomMetadata],
 	);
 
 	return field;
@@ -1581,7 +1579,7 @@ export const BaseControl = forwardRef<
 	BaseControlProps
 >(function BaseControl(props, ref) {
 	function formatValue(value: unknown): string {
-		const serialized = serialize(value);
+		const serialized = defaultSerialize(value);
 
 		if (typeof serialized === 'string') {
 			return serialized;

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -7,7 +7,6 @@ import {
 	getRelativePath,
 	getPathValue,
 	normalize,
-	serialize as defaultSerialize,
 	deepEqual,
 	FormError,
 } from '@conform-to/dom/future';
@@ -164,7 +163,6 @@ export function pruneListKeys(
 export function getDefaultPayload(
 	context: FormContext<any>,
 	name: string,
-	serialize: Serialize = defaultSerialize,
 ): unknown {
 	const value = getPathValue(
 		context.state.serverValue ??
@@ -173,13 +171,12 @@ export function getDefaultPayload(
 		name,
 	);
 
-	return normalize(value, serialize);
+	return normalize(value, context.serialize, name);
 }
 
 export function getDefaultValue(
 	context: FormContext<any>,
 	name: string,
-	serialize: Serialize = defaultSerialize,
 ): string {
 	const value = getPathValue(
 		context.state.serverValue ??
@@ -187,7 +184,9 @@ export function getDefaultValue(
 			context.state.defaultValue,
 		name,
 	);
-	const serializedValue = serialize(value);
+	const serializedValue = context.serialize(value, {
+		name,
+	});
 
 	if (typeof serializedValue === 'string') {
 		return serializedValue;
@@ -199,7 +198,6 @@ export function getDefaultValue(
 export function getDefaultOptions(
 	context: FormContext<any>,
 	name: string,
-	serialize: Serialize = defaultSerialize,
 ): string[] {
 	const value = getPathValue(
 		context.state.serverValue ??
@@ -207,7 +205,7 @@ export function getDefaultOptions(
 			context.state.defaultValue,
 		name,
 	);
-	const serializedValue = serialize(value);
+	const serializedValue = context.serialize(value, { name });
 
 	if (
 		Array.isArray(serializedValue) &&
@@ -226,7 +224,6 @@ export function getDefaultOptions(
 export function isDefaultChecked(
 	context: FormContext<any>,
 	name: string,
-	serialize: Serialize = defaultSerialize,
 ): boolean {
 	const value = getPathValue(
 		context.state.serverValue ??
@@ -234,10 +231,10 @@ export function isDefaultChecked(
 			context.state.defaultValue,
 		name,
 	);
-	const serializedValue = serialize(value);
+	const serializedValue = context.serialize(value, { name });
 
 	if (typeof serializedValue === 'string') {
-		return serializedValue === serialize(true);
+		return serializedValue === context.serialize(true, { name });
 	}
 
 	return false;
@@ -486,7 +483,7 @@ export function getField<
 	const {
 		key,
 		name,
-		serialize = defaultSerialize,
+		serialize,
 		extendFieldMetadata,
 		form = getFormMetadata(context, {
 			serialize,
@@ -512,16 +509,16 @@ export function getField<
 		multiple: constraint?.multiple,
 		accept: constraint?.accept,
 		get defaultValue() {
-			return getDefaultValue(context, name, serialize);
+			return getDefaultValue(context, name);
 		},
 		get defaultOptions() {
-			return getDefaultOptions(context, name, serialize);
+			return getDefaultOptions(context, name);
 		},
 		get defaultChecked() {
-			return isDefaultChecked(context, name, serialize);
+			return isDefaultChecked(context, name);
 		},
 		get defaultPayload() {
-			return getDefaultPayload(context, name, serialize);
+			return getDefaultPayload(context, name);
 		},
 		get touched() {
 			return isTouched(context.state, name);

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -1,6 +1,5 @@
 import {
 	type FieldName,
-	type Serialize,
 	appendPath,
 	formatPath,
 	parsePath,
@@ -170,6 +169,10 @@ export function getDefaultPayload(
 			context.state.defaultValue,
 		name,
 	);
+
+	if (value === null) {
+		return null;
+	}
 
 	return normalize(value, context.serialize, name);
 }
@@ -379,7 +382,6 @@ export function getFormMetadata<
 >(
 	context: FormContext<ErrorShape>,
 	options?: {
-		serialize?: Serialize | undefined;
 		extendFormMetadata?:
 			| ((metadata: BaseFormMetadata<ErrorShape>) => CustomFormMetadata)
 			| undefined;
@@ -426,21 +428,18 @@ export function getFormMetadata<
 		getField(name) {
 			return getField(context, {
 				name,
-				serialize: options?.serialize,
 				extendFieldMetadata: options?.extendFieldMetadata,
 			});
 		},
 		getFieldset(name) {
 			return getFieldset(context, {
 				name,
-				serialize: options?.serialize,
 				extendFieldMetadata: options?.extendFieldMetadata,
 			});
 		},
 		getFieldList(name) {
 			return getFieldList(context, {
 				name,
-				serialize: options?.serialize,
 				extendFieldMetadata: options?.extendFieldMetadata,
 			});
 		},
@@ -466,7 +465,6 @@ export function getField<
 	context: FormContext<ErrorShape>,
 	options: {
 		name: FieldName<FieldShape>;
-		serialize?: Serialize | undefined;
 		extendFieldMetadata?:
 			| (<F>(
 					metadata: BaseFieldMetadata<F, ErrorShape>,
@@ -483,10 +481,8 @@ export function getField<
 	const {
 		key,
 		name,
-		serialize,
 		extendFieldMetadata,
 		form = getFormMetadata(context, {
-			serialize,
 			extendFieldMetadata,
 		}),
 	} = options;
@@ -544,7 +540,6 @@ export function getField<
 		getFieldset() {
 			return getFieldset(context, {
 				name: name as string,
-				serialize,
 				extendFieldMetadata,
 			});
 		},
@@ -553,7 +548,6 @@ export function getField<
 		getFieldList() {
 			return getFieldList(context, {
 				name,
-				serialize,
 				extendFieldMetadata,
 			});
 		},
@@ -578,7 +572,6 @@ export function getFieldset<
 	context: FormContext<ErrorShape>,
 	options: {
 		name?: FieldName<FieldShape> | undefined;
-		serialize?: Serialize | undefined;
 		extendFieldMetadata?:
 			| (<F>(
 					metadata: BaseFieldMetadata<F, ErrorShape>,
@@ -595,13 +588,11 @@ export function getFieldset<
 		get(target, name, receiver) {
 			if (typeof name === 'string') {
 				options.form ??= getFormMetadata(context, {
-					serialize: options?.serialize,
 					extendFieldMetadata: options?.extendFieldMetadata,
 				});
 
 				return getField(context, {
 					name: appendPath(options?.name, name),
-					serialize: options.serialize,
 					extendFieldMetadata: options.extendFieldMetadata,
 					form: options.form,
 				});
@@ -623,7 +614,6 @@ export function getFieldList<
 	context: FormContext<ErrorShape>,
 	options: {
 		name: FieldName<FieldShape>;
-		serialize?: Serialize | undefined;
 		extendFieldMetadata?:
 			| (<F>(
 					metadata: BaseFieldMetadata<F, ErrorShape>,
@@ -652,7 +642,6 @@ export function getFieldList<
 			CustomFieldMetadata
 		>(context, {
 			name: appendPath(options.name, index),
-			serialize: options.serialize,
 			extendFieldMetadata: options.extendFieldMetadata,
 			key,
 		});

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -152,7 +152,7 @@ export type CustomControlOptions<Value = unknown, DefaultValue = Value> = {
 	 * Use this to coerce unknown DOM-derived data into a typed shape.
 	 * Any thrown error is surfaced to the caller.
 	 */
-	parse: (payload: unknown) => Value | null | undefined;
+	parse: (payload: unknown) => Value | null;
 	/**
 	 * Optional serializer to convert the parsed payload back to a form value for populating the base control(s).
 	 */

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -1,4 +1,5 @@
 import type {
+	CustomSerialize,
 	FieldName,
 	FormError,
 	FormValue,
@@ -343,9 +344,9 @@ export type FormsConfig<
 	 */
 	intentName: string;
 	/**
-	 * A custom serialization function for converting form data.
+	 * A custom serializer for converting form values.
 	 */
-	serialize: Serialize;
+	serialize: CustomSerialize;
 	/**
 	 * Determines when validation should run for the first time on a field.
 	 * @default "onSubmit"
@@ -425,7 +426,7 @@ export type GlobalFormOptions = {
 	 */
 	intentName: string;
 	/**
-	 * A custom serialization function for converting form data.
+	 * A field-aware serializer for converting form data.
 	 */
 	serialize: Serialize;
 	/**
@@ -501,6 +502,11 @@ export type BaseFormOptions<
 		| undefined;
 	/** Initial form values. Can be a partial object matching your form structure. */
 	defaultValue?: DefaultValue<FormShape> | undefined;
+	/**
+	 * Override serialization for specific fields on this form and delegate the rest
+	 * to the configured global serializer.
+	 */
+	serialize?: CustomSerialize | undefined;
 	/** HTML validation attributes for fields (required, minLength, pattern, etc.). */
 	constraint?: Record<string, ValidationAttributes> | undefined;
 	/**
@@ -559,6 +565,8 @@ export interface FormContext<
 	formId: string;
 	/** Internal form state with validation results and field data */
 	state: FormState<ErrorShape>;
+	/** Serializer used to derive field defaults and sync values for this form. */
+	serialize: Serialize;
 	/** HTML validation attributes for fields */
 	constraint: Record<string, ValidationAttributes> | null;
 	/** Form submission event handler */

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -346,7 +346,7 @@ export type FormsConfig<
 	/**
 	 * A custom serializer for converting form values.
 	 */
-	serialize: CustomSerialize;
+	serialize?: CustomSerialize | undefined;
 	/**
 	 * Determines when validation should run for the first time on a field.
 	 * @default "onSubmit"

--- a/packages/conform-react/future/util.ts
+++ b/packages/conform-react/future/util.ts
@@ -1,4 +1,8 @@
-import type { FormError } from '@conform-to/dom/future';
+import type {
+	CustomSerialize,
+	FormError,
+	Serialize,
+} from '@conform-to/dom/future';
 import {
 	formatIssues,
 	formatPath,
@@ -132,6 +136,22 @@ export function normalizeFormError<ErrorShape>(
 	}
 
 	return error;
+}
+
+export function resolveSerialize(
+	customSerialize: CustomSerialize | undefined,
+	defaultSerialize: Serialize,
+): Serialize {
+	if (typeof customSerialize === 'undefined') {
+		return defaultSerialize;
+	}
+
+	return function serializeValue(value, context) {
+		return customSerialize(value, {
+			name: context.name,
+			defaultSerialize,
+		});
+	};
 }
 
 export function normalizeValidateResult<ErrorShape, Value>(

--- a/packages/conform-react/future/util.ts
+++ b/packages/conform-react/future/util.ts
@@ -149,7 +149,7 @@ export function resolveSerialize(
 	return function serializeValue(value, context) {
 		return customSerialize(value, {
 			name: context.name,
-			defaultSerialize,
+			defaultSerialize: (value) => defaultSerialize(value, context),
 		});
 	};
 }

--- a/packages/conform-react/tests/state.test.ts
+++ b/packages/conform-react/tests/state.test.ts
@@ -7,7 +7,7 @@ import {
 	afterAll,
 	beforeEach,
 } from 'vitest';
-import { DEFAULT_INTENT_NAME } from '@conform-to/dom/future';
+import { DEFAULT_INTENT_NAME, defaultSerialize } from '@conform-to/dom/future';
 import {
 	getDefaultPayload,
 	getDefaultOptions,
@@ -33,6 +33,7 @@ function createContext(
 ): FormContext<any> {
 	return {
 		formId: 'test-id',
+		serialize: defaultSerialize,
 		constraint: null,
 		state: initializeState(),
 		handleSubmit: vi.fn(),
@@ -1369,6 +1370,33 @@ test('isDefaultChecked', () => {
 
 	// Test with undefined/missing values
 	expect(isDefaultChecked(createContext(), 'missing')).toBe(false);
+});
+
+test('default field serialization receives the field name', () => {
+	const serialize = vi.fn((value, ctx: { name: string | undefined }) => {
+		if (ctx.name === 'json') {
+			return JSON.stringify(value);
+		}
+
+		return value == null ? value : String(value);
+	});
+	const context = createContext({
+		state: initializeState({
+			defaultValue: {
+				json: {
+					foo: 'bar',
+				},
+			},
+		}),
+		serialize,
+	});
+
+	expect(getDefaultValue(context, 'json')).toBe('{"foo":"bar"}');
+	expect(getDefaultPayload(context, 'json')).toBe('{"foo":"bar"}');
+	expect(serialize).toHaveBeenCalledWith(
+		{ foo: 'bar' },
+		expect.objectContaining({ name: 'json' }),
+	);
 });
 
 test('getDefaultListKey', () => {

--- a/packages/conform-react/tests/state.test.ts
+++ b/packages/conform-react/tests/state.test.ts
@@ -1238,6 +1238,29 @@ describe('form state', () => {
 		expect(getDefaultOptions(context, 'tasks')).toEqual(['Final 1']);
 		expect(getDefaultPayload(context, 'tasks')).toBe('Final 1');
 		expect(isTouched(context.state)).toBe(true);
+
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'server',
+				entries: [
+					['title', 'My Tasks'],
+					['tasks[0]', 'Updated 1'],
+					['tasks[1]', 'Updated 2'],
+					['tasks[2]', 'Updated 3'],
+					['tasks[3]', 'Updated 4'],
+				],
+				targetValue: {
+					title: 'My Tasks',
+					tasks: null,
+				},
+			}),
+		);
+
+		expect(getListKey(context, 'tasks')).toEqual([]);
+		expect(getDefaultOptions(context, 'tasks')).toEqual([]);
+		expect(getDefaultPayload(context, 'tasks')).toBe(null);
+		expect(isTouched(context.state)).toBe(true);
 	});
 
 	test('server reset with list', () => {
@@ -1399,6 +1422,33 @@ test('default field serialization receives the field name', () => {
 	);
 });
 
+test('field metadata serialize override updates default values', () => {
+	const context = createContext({
+		state: initializeState({
+			defaultValue: {
+				metadata: {
+					foo: 'bar',
+				},
+			},
+		}),
+		serialize(value, ctx) {
+			if (ctx.name === 'metadata') {
+				return typeof value === 'string' || value == null
+					? value
+					: JSON.stringify(value);
+			}
+
+			return defaultSerialize(value);
+		},
+	});
+	const field = getField(context, {
+		name: 'metadata',
+	});
+
+	expect(field.defaultValue).toBe('{"foo":"bar"}');
+	expect(field.defaultPayload).toBe('{"foo":"bar"}');
+});
+
 test('getDefaultListKey', () => {
 	const prefix = 'test-prefix';
 	const initialValue = {
@@ -1433,6 +1483,7 @@ test('getFormMetadata', () => {
 		state: initializeState({
 			defaultValue: { username: 'test' },
 		}),
+		serialize: (value) => value?.toString(),
 	});
 
 	// Add some touched fields and errors
@@ -1454,9 +1505,7 @@ test('getFormMetadata', () => {
 		}),
 	);
 
-	let metadata = getFormMetadata(context, {
-		serialize: (value) => value?.toString(),
-	});
+	let metadata = getFormMetadata(context);
 
 	// Test basic properties
 	expect(metadata.id).toBe('test-id');
@@ -1496,9 +1545,7 @@ test('getFormMetadata', () => {
 		}),
 	);
 
-	metadata = getFormMetadata(context, {
-		serialize: (value) => value?.toString(),
-	});
+	metadata = getFormMetadata(context);
 
 	expect(metadata.errors).toEqual(['Something went wrong']);
 	expect(metadata.valid).toBe(false);
@@ -1516,9 +1563,7 @@ test('getFormMetadata', () => {
 			error: null,
 		}),
 	);
-	metadata = getFormMetadata(context, {
-		serialize: (value) => value?.toString(),
-	});
+	metadata = getFormMetadata(context);
 
 	expect(metadata.errors).toBe(undefined);
 	expect(metadata.valid).toBe(true);
@@ -1667,11 +1712,11 @@ test('getFieldset', () => {
 				},
 			},
 		}),
+		serialize: (value) => String(value),
 	});
 
 	const fieldset = getFieldset(context, {
 		name: 'profile',
-		serialize: (value) => String(value),
 	});
 
 	// Test dynamic property access via Proxy
@@ -1692,9 +1737,7 @@ test('getFieldset', () => {
 	expect(deepField.defaultValue).toBe('deep');
 
 	// Test root fieldset (no name)
-	const rootFieldset = getFieldset(context, {
-		serialize: (value) => String(value),
-	});
+	const rootFieldset = getFieldset(context, {});
 	const profileField = rootFieldset.profile!;
 	expect(profileField.name).toBe('profile');
 });
@@ -1710,6 +1753,7 @@ test('getFieldList', () => {
 				],
 			},
 		}),
+		serialize: (value) => String(value),
 	});
 
 	// Mock list keys
@@ -1721,7 +1765,6 @@ test('getFieldList', () => {
 	// Test simple array
 	const tagFields = getFieldList(context, {
 		name: 'tags',
-		serialize: (value) => String(value),
 	});
 
 	expect(tagFields).toHaveLength(3);
@@ -1735,7 +1778,6 @@ test('getFieldList', () => {
 	// Test object array
 	const userFields = getFieldList(context, {
 		name: 'users',
-		serialize: (value) => String(value),
 	});
 
 	expect(userFields).toHaveLength(2);

--- a/packages/conform-react/tests/useControl.browser.test.tsx
+++ b/packages/conform-react/tests/useControl.browser.test.tsx
@@ -912,7 +912,7 @@ describe('future export: useControl', () => {
 							: JSON.stringify(value);
 					}
 
-					return context.defaultSerialize(value, context);
+					return context.defaultSerialize(value);
 				},
 				onValidate({ error }) {
 					return error;

--- a/packages/conform-react/tests/useControl.browser.test.tsx
+++ b/packages/conform-react/tests/useControl.browser.test.tsx
@@ -18,49 +18,6 @@ describe('future export: useControl', () => {
 		);
 	}
 
-	function ConformForm(props: {
-		id?: string;
-		updateButton?: {
-			action: string;
-			name?: string;
-			value: unknown;
-		};
-		formKey?: string;
-		children: React.ReactNode;
-	}) {
-		const { form, intent } = useForm({
-			id: props.id,
-			key: props.formKey,
-			onValidate({ error }) {
-				return error;
-			},
-			onSubmit(event) {
-				event.preventDefault();
-			},
-		});
-
-		return (
-			<form {...form.props}>
-				{props.children}
-				<button type="submit">Submit</button>
-				<button
-					type="button"
-					onClick={() =>
-						intent.update({
-							name: props.updateButton?.name,
-							value: props.updateButton?.value ?? null,
-						})
-					}
-				>
-					{props.updateButton?.action ?? 'Clear'}
-				</button>
-				<button type="button" onClick={() => intent.reset()}>
-					Reset
-				</button>
-			</form>
-		);
-	}
-
 	function Input(props: {
 		name?: string;
 		type?: string;
@@ -75,10 +32,10 @@ describe('future export: useControl', () => {
 		options?: string[];
 		multiple?: boolean;
 	}) {
-		const baseName = `${props.name}-base`;
-		const baseId = `${baseName}-${props.value}`;
+		const name = `${props.name}-base`;
+		const baseId = `${props.name}-base-${props.value}`;
 		const controlName = `${props.name}-control`;
-		const controlId = `${controlName}-${props.value}`;
+		const controlId = `${props.name}-control-${props.value}`;
 		// @ts-expect-error - We know what we're doing with the control type here
 		const control = useControl({
 			defaultValue: props.defaultValue,
@@ -101,7 +58,7 @@ describe('future export: useControl', () => {
 				{props.type === 'textarea' ? (
 					<textarea
 						id={baseId}
-						name={baseName}
+						name={name}
 						ref={control.register}
 						defaultValue={props.defaultValue}
 						onChange={(event) => props.onChange?.(event.target.value)}
@@ -111,7 +68,7 @@ describe('future export: useControl', () => {
 				) : props.type === 'select' ? (
 					<select
 						id={baseId}
-						name={baseName}
+						name={name}
 						ref={control.register}
 						defaultValue={props.defaultValue}
 						onChange={(event) => {
@@ -135,7 +92,7 @@ describe('future export: useControl', () => {
 					<input
 						id={baseId}
 						type={props.type}
-						name={baseName}
+						name={name}
 						ref={control.register}
 						defaultValue={props.defaultValue}
 						defaultChecked={props.defaultChecked}
@@ -175,7 +132,6 @@ describe('future export: useControl', () => {
 				) : props.type === 'textarea' ? (
 					<textarea
 						id={controlId}
-						name={controlName}
 						value={control.value ?? props.defaultValue}
 						onChange={(event) => control.change(event.target.value)}
 						onBlur={control.blur}
@@ -184,7 +140,6 @@ describe('future export: useControl', () => {
 				) : props.type === 'select' ? (
 					<select
 						id={controlId}
-						name={controlName}
 						value={props.multiple ? control.options ?? [] : control.value ?? ''}
 						onChange={(event) =>
 							control.change(
@@ -209,7 +164,6 @@ describe('future export: useControl', () => {
 				) : (
 					<input
 						id={controlId}
-						name={controlName}
 						type={props.type}
 						value={control.value ?? props.defaultValue}
 						onChange={(event) =>
@@ -233,9 +187,10 @@ describe('future export: useControl', () => {
 		);
 	}
 
-	function Fieldset<Payload>(props: {
+	function CustomControl<Payload>(props: {
 		label?: string;
 		name: string;
+		type?: 'fieldset' | undefined;
 		defaultValue: unknown;
 		parse: (payload: unknown) => Payload;
 		serialize?: (value: Payload) => FormValue;
@@ -249,12 +204,20 @@ describe('future export: useControl', () => {
 
 		return (
 			<>
-				<BaseControl
-					type="fieldset"
-					name={props.name}
-					ref={control.register}
-					defaultValue={control.defaultValue}
-				/>
+				{props.type === 'fieldset' ? (
+					<BaseControl
+						type={props.type}
+						name={props.name}
+						ref={control.register}
+						defaultValue={control.defaultValue}
+					/>
+				) : (
+					<BaseControl
+						name={props.name}
+						ref={control.register}
+						defaultValue={`${control.defaultValue ?? ''}`}
+					/>
+				)}
 				<button
 					type="button"
 					onClick={() => control.change(props.changeButtonValue ?? null)}
@@ -934,10 +897,105 @@ describe('future export: useControl', () => {
 		await expect.element(controlInput).toHaveValue('hello world');
 	});
 
+	it('supports JSON-backed standard controls with form serialization', async () => {
+		function JsonForm() {
+			const { form, fields, intent } = useForm({
+				defaultValue: {
+					json: {
+						foo: 'bar',
+					},
+				},
+				serialize(value, context) {
+					if (context.name === 'json') {
+						return typeof value === 'string' || value == null
+							? value
+							: JSON.stringify(value);
+					}
+
+					return context.defaultSerialize(value, context);
+				},
+				onValidate({ error }) {
+					return error;
+				},
+				onSubmit(event) {
+					event.preventDefault();
+				},
+			});
+
+			return (
+				<form {...form.props}>
+					<CustomControl
+						name={fields.json.name}
+						label="JSON payload"
+						defaultValue={fields.json.defaultValue}
+						parse={(payload) => {
+							if (typeof payload !== 'string') {
+								return null;
+							}
+
+							try {
+								return JSON.parse(payload) as { foo: string };
+							} catch {
+								return null;
+							}
+						}}
+						serialize={(value) => JSON.stringify(value)}
+						changeButtonValue={{ foo: 'baz' }}
+					/>
+					<button
+						type="button"
+						onClick={() =>
+							intent.update({
+								name: fields.json.name,
+								value: { foo: 'qux' },
+							})
+						}
+					>
+						Update
+					</button>
+					<button type="button" onClick={() => intent.reset()}>
+						Reset
+					</button>
+				</form>
+			);
+		}
+
+		const screen = render(<JsonForm />);
+		const formElement = screen.container.querySelector('form');
+		const payload = screen.getByLabelText('JSON payload');
+
+		await expect.element(payload).toHaveTextContent('{"foo":"bar"}');
+		await expect.element(formElement).toHaveFormValues({
+			json: '{"foo":"bar"}',
+		});
+
+		await userEvent.click(screen.getByText('Change'));
+
+		await expect.element(payload).toHaveTextContent('{"foo":"baz"}');
+		await expect.element(formElement).toHaveFormValues({
+			json: '{"foo":"baz"}',
+		});
+
+		await userEvent.click(screen.getByText('Update'));
+
+		await expect.element(payload).toHaveTextContent('{"foo":"qux"}');
+		await expect.element(formElement).toHaveFormValues({
+			json: '{"foo":"qux"}',
+		});
+
+		await userEvent.click(screen.getByText('Reset'));
+
+		await expect.element(payload).toHaveTextContent('{"foo":"bar"}');
+		await expect.element(formElement).toHaveFormValues({
+			json: '{"foo":"bar"}',
+		});
+	});
+
 	it('supports emulating a fieldset', async () => {
 		const screen = render(
 			<Form>
-				<Fieldset
+				<CustomControl
+					type="fieldset"
 					name="nested.list"
 					label="List value"
 					defaultValue={[{ key: '', value: '' }]}
@@ -1012,45 +1070,84 @@ describe('future export: useControl', () => {
 			}
 		}
 
-		const fieldset = (
-			<Fieldset
-				name="address"
-				label="Address value"
-				defaultValue={{ street: '', city: '' }}
-				parse={(value) => {
-					if (
-						typeof value !== 'object' ||
-						value === null ||
-						!('street' in value) ||
-						!('city' in value) ||
-						typeof value.street !== 'string' ||
-						typeof value.city !== 'string'
-					) {
-						throw new Error('Invalid payload');
-					}
+		function AddressForm(props: {
+			id?: string;
+			updateButton?: {
+				action: string;
+				name?: string;
+				value: unknown;
+			};
+			formKey?: string;
+		}) {
+			const { form, intent } = useForm({
+				id: props.id,
+				key: props.formKey,
+				onValidate({ error }) {
+					return error;
+				},
+				onSubmit(event) {
+					event.preventDefault();
+				},
+			});
 
-					return new Address(value.street, value.city);
-				}}
-				serialize={(value: Address) => {
-					const address = value.toString();
-					const [street = '', city = ''] = address.split(', ');
+			return (
+				<form {...form.props}>
+					<input type="text" name="others" />
+					<CustomControl
+						type="fieldset"
+						name="address"
+						label="Address value"
+						defaultValue={{ street: '', city: '' }}
+						parse={(value) => {
+							if (
+								typeof value !== 'object' ||
+								value === null ||
+								!('street' in value) ||
+								!('city' in value) ||
+								typeof value.street !== 'string' ||
+								typeof value.city !== 'string'
+							) {
+								throw new Error('Invalid payload');
+							}
 
-					return { street, city };
-				}}
-				changeButtonValue={new Address('123 Main St', 'Anytown')}
-			/>
-		);
+							return new Address(value.street, value.city);
+						}}
+						serialize={(value: Address) => {
+							const address = value.toString();
+							const [street = '', city = ''] = address.split(', ');
+
+							return { street, city };
+						}}
+						changeButtonValue={new Address('123 Main St', 'Anytown')}
+					/>
+					<button type="submit">Submit</button>
+					<button
+						type="button"
+						onClick={() =>
+							intent.update({
+								name: props.updateButton?.name,
+								value: props.updateButton?.value ?? null,
+							})
+						}
+					>
+						{props.updateButton?.action ?? 'Clear'}
+					</button>
+					<button type="button" onClick={() => intent.reset()}>
+						Reset
+					</button>
+				</form>
+			);
+		}
+
 		const screen = render(
-			<ConformForm
+			<AddressForm
 				formKey="foo"
 				updateButton={{
 					action: 'Use default address',
 					name: 'address',
 					value: { street: '456 Elm St', city: 'Othertown' },
 				}}
-			>
-				{fieldset}
-			</ConformForm>,
+			/>,
 		);
 		const formElement = screen.container.querySelector('form');
 		const addressValue = screen.getByLabelText('Address value');
@@ -1101,17 +1198,14 @@ describe('future export: useControl', () => {
 		});
 
 		screen.rerender(
-			<ConformForm
+			<AddressForm
 				formKey="bar"
 				updateButton={{
 					action: 'Update others',
 					name: 'others',
 					value: 'some value',
 				}}
-			>
-				<input type="text" name="others" />
-				{fieldset}
-			</ConformForm>,
+			/>,
 		);
 
 		const updateOthersButton = screen.getByText('Update others');


### PR DESCRIPTION
The `serialize` options now let you customize serialization based on `ctx.name`, both globally through `configureForms()` and per form through `useForm()`, while delegating everything else back to Conform's default serializer with `ctx.defaultSerialize`.

This changes the serializer callback signature to:

```ts
serialize(value, ctx) {
  // Custom serialization for a specific field name
  if (ctx.name === 'metadata') {
    return typeof value === 'string' || value == null
      ? value
      : JSON.stringify(value);
  }
  return ctx.defaultSerialize(value);
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

## Implementation Details

The serializer API is now field-aware: serialize(value, ctx) => FormValue | null | undefined where ctx exposes ctx.name and ctx.defaultSerialize(value). This enables field-specific serialization and delegation to Conform’s default serializer.

### Key changes
- Types: removed SerializedValue; added CustomSerialize (receives ctx.name and ctx.defaultSerialize). Serialize signature updated to accept ctx.
- Built-in serializer renamed to defaultSerialize and re-exported as such.
- Boolean handling: serializing false now maps to null.
- resolveSerialize(customSerialize, defaultSerialize) added to wrap custom serializers and wire ctx.defaultSerialize.
- normalize and recursive normalization now accept and propagate a name/path so serializers receive field path context.
- Per-form serializer resolution: configureForms() supplies a global default; useForm() resolves a per-form serialize and exposes it on the form context. Helpers like isDirty should be passed form.context.serialize to match form behavior.

### Docs & Tests
- Documentation updated across configureForms, useForm, isDirty, and useControl to document ctx.name and ctx.defaultSerialize and the new serialize signature.
- Tests updated to use defaultSerialize and cover name-aware serialization (e.g., json/wysiwyg fields), intent.update behavior, and defaultValue/defaultPayload computations.

### Usage example
```js
useForm({
  serialize(value, ctx) {
    if (ctx.name === 'wysiwyg') {
      return typeof value === 'string' || value == null ? value : JSON.stringify(value);
    }
    return ctx.defaultSerialize(value);
  }
})
```

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->