### PR TITLE
test: stabilize future browser test runs

### DIFF
--- a/packages/conform-react/tests/PreserveBoundary.browser.test.tsx
+++ b/packages/conform-react/tests/PreserveBoundary.browser.test.tsx
@@ -1,7 +1,7 @@
 /// <reference types="@vitest/browser/matchers" />
 import { describe, it, expect } from 'vitest';
 import { render } from 'vitest-browser-react';
-import { Locator, userEvent } from '@vitest/browser/context';
+import { Locator, userEvent } from 'vitest/browser';
 import { PreserveBoundary, useFormData } from '../future';
 import { useState, useRef } from 'react';
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,9 +5,27 @@ const defaultBrowsers = ['chromium', 'firefox', 'webkit'] as const;
 const browsers = process.env.BROWSER
 	? [process.env.BROWSER as (typeof defaultBrowsers)[number]]
 	: [...defaultBrowsers];
+const runMultipleBrowsers = browsers.length > 1;
+
+if (runMultipleBrowsers) {
+	// Multi-browser runs add enough process listeners through Vitest/Playwright
+	// startup that Node's default limit warns even though this is expected here.
+	process.setMaxListeners(20);
+}
 
 export default defineConfig({
 	test: {
+		deps: {
+			optimizer: {
+				client: {
+					/**
+					 * Prebundle the React dev JSX runtime so Vitest doesn't re-optimize it
+					 * mid-run and reload large browser suites while they are being collected.
+					 */
+					include: ['react/jsx-dev-runtime'],
+				},
+			},
+		},
 		projects: [
 			// legacy setup to be moved into the packages
 			{
@@ -29,15 +47,20 @@ export default defineConfig({
 					environment: 'node',
 				},
 			},
-			...defineTests('conform-dom'),
-			...defineTests('conform-react'),
-			...defineTests('conform-zod'),
-			...defineTests('conform-valibot'),
+			...defineTests('conform-dom', { browserApiPort: 63316 }),
+			...defineTests('conform-react', { browserApiPort: 63317 }),
+			...defineTests('conform-zod', { browserApiPort: 63318 }),
+			...defineTests('conform-valibot', { browserApiPort: 63319 }),
 		],
 	},
 });
 
-function defineTests(packageName: string): TestProjectInlineConfiguration[] {
+function defineTests(
+	packageName: string,
+	options: {
+		browserApiPort: number;
+	},
+): TestProjectInlineConfiguration[] {
 	return [
 		{
 			test: {
@@ -46,7 +69,11 @@ function defineTests(packageName: string): TestProjectInlineConfiguration[] {
 				browser: {
 					enabled: true,
 					headless: true,
-					provider: playwright(),
+					provider: playwright(
+						runMultipleBrowsers ? { actionTimeout: 1_000 } : undefined,
+					),
+					api: options.browserApiPort,
+					fileParallelism: !runMultipleBrowsers,
 					instances: browsers.map((browser) => ({ browser })),
 				},
 				// This covers both .browser.test.ts/tsx and .test.ts/tsx files
@@ -55,10 +82,18 @@ function defineTests(packageName: string): TestProjectInlineConfiguration[] {
 					`**/node_modules/**`,
 					`packages/${packageName}/**/tests/**/*.node.test.{ts,tsx}`,
 				],
-				testTimeout: process.env.CI ? 30_000 : 5_000,
+				testTimeout: process.env.CI
+					? 30_000
+					: runMultipleBrowsers
+						? 15_000
+						: 5_000,
 				expect: {
 					poll: {
-						timeout: process.env.CI ? 10_000 : 1_000,
+						timeout: process.env.CI
+							? 10_000
+							: runMultipleBrowsers
+								? 5_000
+								: 1_000,
 					},
 				},
 			},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

This PR improves the stability of browser test execution in Vitest by adjusting test configuration and timing parameters.

**Key Changes:**

1. **Updated test imports** - Changed `PreserveBoundary.browser.test.tsx` to import `Locator` and `userEvent` from `vitest/browser` instead of `@vitest/browser/context`.

2. **Enhanced browser configuration** - Modified `vitest.config.ts` to:
   - Prebundle React's dev JSX runtime via `deps.optimizer.client.include`
   - Adjust timeouts and expectations based on browser environment (multi-browser vs single-browser runs)
   - Disable file parallelism when running multiple browsers
   - Set conditional action timeout for Playwright in multi-browser scenarios
   - Increase Node's listener limit to suppress warnings during multi-browser startup

3. **Updated test definitions** - Browser suite projects now pass `browserApiPort` to `defineTests()` for proper API routing in parallel browser scenarios.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->