### PR TITLE
feat: improve ErrorShape handling in future APIs

### DIFF
--- a/.changeset/direct-error-payloads.md
+++ b/.changeset/direct-error-payloads.md
@@ -1,0 +1,50 @@
+---
+'@conform-to/dom': minor
+'@conform-to/react': minor
+'@conform-to/zod': minor
+'@conform-to/valibot': minor
+---
+
+feat: improve ErrorShape handling in future APIs
+
+Previously, `form.errors` and `field.errors` were always arrays, even when you provided a custom `ErrorShape`. The future APIs now use `ErrorShape` as the final error shape directly, so custom validation can return a string or object without Conform wrapping it in another array.
+
+You may need to update existing code in a few places:
+
+If you were using a custom `ErrorShape`, either by specifying it in the generics or through the `isError` option from `configureForms`, update it from `ErrorShape` to `ErrorShape[]` to keep the array structure you had before. For example, if you previously used `string`, change it to `string[]` to keep the errors as arrays of strings:
+
+```diff
+const forms = configureForms({
+-  isError: shape<string>(),
++  isError: shape<string[]>(),
+});
+```
+
+`report()` now accepts either schema `issues` or an explicit error payload, but not both in the same `error` object. If you were using both to add more messages on top of schema validation, append another issue instead.
+
+```diff
+const result = schema.safeParse(submission.payload);
+const isEmailUnique = await checkEmailUnique(submission.payload.email);
+
+if (!result.success || !isEmailUnique) {
+  const issues = !result.success ? [...result.error.issues] : [];
+
++ if (!isEmailUnique) {
++   issues.push({
++     message: 'Email is already taken',
++     path: ['email'],
++   });
++ }
+
+  return {
+    result: report(submission, {
+      error: {
+        issues,
+-       fieldErrors: {
+-         email: !isEmailUnique ? ['Email is already taken'] : [],
+-       },
+      },
+    }),
+  };
+}
+```

--- a/docs/api/react/future/configureForms.md
+++ b/docs/api/react/future/configureForms.md
@@ -62,7 +62,7 @@ Type guard that defines your custom error shape for TypeScript inference. Use th
 import { configureForms, shape } from '@conform-to/react/future';
 
 const { useForm } = configureForms({
-  isError: shape<string>(),
+  isError: shape<string[]>(),
 });
 ```
 

--- a/docs/api/react/future/report.md
+++ b/docs/api/react/future/report.md
@@ -16,15 +16,14 @@ const result = report(submission, options);
 
 The form submission object created by [`parseSubmission(formData)`](./parseSubmission.md). Contains parsed form data with structured payload, field names, and submission intent.
 
-### `options.error?: { issues?: StandardSchemaV1.Issue[]; formErrors?: ErrorShape[]; fieldErrors?: Record<string, ErrorShape[]> } | null`
+### `options.error?: { issues: StandardSchemaV1.Issue[] } | { formErrors?: ErrorShape | null; fieldErrors?: Record<string, ErrorShape | null> } | null`
 
-Error information to include in the result. Can contain:
+Error information to include in the result. Choose one of these shapes:
 
-- `issues?: StandardSchemaV1.Issue[]` - Standard schema issues that will be automatically formatted. Zod and Valibot issues are also compatible.
-- `formErrors?: ErrorShape[]` - Form-level error messages
-- `fieldErrors?: Record<string, ErrorShape[]>` - Field-specific error messages mapped by field name
+- `{ issues: StandardSchemaV1.Issue[] }`: Standard schema issues that will be automatically formatted. Compatible with Zod and Valibot issues.
+- `{ formErrors?: ErrorShape | null; fieldErrors?: Record<string, ErrorShape | null> }`: Explicit form-level and field-level error payloads.
 
-Set to `null` to indicate validation passed with no errors. When both `issues` and `formErrors` / `fieldErrors` are provided, they will be merged together, with `issues` being formatted first.
+Set to `null` to indicate validation passed with no errors. If you need schema issues and additional errors together, append additional issue before calling `report()`, or construct an explicit error payload yourself.
 
 ### `options.value?: Record<string, unknown> | null`
 
@@ -66,6 +65,8 @@ The form value to apply, if different from the submission payload.
 ### `error?: FormError | null`
 
 Validation result, if any was provided in the options.
+
+For schema-based validation, the default error shape is `string[]`.
 
 ### `reset?: boolean`
 

--- a/docs/api/react/future/useField.md
+++ b/docs/api/react/future/useField.md
@@ -82,13 +82,13 @@ Whether this field currently has no validation errors.
 
 Whether this field currently has validation errors. This is equivalent to `!valid`.
 
-### `errors: ErrorShape[] | undefined`
+### `errors: ErrorShape | undefined`
 
-Array of validation error messages for this field.
+Validation error for this field.
 
-### `fieldErrors: Record<string, ErrorShape[]>`
+### `fieldErrors: Record<string, ErrorShape>`
 
-Object containing errors for all touched subfields.
+Object containing validation errors for all touched subfields.
 
 ### `ariaInvalid: boolean | undefined`
 

--- a/docs/api/react/future/useFormMetadata.md
+++ b/docs/api/react/future/useFormMetadata.md
@@ -50,13 +50,13 @@ Whether the form currently has no validation errors.
 
 Whether the form currently has any validation errors. This is equivalent to `!valid`.
 
-### `errors: ErrorShape[] | undefined`
+### `errors: ErrorShape | undefined`
 
-Form-level validation errors, if any exist.
+Form-level validation error, if any exists.
 
-### `fieldErrors: Record<string, ErrorShape[]>`
+### `fieldErrors: Record<string, ErrorShape>`
 
-Object containing errors for all touched fields.
+Object containing validation errors for all touched fields.
 
 ### `defaultValue: Record<string, unknown>`
 

--- a/docs/api/valibot/future/formatResult.md
+++ b/docs/api/valibot/future/formatResult.md
@@ -20,7 +20,7 @@ The Valibot validation result to be formatted. This should be the result from `v
 
 Optional. Set to `true` if you want both the error and the parsed value returned in an object. This is useful when you are parsing the form value manually and still want to access the parsed value in the `onSubmit` handler on the `useForm` hook.
 
-### `options.formatIssues?: (issue: BaseIssue<unknown>[], name: string) => ErrorShape[]`
+### `options.formatIssues?: (issue: BaseIssue<unknown>[], name: string) => ErrorShape`
 
 Optional. A function to customize how valibot issues are formatted for each field. This is particularly useful if you want to include additional information from the `BaseIssue` object in the error messages, or if you need to support internationalization.
 
