### PR TITLE
feat: set `pattern` constraint for regular expressions

### DIFF
--- a/.changeset/pattern-constraint-regex.md
+++ b/.changeset/pattern-constraint-regex.md
@@ -5,15 +5,12 @@
 '@conform-to/zod': minor
 ---
 
-# Enable browser-native regex validation
+`getZodConstraint`, `getValibotConstraint`, and the future `getConstraints` helpers can now derive HTML `pattern` constraints from Zod and Valibot schemas. When a field uses multiple regex validators, Conform combines them into a single `pattern` when possible.
 
-Constructing `pattern` constraints from regex-refined string schemas allows for pattern-based validation without requiring client-side JavaScript.
-
-This allows your schemas to directly influence `:valid` and `:invalid` pseudo-classes.
+Pattern generation is best-effort. Case-insensitive regexes and regexes that serialize to an invalid HTML `pattern` are skipped, and backreferences may behave differently when multiple regex validators are combined.
 
 ```tsx
-import { configureForms } from '@conform-to/react/future';
-import { getConstraints } from '@conform-to/zod/v4/future';
+import { getZodConstraint } from '@conform-to/zod/v4';
 import { z } from 'zod';
 
 const schema = z.object({
@@ -25,19 +22,7 @@ const schema = z.object({
     .regex(/[!@#$%^&*]/), // special
 });
 
-const configuredForms = configureForms({
-  extendFieldMetadata(metadata) {
-    return {
-      get inputProps() {
-        return {
-          // all of uppercase, digit, and special must match
-          // '^(?=.*(?:[A-Z]))(?=.*(?:[0-9]))(?=.*(?:[!@#$%^&*])).*$'
-          pattern: metadata.pattern,
-          // ...
-        };
-      },
-    };
-  },
-  getConstraints,
-});
+const constraint = getZodConstraint(schema);
+console.log(constraint.password.pattern);
+// ^? '^(?=.*(?:[A-Z]))(?=.*(?:[0-9]))(?=.*(?:[!@#$%^&*])).*$'
 ```

--- a/.changeset/pattern-constraint-regex.md
+++ b/.changeset/pattern-constraint-regex.md
@@ -1,0 +1,43 @@
+---
+'@conform-to/dom': minor
+'@conform-to/react': minor
+'@conform-to/valibot': minor
+'@conform-to/zod': minor
+---
+
+# Enable browser-native regex validation
+
+Constructing `pattern` constraints from regex-refined string schemas allows for pattern-based validation without requiring client-side JavaScript.
+
+This allows your schemas to directly influence `:valid` and `:invalid` pseudo-classes.
+
+```tsx
+import { configureForms } from '@conform-to/react/future';
+import { getConstraints } from '@conform-to/zod/v4/future';
+import { z } from 'zod';
+
+const schema = z.object({
+  password: z
+    .string()
+    .min(8)
+    .regex(/[A-Z]/) // uppercase
+    .regex(/[0-9]/) // digit
+    .regex(/[!@#$%^&*]/), // special
+});
+
+const configuredForms = configureForms({
+  extendFieldMetadata(metadata) {
+    return {
+      get inputProps() {
+        return {
+          // all of uppercase, digit, and special must match
+          // '^(?=.*(?:[A-Z]))(?=.*(?:[0-9]))(?=.*(?:[!@#$%^&*])).*$'
+          pattern: metadata.pattern,
+          // ...
+        };
+      },
+    };
+  },
+  getConstraints,
+});
+```

--- a/docs/api/valibot/future/getConstraints.md
+++ b/docs/api/valibot/future/getConstraints.md
@@ -16,6 +16,40 @@ The value to introspect. If it's not a valid valibot schema, the function return
 
 ## Examples
 
+### Deriving constraints from a schema
+
+```tsx
+import { getConstraints } from '@conform-to/valibot/future';
+import {
+  maxLength,
+  minLength,
+  object,
+  optional,
+  pipe,
+  regex,
+  string,
+} from 'valibot';
+
+const schema = object({
+  title: pipe(string(), minLength(5), maxLength(20)),
+  description: optional(pipe(string(), minLength(100), maxLength(1000))),
+  password: pipe(
+    string(),
+    regex(/[A-Z]/, 'Must contain an uppercase letter'),
+    regex(/[0-9]/, 'Must contain a number'),
+  ),
+});
+const constraint = getConstraints(schema);
+// {
+//   title: { required: true, minLength: 5, maxLength: 20 },
+//   description: { required: false, minLength: 100, maxLength: 1000 },
+//   password: {
+//     required: true,
+//     pattern: '^(?=.*(?:[A-Z]))(?=.*(?:[0-9])).*$',
+//   },
+// }
+```
+
 ### Passing constraints to useForm
 
 Call `getConstraints` directly and pass the result to `useForm` to enable native HTML validation attributes (e.g. `required`, `minLength`, `min`, `pattern`) on your form fields:
@@ -41,3 +75,12 @@ const { useForm } = configureForms({
   getConstraints,
 });
 ```
+
+## Tips
+
+### Pattern limitations
+
+The `pattern` generation is best-effort with the following limitations:
+
+- **Regex flags**: The `i` (case-insensitive) flag is **not supported**. No `pattern` is generated for case-insensitive regexes or when the serialized regex is not a valid HTML `pattern` under the browser's `v` flag.
+- **Backreferences**: Numbered backreferences (`\1`, `\2`, etc.) may break when multiple regex validators for the same field are combined into one `pattern`. Named backreferences (`\k<name>`) are more reliable, but each regex combined into the same `pattern` must use unique group names.

--- a/docs/api/valibot/getValibotConstraint.md
+++ b/docs/api/valibot/getValibotConstraint.md
@@ -32,3 +32,35 @@ function Example() {
   // ...
 }
 ```
+
+## Pattern constraint
+
+The `getValibotConstraint` helper also extracts regex constraints into the HTML5 `pattern` attribute. This enables native browser validation alongside Valibot validation.
+
+### Using `enumType()`
+
+Enum values become a pattern matching any valid option:
+
+```tsx
+import { enumType } from 'valibot';
+
+const schema = object({
+  status: enumType(['pending', 'approved', 'rejected']),
+});
+// Generates pattern: "pending|approved|rejected"
+```
+
+### Using `regex()`
+
+```tsx
+import { regex } from 'valibot';
+
+const schema = object({
+  otpCode: pipe(string(), regex(/^\d{4}$/, 'Must be 4 digits')),
+});
+```
+
+### Limitations
+
+- **Regex flags**: The `i` (case-insensitive) flag is **not supported** — HTML5 `pattern` doesn't support case-insensitive matching.
+- **Backreferences**: Numbered backreferences (`\1`, `\2`, etc.) may break across multiple fields in your schema. Named backreferences (`\k<name>`) are more reliable, but require each field's regexes to have unique group names.

--- a/docs/api/valibot/getValibotConstraint.md
+++ b/docs/api/valibot/getValibotConstraint.md
@@ -16,51 +16,41 @@ The valibot schema to be introspected.
 
 ```tsx
 import { getValibotConstraint } from '@conform-to/valibot';
-import { useForm } from '@conform-to/react';
-import { object, pipe, string, minLength, optional } from 'valibot';
+import {
+  maxLength,
+  minLength,
+  object,
+  optional,
+  pipe,
+  regex,
+  string,
+} from 'valibot';
 
 const schema = object({
   title: pipe(string(), minLength(5), maxLength(20)),
   description: optional(pipe(string(), minLength(100), maxLength(1000))),
+  password: pipe(
+    string(),
+    regex(/[A-Z]/, 'Must contain an uppercase letter'),
+    regex(/[0-9]/, 'Must contain a number'),
+  ),
 });
-
-function Example() {
-  const [form, fields] = useForm({
-    constraint: getValibotConstraint(schema),
-  });
-
-  // ...
-}
+const constraint = getValibotConstraint(schema);
+// {
+//   title: { required: true, minLength: 5, maxLength: 20 },
+//   description: { required: false, minLength: 100, maxLength: 1000 },
+//   password: {
+//     required: true,
+//     pattern: '^(?=.*(?:[A-Z]))(?=.*(?:[0-9])).*$',
+//   },
+// }
 ```
 
-## Pattern constraint
+## Tips
 
-The `getValibotConstraint` helper also extracts regex constraints into the HTML5 `pattern` attribute. This enables native browser validation alongside Valibot validation.
+### Pattern limitations
 
-### Using `enumType()`
+The `pattern` generation is best-effort with the following limitations:
 
-Enum values become a pattern matching any valid option:
-
-```tsx
-import { enumType } from 'valibot';
-
-const schema = object({
-  status: enumType(['pending', 'approved', 'rejected']),
-});
-// Generates pattern: "pending|approved|rejected"
-```
-
-### Using `regex()`
-
-```tsx
-import { regex } from 'valibot';
-
-const schema = object({
-  otpCode: pipe(string(), regex(/^\d{4}$/, 'Must be 4 digits')),
-});
-```
-
-### Limitations
-
-- **Regex flags**: The `i` (case-insensitive) flag is **not supported** — HTML5 `pattern` doesn't support case-insensitive matching.
-- **Backreferences**: Numbered backreferences (`\1`, `\2`, etc.) may break across multiple fields in your schema. Named backreferences (`\k<name>`) are more reliable, but require each field's regexes to have unique group names.
+- **Regex flags**: The `i` (case-insensitive) flag is **not supported**. No `pattern` is generated for case-insensitive regexes or when the serialized regex is not a valid HTML `pattern` under the browser's `v` flag.
+- **Backreferences**: Numbered backreferences (`\1`, `\2`, etc.) may break when multiple regex validators for the same field are combined into one `pattern`. Named backreferences (`\k<name>`) are more reliable, but each regex combined into the same `pattern` must use unique group names.

--- a/docs/api/zod/future/getConstraints.md
+++ b/docs/api/zod/future/getConstraints.md
@@ -18,6 +18,33 @@ The value to introspect. If it's not a valid zod schema, the function returns `u
 
 ## Examples
 
