### PR TITLE
docs: remove jsdocs tags for better example formatting

### DIFF
--- a/packages/conform-dom/dom.ts
+++ b/packages/conform-dom/dom.ts
@@ -732,8 +732,8 @@ export function updateField(
 			/**
 			 * Triggering react custom change event
 			 * Solution based on dom-testing-library
-			 * @see https://github.com/facebook/react/issues/10135#issuecomment-401496776
-			 * @see https://github.com/testing-library/dom-testing-library/blob/main/src/events.js#L104-L123
+			 * See https://github.com/facebook/react/issues/10135#issuecomment-401496776
+			 * See https://github.com/testing-library/dom-testing-library/blob/main/src/events.js#L104-L123
 			 */
 			const { set: valueSetter } =
 				Object.getOwnPropertyDescriptor(element, 'value') || {};

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -68,7 +68,7 @@ export function normalizeFormError<ErrorShape>(
  * It utilizes the submitter argument on the FormData constructor from modern browsers
  * with fallback to append the submitter value in case it is not unsupported.
  *
- * @see https://developer.mozilla.org/en-US/docs/Web/API/FormData/FormData#parameters
+ * See https://developer.mozilla.org/en-US/docs/Web/API/FormData/FormData#parameters
  */
 export function getFormData(
 	form: HTMLFormElement,
@@ -99,7 +99,7 @@ export function getFormData(
 /**
  * Convert a string path into an array of segments.
  *
- * @example
+ * **Example:**
  * ```js
  * parsePath("object.key");       // → ['object', 'key']
  * parsePath("array[0].content"); // → ['array', 0, 'content']
@@ -158,7 +158,7 @@ export function parsePath(path: string | undefined): Array<string | number> {
 /**
  * Returns a formatted name from the path segments based on the dot and bracket notation.
  *
- * @example
+ * **Example:**
  * ```js
  * formatPath(['object', 'key']); // → "object.key"
  * formatPath(['array', 0, 'content']); // → "array[0].content"
@@ -209,7 +209,7 @@ export function appendPath(
 /**
  * Returns true if `prefix` is a valid leading path of `name`.
  *
- * @example
+ * **Example:**
  * ```js
  * isPathPrefix("foo.bar.baz", "foo.bar")        // → true
  * isPathPrefix("foo.bar[3].baz", "foo.bar[3]")  // → true
@@ -229,7 +229,7 @@ export function isPathPrefix(name: string, prefix: string) {
  * @param basePath     Base path as a dot/bracket string or array of segments
  * @returns               The “tail” segments, or `null` if `fullPath` isn’t nested under `basePath`
  *
- * @example
+ * **Example:**
  * ```js
  * getRelativePath("foo.bar[0].qux", ["foo","bar"])  // → [0, "qux"]
  * getRelativePath("a.b.c.d", ["a","b"])             // → ["c","d"]
@@ -397,8 +397,9 @@ function isEmptyValue(
  * This function structures the form values based on the naming convention.
  * It also includes all the field names and extracts the intent from the submission.
  *
- * @see https://conform.guide/api/react/future/parseSubmission
- * @example
+ * See https://conform.guide/api/react/future/parseSubmission
+ *
+ * **Example:**
  * ```ts
  * const formData = new FormData();
  *
@@ -505,8 +506,9 @@ export function parseSubmission(
  * file inputs cannot be initialized with files.
  * You can specify `keepFiles: true` to keep the files if needed.
  *
- * @see https://conform.guide/api/react/future/report
- * @example
+ * See https://conform.guide/api/react/future/report
+ *
+ * **Example:**
  * ```ts
  * // Report the submission with the field errors
  * report(submission, {
@@ -680,8 +682,9 @@ export function report<ErrorShape>(
 /**
  * A utility function that checks whether the current form data differs from the default values.
  *
- * @see https://conform.guide/api/react/future/isDirty
- * @example Enable a submit button only if the form is dirty
+ * See https://conform.guide/api/react/future/isDirty
+ *
+ * **Example: Enable a submit button only if the form is dirty**
  *
  * ```tsx
  * const dirty = useFormData(
@@ -736,7 +739,7 @@ export function isDirty(
 		 * Useful for ignoring hidden inputs like CSRF tokens or internal fields added by frameworks
 		 * (e.g. Next.js uses hidden inputs to support server actions).
 		 *
-		 * @example
+		 * **Example:**
 		 * ```ts
 		 * isDirty(formData, {
 		 *   skipEntry: (name) => name === 'csrf-token',
@@ -945,7 +948,9 @@ export function normalize(
 /**
  * Retrieve a field value from FormData with optional type guards.
  *
- * @example
+ * **Example:**
+ *
+ * ```ts
  * // Basic field access: return `unknown`
  * const email = getFieldValue(formData, 'email');
  * // String type: returns `string`
@@ -960,6 +965,7 @@ export function normalize(
  * const items = getFieldValue<Item[]>(formData, 'items', { type: 'object', array: true });
  * // Optional string type: returns `string | undefined`
  * const bio = getFieldValue(formData, 'bio', { type: 'string', optional: true });
+ * ```
  */
 export function getFieldValue<
 	FieldShape extends Array<Record<string, unknown>>,

--- a/packages/conform-dom/types.ts
+++ b/packages/conform-dom/types.ts
@@ -60,7 +60,7 @@ export type Submission<
 	 * The submitted values mapped by field name.
 	 * Supports nested names like `user.email` or indexed names like `items[0].id`.
 	 *
-	 * @example
+	 * **Example:**
 	 * ```json
 	 * {
 	 *   "username": "johndoe",
@@ -119,8 +119,9 @@ export type FieldName<FieldShape> = string & {
 };
 
 /**
- * The input attributes related to form field constraints
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Constraint_validation
+ * The input attributes related to form field constraints.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/HTML/Constraint_validation
  */
 export type ValidationAttributes = {
 	required?: boolean | undefined;

--- a/packages/conform-react/future/forms.tsx
+++ b/packages/conform-react/future/forms.tsx
@@ -132,8 +132,9 @@ export function configureForms<
 	 * - **Schema first**: Pass a schema as the first argument for automatic validation with type inference
 	 * - **Manual configuration**: Pass options with custom `onValidate` handler for manual validation
 	 *
-	 * @see https://conform.guide/api/react/future/useForm
-	 * @example Schema first setup with zod:
+	 * See https://conform.guide/api/react/future/useForm
+	 *
+	 * **Schema first setup with zod:**
 	 *
 	 * ```tsx
 	 * const { form, fields } = useForm(zodSchema, {
@@ -149,13 +150,13 @@ export function configureForms<
 	 * );
 	 * ```
 	 *
-	 * @example Manual configuration setup with custom validation:
+	 * **Manual configuration setup with custom validation:**
 	 *
 	 * ```tsx
 	 * const { form, fields } = useForm({
-	 *    onValidate({ payload, error }) {
+	 *   onValidate({ payload, error }) {
 	 *     if (!payload.email) {
-	 * 		 error.fieldErrors.email = ['Required'];
+	 *       error.fieldErrors.email = ['Required'];
 	 *     }
 	 *     return error;
 	 *   }
@@ -454,8 +455,9 @@ export function configureForms<
 	 * A React hook that provides access to form-level metadata and state.
 	 * Requires `FormProvider` context when used in child components.
 	 *
-	 * @see https://conform.guide/api/react/future/useFormMetadata
-	 * @example
+	 * See https://conform.guide/api/react/future/useFormMetadata
+	 *
+	 * **Example:**
 	 * ```tsx
 	 * function ErrorSummary() {
 	 *   const form = useFormMetadata();
@@ -494,8 +496,9 @@ export function configureForms<
 	 * A React hook that provides access to a specific field's metadata and state.
 	 * Requires `FormProvider` context when used in child components.
 	 *
-	 * @see https://conform.guide/api/react/future/useField
-	 * @example
+	 * See https://conform.guide/api/react/future/useField
+	 *
+	 * **Example:**
 	 * ```tsx
 	 * function FormField({ name, label }) {
 	 *   const field = useField(name);
@@ -538,8 +541,9 @@ export function configureForms<
 	 * Intent dispatchers allow you to trigger form operations like validation, field updates,
 	 * and array manipulations without manual form submission.
 	 *
-	 * @see https://conform.guide/api/react/future/useIntent
-	 * @example
+	 * See https://conform.guide/api/react/future/useIntent
+	 *
+	 * **Example:**
 	 * ```tsx
 	 * function ResetButton() {
 	 *   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -592,8 +596,9 @@ export const FormProvider = defaultForms.FormProvider;
  * - **Schema first**: Pass a schema as the first argument for automatic validation with type inference
  * - **Manual configuration**: Pass options with custom `onValidate` handler for manual validation
  *
- * @see https://conform.guide/api/react/future/useForm
- * @example Schema first setup with zod:
+ * See https://conform.guide/api/react/future/useForm
+ *
+ * **Schema first setup with zod:**
  *
  * ```tsx
  * const { form, fields } = useForm(zodSchema, {
@@ -609,13 +614,13 @@ export const FormProvider = defaultForms.FormProvider;
  * );
  * ```
  *
- * @example Manual configuration setup with custom validation:
+ * **Manual configuration setup with custom validation:**
  *
  * ```tsx
  * const { form, fields } = useForm({
- *    onValidate({ payload, error }) {
+ *   onValidate({ payload, error }) {
  *     if (!payload.email) {
- * 		 error.fieldErrors.email = ['Required'];
+ *       error.fieldErrors.email = ['Required'];
  *     }
  *     return error;
  *   }
@@ -635,8 +640,9 @@ export const useForm = defaultForms.useForm;
  * A React hook that provides access to form-level metadata and state.
  * Requires `FormProvider` context when used in child components.
  *
- * @see https://conform.guide/api/react/future/useFormMetadata
- * @example
+ * See https://conform.guide/api/react/future/useFormMetadata
+ *
+ * **Example:**
  * ```tsx
  * function ErrorSummary() {
  *   const form = useFormMetadata();
@@ -655,8 +661,9 @@ export const useFormMetadata = defaultForms.useFormMetadata;
  * A React hook that provides access to a specific field's metadata and state.
  * Requires `FormProvider` context when used in child components.
  *
- * @see https://conform.guide/api/react/future/useField
- * @example
+ * See https://conform.guide/api/react/future/useField
+ *
+ * **Example:**
  * ```tsx
  * function FormField({ name, label }) {
  *   const field = useField(name);
@@ -678,8 +685,9 @@ export const useField = defaultForms.useField;
  * Intent dispatchers allow you to trigger form operations like validation, field updates,
  * and array manipulations without manual form submission.
  *
- * @see https://conform.guide/api/react/future/useIntent
- * @example
+ * See https://conform.guide/api/react/future/useIntent
+ *
+ * **Example:**
  * ```tsx
  * function ResetButton() {
  *   const buttonRef = useRef<HTMLButtonElement>(null);

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -82,7 +82,7 @@ export const FormContextContext = createContext<FormContext[]>([]);
  * Preserves form field values when its contents are unmounted.
  * Useful for multi-step forms and virtualized lists.
  *
- * @see https://conform.guide/api/react/future/PreserveBoundary
+ * See https://conform.guide/api/react/future/PreserveBoundary
  */
 export function PreserveBoundary(props: {
 	/**
@@ -520,7 +520,7 @@ export function useConform<
  * This is useful when emulating native input behavior — typically by rendering a hidden base control
  * and syncing it with a custom input.
  *
- * @example
+ * **Example:**
  * ```ts
  * const control = useControl(options);
  * ```
@@ -768,7 +768,7 @@ export function useControl(options: ControlOptions = {}): Control<any> {
 				if (element.type === 'checkbox' || element.type === 'radio') {
 					// React set the value as empty string incorrectly when the value is undefined
 					// This make sure the checkbox value falls back to the default value "on" properly
-					// @see https://github.com/facebook/react/issues/17590
+					// See https://github.com/facebook/react/issues/17590
 					const value =
 						'value' in optionsRef.current && optionsRef.current.value
 							? optionsRef.current.value
@@ -886,8 +886,9 @@ export function useControl(options: ControlOptions = {}): Control<any> {
  * Returns `undefined` when the form element is not available (e.g., on SSR or initial client render),
  * unless a `fallback` is provided.
  *
- * @see https://conform.guide/api/react/future/useFormData
- * @example
+ * See https://conform.guide/api/react/future/useFormData
+ *
+ * **Example:**
  * ```ts
  * const value = useFormData(
  *   formRef,
@@ -1031,7 +1032,7 @@ export function useLatest<Value>(value: Value) {
  * A component that renders hidden base control(s) based on the shape of defaultValue.
  * Used with useControl to sync complex values with form data.
  *
- * @example
+ * **Example:**
  * ```tsx
  * const control = useControl<{ street: string; city: string }>({
  *   defaultValue: { street: '123 Main St', city: 'Anytown' },

--- a/packages/conform-react/future/memoize.ts
+++ b/packages/conform-react/future/memoize.ts
@@ -38,7 +38,7 @@ export function defaultEqualityCheck(prevArgs: any[], nextArgs: any[]) {
  * @param isEqual - Custom equality function to compare arguments (defaults to shallow comparison)
  * @returns Memoized function with cache clearing capability
  *
- * @example
+ * **Example:**
  * ```ts
  * // Async validation with API call
  * const validateUsername = useMemo(

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -228,7 +228,7 @@ export type FormAction<
 /**
  * Augment this interface to customize schema type inference for your schema library.
  *
- * @example
+ * **Example:**
  * ```ts
  * import type { ZodTypeAny, input, output } from 'zod';
  * import type { ZodSchemaOptions } from '@conform-to/zod/v3/future';
@@ -362,7 +362,7 @@ export type FormsConfig<
 	 * Runtime type guard to check if a value is a schema.
 	 * Used to determine if the first argument to useForm is a schema or options object.
 	 *
-	 * @example
+	 * **Example:**
 	 * ```ts
 	 * import { configureForms } from '@conform-to/react/future';
 	 * import {
@@ -572,7 +572,7 @@ export interface IntentDispatcher<
 	 *
 	 * @param options.defaultValue - The value to reset the form to. Pass `null` to clear all fields, or omit to reset to the initial default value from `useForm`.
 	 *
-	 * @example
+	 * **Example:**
 	 * ```tsx
 	 * // Reset to initial default value
 	 * intent.reset()
@@ -1060,7 +1060,7 @@ export type SubmitHandler<
 /**
  * Infer the base error shape from a FormsConfig.
  *
- * @example
+ * **Example:**
  * ```ts
  * const { config } = configureForms({ isError: shape<{ message: string }>() });
  * type ErrorShape = InferBaseErrorShape<typeof config>; // { message: string }
@@ -1075,7 +1075,7 @@ export type InferBaseErrorShape<Config> =
  * Infer the custom form metadata extension from a FormsConfig.
  * Use this to compose with FormMetadata, FieldMetadata, or Fieldset types.
  *
- * @example
+ * **Example:**
  * ```ts
  * const { config } = configureForms({
  *   extendFormMetadata: (meta) => ({ customProp: meta.id })
@@ -1096,7 +1096,7 @@ export type InferCustomFormMetadata<Config> =
  * Infer the custom field metadata extension from a FormsConfig.
  * Use this to compose with FieldMetadata or Fieldset types.
  *
- * @example
+ * **Example:**
  * ```ts
  * const { config } = configureForms({
  *   extendFieldMetadata: (meta) => ({ inputProps: { name: meta.name } })
@@ -1115,7 +1115,7 @@ export type InferCustomFieldMetadata<Config> =
  * Keys in ConditionalKeys will only be present when FieldShape extends the specified type.
  * Uses ConditionalFieldMetadata wrapper that RestoreFieldShape will detect and evaluate.
  *
- * @example
+ * **Example:**
  * ```ts
  * type Result = MakeConditional<
  *   { textFieldProps: {...}, dateRangePickerProps: {...} },

--- a/packages/conform-react/future/util.ts
+++ b/packages/conform-react/future/util.ts
@@ -288,14 +288,14 @@ export function generateUniqueKey() {
  * - `isError`: Specify the error shape for type inference
  * - `when`: Narrow field metadata to specific shapes for conditional props
  *
- * @example Specify error shape
+ * **Example: Specify error shape**
  * ```ts
  * configureForms({
  *   isError: shape<string[]>(),  // errors are string arrays
  * });
  * ```
  *
- * @example Conditional field metadata
+ * **Example: Conditional field metadata**
  * ```ts
  * extendFieldMetadata(metadata, { when }) {
  *   return {

--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -170,7 +170,7 @@ export function getAriaAttributes(
  * Derives the properties of a form element based on the form metadata,
  * including `id`, `onSubmit`, `noValidate`, and `aria-describedby`.
  *
- * @example
+ * **Example:**
  * ```tsx
  * <form {...getFormProps(metadata)} />
  * ```
@@ -191,7 +191,7 @@ export function getFormProps<Schema extends Record<string, any>, FormError>(
  * Derives the properties of a fieldset element based on the field metadata,
  * including `id`, `name`, `form`, and `aria-describedby`.
  *
- * @example
+ * **Example:**
  * ```tsx
  * <fieldset {...getFieldsetProps(metadata)} />
  * ```
@@ -233,8 +233,9 @@ export function getFormControlProps<Schema>(
  * Depends on the provided options, it will also set `defaultChecked` / `checked` if it is a checkbox or radio button,
  * or otherwise `defaultValue` / `value`.
  *
- * @see https://conform.guide/api/react/getInputProps
- * @example
+ * See https://conform.guide/api/react/getInputProps
+ *
+ * **Example:**
  * ```tsx
  * // To setup an uncontrolled input
  * <input {...getInputProps(metadata, { type: 'text' })} />
@@ -283,8 +284,9 @@ export function getInputProps<Schema, Options extends InputOptions>(
  * and constraint attributes such as `required` or `multiple`.
  * Depends on the provided options, it will also set `defaultValue` / `value`.
  *
- * @see https://conform.guide/api/react/getSelectProps
- * @example
+ * See https://conform.guide/api/react/getSelectProps
+ *
+ * **Example:**
  * ```tsx
  * // To setup an uncontrolled select
  * <select {...getSelectProps(metadata)} />
@@ -316,8 +318,9 @@ export function getSelectProps<Schema>(
  * and constraint attributes such as `required`, `minLength` or `maxLength`.
  * Depends on the provided options, it will also set `defaultValue` / `value`.
  *
- * @see https://conform.guide/api/react/getTextareaProps
- * @example
+ * See https://conform.guide/api/react/getTextareaProps
+ *
+ * **Example:**
  * ```tsx
  * // To setup an uncontrolled textarea
  * <textarea {...getTextareaProps(metadata)} />
@@ -346,8 +349,9 @@ export function getTextareaProps<Schema>(
  * Derives the properties of a collection of checkboxes or radio buttons based on the field metadata,
  * including common form control attributes like `key`, `id`, `name`, `form`, `autoFocus`, `aria-invalid`, `aria-describedby` and `required`.
  *
- * @see https://conform.guide/api/react/getCollectionProps
- * @example
+ * See https://conform.guide/api/react/getCollectionProps
+ *
+ * **Example:**
  * ```tsx
  * <fieldset>
  *   {getCollectionProps(metadata, {

--- a/packages/conform-valibot/coercion.ts
+++ b/packages/conform-valibot/coercion.ts
@@ -603,7 +603,7 @@ function enableTypeCoercion<T extends GenericSchema | GenericSchemaAsync>(
 /**
  * Creates configured coercion functions for form value parsing.
  *
- * @example
+ * **Example:**
  *
  * ```tsx
  * import { configureCoercion } from '@conform-to/valibot/future';
@@ -714,7 +714,7 @@ export function configureCoercion(config?: {
 		 *
 		 * Results are cached per schema, so this can be called inline.
 		 *
-		 * @example
+		 * **Example:**
 		 *
 		 * ```tsx
 		 * const schema = coerceFormValue(v.object({
@@ -768,7 +768,7 @@ export function configureCoercion(config?: {
 		 *
 		 * Results are cached per schema, so this can be called inline.
 		 *
-		 * @example
+		 * **Example:**
 		 *
 		 * ```tsx
 		 * const schema = coerceStructure(v.object({

--- a/packages/conform-valibot/future.ts
+++ b/packages/conform-valibot/future.ts
@@ -57,7 +57,7 @@ const defaultCoercion = configureCoercion();
  *
  * Results are cached per schema, so this can be called inline.
  *
- * @example
+ * **Example:**
  *
  * ```tsx
  * import { coerceFormValue } from '@conform-to/valibot/future';
@@ -93,7 +93,7 @@ export const coerceFormValue = defaultCoercion.coerceFormValue;
  *
  * Results are cached per schema, so this can be called inline.
  *
- * @example
+ * **Example:**
  *
  * ```tsx
  * import { coerceStructure } from '@conform-to/valibot/future';

--- a/packages/conform-zod/default/coercion.ts
+++ b/packages/conform-zod/default/coercion.ts
@@ -111,7 +111,7 @@ function coerceBigInt(value: unknown) {
 /**
  * A file schema is usually defined with `z.instanceof(File)`
  * which is implemented with `z.custom()` based on ZodAny with a `superRefine` check
- * @see https://github.com/colinhacks/zod/blob/eea05ae3dab628e7a834397414e5145e935e418b/src/types.ts#L5250-L5285
+ * See https://github.com/colinhacks/zod/blob/eea05ae3dab628e7a834397414e5145e935e418b/src/types.ts#L5250-L5285
  */
 function isFileSchema(schema: ZodEffects<any, any, any>): boolean {
 	if (typeof File === 'undefined') {
@@ -386,7 +386,7 @@ export function enableTypeCoercion<Schema extends ZodTypeAny>(
 
 /**
  * A helper that enhance the zod schema to strip empty value and coerce form value to the expected type with option to customize type coercion.
- * @example
+ * **Example:**
  *
  * ```tsx
  * import { coerceFormValue } from '@conform-to/zod/v3/future'; // Or import `@conform-to/zod/v4/future`.

--- a/packages/conform-zod/default/format.ts
+++ b/packages/conform-zod/default/format.ts
@@ -5,7 +5,7 @@ import { formatPath } from '@conform-to/dom/future';
 /**
  * Transforms Zod validation results into Conform's error format.
  *
- * @example
+ * **Example:**
  * ```ts
  * const result = schema.safeParse(formData);
  * const error = formatResult(result);

--- a/packages/conform-zod/v3/coercion.ts
+++ b/packages/conform-zod/v3/coercion.ts
@@ -124,7 +124,7 @@ function createStructuralCoercion(
 /**
  * A file schema is usually defined with `z.instanceof(File)`
  * which is implemented with `z.custom()` based on ZodAny with a `superRefine` check
- * @see https://github.com/colinhacks/zod/blob/eea05ae3dab628e7a834397414e5145e935e418b/src/types.ts#L5250-L5285
+ * See https://github.com/colinhacks/zod/blob/eea05ae3dab628e7a834397414e5145e935e418b/src/types.ts#L5250-L5285
  */
 function isFileSchema(schema: ZodEffects<any, any, any>): boolean {
 	if (typeof File === 'undefined') {
@@ -448,7 +448,7 @@ function coerceType<Schema extends ZodTypeAny>(
 /**
  * Creates configured coercion functions for form value parsing.
  *
- * @example
+ * **Example:**
  *
  * ```tsx
  * import { configureCoercion } from '@conform-to/zod/v3/future';
@@ -478,7 +478,7 @@ export function configureCoercion(config?: {
 	 * `undefined` to indicate empty.
 	 *
 	 * @default (value) => value === '' ? undefined : value
-	 * @example Treat whitespace-only strings as empty:
+	 * **Example: Treat whitespace-only strings as empty**
 	 *
 	 * ```ts
 	 * stripEmptyString: (value) => {
@@ -558,7 +558,7 @@ export function configureCoercion(config?: {
 		 *
 		 * Results are cached per schema, so this can be called inline.
 		 *
-		 * @example
+		 * **Example:**
 		 *
 		 * ```tsx
 		 * const schema = coerceFormValue(z.object({
@@ -608,7 +608,7 @@ export function configureCoercion(config?: {
 		 *
 		 * Results are cached per schema, so this can be called inline.
 		 *
-		 * @example
+		 * **Example:**
 		 *
 		 * ```tsx
 		 * const schema = coerceStructure(z.object({

--- a/packages/conform-zod/v3/format.ts
+++ b/packages/conform-zod/v3/format.ts
@@ -5,7 +5,7 @@ import { formatPath } from '@conform-to/dom/future';
 /**
  * Transforms Zod validation results into Conform's error format.
  *
- * @example
+ * **Example:**
  * ```ts
  * const result = schema.safeParse(formData);
  * const error = formatResult(result);

--- a/packages/conform-zod/v3/future.ts
+++ b/packages/conform-zod/v3/future.ts
@@ -57,7 +57,7 @@ const defaultCoercion = configureCoercion();
  *
  * Results are cached per schema, so this can be called inline.
  *
- * @example
+ * **Example:**
  *
  * ```tsx
  * import { coerceFormValue } from '@conform-to/zod/v3/future';
@@ -93,7 +93,7 @@ export const coerceFormValue = defaultCoercion.coerceFormValue;
  *
  * Results are cached per schema, so this can be called inline.
  *
- * @example
+ * **Example:**
  *
  * ```tsx
  * import { coerceStructure } from '@conform-to/zod/v3/future';

--- a/packages/conform-zod/v4/coercion.ts
+++ b/packages/conform-zod/v4/coercion.ts
@@ -419,7 +419,7 @@ function coerceType(
 /**
  * Creates configured coercion functions for form value parsing.
  *
- * @example
+ * **Example:**
  *
  * ```tsx
  * import { configureCoercion } from '@conform-to/zod/v4/future';
@@ -522,7 +522,7 @@ export function configureCoercion(config?: {
 		 *
 		 * Results are cached per schema, so this can be called inline.
 		 *
-		 * @example
+		 * **Example:**
 		 *
 		 * ```tsx
 		 * const schema = coerceFormValue(z.object({
@@ -573,7 +573,7 @@ export function configureCoercion(config?: {
 		 *
 		 * Results are cached per schema, so this can be called inline.
 		 *
-		 * @example
+		 * **Example:**
 		 *
 		 * ```tsx
 		 * const schema = coerceStructure(z.object({

--- a/packages/conform-zod/v4/format.ts
+++ b/packages/conform-zod/v4/format.ts
@@ -5,7 +5,7 @@ import { appendPath } from '@conform-to/dom/future';
 /**
  * Transforms Zod validation results into Conform's error format.
  *
- * @example
+ * **Example:**
  * ```ts
  * const result = schema.safeParse(formData);
  * const error = formatResult(result);

--- a/packages/conform-zod/v4/future.ts
+++ b/packages/conform-zod/v4/future.ts
@@ -57,7 +57,7 @@ const defaultCoercion = configureCoercion();
  *
  * Results are cached per schema, so this can be called inline.
  *
- * @example
+ * **Example:**
  *
  * ```tsx
  * import { coerceFormValue } from '@conform-to/zod/v4/future';
@@ -93,7 +93,7 @@ export const coerceFormValue = defaultCoercion.coerceFormValue;
  *
  * Results are cached per schema, so this can be called inline.
  *
- * @example
+ * **Example:**
  *
  * ```tsx
  * import { coerceStructure } from '@conform-to/zod/v4/future';


### PR DESCRIPTION
I have noticed a lot of examples in our jsdocs are not properly indented. This seems to be caused by how TypeScript handles the `@example` tag. Removing the tag for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

This PR updates JSDoc formatting across the Conform codebase to replace `@example` tags with markdown-styled `**Example:**` labels, improving how examples are rendered in documentation.

**Scope of changes:**
- **13 files modified** spanning multiple packages: `conform-dom` (3 files), `conform-react` (7 files), `conform-zod` (4 files), and `conform-valibot` (2 files)
- **~95 lines changed** across all modifications
- All changes are documentation-only; no functional code, type signatures, or runtime behavior was altered

**Key transformations:**
- Replaced `@example` JSDoc tags with bolded `**Example:**` markdown labels
- Converted some `@see` tags to plain "See …" text references
- Adjusted indentation and formatting in example code blocks for consistency

**Affected exported entities:** None—all changes are limited to JSDoc comments and example formatting.

**Estimated review effort:** Low

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->