@@ -41,14 +41,14 @@ const error = formatResult(result, {
 It returns the formatted error object by default:
 
 ```ts
-FormError<string> | null;
+FormError<string[]> | null;
 ```
 
 If `includeValue` is set to `true`, it returns an object containing both the error and the parsed value instead:
 
 ```ts
 {
-  error: FormError<string> | null;
+  error: FormError<string[]> | null;
   value: (SafeParseResult < Schema > ['output']) | undefined;
 }
 ```

--- a/docs/api/zod/future/formatResult.md
+++ b/docs/api/zod/future/formatResult.md
@@ -20,7 +20,7 @@ The Zod validation result to be formatted. This should be the result from `schem
 
 Optional. Set to `true` if you want both the error and the parsed value returned in an object. This is useful when you are parsing the form value manually and still want to access the parsed value in the `onSubmit` handler on the `useForm` hook.
 
-### `options.formatIssues?: (issues: ZodIssue[], name: string) => ErrorShape[]`
+### `options.formatIssues?: (issues: ZodIssue[], name: string) => ErrorShape`
 
 Optional. A function to customize how zod issues are formatted for each field. This is particularly useful if you want to include additional information from the `ZodIssue` object in the error messages, or if you need to support internationalization.
 
@@ -41,14 +41,14 @@ const error = formatResult(result, {
 It returns the formatted error object by default:
 
 ```ts
-FormError<string> | null;
+FormError<string[]> | null;
 ```
 
 If `includeValue` is set to `true`, it returns an object containing both the error and the parsed value instead:
 
 ```ts
 {
-  error: FormError<string> | null;
+  error: FormError<string[]> | null;
   value: Output | undefined;
 }
 ```

--- a/examples/material-ui/src/forms.ts
+++ b/examples/material-ui/src/forms.ts
@@ -16,7 +16,7 @@ const forms = configureForms({
 	getConstraints,
 	shouldValidate: 'onBlur',
 	shouldRevalidate: 'onInput',
-	isError: shape<string>(),
+	isError: shape<string[]>(),
 	extendFieldMetadata(metadata) {
 		return {
 			get textFieldProps() {

--- a/examples/react-aria/src/forms.ts
+++ b/examples/react-aria/src/forms.ts
@@ -33,7 +33,7 @@ const forms = configureForms({
 	getConstraints,
 	shouldValidate: 'onBlur',
 	shouldRevalidate: 'onInput',
-	isError: shape<string>(),
+	isError: shape<string[]>(),
 	extendFormMetadata(metadata) {
 		return {
 			get props() {
@@ -129,12 +129,11 @@ const forms = configureForms({
 							defaultValue: fieldset.defaultPayload,
 							isInvalid: !fieldset.valid,
 							errors: [
-								...new Set(
-									(fieldset.errors ?? []).concat(
-										fieldset.fieldErrors.start ?? [],
-										fieldset.fieldErrors.end ?? [],
-									),
-								),
+								...new Set<string>([
+									...(fieldset.errors ?? []),
+									...(fieldset.fieldErrors.start ?? []),
+									...(fieldset.fieldErrors.end ?? []),
+								]),
 							],
 						} satisfies Partial<React.ComponentProps<typeof DateRangePicker>>;
 					},

--- a/examples/react-router/app/routes/login.tsx
+++ b/examples/react-router/app/routes/login.tsx
@@ -8,24 +8,24 @@ import { Form, redirect } from 'react-router';
 import type { Route } from './+types/login';
 
 function validate(value: Record<string, unknown>) {
-	const error: FormError = {
-		formErrors: [],
+	const error: FormError<string> = {
+		formErrors: null,
 		fieldErrors: {},
 	};
 
 	if (!value.email) {
-		error.fieldErrors.email = ['Email is required'];
+		error.fieldErrors.email = 'Email is required';
 	} else if (typeof value.email !== 'string' || !value.email.includes('@')) {
-		error.fieldErrors.email = ['Email is invalid'];
+		error.fieldErrors.email = 'Email is invalid';
 	}
 
 	if (!value.password) {
-		error.fieldErrors.password = ['Password is required'];
+		error.fieldErrors.password = 'Password is required';
 	}
 
 	if (
-		error.formErrors.length === 0 &&
-		Object.values(error.fieldErrors).every((message) => message.length === 0)
+		error.formErrors === null &&
+		Object.keys(error.fieldErrors).length === 0
 	) {
 		return null;
 	}

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -8,13 +8,56 @@ import type {
 	SubmissionResult,
 	UnknownObject,
 	Serialize,
+	StandardSchemaError,
+	CustomError,
 } from './types';
 import { isGlobalInstance, isSubmitter } from './dom';
 import { deepEqual, getTypeName, isPlainObject, stripFiles } from './util';
-import type { StandardSchemaIssue } from './standard-schema';
 import { formatIssues } from './standard-schema';
 
 export const DEFAULT_INTENT_NAME = '__INTENT__';
+
+/**
+ * Returns whether an error payload contains a meaningful value.
+ * Empty arrays are treated as no error.
+ */
+export function hasError<ErrorShape>(
+	error: ErrorShape | null | undefined,
+): error is ErrorShape {
+	return error != null && (!Array.isArray(error) || error.length > 0);
+}
+
+/**
+ * Normalizes a form error object by removing empty error payloads.
+ * Returns `null` when no form-level or field-level errors remain.
+ */
+export function normalizeFormError<ErrorShape>(
+	error: CustomError<ErrorShape> | null,
+): FormError<ErrorShape> | null {
+	if (error === null) {
+		return null;
+	}
+
+	const formErrors = hasError(error.formErrors) ? error.formErrors : null;
+	const fieldErrors = Object.entries(error.fieldErrors ?? {}).reduce<
+		Record<string, ErrorShape | null>
+	>((result, [name, value]) => {
+		if (hasError(value)) {
+			result[name] = value;
+		}
+
+		return result;
+	}, {});
+
+	if (formErrors === null && Object.keys(fieldErrors).length === 0) {
+		return null;
+	}
+
+	return {
+		formErrors,
+		fieldErrors,
+	};
+}
 
 /**
  * Construct a form data with the submitter value.
@@ -483,15 +526,11 @@ export function parseSubmission(
  * })
  * ```
  */
-export function report<ErrorShape = string>(
+export function report<ErrorShape>(
 	submission: Submission,
-	options?: {
+	options: {
 		keepFiles?: false;
-		error?: {
-			issues?: undefined;
-			formErrors?: ErrorShape[];
-			fieldErrors?: Record<string, ErrorShape[]>;
-		} | null;
+		error: CustomError<ErrorShape>;
 		value?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
@@ -500,15 +539,11 @@ export function report<ErrorShape = string>(
 	ErrorShape,
 	Exclude<JsonPrimitive | FormDataEntryValue, File>
 >;
-export function report<ErrorShape = string>(
+export function report<ErrorShape>(
 	submission: Submission,
 	options: {
 		keepFiles: true;
-		error?: {
-			issues?: undefined;
-			formErrors?: ErrorShape[];
-			fieldErrors?: Record<string, ErrorShape[]>;
-		} | null;
+		error: CustomError<ErrorShape>;
 		value?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
@@ -516,33 +551,58 @@ export function report<ErrorShape = string>(
 ): SubmissionResult<ErrorShape>;
 export function report(
 	submission: Submission,
-	options?: {
+	options: {
 		keepFiles?: false;
-		error?: {
-			issues: ReadonlyArray<StandardSchemaIssue>;
-			formErrors?: string[];
-			fieldErrors?: Record<string, string[]>;
-		};
+		error: StandardSchemaError;
 		value?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
 	},
-): SubmissionResult<string, Exclude<JsonPrimitive | FormDataEntryValue, File>>;
+): SubmissionResult<
+	string[],
+	Exclude<JsonPrimitive | FormDataEntryValue, File>
+>;
+export function report(
+	submission: Submission,
+	options: {
+		keepFiles: true;
+		error: StandardSchemaError;
+		value?: Record<string, FormValue> | null;
+		hideFields?: string[];
+		reset?: boolean;
+	},
+): SubmissionResult<string[]>;
 export function report(
 	submission: Submission,
 	options?: {
-		keepFiles: true;
-		error?: {
-			issues: ReadonlyArray<StandardSchemaIssue>;
-			formErrors?: string[];
-			fieldErrors?: Record<string, string[]>;
-		};
+		keepFiles?: false;
+		error?: null;
 		value?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
 	},
-): SubmissionResult<string>;
-export function report<ErrorShape = string>(
+): SubmissionResult<never, Exclude<JsonPrimitive | FormDataEntryValue, File>>;
+export function report(
+	submission: Submission,
+	options: {
+		keepFiles: true;
+		error?: null;
+		value?: Record<string, FormValue> | null;
+		hideFields?: string[];
+		reset?: boolean;
+	},
+): SubmissionResult<never>;
+export function report<ErrorShape>(
+	submission: Submission,
+	options?: {
+		keepFiles?: boolean;
+		error?: CustomError<ErrorShape> | null;
+		value?: Record<string, FormValue> | null;
+		hideFields?: string[];
+		reset?: boolean;
+	},
+): SubmissionResult<ErrorShape>;
+export function report<ErrorShape>(
 	submission: Submission,
 	options: {
 		/**
@@ -554,11 +614,7 @@ export function report<ErrorShape = string>(
 		 * Error information to include in the result.
 		 * Set to `null` to indicate validation passed with no errors.
 		 */
-		error?: {
-			issues?: ReadonlyArray<StandardSchemaIssue>;
-			formErrors?: string[];
-			fieldErrors?: Record<string, string[]>;
-		} | null;
+		error?: StandardSchemaError | CustomError<ErrorShape> | null;
 		/**
 		 * The form value to set. Use this to update the form or reset it
 		 * to a specific value when combined with `reset: true`.
@@ -574,33 +630,15 @@ export function report<ErrorShape = string>(
 		 */
 		reset?: boolean;
 	} = {},
-): SubmissionResult<string | ErrorShape> {
-	let error: FormError<string | ErrorShape> | null | undefined;
+): SubmissionResult<string[] | ErrorShape | never> {
+	let error: FormError<string[] | ErrorShape> | null | undefined;
 
 	if (options.error == null) {
 		error = options.error;
-	} else {
+	} else if ('issues' in options.error) {
 		error = formatIssues(options.error.issues ?? []);
-
-		if (options.error.formErrors) {
-			error.formErrors.push(...options.error.formErrors);
-		}
-
-		if (options.error.fieldErrors) {
-			for (const [name, messages] of Object.entries(
-				options.error.fieldErrors,
-			)) {
-				if (messages.length === 0) {
-					continue;
-				}
-
-				if (!error.fieldErrors[name]) {
-					error.fieldErrors[name] = messages;
-				} else {
-					error.fieldErrors[name].push(...messages);
-				}
-			}
-		}
+	} else {
+		error = normalizeFormError(options.error);
 	}
 
 	const targetValue =

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -19,16 +19,20 @@ export const DEFAULT_INTENT_NAME = '__INTENT__';
 
 /**
  * Returns whether an error payload contains a meaningful value.
- * Empty arrays are treated as no error.
+ * Empty strings and empty arrays are treated as no error.
  */
 export function hasError<ErrorShape>(
 	error: ErrorShape | null | undefined,
 ): error is ErrorShape {
-	return error != null && (!Array.isArray(error) || error.length > 0);
+	return (
+		error != null && error !== '' && (!Array.isArray(error) || error.length > 0)
+	);
 }
 
 /**
- * Normalizes a form error object by removing empty error payloads.
+ * Normalizes a form error object by removing empty error payloads such as
+ * empty strings and empty arrays.
+ *
  * Returns `null` when no form-level or field-level errors remain.
  */
 export function normalizeFormError<ErrorShape>(

--- a/packages/conform-dom/future/index.ts
+++ b/packages/conform-dom/future/index.ts
@@ -23,6 +23,7 @@ export {
 	report,
 	defaultSerialize,
 	getFieldValue,
+	normalizeFormError,
 } from '../formdata';
 export { isPlainObject, deepEqual } from '../util';
 export {

--- a/packages/conform-dom/standard-schema.ts
+++ b/packages/conform-dom/standard-schema.ts
@@ -1,23 +1,12 @@
-import type { FormError } from './types';
+import type { FormError, StandardSchemaIssue } from './types';
 import { formatPath } from './formdata';
 import { isPlainObject } from './util';
 
-/**
- * A widened version of `StandardSchemaV1.Issue`.
- *
- * The `path` elements and `PropertyKey` fields are loosened to `unknown`
- * to stay compatible with Valibot's native issue type.
- */
-export type StandardSchemaIssue = {
-	readonly message: string;
-	readonly path?: ReadonlyArray<unknown | { key: unknown }> | undefined;
-};
-
 export function formatIssues(
 	issues: Readonly<StandardSchemaIssue[]>,
-): FormError<string> {
-	const error: FormError<string> = {
-		formErrors: [],
+): FormError<string[]> {
+	const error: FormError<string[]> = {
+		formErrors: null,
 		fieldErrors: {},
 	};
 
@@ -40,6 +29,7 @@ export function formatIssues(
 		const name = formatPath(segments ?? []);
 
 		if (!name) {
+			error.formErrors ??= [];
 			error.formErrors.push(issue.message);
 		} else {
 			error.fieldErrors[name] ??= [];

--- a/packages/conform-dom/tests/formdata.test.ts
+++ b/packages/conform-dom/tests/formdata.test.ts
@@ -13,6 +13,7 @@ import {
 	DEFAULT_INTENT_NAME,
 	defaultSerialize,
 	getFieldValue,
+	normalizeFormError,
 } from '../formdata';
 
 function createFormData(
@@ -1072,8 +1073,9 @@ describe('report', () => {
 		expect(result).toEqual({
 			submission,
 			targetValue: undefined,
+			reset: undefined,
 			error: {
-				formErrors: [],
+				formErrors: null,
 				fieldErrors: {
 					name: ['Name is required'],
 					email: ['Invalid email format'],
@@ -1213,6 +1215,7 @@ describe('report', () => {
 		expect(result).toEqual({
 			submission,
 			targetValue: undefined,
+			reset: undefined,
 			error: {
 				formErrors: ['Form is invalid'],
 				fieldErrors: {
@@ -1220,29 +1223,36 @@ describe('report', () => {
 				},
 			},
 		});
+	});
 
-		const result2 = report(submission, {
+	it('supports explicit error payloads', () => {
+		const submission = {
+			payload: {
+				name: '',
+				email: '',
+			},
+			fields: ['name', 'email'],
+			intent: null,
+		};
+		const result = report(submission, {
 			error: {
-				issues: [
-					{ path: [], message: 'Form is invalid' },
-					{ path: ['name'], message: 'Name is required' },
-				],
 				formErrors: ['Something went wrong'],
 				fieldErrors: {
-					name: ['Name is too short'],
-					description: ['Description is too short'],
+					name: ['Name is already taken'],
+					email: ['Email is invalid'],
 				},
 			},
 		});
 
-		expect(result2).toEqual({
+		expect(result).toEqual({
 			submission,
 			targetValue: undefined,
+			reset: undefined,
 			error: {
-				formErrors: ['Form is invalid', 'Something went wrong'],
+				formErrors: ['Something went wrong'],
 				fieldErrors: {
-					name: ['Name is required', 'Name is too short'],
-					description: ['Description is too short'],
+					name: ['Name is already taken'],
+					email: ['Email is invalid'],
 				},
 			},
 		});
@@ -1767,5 +1777,59 @@ describe('getFieldValue', () => {
 		expect(() =>
 			getFieldValue(formData, 'email', { type: 'object', optional: true }),
 		).toThrow('Expected field "email" to be an object, but got string');
+	});
+});
+
+test('normalizeFormError', () => {
+	// Test error without messages
+	expect(
+		normalizeFormError({
+			formErrors: [],
+			fieldErrors: { email: [], password: [] },
+		}),
+	).toBeNull();
+	expect(
+		normalizeFormError({
+			formErrors: null,
+			fieldErrors: { email: null, password: [] },
+		}),
+	).toBeNull();
+	expect(
+		normalizeFormError({
+			formErrors: null,
+			fieldErrors: {},
+		}),
+	).toBeNull();
+
+	// Test null error
+	expect(normalizeFormError(null)).toBeNull();
+
+	// Test non-empty error
+	expect(
+		normalizeFormError({
+			formErrors: [],
+			fieldErrors: { email: null, password: ['Required'] },
+		}),
+	).toEqual({
+		formErrors: null,
+		fieldErrors: { password: ['Required'] },
+	});
+	expect(
+		normalizeFormError({
+			formErrors: { message: 'Form error' },
+			fieldErrors: {},
+		}),
+	).toEqual({
+		formErrors: { message: 'Form error' },
+		fieldErrors: {},
+	});
+	expect(
+		normalizeFormError({
+			formErrors: ['Form error'],
+			fieldErrors: { email: ['Required'] },
+		}),
+	).toEqual({
+		formErrors: ['Form error'],
+		fieldErrors: { email: ['Required'] },
 	});
 });

--- a/packages/conform-dom/tests/formdata.test.ts
+++ b/packages/conform-dom/tests/formdata.test.ts
@@ -1800,6 +1800,12 @@ test('normalizeFormError', () => {
 			fieldErrors: {},
 		}),
 	).toBeNull();
+	expect(
+		normalizeFormError({
+			formErrors: '',
+			fieldErrors: { email: '', password: null },
+		}),
+	).toBeNull();
 
 	// Test null error
 	expect(normalizeFormError(null)).toBeNull();
@@ -1831,5 +1837,14 @@ test('normalizeFormError', () => {
 	).toEqual({
 		formErrors: ['Form error'],
 		fieldErrors: { email: ['Required'] },
+	});
+	expect(
+		normalizeFormError({
+			formErrors: '',
+			fieldErrors: { email: '', password: 'Required' },
+		}),
+	).toEqual({
+		formErrors: null,
+		fieldErrors: { password: 'Required' },
 	});
 });

--- a/packages/conform-dom/types.ts
+++ b/packages/conform-dom/types.ts
@@ -16,15 +16,36 @@ export type FormValue<
 /**
  * Form error object that contains both form errors and field errors.
  */
-export type FormError<ErrorShape = string> = {
+export type FormError<ErrorShape = string[]> = {
 	/**
-	 * The error of the form.
+	 * The form-level error payload.
+	 * Set to `null` when there is no form-level error.
 	 */
-	formErrors: ErrorShape[];
+	formErrors: ErrorShape | null;
 	/**
-	 * The field errors based on the field name.
+	 * Field-level error payloads mapped by field name.
+	 * Use `null` to explicitly clear a field error.
 	 */
-	fieldErrors: Record<string, ErrorShape[]>;
+	fieldErrors: Record<string, ErrorShape | null>;
+};
+
+/**
+ * A widened version of `StandardSchemaV1.Issue`.
+ *
+ * The `path` elements and `PropertyKey` fields are loosened to `unknown`
+ * to stay compatible with Valibot's native issue type.
+ */
+export type StandardSchemaIssue = {
+	readonly message: string;
+	readonly path?: ReadonlyArray<unknown | { key: unknown }> | undefined;
+};
+
+export type StandardSchemaError = Partial<Record<keyof FormError, never>> & {
+	issues: ReadonlyArray<StandardSchemaIssue>;
+};
+
+export type CustomError<ErrorShape> = Partial<FormError<ErrorShape>> & {
+	issues?: never;
 };
 
 /**
@@ -69,7 +90,7 @@ export type Submission<
  * The result of a submission.
  */
 export type SubmissionResult<
-	ErrorShape = string,
+	ErrorShape = string[],
 	ValueType extends JsonPrimitive | FormDataEntryValue =
 		| JsonPrimitive
 		| FormDataEntryValue,

--- a/packages/conform-react/future/forms.tsx
+++ b/packages/conform-react/future/forms.tsx
@@ -33,7 +33,7 @@ import {
 export function configureForms<
 	BaseErrorShape = any,
 	BaseSchema = StandardSchemaV1,
-	SchemaErrorShape = string,
+	SchemaErrorShape = string[],
 	CustomFormMetadata extends Record<string, unknown> = {},
 	CustomFieldMetadata extends Record<string, unknown> = {},
 >(

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -12,6 +12,7 @@ import {
 	parseSubmission,
 	requestSubmit,
 	report,
+	normalizeFormError,
 	defaultSerialize,
 	isPlainObject,
 	isGlobalInstance,
@@ -237,10 +238,16 @@ export function useConform<
 			result: SubmissionResult<ErrorShape>,
 			options = optionsRef.current,
 		) => {
+			const normalizedResult = !result.error
+				? result
+				: {
+						...result,
+						error: normalizeFormError(result.error),
+					};
 			const intent = result.submission.intent
 				? deserializeIntent(result.submission.intent)
 				: null;
-			const finalResult = applyIntent(result, intent, {
+			const finalResult = applyIntent(normalizedResult, intent, {
 				handlers: intentHandlers,
 			});
 			const formElement = getFormElement(formRef);
@@ -259,7 +266,7 @@ export function useConform<
 					intent,
 					ctx: {
 						handlers: intentHandlers,
-						cancelled: finalResult !== result,
+						cancelled: finalResult !== normalizedResult,
 						reset(defaultValue) {
 							return initializeState<ErrorShape>({
 								defaultValue: defaultValue ?? options.defaultValue,
@@ -270,10 +277,10 @@ export function useConform<
 			);
 
 			// TODO: move on error handler to a new effect
-			if (formElement && result.error) {
+			if (formElement && finalResult.error) {
 				optionsRef.current.onError?.({
 					formElement,
-					error: result.error,
+					error: finalResult.error,
 					intent,
 				});
 			}
@@ -389,10 +396,13 @@ export function useConform<
 				resolvedValue = lastAsyncResult.resolvedValue;
 			} else {
 				const value = resolveIntent(submission);
-				const submissionResult = report<ErrorShape>(submission, {
-					keepFiles: true,
-					value,
-				});
+				const submissionResult: SubmissionResult<ErrorShape> = report(
+					submission,
+					{
+						keepFiles: true,
+						value,
+					},
+				);
 
 				const validateResult =
 					// Skip validation on form reset
@@ -400,7 +410,7 @@ export function useConform<
 						? optionsRef.current.onValidate?.({
 								payload: value,
 								error: {
-									formErrors: [],
+									formErrors: null,
 									fieldErrors: {},
 								},
 								intent: submission.intent

--- a/packages/conform-react/future/intent.ts
+++ b/packages/conform-react/future/intent.ts
@@ -306,9 +306,9 @@ export const intentHandlers: {
 				return result;
 			}
 
-			const arrayErrors = result.error?.fieldErrors[options.name];
+			const listError = result.error?.fieldErrors[options.name];
 
-			if (options.onInvalid === 'revert' && arrayErrors?.length) {
+			if (options.onInvalid === 'revert' && listError != null) {
 				return {
 					...result,
 					targetValue: undefined,
@@ -320,20 +320,33 @@ export const intentHandlers: {
 					options.index ??
 					getPathArray(result.submission.payload, options.name).length;
 				const insertedItemPath = appendPath(options.name, index);
-				const insertedItemErrors = result.error?.fieldErrors[insertedItemPath];
+				const insertedItemError = result.error?.fieldErrors[insertedItemPath];
+				const fromFieldError = result.error?.fieldErrors[options.from];
 
-				if (insertedItemErrors?.length) {
-					const fromErrors = result.error?.fieldErrors[options.from] ?? [];
-
+				if (fromFieldError != null) {
 					return {
 						...result,
 						targetValue: undefined,
 						error: {
-							formErrors: result.error?.formErrors ?? [],
+							formErrors: result.error?.formErrors ?? null,
 							fieldErrors: {
 								...result.error?.fieldErrors,
-								[options.from]: [...fromErrors, ...insertedItemErrors],
-								[insertedItemPath]: [],
+								[insertedItemPath]: null,
+							},
+						},
+					};
+				}
+
+				if (insertedItemError != null) {
+					return {
+						...result,
+						targetValue: undefined,
+						error: {
+							formErrors: result.error?.formErrors ?? null,
+							fieldErrors: {
+								...result.error?.fieldErrors,
+								[options.from]: insertedItemError,
+								[insertedItemPath]: null,
 							},
 						},
 					};

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -287,7 +287,7 @@ export function getListKey(context: FormContext<any>, name: string): string[] {
 export function getErrors<ErrorShape>(
 	state: FormState<ErrorShape>,
 	name?: string,
-): ErrorShape[] | undefined {
+): ErrorShape | undefined {
 	const error = state.serverError ?? state.clientError;
 
 	if (!error || !isTouched(state, name)) {
@@ -296,7 +296,7 @@ export function getErrors<ErrorShape>(
 
 	const errors = name ? error.fieldErrors[name] : error.formErrors;
 
-	if (errors && errors.length > 0) {
+	if (errors != null) {
 		return errors;
 	}
 }
@@ -305,7 +305,7 @@ export function getFieldErrors<ErrorShape>(
 	state: FormState<ErrorShape>,
 	name?: string,
 ) {
-	const result: Record<string, ErrorShape[]> = {};
+	const result: Record<string, ErrorShape> = {};
 	const error = state.serverError ?? state.clientError;
 
 	if (error) {
@@ -333,13 +333,15 @@ export function getFieldErrors<ErrorShape>(
 /**
  * Checks if fieldErrors contains any errors at the given name or any child path.
  */
-export function hasFieldError(error: FormError<any>, name: string): boolean {
+export function hasFieldError<ErrorShape>(
+	error: FormError<ErrorShape>,
+	name: string,
+): boolean {
 	const basePath = parsePath(name);
 
-	return Object.keys(error.fieldErrors).some(
-		(field) =>
-			getRelativePath(field, basePath) !== null &&
-			error.fieldErrors[field]?.length,
+	return Object.entries(error.fieldErrors).some(
+		([field, fieldError]) =>
+			getRelativePath(field, basePath) !== null && fieldError !== null,
 	);
 }
 

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -817,10 +817,10 @@ export type FieldMetadata<
 			valid: boolean;
 			/** @deprecated Use `.valid` instead. This was not an intentionl breaking change and would be removed in the next minor version soon  */
 			invalid: boolean;
-			/** Array of validation error messages for this field. */
-			errors: ErrorShape[] | undefined;
-			/** Object containing errors for all touched subfields. */
-			fieldErrors: Record<string, ErrorShape[]>;
+			/** Validation error for this field. */
+			errors: ErrorShape | undefined;
+			/** Object containing validation errors for all touched subfields. */
+			fieldErrors: Record<string, ErrorShape>;
 			/** Boolean value for the `aria-invalid` attribute. Indicates whether the field has validation errors for screen readers. */
 			ariaInvalid: boolean | undefined;
 			/** String value for the `aria-describedby` attribute. Contains the errorId when invalid, undefined otherwise. Merge with descriptionId manually if needed (e.g. `${metadata.descriptionId} ${metadata.ariaDescribedBy}`). */
@@ -889,10 +889,10 @@ export type FormMetadata<
 		valid: boolean;
 		/** @deprecated Use `.valid` instead. This was not an intentional breaking change and would be removed in the next minor version soon  */
 		invalid: boolean;
-		/** Form-level validation errors, if any exist. */
-		errors: ErrorShape[] | undefined;
-		/** Object containing errors for all touched fields. */
-		fieldErrors: Record<string, ErrorShape[]>;
+		/** Form-level validation error, if any exists. */
+		errors: ErrorShape | undefined;
+		/** Object containing validation errors for all touched fields. */
+		fieldErrors: Record<string, ErrorShape>;
 		/** The form's initial default values. */
 		defaultValue: Record<string, unknown>;
 		/** Form props object for spreading onto the <form> element. */

--- a/packages/conform-react/future/util.ts
+++ b/packages/conform-react/future/util.ts
@@ -10,6 +10,7 @@ import {
 	getPathValue,
 	isPlainObject,
 	setPathValue,
+	normalizeFormError,
 } from '@conform-to/dom/future';
 import type { StandardSchemaV1 } from './standard-schema';
 import {
@@ -118,26 +119,6 @@ export function createPathIndexUpdater(
 	};
 }
 
-/**
- * Returns null if error object has no actual error messages,
- * otherwise returns the error as-is.
- */
-export function normalizeFormError<ErrorShape>(
-	error: FormError<ErrorShape> | null,
-): FormError<ErrorShape> | null {
-	if (
-		error &&
-		error.formErrors.length === 0 &&
-		Object.entries(error.fieldErrors).every(([, messages]) =>
-			Array.isArray(messages) ? messages.length === 0 : !messages,
-		)
-	) {
-		return null;
-	}
-
-	return error;
-}
-
 export function resolveSerialize(
 	customSerialize: CustomSerialize | undefined,
 	defaultSerialize: Serialize,
@@ -207,7 +188,7 @@ export function resolveValidateResult<ErrorShape, Value>(
 export function resolveStandardSchemaResult<Value>(
 	result: StandardSchemaV1.Result<Value>,
 ): {
-	error: FormError<string> | null;
+	error: FormError<string[]> | null;
 	value?: Value;
 } {
 	if (!result.issues) {
@@ -310,7 +291,7 @@ export function generateUniqueKey() {
  * @example Specify error shape
  * ```ts
  * configureForms({
- *   isError: shape<string>(),  // errors are strings
+ *   isError: shape<string[]>(),  // errors are string arrays
  * });
  * ```
  *

--- a/packages/conform-react/tests/intent.test.ts
+++ b/packages/conform-react/tests/intent.test.ts
@@ -324,7 +324,7 @@ test('actionHandlers.insert', () => {
 		items: ['a', 'b', 'new'],
 	});
 
-	const validResult: SubmissionResult<string> = {
+	const validResult: SubmissionResult<string[]> = {
 		submission: {
 			intent: null,
 			payload: { items: [], newItem: 'value' },
@@ -340,7 +340,7 @@ test('actionHandlers.insert', () => {
 		}),
 	).toBe(validResult);
 
-	const invalidResult: SubmissionResult<string> = {
+	const invalidResult: SubmissionResult<string[]> = {
 		submission: {
 			intent: null,
 			payload: { items: [], newItem: 'bad' },
@@ -360,13 +360,45 @@ test('actionHandlers.insert', () => {
 		error: {
 			formErrors: [],
 			fieldErrors: {
-				'items[0]': [],
+				'items[0]': null,
 				newItem: ['Invalid'],
 			},
 		},
 	});
 
-	const maxResult: SubmissionResult<string> = {
+	const resultWithFromError: SubmissionResult<string[]> = {
+		submission: {
+			intent: null,
+			payload: { items: [], newItem: 'bad' },
+			fields: [],
+		},
+		targetValue: { items: ['bad'], newItem: '' },
+		error: {
+			formErrors: [],
+			fieldErrors: {
+				'items[0]': ['Invalid'],
+				newItem: ['Existing error'],
+			},
+		},
+	};
+	expect(
+		intentHandlers.insert.apply?.(resultWithFromError, {
+			name: 'items',
+			from: 'newItem',
+		}),
+	).toEqual({
+		...resultWithFromError,
+		targetValue: undefined,
+		error: {
+			formErrors: [],
+			fieldErrors: {
+				'items[0]': null,
+				newItem: ['Existing error'],
+			},
+		},
+	});
+
+	const maxResult: SubmissionResult<string[]> = {
 		submission: { intent: null, payload: { items: ['a', 'b'] }, fields: [] },
 		targetValue: { items: ['a', 'b', 'c'] },
 		error: { formErrors: [], fieldErrors: { items: ['Max 2 items'] } },
@@ -382,7 +414,7 @@ test('actionHandlers.insert', () => {
 		error: { formErrors: [], fieldErrors: { items: ['Max 2 items'] } },
 	});
 
-	const normalResult: SubmissionResult<string> = {
+	const normalResult: SubmissionResult<string[]> = {
 		submission: { intent: null, payload: { items: ['a'] }, fields: [] },
 		targetValue: { items: ['a', 'b'] },
 		error: null,
@@ -409,7 +441,7 @@ test('actionHandlers.remove', () => {
 		items: ['a', 'c'],
 	});
 
-	const minResult: SubmissionResult<string> = {
+	const minResult: SubmissionResult<string[]> = {
 		submission: { intent: null, payload: { items: ['a'] }, fields: [] },
 		targetValue: { items: [] },
 		error: { formErrors: [], fieldErrors: { items: ['Min 1 item'] } },
@@ -426,7 +458,7 @@ test('actionHandlers.remove', () => {
 		error: { formErrors: [], fieldErrors: { items: ['Min 1 item'] } },
 	});
 
-	const insertResult: SubmissionResult<string> = {
+	const insertResult: SubmissionResult<string[]> = {
 		submission: { intent: null, payload: { items: ['a'] }, fields: [] },
 		targetValue: { items: [] },
 		error: { formErrors: [], fieldErrors: { items: ['Min 1 item'] } },
@@ -443,7 +475,7 @@ test('actionHandlers.remove', () => {
 		targetValue: { items: [''] },
 	});
 
-	const noRevertResult: SubmissionResult<string> = {
+	const noRevertResult: SubmissionResult<string[]> = {
 		submission: { intent: null, payload: { items: ['a'] }, fields: [] },
 		targetValue: { items: [] },
 		error: { formErrors: [], fieldErrors: { items: ['Min 1 item'] } },
@@ -455,7 +487,7 @@ test('actionHandlers.remove', () => {
 		}),
 	).toBe(noRevertResult);
 
-	const normalResult: SubmissionResult<string> = {
+	const normalResult: SubmissionResult<string[]> = {
 		submission: { intent: null, payload: { items: ['a', 'b'] }, fields: [] },
 		targetValue: { items: ['a'] },
 		error: null,

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -141,9 +141,9 @@ test('useForm', () => {
 		},
 	});
 
-	expectTypeOf(basicForm.form).toEqualTypeOf<FormMetadata<string>>();
+	expectTypeOf(basicForm.form).toEqualTypeOf<FormMetadata<string[]>>();
 	expectTypeOf(basicForm.fields).toEqualTypeOf<
-		Fieldset<Record<string, any>, string>
+		Fieldset<Record<string, any>, string[]>
 	>();
 	expectTypeOf(basicForm.intent).toEqualTypeOf<
 		IntentDispatcher<Record<string, any>>
@@ -152,22 +152,20 @@ test('useForm', () => {
 	const errorShapeInferred = useForm({
 		onValidate({ error }) {
 			return {
-				formErrors: error.formErrors.map((message) => ({ message })),
+				formErrors: error.formErrors?.join(', ') ?? null,
 				fieldErrors: Object.fromEntries(
 					Object.entries(error.fieldErrors).map(([key, messages]) => [
 						key,
-						messages.map((message) => ({ message })),
+						messages?.join(', ') ?? null,
 					]),
 				),
 			};
 		},
 	});
 
-	expectTypeOf(errorShapeInferred.form).toEqualTypeOf<
-		FormMetadata<{ message: string }>
-	>();
+	expectTypeOf(errorShapeInferred.form).toEqualTypeOf<FormMetadata<string>>();
 	expectTypeOf(errorShapeInferred.fields).toEqualTypeOf<
-		Fieldset<Record<string, any>, { message: string }>
+		Fieldset<Record<string, any>, string>
 	>();
 	expectTypeOf(errorShapeInferred.intent).toEqualTypeOf<
 		IntentDispatcher<Record<string, any>>
@@ -189,9 +187,9 @@ test('useForm', () => {
 		lastResult: null,
 	});
 
-	expectTypeOf(schemaBasedForm.form).toEqualTypeOf<FormMetadata<string>>();
+	expectTypeOf(schemaBasedForm.form).toEqualTypeOf<FormMetadata<string[]>>();
 	expectTypeOf(schemaBasedForm.fields).toEqualTypeOf<
-		Fieldset<{ email: string; password: string }, string>
+		Fieldset<{ email: string; password: string }, string[]>
 	>();
 	expectTypeOf(schemaBasedForm.intent).toEqualTypeOf<
 		IntentDispatcher<{ email: string; password: string }>
@@ -200,11 +198,11 @@ test('useForm', () => {
 	const testSchemaWithCustomErrorShape = useForm(testSchema, {
 		onValidate({ error }) {
 			return {
-				formErrors: error.formErrors.map((message) => ({ message })),
+				formErrors: error.formErrors?.join(', ') ?? null,
 				fieldErrors: Object.fromEntries(
 					Object.entries(error.fieldErrors).map(([key, messages]) => [
 						key,
-						messages.map((message) => ({ message })),
+						messages?.join(', ') ?? null,
 					]),
 				),
 			};
@@ -212,10 +210,10 @@ test('useForm', () => {
 	});
 
 	expectTypeOf(testSchemaWithCustomErrorShape.form).toEqualTypeOf<
-		FormMetadata<{ message: string }>
+		FormMetadata<string>
 	>();
 	expectTypeOf(testSchemaWithCustomErrorShape.fields).toEqualTypeOf<
-		Fieldset<{ email: string; password: string }, { message: string }>
+		Fieldset<{ email: string; password: string }, string>
 	>();
 	expectTypeOf(testSchemaWithCustomErrorShape.intent).toEqualTypeOf<
 		IntentDispatcher<{ email: string; password: string }>
@@ -256,10 +254,10 @@ describe('configureForms', () => {
 		});
 
 		expectTypeOf(basicForm.form).toEqualTypeOf<
-			FormMetadata<{ message: string }>
+			FormMetadata<{ message: string }[]>
 		>();
 		expectTypeOf(basicForm.fields).toEqualTypeOf<
-			Fieldset<Record<string, any>, { message: string }>
+			Fieldset<Record<string, any>, { message: string }[]>
 		>();
 		expectTypeOf(basicForm.intent).toEqualTypeOf<
 			IntentDispatcher<Record<string, any>>
@@ -268,14 +266,18 @@ describe('configureForms', () => {
 		const errorShapeInferred = custom.useForm({
 			onValidate({ error }) {
 				return {
-					formErrors: error.formErrors.map((error) => ({
-						...error,
-						type: 'custom',
-					})),
+					formErrors:
+						error.formErrors?.map((error) => ({
+							...error,
+							type: 'custom',
+						})) ?? null,
 					fieldErrors: Object.fromEntries(
 						Object.entries(error.fieldErrors).map(([key, messages]) => [
 							key,
-							messages.map((error) => ({ ...error, type: 'custom' })),
+							messages?.map((error) => ({
+								...error,
+								type: 'custom',
+							})) ?? null,
 						]),
 					),
 				};
@@ -283,10 +285,10 @@ describe('configureForms', () => {
 		});
 
 		expectTypeOf(errorShapeInferred.form).toEqualTypeOf<
-			FormMetadata<{ message: string; type: string }>
+			FormMetadata<{ message: string; type: string }[]>
 		>();
 		expectTypeOf(errorShapeInferred.fields).toEqualTypeOf<
-			Fieldset<Record<string, any>, { message: string; type: string }>
+			Fieldset<Record<string, any>, { message: string; type: string }[]>
 		>();
 		expectTypeOf(errorShapeInferred.intent).toEqualTypeOf<
 			IntentDispatcher<Record<string, any>>
@@ -297,10 +299,10 @@ describe('configureForms', () => {
 		});
 
 		expectTypeOf(schemaBasedForm.form).toEqualTypeOf<
-			FormMetadata<{ message: string }>
+			FormMetadata<{ message: string }[]>
 		>();
 		expectTypeOf(schemaBasedForm.fields).toEqualTypeOf<
-			Fieldset<{ email: string; password: string }, { message: string }>
+			Fieldset<{ email: string; password: string }, { message: string }[]>
 		>();
 		expectTypeOf(schemaBasedForm.intent).toEqualTypeOf<
 			IntentDispatcher<{ email: string; password: string }>
@@ -309,14 +311,12 @@ describe('configureForms', () => {
 		const testSchemaWithCustomErrorShape = custom.useForm(testSchema, {
 			onValidate({ error }) {
 				return {
-					formErrors: error.formErrors.map((error) => ({
-						...error,
-						type: 'custom',
-					})),
+					formErrors:
+						error.formErrors?.map((error) => error.message).join(', ') ?? null,
 					fieldErrors: Object.fromEntries(
 						Object.entries(error.fieldErrors).map(([key, messages]) => [
 							key,
-							messages.map((error) => ({ ...error, type: 'custom' })),
+							messages?.map((error) => error.message).join(', ') ?? null,
 						]),
 					),
 				};
@@ -324,13 +324,10 @@ describe('configureForms', () => {
 		});
 
 		expectTypeOf(testSchemaWithCustomErrorShape.form).toEqualTypeOf<
-			FormMetadata<{ message: string; type: string }>
+			FormMetadata<string>
 		>();
 		expectTypeOf(testSchemaWithCustomErrorShape.fields).toEqualTypeOf<
-			Fieldset<
-				{ email: string; password: string },
-				{ message: string; type: string }
-			>
+			Fieldset<{ email: string; password: string }, string>
 		>();
 		expectTypeOf(testSchemaWithCustomErrorShape.intent).toEqualTypeOf<
 			IntentDispatcher<{ email: string; password: string }>
@@ -352,14 +349,15 @@ describe('configureForms', () => {
 		const errorShapeInferred = custom.useForm({
 			onValidate({ error }) {
 				return {
-					formErrors: error.formErrors.map((message) => ({
-						message,
-						type: 'custom',
-					})),
+					formErrors: error.formErrors
+						? { message: error.formErrors.join(', '), type: 'custom' }
+						: null,
 					fieldErrors: Object.fromEntries(
 						Object.entries(error.fieldErrors).map(([key, messages]) => [
 							key,
-							messages.map((message) => ({ message, type: 'custom' })),
+							messages
+								? { message: messages.join(', '), type: 'custom' }
+								: null,
 						]),
 					),
 				};
@@ -385,14 +383,15 @@ describe('configureForms', () => {
 		const testSchemaWithCustomErrorShape = custom.useForm(testSchema, {
 			onValidate({ error }) {
 				return {
-					formErrors: error.formErrors.map((message) => ({
-						message,
-						type: 'custom',
-					})),
+					formErrors: error.formErrors
+						? { message: error.formErrors.join(', '), type: 'custom' }
+						: null,
 					fieldErrors: Object.fromEntries(
 						Object.entries(error.fieldErrors).map(([key, messages]) => [
 							key,
-							messages.map((message) => ({ message, type: 'custom' })),
+							messages
+								? { message: messages.join(', '), type: 'custom' }
+								: null,
 						]),
 					),
 				};
@@ -418,9 +417,9 @@ describe('configureForms', () => {
 			validateSchema() {
 				return {
 					error: {
-						formErrors: [{ message: 'Form error' }],
+						formErrors: { message: 'Form error' },
 						fieldErrors: {
-							email: [{ message: 'Email error' }],
+							email: { message: 'Email error' },
 						},
 					},
 				};
@@ -447,14 +446,15 @@ describe('configureForms', () => {
 		const errorShapeInferred = custom.useForm({
 			onValidate({ error }) {
 				return {
-					formErrors: error.formErrors.map((error) => ({
-						...error,
-						type: 'custom',
-					})),
+					formErrors: error.formErrors
+						? { message: error.formErrors.message, type: 'custom' }
+						: null,
 					fieldErrors: Object.fromEntries(
-						Object.entries(error.fieldErrors).map(([key, messages]) => [
+						Object.entries(error.fieldErrors).map(([key, fieldError]) => [
 							key,
-							messages.map((error) => ({ ...error, type: 'custom' })),
+							fieldError
+								? { message: fieldError.message, type: 'custom' }
+								: null,
 						]),
 					),
 				};
@@ -488,14 +488,15 @@ describe('configureForms', () => {
 		const testSchemaWithCustomErrorShape = custom.useForm(testSchema, {
 			onValidate({ error }) {
 				return {
-					formErrors: error.formErrors.map((error) => ({
-						...error,
-						type: 'custom',
-					})),
+					formErrors: error.formErrors
+						? { message: error.formErrors.message, type: 'custom' }
+						: null,
 					fieldErrors: Object.fromEntries(
-						Object.entries(error.fieldErrors).map(([key, messages]) => [
+						Object.entries(error.fieldErrors).map(([key, fieldError]) => [
 							key,
-							messages.map((error) => ({ ...error, type: 'custom' })),
+							fieldError
+								? { message: fieldError.message, type: 'custom' }
+								: null,
 						]),
 					),
 				};

--- a/packages/conform-react/tests/useField.browser.test.tsx
+++ b/packages/conform-react/tests/useField.browser.test.tsx
@@ -55,7 +55,7 @@ describe.each(testCases)(
 		function ExampleForm({
 			children,
 			...options
-		}: Partial<FormOptions<Schema, string, Schema>> & {
+		}: Partial<FormOptions<Schema, string[], Schema>> & {
 			children?: React.ReactNode;
 		}) {
 			const { form, fields, intent } = useForm({

--- a/packages/conform-react/tests/useForm.browser.test.tsx
+++ b/packages/conform-react/tests/useForm.browser.test.tsx
@@ -55,8 +55,8 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 	};
 
 	function validateForm(value: Record<string, FormValue>) {
-		const error: FormError<string> = {
-			formErrors: [],
+		const error: FormError<string[]> = {
+			formErrors: null,
 			fieldErrors: {},
 		};
 
@@ -111,8 +111,8 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 		};
 	}
 
-	function Form(props: Partial<FormOptions<Schema, string, Schema>>) {
-		const { form, fields, intent } = useForm<Schema, string, Schema>({
+	function Form(props: Partial<FormOptions<Schema, string[], Schema>>) {
+		const { form, fields, intent } = useForm<Schema, string[], Schema>({
 			onValidate({ payload }) {
 				return validateForm(payload);
 			},
@@ -1455,7 +1455,7 @@ describe('configureForms customization', () => {
 		});
 
 		function Form() {
-			const { form, fields } = customized.useForm<Schema, string>({
+			const { form, fields } = customized.useForm<Schema, string[]>({
 				onValidate({ payload, error }) {
 					if (!payload.title) {
 						error.fieldErrors.title = ['Title is required'];
@@ -1513,7 +1513,7 @@ describe('configureForms customization', () => {
 		});
 
 		function Form() {
-			const { form, fields } = customized.useForm<Schema, string>({
+			const { form, fields } = customized.useForm<Schema, string[]>({
 				onValidate({ payload, error }) {
 					if (!payload.title) {
 						error.fieldErrors.title = ['Title is required'];
@@ -1562,7 +1562,7 @@ describe('configureForms customization', () => {
 		});
 
 		function Form() {
-			const { form, fields } = customized.useForm<Schema, string>({
+			const { form, fields } = customized.useForm<Schema, string[]>({
 				shouldValidate: 'onSubmit',
 				shouldRevalidate: 'onBlur',
 				onValidate({ payload, error }) {
@@ -1634,7 +1634,7 @@ describe('configureForms customization', () => {
 		});
 
 		function Form() {
-			const { form, fields } = customized.useForm<Schema, string>({
+			const { form, fields } = customized.useForm<Schema, string[]>({
 				onValidate({ payload, error }) {
 					if (!payload.title) {
 						error.fieldErrors.title = ['Title is required'];
@@ -1692,7 +1692,7 @@ describe('configureForms customization', () => {
 		});
 
 		function Form() {
-			const { form, fields } = customized.useForm<Schema, string>({
+			const { form, fields } = customized.useForm<Schema, string[]>({
 				id: 'test-form',
 				onValidate({ payload, error }) {
 					if (!payload.title) {
@@ -1752,7 +1752,7 @@ describe('configureForms customization', () => {
 			},
 		};
 
-		const customized = configureForms<string, MockSchema>({
+		const customized = configureForms<string[], MockSchema>({
 			isSchema(value): value is MockSchema {
 				return (
 					typeof value === 'object' &&
@@ -1781,7 +1781,7 @@ describe('configureForms customization', () => {
 
 				const hasErrors = Object.keys(errors).length > 0;
 				return {
-					error: hasErrors ? { formErrors: [], fieldErrors: errors } : null,
+					error: hasErrors ? { formErrors: null, fieldErrors: errors } : null,
 					value: hasErrors ? undefined : (payload as any),
 				};
 			},

--- a/packages/conform-react/tests/useForm.node.test.tsx
+++ b/packages/conform-react/tests/useForm.node.test.tsx
@@ -14,7 +14,7 @@ const testCases: Array<{ name: string; useForm: typeof useFormDefault }> = [
 describe.each(testCases)('future export: useForm - $name', ({ useForm }) => {
 	test('default state', () => {
 		const { form, fields } = serverRenderHook(() =>
-			useForm<{ title: string; description: string }, string>({
+			useForm<{ title: string; description: string }, string[]>({
 				lastResult: null,
 				onValidate: () => undefined,
 			}),
@@ -28,7 +28,7 @@ describe.each(testCases)('future export: useForm - $name', ({ useForm }) => {
 
 		// Test if the form state is stable
 		const secondUseFormResult = serverRenderHook(() =>
-			useForm<{ title: string; description: string }, string>({
+			useForm<{ title: string; description: string }, string[]>({
 				lastResult: null,
 				onValidate: () => undefined,
 			}),
@@ -55,7 +55,7 @@ describe.each(testCases)('future export: useForm - $name', ({ useForm }) => {
 
 	test('initialize with last submission result', () => {
 		const { form, fields } = serverRenderHook(() =>
-			useForm<{ title: string; description: string }, string>({
+			useForm<{ title: string; description: string }, string[]>({
 				lastResult: createResult(
 					[
 						['title', 'Example'],
@@ -84,7 +84,7 @@ describe.each(testCases)('future export: useForm - $name', ({ useForm }) => {
 
 	test('initialize with validate intent', () => {
 		const { form, fields } = serverRenderHook(() =>
-			useForm<{ title: string; description: string }, string>({
+			useForm<{ title: string; description: string }, string[]>({
 				lastResult: createResult(
 					[
 						['title', 'Example'],
@@ -120,7 +120,7 @@ describe.each(testCases)('future export: useForm - $name', ({ useForm }) => {
 
 	test('initialize with update result', () => {
 		const { form, fields } = serverRenderHook(() =>
-			useForm<{ title: string; description: string }, string>({
+			useForm<{ title: string; description: string }, string[]>({
 				lastResult: createResult(
 					[
 						['title', 'Example'],
@@ -159,7 +159,7 @@ describe.each(testCases)('future export: useForm - $name', ({ useForm }) => {
 
 	test('initialize with reset intent', () => {
 		const { form, fields } = serverRenderHook(() =>
-			useForm<{ title: string; description: string }, string>({
+			useForm<{ title: string; description: string }, string[]>({
 				lastResult: createResult(
 					[
 						['title', 'Example'],
@@ -197,7 +197,7 @@ describe.each(testCases)('future export: useForm - $name', ({ useForm }) => {
 
 	test('initialize with insert intent', () => {
 		const { form, fields } = serverRenderHook(() =>
-			useForm<{ title: string; notes: string[] }, string>({
+			useForm<{ title: string; notes: string[] }, string[]>({
 				lastResult: createResult(
 					[
 						['title', 'Example'],
@@ -243,7 +243,7 @@ describe.each(testCases)('future export: useForm - $name', ({ useForm }) => {
 
 	test('initialize with reorder intent', () => {
 		const { form, fields } = serverRenderHook(() =>
-			useForm<{ title: string; notes: string[] }, string>({
+			useForm<{ title: string; notes: string[] }, string[]>({
 				lastResult: createResult(
 					[
 						['title', 'Example'],
@@ -300,7 +300,7 @@ describe.each(testCases)('future export: useForm - $name', ({ useForm }) => {
 
 	test('initialize with remove intent', () => {
 		const { form, fields } = serverRenderHook(() =>
-			useForm<{ title: string; notes: string[] }, string>({
+			useForm<{ title: string; notes: string[] }, string[]>({
 				lastResult: createResult(
 					[
 						['title', 'Example'],
@@ -366,7 +366,7 @@ describe('configureForms customization', () => {
 		});
 
 		const { fields } = serverRenderHook(() =>
-			customized.useForm<{ title: string }, string>({
+			customized.useForm<{ title: string }, string[]>({
 				id: 'test',
 				lastResult: createResult([['title', 'Example']], {
 					error: {
@@ -404,7 +404,7 @@ describe('configureForms customization', () => {
 		});
 
 		const { form } = serverRenderHook(() =>
-			customized.useForm<{ title: string }, string>({
+			customized.useForm<{ title: string }, string[]>({
 				id: 'test',
 				lastResult: createResult([['title', 'Example']], {
 					error: {

--- a/packages/conform-react/tests/useFormMetadata.browser.test.tsx
+++ b/packages/conform-react/tests/useFormMetadata.browser.test.tsx
@@ -61,7 +61,7 @@ describe.each(testCases)(
 		function Form({
 			children,
 			...options
-		}: Partial<FormOptions<Schema, string, Schema>> & {
+		}: Partial<FormOptions<Schema, string[], Schema>> & {
 			children?: React.ReactNode;
 		}) {
 			const { form, fields, intent } = useForm({

--- a/packages/conform-react/tests/useIntent.browser.test.tsx
+++ b/packages/conform-react/tests/useIntent.browser.test.tsx
@@ -76,7 +76,7 @@ describe.each(testCases)(
 			);
 		}
 
-		function Form(props: Partial<FormOptions<Schema, string, Schema>>) {
+		function Form(props: Partial<FormOptions<Schema, string[], Schema>>) {
 			const { form, fields, intent } = useForm({
 				onValidate({ payload, error }) {
 					if (!payload.title) {

--- a/packages/conform-react/tests/util.test.ts
+++ b/packages/conform-react/tests/util.test.ts
@@ -7,7 +7,6 @@ import {
 	getPathArray,
 	updatePathValue,
 	createPathIndexUpdater,
-	normalizeFormError,
 	normalizeValidateResult,
 	resolveValidateResult,
 	resolveStandardSchemaResult,
@@ -130,32 +129,6 @@ test('createPathIndexUpdater', () => {
 	expect(nestedUpdater('form.items[0].field')).toBe('form.items[1].field');
 });
 
-test('normalizeFormError', () => {
-	// Test error with messages
-	const errorWithMessages: FormError<string> = {
-		formErrors: ['Form error'],
-		fieldErrors: { email: ['Required'] },
-	};
-	expect(normalizeFormError(errorWithMessages)).toBe(errorWithMessages);
-
-	// Test error without messages
-	const emptyError: FormError<string> = {
-		formErrors: [],
-		fieldErrors: { email: [] },
-	};
-	expect(normalizeFormError(emptyError)).toBeNull();
-
-	// Test null error
-	expect(normalizeFormError(null)).toBeNull();
-
-	// Test mixed empty/non-empty fields
-	const mixedError: FormError<string> = {
-		formErrors: [],
-		fieldErrors: { email: [], password: ['Required'] },
-	};
-	expect(normalizeFormError(mixedError)).toBe(mixedError);
-});
-
 test('normalizeValidateResult', () => {
 	// Test result with error property
 	const resultWithError = {
@@ -168,7 +141,7 @@ test('normalizeValidateResult', () => {
 	});
 
 	// Test direct error result
-	const directError: FormError<string> = {
+	const directError: FormError<string[]> = {
 		formErrors: ['Direct error'],
 		fieldErrors: {},
 	};
@@ -190,7 +163,7 @@ test('resolveValidateResult', () => {
 	expect(resolved1.asyncResult).toBeInstanceOf(Promise);
 
 	// Test Array result [sync, async]
-	const syncError: FormError<string> = {
+	const syncError: FormError<string[]> = {
 		formErrors: ['Sync error'],
 		fieldErrors: {},
 	};
@@ -200,7 +173,7 @@ test('resolveValidateResult', () => {
 	expect(resolved2.asyncResult).toBeInstanceOf(Promise);
 
 	// Test direct result
-	const directError: FormError<string> = {
+	const directError: FormError<string[]> = {
 		formErrors: ['Direct error'],
 		fieldErrors: {},
 	};

--- a/packages/conform-valibot/format.ts
+++ b/packages/conform-valibot/format.ts
@@ -9,17 +9,17 @@ import { appendPath, type FormError } from '@conform-to/dom/future';
 
 export function formatResult<Schema extends GenericSchema | GenericSchemaAsync>(
 	result: SafeParseResult<Schema>,
-): FormError<string> | null;
+): FormError<string[]> | null;
 export function formatResult<
 	Schema extends GenericSchema | GenericSchemaAsync,
-	ErrorShape = string,
+	ErrorShape = string[],
 >(
 	result: SafeParseResult<Schema>,
 	options: {
 		/** Whether to include the parsed value in the returned object */
 		includeValue: true;
 		/** Custom function to format validation issues for each field */
-		formatIssues: (issues: InferIssue<Schema>[], name: string) => ErrorShape[];
+		formatIssues: (issues: InferIssue<Schema>[], name: string) => ErrorShape;
 	},
 ): {
 	error: FormError<ErrorShape> | null;
@@ -32,36 +32,36 @@ export function formatResult<Schema extends GenericSchema | GenericSchemaAsync>(
 		formatIssues?: undefined;
 	},
 ): {
-	error: FormError<string> | null;
+	error: FormError<string[]> | null;
 	value: InferOutput<Schema> | undefined;
 };
 export function formatResult<
 	Schema extends GenericSchema | GenericSchemaAsync,
-	ErrorShape = string,
+	ErrorShape = string[],
 >(
 	result: SafeParseResult<Schema>,
 	options: {
 		includeValue?: false;
-		formatIssues: (issues: InferIssue<Schema>[], name: string) => ErrorShape[];
+		formatIssues: (issues: InferIssue<Schema>[], name: string) => ErrorShape;
 	},
 ): FormError<ErrorShape> | null;
 export function formatResult<
 	Schema extends GenericSchema | GenericSchemaAsync,
-	ErrorShape = string,
+	ErrorShape = string[],
 >(
 	result: SafeParseResult<Schema>,
 	options?: {
 		includeValue?: boolean;
-		formatIssues?: (issues: InferIssue<Schema>[], name: string) => ErrorShape[];
+		formatIssues?: (issues: InferIssue<Schema>[], name: string) => ErrorShape;
 	},
 ):
-	| FormError<string | ErrorShape>
+	| FormError<string[] | ErrorShape>
 	| {
-			error: FormError<string | ErrorShape> | null;
+			error: FormError<string[] | ErrorShape> | null;
 			value: InferOutput<Schema> | undefined;
 	  }
 	| null {
-	let error: FormError<string | ErrorShape> | null = null;
+	let error: FormError<string[] | ErrorShape> | null = null;
 
 	if (!result.success) {
 		const errorByName: Record<string, InferIssue<Schema>[]> = {};
@@ -88,13 +88,15 @@ export function formatResult<
 			errorByName[name].push(issue);
 		}
 
-		const { '': formErrors = [], ...fieldErrors } = Object.entries(
+		const { '': formErrors = null, ...fieldErrors } = Object.entries(
 			errorByName,
-		).reduce<Record<string, string[] | ErrorShape[]>>(
+		).reduce<Record<string, string[] | ErrorShape>>(
 			(result, [name, issues]) => {
-				result[name] = options?.formatIssues
-					? options.formatIssues(issues, name)
-					: issues.map((issue) => issue.message);
+				if (issues.length > 0) {
+					result[name] = options?.formatIssues
+						? options.formatIssues(issues, name)
+						: issues.map((issue) => issue.message);
+				}
 
 				return result;
 			},

--- a/packages/conform-valibot/tests/format.test.ts
+++ b/packages/conform-valibot/tests/format.test.ts
@@ -32,7 +32,7 @@ describe('formatResult', () => {
 		const error = formatResult(result);
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				name: ['Name is required'],
 				age: ['Must be at least 18'],
@@ -53,7 +53,7 @@ describe('formatResult', () => {
 		const error = formatResult(result);
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				'user.name': ['Name is required'],
 				'user.email': ['Invalid email'],
@@ -72,7 +72,7 @@ describe('formatResult', () => {
 		const error = formatResult(result);
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				'items[0]': ['Item cannot be empty'],
 				'items[2]': ['Item cannot be empty'],
@@ -113,7 +113,7 @@ describe('formatResult', () => {
 
 		expect(formatted).toEqual({
 			error: {
-				formErrors: [],
+				formErrors: null,
 				fieldErrors: {
 					name: ['Name is required'],
 				},
@@ -139,7 +139,7 @@ describe('formatResult', () => {
 		});
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				name: [
 					{
@@ -172,7 +172,7 @@ describe('formatResult', () => {
 
 		expect(formatted).toEqual({
 			error: {
-				formErrors: [],
+				formErrors: null,
 				fieldErrors: {
 					email: ['"invalid"'],
 				},
@@ -199,7 +199,7 @@ describe('formatResult', () => {
 		});
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				password: [
 					'password has 3 errors: Too short, Must contain uppercase, Must contain number',

--- a/packages/conform-zod/default/format.ts
+++ b/packages/conform-zod/default/format.ts
@@ -13,14 +13,14 @@ import { formatPath } from '@conform-to/dom/future';
  */
 export function formatResult(
 	result: SafeParseReturnType<any, any>,
-): FormError<string> | null;
+): FormError<string[]> | null;
 export function formatResult<Output, ErrorShape>(
 	result: SafeParseReturnType<any, Output>,
 	options: {
 		/** Whether to include the parsed value in the returned object */
 		includeValue: true;
 		/** Custom function to format validation issues for each field */
-		formatIssues: (issue: ZodIssue[], name: string) => ErrorShape[];
+		formatIssues: (issue: ZodIssue[], name: string) => ErrorShape;
 	},
 ): {
 	error: FormError<ErrorShape> | null;
@@ -33,30 +33,30 @@ export function formatResult<Output>(
 		formatIssues?: undefined;
 	},
 ): {
-	error: FormError<string> | null;
+	error: FormError<string[]> | null;
 	value: Output | undefined;
 };
 export function formatResult<Output, ErrorShape>(
 	result: SafeParseReturnType<any, Output>,
 	options: {
 		includeValue?: false;
-		formatIssues: (issue: ZodIssue[], name: string) => ErrorShape[];
+		formatIssues: (issue: ZodIssue[], name: string) => ErrorShape;
 	},
 ): FormError<ErrorShape> | null;
 export function formatResult<Output, Input, ErrorShape>(
 	result: SafeParseReturnType<Input, Output>,
 	options?: {
 		includeValue?: boolean;
-		formatIssues?: (issue: ZodIssue[], name: string) => ErrorShape[];
+		formatIssues?: (issue: ZodIssue[], name: string) => ErrorShape;
 	},
 ):
-	| FormError<string | ErrorShape>
+	| FormError<string[] | ErrorShape>
 	| null
 	| {
-			error: FormError<string | ErrorShape> | null;
+			error: FormError<string[] | ErrorShape> | null;
 			value: Output | undefined;
 	  } {
-	let error: FormError<string | ErrorShape> | null = null;
+	let error: FormError<string[] | ErrorShape> | null = null;
 	let value: Output | undefined = undefined;
 
 	if (!result.success) {
@@ -69,13 +69,15 @@ export function formatResult<Output, Input, ErrorShape>(
 			errorByName[name].push(issue);
 		}
 
-		const { '': formErrors = [], ...fieldErrors } = Object.entries(
+		const { '': formErrors = null, ...fieldErrors } = Object.entries(
 			errorByName,
-		).reduce<Record<string, string[] | ErrorShape[]>>(
+		).reduce<Record<string, string[] | ErrorShape>>(
 			(result, [name, issues]) => {
-				result[name] = options?.formatIssues
-					? options.formatIssues(issues, name)
-					: issues.map((issue) => issue.message);
+				if (issues.length > 0) {
+					result[name] = options?.formatIssues
+						? options.formatIssues(issues, name)
+						: issues.map((issue) => issue.message);
+				}
 
 				return result;
 			},

--- a/packages/conform-zod/default/tests/format.test.ts
+++ b/packages/conform-zod/default/tests/format.test.ts
@@ -32,7 +32,7 @@ describe('formatResult', () => {
 		const error = formatResult(result);
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				name: ['Name is required'],
 				age: ['Must be at least 18'],
@@ -53,7 +53,7 @@ describe('formatResult', () => {
 		const error = formatResult(result);
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				'user.name': ['Name is required'],
 				'user.email': ['Invalid email'],
@@ -70,7 +70,7 @@ describe('formatResult', () => {
 		const error = formatResult(result);
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				'items[0]': ['Item cannot be empty'],
 				'items[2]': ['Item cannot be empty'],
@@ -109,7 +109,7 @@ describe('formatResult', () => {
 
 		expect(formatted).toEqual({
 			error: {
-				formErrors: [],
+				formErrors: null,
 				fieldErrors: {
 					name: ['Name is required'],
 				},
@@ -135,7 +135,7 @@ describe('formatResult', () => {
 		});
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				name: [
 					{
@@ -168,7 +168,7 @@ describe('formatResult', () => {
 
 		expect(formatted).toEqual({
 			error: {
-				formErrors: [],
+				formErrors: null,
 				fieldErrors: {
 					email: ['invalid_string'],
 				},
@@ -193,7 +193,7 @@ describe('formatResult', () => {
 		});
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				password: [
 					'password has 3 errors: Too short, Must contain uppercase, Must contain number',

--- a/packages/conform-zod/v3/format.ts
+++ b/packages/conform-zod/v3/format.ts
@@ -13,14 +13,14 @@ import { formatPath } from '@conform-to/dom/future';
  */
 export function formatResult(
 	result: SafeParseReturnType<any, any>,
-): FormError<string> | null;
+): FormError<string[]> | null;
 export function formatResult<Output, ErrorShape>(
 	result: SafeParseReturnType<any, Output>,
 	options: {
 		/** Whether to include the parsed value in the returned object */
 		includeValue: true;
 		/** Custom function to format validation issues for each field */
-		formatIssues: (issue: ZodIssue[], name: string) => ErrorShape[];
+		formatIssues: (issue: ZodIssue[], name: string) => ErrorShape;
 	},
 ): {
 	error: FormError<ErrorShape> | null;
@@ -33,30 +33,30 @@ export function formatResult<Output>(
 		formatIssues?: undefined;
 	},
 ): {
-	error: FormError<string> | null;
+	error: FormError<string[]> | null;
 	value: Output | undefined;
 };
 export function formatResult<Output, ErrorShape>(
 	result: SafeParseReturnType<any, Output>,
 	options: {
 		includeValue?: false;
-		formatIssues: (issue: ZodIssue[], name: string) => ErrorShape[];
+		formatIssues: (issue: ZodIssue[], name: string) => ErrorShape;
 	},
 ): FormError<ErrorShape> | null;
 export function formatResult<Output, Input, ErrorShape>(
 	result: SafeParseReturnType<Input, Output>,
 	options?: {
 		includeValue?: boolean;
-		formatIssues?: (issue: ZodIssue[], name: string) => ErrorShape[];
+		formatIssues?: (issue: ZodIssue[], name: string) => ErrorShape;
 	},
 ):
-	| FormError<string | ErrorShape>
+	| FormError<string[] | ErrorShape>
 	| null
 	| {
-			error: FormError<string | ErrorShape> | null;
+			error: FormError<string[] | ErrorShape> | null;
 			value: Output | undefined;
 	  } {
-	let error: FormError<string | ErrorShape> | null = null;
+	let error: FormError<string[] | ErrorShape> | null = null;
 	let value: Output | undefined = undefined;
 
 	if (!result.success) {
@@ -69,13 +69,15 @@ export function formatResult<Output, Input, ErrorShape>(
 			errorByName[name].push(issue);
 		}
 
-		const { '': formErrors = [], ...fieldErrors } = Object.entries(
+		const { '': formErrors = null, ...fieldErrors } = Object.entries(
 			errorByName,
-		).reduce<Record<string, string[] | ErrorShape[]>>(
+		).reduce<Record<string, string[] | ErrorShape>>(
 			(result, [name, issues]) => {
-				result[name] = options?.formatIssues
-					? options.formatIssues(issues, name)
-					: issues.map((issue) => issue.message);
+				if (issues.length > 0) {
+					result[name] = options?.formatIssues
+						? options.formatIssues(issues, name)
+						: issues.map((issue) => issue.message);
+				}
 
 				return result;
 			},

--- a/packages/conform-zod/v3/tests/format.test.ts
+++ b/packages/conform-zod/v3/tests/format.test.ts
@@ -32,7 +32,7 @@ describe('formatResult', () => {
 		const error = formatResult(result);
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				name: ['Name is required'],
 				age: ['Must be at least 18'],
@@ -53,7 +53,7 @@ describe('formatResult', () => {
 		const error = formatResult(result);
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				'user.name': ['Name is required'],
 				'user.email': ['Invalid email'],
@@ -70,7 +70,7 @@ describe('formatResult', () => {
 		const error = formatResult(result);
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				'items[0]': ['Item cannot be empty'],
 				'items[2]': ['Item cannot be empty'],
@@ -109,7 +109,7 @@ describe('formatResult', () => {
 
 		expect(formatted).toEqual({
 			error: {
-				formErrors: [],
+				formErrors: null,
 				fieldErrors: {
 					name: ['Name is required'],
 				},
@@ -135,7 +135,7 @@ describe('formatResult', () => {
 		});
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				name: [
 					{
@@ -168,7 +168,7 @@ describe('formatResult', () => {
 
 		expect(formatted).toEqual({
 			error: {
-				formErrors: [],
+				formErrors: null,
 				fieldErrors: {
 					email: ['invalid_string'],
 				},
@@ -193,7 +193,7 @@ describe('formatResult', () => {
 		});
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				password: [
 					'password has 3 errors: Too short, Must contain uppercase, Must contain number',

--- a/packages/conform-zod/v4/format.ts
+++ b/packages/conform-zod/v4/format.ts
@@ -13,14 +13,14 @@ import { appendPath } from '@conform-to/dom/future';
  */
 export function formatResult<Output>(
 	result: ZodSafeParseResult<Output>,
-): FormError<string> | null;
-export function formatResult<Output, ErrorShape = string>(
+): FormError<string[]> | null;
+export function formatResult<Output, ErrorShape = string[]>(
 	result: ZodSafeParseResult<Output>,
 	options: {
 		/** Whether to include the parsed value in the returned object */
 		includeValue: true;
 		/** Custom function to format validation issues for each field */
-		formatIssues: (issue: core.$ZodIssue[], name: string) => ErrorShape[];
+		formatIssues: (issue: core.$ZodIssue[], name: string) => ErrorShape;
 	},
 ): {
 	error: FormError<ErrorShape> | null;
@@ -33,30 +33,30 @@ export function formatResult<Output>(
 		formatIssues?: undefined;
 	},
 ): {
-	error: FormError<string> | null;
+	error: FormError<string[]> | null;
 	value: Output | undefined;
 };
-export function formatResult<Output, ErrorShape = string>(
+export function formatResult<Output, ErrorShape = string[]>(
 	result: ZodSafeParseResult<Output>,
 	options: {
 		includeValue?: false;
-		formatIssues: (issue: core.$ZodIssue[], name: string) => ErrorShape[];
+		formatIssues: (issue: core.$ZodIssue[], name: string) => ErrorShape;
 	},
 ): FormError<ErrorShape> | null;
-export function formatResult<Output, ErrorShape = string>(
+export function formatResult<Output, ErrorShape = string[]>(
 	result: ZodSafeParseResult<Output>,
 	options?: {
 		includeValue?: boolean;
-		formatIssues?: (issue: core.$ZodIssue[], name: string) => ErrorShape[];
+		formatIssues?: (issue: core.$ZodIssue[], name: string) => ErrorShape;
 	},
 ):
-	| FormError<string | ErrorShape>
+	| FormError<string[] | ErrorShape>
 	| null
 	| {
-			error: FormError<string | ErrorShape> | null;
+			error: FormError<string[] | ErrorShape> | null;
 			value: Output | undefined;
 	  } {
-	let error: FormError<string | ErrorShape> | null = null;
+	let error: FormError<string[] | ErrorShape> | null = null;
 	let value: Output | undefined = undefined;
 
 	if (!result.success) {
@@ -78,13 +78,15 @@ export function formatResult<Output, ErrorShape = string>(
 			errorByName[name].push(issue);
 		}
 
-		const { '': formErrors = [], ...fieldErrors } = Object.entries(
+		const { '': formErrors = null, ...fieldErrors } = Object.entries(
 			errorByName,
-		).reduce<Record<string, string[] | ErrorShape[]>>(
+		).reduce<Record<string, string[] | ErrorShape>>(
 			(result, [name, issues]) => {
-				result[name] = options?.formatIssues
-					? options.formatIssues(issues, name)
-					: issues.map((issue) => issue.message);
+				if (issues.length > 0) {
+					result[name] = options?.formatIssues
+						? options.formatIssues(issues, name)
+						: issues.map((issue) => issue.message);
+				}
 
 				return result;
 			},

--- a/packages/conform-zod/v4/tests/format.test.ts
+++ b/packages/conform-zod/v4/tests/format.test.ts
@@ -32,7 +32,7 @@ describe('formatResult', () => {
 		const error = formatResult(result);
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				name: ['Name is required'],
 				age: ['Must be at least 18'],
@@ -53,7 +53,7 @@ describe('formatResult', () => {
 		const error = formatResult(result);
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				'user.name': ['Name is required'],
 				'user.email': ['Invalid email'],
@@ -70,7 +70,7 @@ describe('formatResult', () => {
 		const error = formatResult(result);
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				'items[0]': ['Item cannot be empty'],
 				'items[2]': ['Item cannot be empty'],
@@ -109,7 +109,7 @@ describe('formatResult', () => {
 
 		expect(formatted).toEqual({
 			error: {
-				formErrors: [],
+				formErrors: null,
 				fieldErrors: {
 					name: ['Name is required'],
 				},
@@ -135,7 +135,7 @@ describe('formatResult', () => {
 		});
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				name: [
 					{
@@ -168,7 +168,7 @@ describe('formatResult', () => {
 
 		expect(formatted).toEqual({
 			error: {
-				formErrors: [],
+				formErrors: null,
 				fieldErrors: {
 					email: ['invalid_format'],
 				},
@@ -194,7 +194,7 @@ describe('formatResult', () => {
 		});
 
 		expect(error).toEqual({
-			formErrors: [],
+			formErrors: null,
 			fieldErrors: {
 				password: [
 					'password has 3 errors: Too short, Must contain uppercase, Must contain number',


### PR DESCRIPTION
Previously, `form.errors` and `field.errors` were always arrays, even when you provided a custom `ErrorShape`. The future APIs now use `ErrorShape` as the final error shape directly, so custom validation can return a string or object without Conform wrapping it in another array.

You may need to update existing code in a few places:

If you were using a custom `ErrorShape`, either by specifying it in the generics or through the `isError` option from `configureForms`, update it from `ErrorShape` to `ErrorShape[]` to keep the array structure you had before. For example, if you previously used `string`, change it to `string[]` to keep the errors as arrays of strings:

```diff
const forms = configureForms({
-  isError: shape<string>(),
+  isError: shape<string[]>(),
});
```

`report()` now accepts either schema `issues` or an explicit error payload, but not both in the same `error` object. If you were using both to add more messages on top of schema validation, append another issue instead.

```diff
const result = schema.safeParse(submission.payload);
const isEmailUnique = await checkEmailUnique(submission.payload.email);

if (!result.success || !isEmailUnique) {
  const issues = !result.success ? [...result.error.issues] : [];

+ if (!isEmailUnique) {
+   issues.push({
+     message: 'Email is already taken',
+     path: ['email'],
+   });
+ }

  return {
    result: report(submission, {
      error: {
        issues,
-       fieldErrors: {
-         email: !isEmailUnique ? ['Email is already taken'] : [],
-       },
      },
    }),
  };
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

- Purpose: Future APIs now use the configured ErrorShape directly (singular error values, nullable formErrors) instead of always wrapping errors in arrays; report() treats schema issues and an explicit error payload as mutually exclusive.

- Key type & API changes:
  - FormError default: string → string[]; formErrors: ErrorShape | null (was ErrorShape[]); fieldErrors: Record<string, ErrorShape | null> (was Record<string, ErrorShape[]>).
  - New types: StandardSchemaIssue, StandardSchemaError, CustomError<ErrorShape>.
  - report() overloads: accept either { issues: StandardSchemaIssue[] } or an explicit { formErrors?, fieldErrors? }, not both in the same error object.
  - formatIssues callbacks now return ErrorShape (single) instead of ErrorShape[].
  - New helpers: hasError(...) and normalizeFormError(...). normalizeFormError is exported and used to canonicalize error payloads.

- Runtime/implementation notes:
  - Formatters (Zod/Valibot/default) set formErrors = null when only fieldErrors exist; fieldErrors entries are only created when issues exist.
  - React internals (hooks/state/intent) and DOM form handling updated to use singular/nullable error shapes and to normalize errors before applying intent/onError.
  - report() no longer auto-merges schema issues into custom form/field payloads; StandardSchemaError is formatted via formatIssues, otherwise options.error is normalized directly.

- Migration guidance:
  - To preserve prior array semantics, change configured ErrorShape to an array type (e.g., shape<string[]>() or use ErrorShape[] in generics/options).
  - When combining schema validation messages with additional messages, append extra Issue entries to the issues array rather than supplying both issues and a separate form/field payload to report().

- Surface and docs:
  - Documentation and examples updated (configureForms, report, useField, useFormMetadata, formatResult, examples).
  - Tests updated across packages to reflect null vs empty-array semantics and the new ErrorShape defaults.

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->