+### Deriving constraints from a schema
+
+```tsx
+import { getConstraints } from '@conform-to/zod/v3/future';
+// or
+// import { getConstraints } from '@conform-to/zod/v4/future';
+import { z } from 'zod';
+
+const schema = z.object({
+  title: z.string().min(5).max(20),
+  description: z.string().min(100).max(1000).optional(),
+  password: z
+    .string()
+    .regex(/[A-Z]/, 'Must contain an uppercase letter')
+    .regex(/[0-9]/, 'Must contain a number'),
+});
+const constraint = getConstraints(schema);
+// {
+//   title: { required: true, minLength: 5, maxLength: 20 },
+//   description: { required: false, minLength: 100, maxLength: 1000 },
+//   password: {
+//     required: true,
+//     pattern: '^(?=.*(?:[A-Z]))(?=.*(?:[0-9])).*$',
+//   },
+// }
+```
+
 ### Passing constraints to useForm
 
 Call `getConstraints` directly and pass the result to `useForm` to enable native HTML validation attributes (e.g. `required`, `minLength`, `min`, `pattern`) on your form fields:
@@ -43,3 +70,12 @@ const { useForm } = configureForms({
   getConstraints,
 });
 ```
+
+## Tips
+
+### Pattern limitations
+
+The `pattern` generation is best-effort with the following limitations:
+
+- **Regex flags**: The `i` (case-insensitive) flag is **not supported**. No `pattern` is generated for case-insensitive regexes or when the serialized regex is not a valid HTML `pattern` under the browser's `v` flag.
+- **Backreferences**: Numbered backreferences (`\1`, `\2`, etc.) may break when multiple regex validators for the same field are combined into one `pattern`. Named backreferences (`\k<name>`) are more reliable, but each regex combined into the same `pattern` must use unique group names.

--- a/docs/api/zod/getZodConstraint.md
+++ b/docs/api/zod/getZodConstraint.md
@@ -34,3 +34,31 @@ function Example() {
   // ...
 }
 ```
+
+## Pattern constraint
+
+The `getZodConstraint` helper also extracts regex constraints into the HTML5 `pattern` attribute. This enables native browser validation alongside Zod validation.
+
+### Using `z.enum()`
+
+Enum values become a pattern matching any valid option:
+
+```tsx
+const schema = z.object({
+  status: z.enum(['pending', 'approved', 'rejected']),
+});
+// Generates pattern: "pending|approved|rejected"
+```
+
+### Using `z.string().regex()`
+
+```tsx
+const schema = z.object({
+  otpCode: z.string().regex(/^\d{4}$/, 'Must be 4 digits'),
+});
+```
+
+### Limitations
+
+- **Regex flags**: The `i` (case-insensitive) flag is **not supported** — HTML5 `pattern` doesn't support case-insensitive matching.
+- **Backreferences**: Numbered backreferences (`\1`, `\2`, etc.) may break across multiple fields in your schema. Named backreferences (`\k<name>`) are more reliable, but require each field's regexes to have unique group names.

--- a/docs/api/zod/getZodConstraint.md
+++ b/docs/api/zod/getZodConstraint.md
@@ -15,7 +15,6 @@ The zod schema to be introspected.
 ## Example
 
 ```tsx
-import { useForm } from '@conform-to/react';
 import { getZodConstraint } from '@conform-to/zod';
 // If you are using Zod v4, update the imports:
 // import { getZodConstraint } from '@conform-to/zod/v4';
@@ -24,41 +23,27 @@ import { z } from 'zod';
 const schema = z.object({
   title: z.string().min(5).max(20),
   description: z.string().min(100).max(1000).optional(),
+  password: z
+    .string()
+    .regex(/[A-Z]/, 'Must contain an uppercase letter')
+    .regex(/[0-9]/, 'Must contain a number'),
 });
-
-function Example() {
-  const [form, fields] = useForm({
-    constraint: getZodConstraint(schema),
-  });
-
-  // ...
-}
+const constraint = getZodConstraint(schema);
+// {
+//   title: { required: true, minLength: 5, maxLength: 20 },
+//   description: { required: false, minLength: 100, maxLength: 1000 },
+//   password: {
+//     required: true,
+//     pattern: '^(?=.*(?:[A-Z]))(?=.*(?:[0-9])).*$',
+//   },
+// }
 ```
 
-## Pattern constraint
+## Tips
 
-The `getZodConstraint` helper also extracts regex constraints into the HTML5 `pattern` attribute. This enables native browser validation alongside Zod validation.
+### Pattern limitations
 
-### Using `z.enum()`
+The `pattern` generation is best-effort with the following limitations:
 
-Enum values become a pattern matching any valid option:
-
-```tsx
-const schema = z.object({
-  status: z.enum(['pending', 'approved', 'rejected']),
-});
-// Generates pattern: "pending|approved|rejected"
-```
-
-### Using `z.string().regex()`
-
-```tsx
-const schema = z.object({
-  otpCode: z.string().regex(/^\d{4}$/, 'Must be 4 digits'),
-});
-```
-
-### Limitations
-
-- **Regex flags**: The `i` (case-insensitive) flag is **not supported** — HTML5 `pattern` doesn't support case-insensitive matching.
-- **Backreferences**: Numbered backreferences (`\1`, `\2`, etc.) may break across multiple fields in your schema. Named backreferences (`\k<name>`) are more reliable, but require each field's regexes to have unique group names.
+- **Regex flags**: The `i` (case-insensitive) flag is **not supported**. No `pattern` is generated for case-insensitive regexes or when the serialized regex is not a valid HTML `pattern` under the browser's `v` flag.
+- **Backreferences**: Numbered backreferences (`\1`, `\2`, etc.) may break when multiple regex validators for the same field are combined into one `pattern`. Named backreferences (`\k<name>`) are more reliable, but each regex combined into the same `pattern` must use unique group names.

--- a/packages/conform-dom/future/index.ts
+++ b/packages/conform-dom/future/index.ts
@@ -25,7 +25,7 @@ export {
 	getFieldValue,
 	normalizeFormError,
 } from '../formdata';
-export { isPlainObject, deepEqual } from '../util';
+export { isPlainObject, deepEqual, combinePatterns } from '../util';
 export {
 	isFieldElement,
 	isGlobalInstance,

--- a/packages/conform-dom/future/index.ts
+++ b/packages/conform-dom/future/index.ts
@@ -25,7 +25,7 @@ export {
 	getFieldValue,
 	normalizeFormError,
 } from '../formdata';
-export { isPlainObject, deepEqual, combinePatterns } from '../util';
+export { isPlainObject, deepEqual, serializeHtmlPattern } from '../util';
 export {
 	isFieldElement,
 	isGlobalInstance,

--- a/packages/conform-dom/tests/util.test.ts
+++ b/packages/conform-dom/tests/util.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { serializeHtmlPattern, deepEqual } from '../util';
+import { deepEqual, serializeHtmlPattern } from '../util';
 
 test('deepEqual', () => {
 	expect(deepEqual(null, null)).toBe(true);
@@ -41,13 +41,16 @@ test('serializeHtmlPattern', () => {
 	);
 
 	// Unsupported flags
-	expect(serializeHtmlPattern([/[A-Z]/g])).toBeUndefined();
+	expect(serializeHtmlPattern([/[A-Z]/i])).toBeUndefined();
 	expect(serializeHtmlPattern([/[A-Z]/, /[0-9]/i])).toBeUndefined();
 
-	// Supported flags
+	// Other flags
+	expect(serializeHtmlPattern([/[A-Z]/g])).toBe('^(?=.*(?:[A-Z])).*$');
+	expect(serializeHtmlPattern([/[A-Z]/m])).toBe('^(?=.*(?:[A-Z])).*$');
+	expect(serializeHtmlPattern([/[A-Z]/s])).toBe('^(?=.*(?:[A-Z])).*$');
 	expect(serializeHtmlPattern([/[A-Z]/u])).toBe('^(?=.*(?:[A-Z])).*$');
 
-	// Semantic validation: single pattern (uppercase-only)
+	// Semantic validation: single pattern (uppercase)
 	const single = serializeHtmlPattern([/^[A-Z]+$/]);
 	expect(single).toBeDefined();
 	const singleRegex = new RegExp(single || '');
@@ -55,7 +58,7 @@ test('serializeHtmlPattern', () => {
 	expect(singleRegex.test('abc')).toBe(false);
 	expect(singleRegex.test('ABC123')).toBe(false);
 
-	// Semantic validation: multiple patterns (uppercase AND digit)
+	// Semantic validation: multiple patterns (uppercase and digit)
 	const multi = serializeHtmlPattern([/[A-Z]/, /[0-9]/]);
 	expect(multi).toBeDefined();
 	const multiRegex = new RegExp(multi || '');

--- a/packages/conform-dom/tests/util.test.ts
+++ b/packages/conform-dom/tests/util.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { deepEqual } from '../util';
+import { combinePatterns, deepEqual } from '../util';
 
 test('deepEqual', () => {
 	expect(deepEqual(null, null)).toBe(true);
@@ -21,4 +21,42 @@ test('deepEqual', () => {
 	expect(deepEqual(new File([], 'example'), new File([], 'example'))).toBe(
 		false,
 	);
+});
+
+test('combinePatterns', () => {
+	// Empty pattern
+	expect(combinePatterns([])).toBeUndefined();
+
+	// Single pattern
+	expect(combinePatterns([/[A-Z]/])).toBe('^(?=.*(?:[A-Z])).*$');
+	expect(combinePatterns([/^[A-Z]+$/])).toBe('^(?=.*(?:^[A-Z]+$)).*$');
+
+	// Multiple patterns without flags
+	expect(combinePatterns([/[A-Z]/, /[0-9]/])).toBe(
+		'^(?=.*(?:[A-Z]))(?=.*(?:[0-9])).*$',
+	);
+
+	// Unsupported flags
+	expect(combinePatterns([/[A-Z]/g])).toBeUndefined();
+	expect(combinePatterns([/[A-Z]/, /[0-9]/i])).toBeUndefined();
+
+	// Supported flags
+	expect(combinePatterns([/[A-Z]/u])).toBe('^(?=.*(?:[A-Z])).*$');
+
+	// Semantic validation: single pattern (uppercase-only)
+	const single = combinePatterns([/^[A-Z]+$/]);
+	expect(single).toBeDefined();
+	const singleRegex = new RegExp(single || '');
+	expect(singleRegex.test('ABC')).toBe(true);
+	expect(singleRegex.test('abc')).toBe(false);
+	expect(singleRegex.test('ABC123')).toBe(false);
+
+	// Semantic validation: multiple patterns (uppercase AND digit)
+	const multi = combinePatterns([/[A-Z]/, /[0-9]/]);
+	expect(multi).toBeDefined();
+	const multiRegex = new RegExp(multi || '');
+	expect(multiRegex.test('ABC')).toBe(false);
+	expect(multiRegex.test('123')).toBe(false);
+	expect(multiRegex.test('ABC123')).toBe(true);
+	expect(multiRegex.test('abc123')).toBe(false);
 });

--- a/packages/conform-dom/tests/util.test.ts
+++ b/packages/conform-dom/tests/util.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { combinePatterns, deepEqual } from '../util';
+import { serializeHtmlPattern, deepEqual } from '../util';
 
 test('deepEqual', () => {
 	expect(deepEqual(null, null)).toBe(true);
@@ -23,28 +23,32 @@ test('deepEqual', () => {
 	);
 });
 
-test('combinePatterns', () => {
-	// Empty pattern
-	expect(combinePatterns([])).toBeUndefined();
+test('serializeHtmlPattern', () => {
+	// Empty array
+	expect(serializeHtmlPattern([])).toBeUndefined();
 
-	// Single pattern
-	expect(combinePatterns([/[A-Z]/])).toBe('^(?=.*(?:[A-Z])).*$');
-	expect(combinePatterns([/^[A-Z]+$/])).toBe('^(?=.*(?:^[A-Z]+$)).*$');
+	// Single RegExp
+	expect(serializeHtmlPattern(/[A-Z]/)).toBe('^(?=.*(?:[A-Z])).*$');
+	expect(serializeHtmlPattern(/^[A-Z]+$/)).toBe('^(?=.*(?:^[A-Z]+$)).*$');
+
+	// Single pattern in array
+	expect(serializeHtmlPattern([/[A-Z]/])).toBe('^(?=.*(?:[A-Z])).*$');
+	expect(serializeHtmlPattern([/^[A-Z]+$/])).toBe('^(?=.*(?:^[A-Z]+$)).*$');
 
 	// Multiple patterns without flags
-	expect(combinePatterns([/[A-Z]/, /[0-9]/])).toBe(
+	expect(serializeHtmlPattern([/[A-Z]/, /[0-9]/])).toBe(
 		'^(?=.*(?:[A-Z]))(?=.*(?:[0-9])).*$',
 	);
 
 	// Unsupported flags
-	expect(combinePatterns([/[A-Z]/g])).toBeUndefined();
-	expect(combinePatterns([/[A-Z]/, /[0-9]/i])).toBeUndefined();
+	expect(serializeHtmlPattern([/[A-Z]/g])).toBeUndefined();
+	expect(serializeHtmlPattern([/[A-Z]/, /[0-9]/i])).toBeUndefined();
 
 	// Supported flags
-	expect(combinePatterns([/[A-Z]/u])).toBe('^(?=.*(?:[A-Z])).*$');
+	expect(serializeHtmlPattern([/[A-Z]/u])).toBe('^(?=.*(?:[A-Z])).*$');
 
 	// Semantic validation: single pattern (uppercase-only)
-	const single = combinePatterns([/^[A-Z]+$/]);
+	const single = serializeHtmlPattern([/^[A-Z]+$/]);
 	expect(single).toBeDefined();
 	const singleRegex = new RegExp(single || '');
 	expect(singleRegex.test('ABC')).toBe(true);
@@ -52,7 +56,7 @@ test('combinePatterns', () => {
 	expect(singleRegex.test('ABC123')).toBe(false);
 
 	// Semantic validation: multiple patterns (uppercase AND digit)
-	const multi = combinePatterns([/[A-Z]/, /[0-9]/]);
+	const multi = serializeHtmlPattern([/[A-Z]/, /[0-9]/]);
 	expect(multi).toBeDefined();
 	const multiRegex = new RegExp(multi || '');
 	expect(multiRegex.test('ABC')).toBe(false);

--- a/packages/conform-dom/util.ts
+++ b/packages/conform-dom/util.ts
@@ -117,10 +117,11 @@ export function getTypeName(value: unknown): string {
 /**
  * Combines multiple regex patterns into a single HTML pattern attribute.
  *
- * This is done by putting each input pattern into a lookahead assertion.
+ * This is done by putting each input pattern into a lookahead assertion
+ * and stripping all flags.
  *
- * HTML pattern attributes implicitly run with the `v` flag, so `u` and `v` flags are
- * silently stripped. Returns undefined if any pattern has other flags (e.g., `g`, `i`).
+ * Returns undefined if any pattern is case-insensitive, since transforming
+ * it to a case-sensitive pattern is a non-trivial operation.
  *
  * Example: [/[A-Z]/, /[0-9]/] -> '^(?=.*(?:[A-Z]))(?=.*(?:[0-9])).*$'
  */
@@ -129,11 +130,7 @@ export function serializeHtmlPattern(
 ): string | undefined {
 	const patterns = Array.isArray(pattern) ? pattern : [pattern];
 
-	if (patterns.length === 0) {
-		return undefined;
-	}
-
-	if (patterns.some((p) => p.flags.replace(/[uv]/g, ''))) {
+	if (patterns.length === 0 || patterns.some((p) => p.flags.includes('i'))) {
 		return undefined;
 	}
 

--- a/packages/conform-dom/util.ts
+++ b/packages/conform-dom/util.ts
@@ -134,5 +134,13 @@ export function serializeHtmlPattern(
 		return undefined;
 	}
 
-	return `^${patterns.map((p) => `(?=.*(?:${p.source}))`).join('')}.*$`;
+	const serializedPattern = `^${patterns.map((p) => `(?=.*(?:${p.source}))`).join('')}.*$`;
+
+	try {
+		new RegExp(serializedPattern, 'v');
+	} catch {
+		return undefined;
+	}
+
+	return serializedPattern;
 }

--- a/packages/conform-dom/util.ts
+++ b/packages/conform-dom/util.ts
@@ -113,3 +113,25 @@ export function getTypeName(value: unknown): string {
 	}
 	return typeof value;
 }
+
+/**
+ * Combines multiple regex patterns into a single HTML pattern attribute.
+ *
+ * This is done by putting each input pattern into a lookahead assertion.
+ *
+ * HTML pattern attributes implicitly run with the `v` flag, so `u` and `v` flags are
+ * silently stripped. Returns undefined if any pattern has other flags (e.g., `g`, `i`).
+ *
+ * Example: [/[A-Z]/, /[0-9]/] -> '^(?=.*(?:[A-Z]))(?=.*(?:[0-9])).*$'
+ */
+export function combinePatterns(patterns: RegExp[]): string | undefined {
+	if (patterns.length === 0) {
+		return undefined;
+	}
+
+	if (patterns.some((p) => p.flags.replace(/[uv]/g, ''))) {
+		return undefined;
+	}
+
+	return `^${patterns.map((p) => `(?=.*(?:${p.source}))`).join('')}.*$`;
+}

--- a/packages/conform-dom/util.ts
+++ b/packages/conform-dom/util.ts
@@ -124,7 +124,11 @@ export function getTypeName(value: unknown): string {
  *
  * Example: [/[A-Z]/, /[0-9]/] -> '^(?=.*(?:[A-Z]))(?=.*(?:[0-9])).*$'
  */
-export function combinePatterns(patterns: RegExp[]): string | undefined {
+export function serializeHtmlPattern(
+	pattern: RegExp | RegExp[],
+): string | undefined {
+	const patterns = Array.isArray(pattern) ? pattern : [pattern];
+
 	if (patterns.length === 0) {
 		return undefined;
 	}

--- a/packages/conform-valibot/constraint.ts
+++ b/packages/conform-valibot/constraint.ts
@@ -1,6 +1,6 @@
 import type { Constraint } from '@conform-to/dom';
 import { getPaths, formatPaths, getRelativePath } from '@conform-to/dom';
-import { combinePatterns } from '@conform-to/dom/future';
+import { serializeHtmlPattern } from '@conform-to/dom/future';
 import type { GenericSchema, GenericSchemaAsync } from 'valibot';
 
 const keys: Array<keyof Constraint> = [
@@ -156,10 +156,10 @@ export function getValibotConstraint<
 				(v) => 'type' in v && v.type === 'regex',
 			);
 			if (regexValidators?.length) {
-				const pattern = combinePatterns(
+				const pattern = serializeHtmlPattern(
 					regexValidators.map(
 						// @ts-expect-error
-						(v) => (v as { requirement: RegExp }).requirement,
+						(v) => v.requirement,
 					),
 				);
 				if (pattern) {

--- a/packages/conform-valibot/constraint.ts
+++ b/packages/conform-valibot/constraint.ts
@@ -1,5 +1,6 @@
 import type { Constraint } from '@conform-to/dom';
 import { getPaths, formatPaths, getRelativePath } from '@conform-to/dom';
+import { combinePatterns } from '@conform-to/dom/future';
 import type { GenericSchema, GenericSchemaAsync } from 'valibot';
 
 const keys: Array<keyof Constraint> = [
@@ -148,6 +149,22 @@ export function getValibotConstraint<
 			);
 			if (maxLength && 'requirement' in maxLength) {
 				constraint.maxLength = maxLength.requirement as number;
+			}
+			// @ts-expect-error
+			const regexValidators = schema.pipe?.filter(
+				// @ts-expect-error
+				(v) => 'type' in v && v.type === 'regex',
+			);
+			if (regexValidators?.length) {
+				const pattern = combinePatterns(
+					regexValidators.map(
+						// @ts-expect-error
+						(v) => (v as { requirement: RegExp }).requirement,
+					),
+				);
+				if (pattern) {
+					constraint.pattern = pattern;
+				}
 			}
 		} else if (
 			schema.type === 'optional' ||

--- a/packages/conform-valibot/tests/constraint.test.ts
+++ b/packages/conform-valibot/tests/constraint.test.ts
@@ -24,6 +24,7 @@ import {
 	objectWithRest,
 	optional,
 	pipe,
+	regex,
 	strictObject,
 	string,
 	tuple,
@@ -373,5 +374,31 @@ describe('constraint', () => {
 		expect(
 			constraint['conditions[0].conditions[1].conditions[2].type'],
 		).toEqual({ required: true });
+	});
+
+	test('regex patterns', () => {
+		const schema = object({
+			empty: string(),
+			single: pipe(string(), regex(/^[A-Z]+$/)),
+			multiple: pipe(
+				string(),
+				regex(/[A-Z]/, 'uppercase'),
+				regex(/[0-9]/, 'digit'),
+			),
+		});
+
+		expect(getValibotConstraint(schema)).toEqual({
+			empty: {
+				required: true,
+			},
+			single: {
+				required: true,
+				pattern: '^(?=.*(?:^[A-Z]+$)).*$',
+			},
+			multiple: {
+				required: true,
+				pattern: '^(?=.*(?:[A-Z]))(?=.*(?:[0-9])).*$',
+			},
+		});
 	});
 });

--- a/packages/conform-zod/default/constraint.ts
+++ b/packages/conform-zod/default/constraint.ts
@@ -1,6 +1,6 @@
 import type { Constraint } from '@conform-to/dom';
 import { getPaths, formatPaths, getRelativePath } from '@conform-to/dom';
-import { combinePatterns } from '@conform-to/dom/future';
+import { serializeHtmlPattern } from '@conform-to/dom/future';
 import type {
 	ZodTypeAny,
 	ZodFirstPartySchemaTypes,
@@ -136,7 +136,7 @@ export function getZodConstraint(
 					check.kind === 'regex',
 			);
 			if (regexChecks.length > 0) {
-				const pattern = combinePatterns(regexChecks.map((c) => c.regex));
+				const pattern = serializeHtmlPattern(regexChecks.map((c) => c.regex));
 				if (pattern) {
 					constraint.pattern = pattern;
 				}

--- a/packages/conform-zod/default/constraint.ts
+++ b/packages/conform-zod/default/constraint.ts
@@ -1,10 +1,12 @@
 import type { Constraint } from '@conform-to/dom';
 import { getPaths, formatPaths, getRelativePath } from '@conform-to/dom';
+import { combinePatterns } from '@conform-to/dom/future';
 import type {
 	ZodTypeAny,
 	ZodFirstPartySchemaTypes,
 	ZodNumber,
 	ZodString,
+	ZodStringCheck,
 } from 'zod';
 
 const keys: Array<keyof Constraint> = [
@@ -128,6 +130,16 @@ export function getZodConstraint(
 			}
 			if (_schema.maxLength !== null) {
 				constraint.maxLength = _schema.maxLength;
+			}
+			const regexChecks = def.checks.filter(
+				(check): check is ZodStringCheck & { kind: 'regex' } =>
+					check.kind === 'regex',
+			);
+			if (regexChecks.length > 0) {
+				const pattern = combinePatterns(regexChecks.map((c) => c.regex));
+				if (pattern) {
+					constraint.pattern = pattern;
+				}
 			}
 		} else if (def.typeName === 'ZodOptional') {
 			constraint.required = false;

--- a/packages/conform-zod/default/tests/constraint.test.ts
+++ b/packages/conform-zod/default/tests/constraint.test.ts
@@ -360,4 +360,26 @@ describe('getZodConstraint', () => {
 			constraint['conditions[0].conditions[1].conditions[2].type'],
 		).toEqual({ required: true });
 	});
+
+	test('regex patterns', () => {
+		const schema = z.object({
+			empty: z.string(),
+			single: z.string().regex(/^[A-Z]+$/),
+			multiple: z.string().regex(/[A-Z]/, 'uppercase').regex(/[0-9]/, 'digit'),
+		});
+
+		expect(getZodConstraint(schema)).toEqual({
+			empty: {
+				required: true,
+			},
+			single: {
+				required: true,
+				pattern: '^(?=.*(?:^[A-Z]+$)).*$',
+			},
+			multiple: {
+				required: true,
+				pattern: '^(?=.*(?:[A-Z]))(?=.*(?:[0-9])).*$',
+			},
+		});
+	});
 });

--- a/packages/conform-zod/v3/constraint.ts
+++ b/packages/conform-zod/v3/constraint.ts
@@ -1,10 +1,12 @@
 import type { Constraint } from '@conform-to/dom';
 import { getPaths, formatPaths, getRelativePath } from '@conform-to/dom';
+import { serializeHtmlPattern } from '@conform-to/dom/future';
 import type {
 	ZodTypeAny,
 	ZodFirstPartySchemaTypes,
 	ZodNumber,
 	ZodString,
+	ZodStringCheck,
 } from 'zod/v3';
 
 const keys: Array<keyof Constraint> = [
@@ -128,6 +130,16 @@ export function getZodConstraint(
 			}
 			if (_schema.maxLength !== null) {
 				constraint.maxLength = _schema.maxLength;
+			}
+			const regexChecks = def.checks.filter(
+				(check): check is ZodStringCheck & { kind: 'regex' } =>
+					check.kind === 'regex',
+			);
+			if (regexChecks.length > 0) {
+				const pattern = serializeHtmlPattern(regexChecks.map((c) => c.regex));
+				if (pattern) {
+					constraint.pattern = pattern;
+				}
 			}
 		} else if (def.typeName === 'ZodOptional') {
 			constraint.required = false;

--- a/packages/conform-zod/v3/tests/constraint.test.ts
+++ b/packages/conform-zod/v3/tests/constraint.test.ts
@@ -360,4 +360,26 @@ describe('getZodConstraint', () => {
 			constraint['conditions[0].conditions[1].conditions[2].type'],
 		).toEqual({ required: true });
 	});
+
+	test('regex patterns', () => {
+		const schema = z.object({
+			empty: z.string(),
+			single: z.string().regex(/^[A-Z]+$/),
+			multiple: z.string().regex(/[A-Z]/).regex(/[0-9]/),
+		});
+
+		expect(getZodConstraint(schema)).toEqual({
+			empty: {
+				required: true,
+			},
+			single: {
+				required: true,
+				pattern: '^(?=.*(?:^[A-Z]+$)).*$',
+			},
+			multiple: {
+				required: true,
+				pattern: '^(?=.*(?:[A-Z]))(?=.*(?:[0-9])).*$',
+			},
+		});
+	});
 });

--- a/packages/conform-zod/v4/constraint.ts
+++ b/packages/conform-zod/v4/constraint.ts
@@ -1,5 +1,6 @@
 import type { Constraint } from '@conform-to/dom';
 import { getPaths, formatPaths, getRelativePath } from '@conform-to/dom';
+import { combinePatterns } from '@conform-to/dom/future';
 import {
 	$ZodType,
 	$ZodTypes,
@@ -130,6 +131,12 @@ export function getZodConstraint(schema: $ZodType): Record<string, Constraint> {
 			}
 			if (_schema._zod.bag.maximum != null) {
 				constraint.maxLength = _schema._zod.bag.maximum;
+			}
+			if (_schema._zod.bag.patterns?.size) {
+				const pattern = combinePatterns([..._schema._zod.bag.patterns]);
+				if (pattern) {
+					constraint.pattern = pattern;
+				}
 			}
 		} else if (def.type === 'optional') {
 			constraint.required = false;

--- a/packages/conform-zod/v4/constraint.ts
+++ b/packages/conform-zod/v4/constraint.ts
@@ -1,6 +1,6 @@
 import type { Constraint } from '@conform-to/dom';
 import { getPaths, formatPaths, getRelativePath } from '@conform-to/dom';
-import { combinePatterns } from '@conform-to/dom/future';
+import { serializeHtmlPattern } from '@conform-to/dom/future';
 import {
 	$ZodType,
 	$ZodTypes,
@@ -133,7 +133,7 @@ export function getZodConstraint(schema: $ZodType): Record<string, Constraint> {
 				constraint.maxLength = _schema._zod.bag.maximum;
 			}
 			if (_schema._zod.bag.patterns?.size) {
-				const pattern = combinePatterns([..._schema._zod.bag.patterns]);
+				const pattern = serializeHtmlPattern([..._schema._zod.bag.patterns]);
 				if (pattern) {
 					constraint.pattern = pattern;
 				}

--- a/packages/conform-zod/v4/tests/constraint.test.ts
+++ b/packages/conform-zod/v4/tests/constraint.test.ts
@@ -457,4 +457,26 @@ describe('getZodConstraint', () => {
 			required: true,
 		});
 	});
+
+	test('regex patterns', () => {
+		const schema = z.object({
+			empty: z.string(),
+			single: z.string().regex(/^[A-Z]+$/),
+			multiple: z.string().regex(/[A-Z]/, 'uppercase').regex(/[0-9]/, 'digit'),
+		});
+
+		expect(getZodConstraint(schema)).toEqual({
+			empty: {
+				required: true,
+			},
+			single: {
+				required: true,
+				pattern: '^(?=.*(?:^[A-Z]+$)).*$',
+			},
+			multiple: {
+				required: true,
+				pattern: '^(?=.*(?:[A-Z]))(?=.*(?:[0-9])).*$',
+			},
+		});
+	});
 });


### PR DESCRIPTION
This PR lets Conform construct an HTML [`pattern`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/pattern) attribute based on regular expressions from zod v3, v4, and valibot schemas.

These validators allow multiple regexes for string schemas. For example in zod,

```ts
z.string().regex(/a/).regex(/b/)
```

matches strings containing at least one "a" and one "b" in any order. But because `<input>` accepts only one `pattern` attribute, multiple regexes need to be combined into one, using positive lookahead assertions:

```py
 in: [A-Z], [0-9]
out: ^(?=.*(?:[A-Z]))(?=.*(?:[0-9])).*$
```

The correctness of `out` is supported by [this jsfiddle](https://jsfiddle.net/8co0aLjw/) featuring an input whose text turns green if and only if it matches both `in` patterns.

The `i` flag is not supported, because HTML patterns don't support case-insensitive matching.

Backreferences have limited support. Using named backreferences over numbered backreferences is recommended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

- Added combinePatterns(patterns: RegExp[]): string | undefined in packages/conform-dom/util.ts and re-exported it from packages/conform-dom/future. It returns undefined for empty input or when any regex has unsupported flags (allowed flags u/v are stripped). For valid inputs it builds a single anchored pattern that conjuncts multiple regexes with positive lookaheads (e.g. ^(?=.*(?:[A-Z]))(?=.*(?:[0-9])).*$). HTML pattern generation assumes browser behavior using the v flag by default; supported flags are stripped and unsupported flags are not mapped.  
- Zod (default): getZodConstraint now collects ZodString regex checks (def.checks kind === 'regex') and sets constraint.pattern via combinePatterns.  
- Zod v4: getZodConstraint now reads _schema._zod.bag.patterns and sets constraint.pattern via combinePatterns.  
- Valibot: getValibotConstraint now inspects schema.pipe for regex validators and sets constraint.pattern via combinePatterns.  
- Tests: Added unit tests for combinePatterns and Vitest cases verifying single and chained regex → combined pattern behavior for zod/default, zod/v4, and valibot; tests cover empty-input and unsupported/supported flags.  
- Changeset: Adds documentation and example showing mapping of schema regex validators to the HTML pattern attribute and how to expose it via inputProps.

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->