### PR TITLE
fix: `report` should infer a `SubmissionResult` with `File` values stripped by default.

### DIFF
--- a/.changeset/future-report-file-types.md
+++ b/.changeset/future-report-file-types.md
@@ -1,0 +1,6 @@
+---
+'@conform-to/dom': patch
+'@conform-to/react': patch
+---
+
+fix: `report` should infer a `SubmissionResult` with `File` values stripped by default.

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -430,12 +430,12 @@ export function parseSubmission(
 		 * The name of the submit button field that indicates the submission intent.
 		 * Defaults to `__INTENT__`.
 		 */
-		intentName?: string;
+		intentName?: string | undefined;
 		/**
 		 * A function to exclude specific form fields from being parsed.
 		 * Return `true` to skip the entry.
 		 */
-		skipEntry?: (name: string) => boolean;
+		skipEntry?: ((name: string) => boolean) | undefined;
 		/**
 		 * Whether to strip empty values (empty strings, empty files, arrays with all empty values)
 		 * from the submission payload. Defaults to `false`.
@@ -444,7 +444,7 @@ export function parseSubmission(
 		 * If you are using a schema library like Zod or Valibot, our integration
 		 * already strips empty values for you. There is no need to use this option.
 		 */
-		stripEmptyValues?: boolean;
+		stripEmptyValues?: boolean | undefined;
 	},
 ): Submission {
 	const intentName = options?.intentName ?? DEFAULT_INTENT_NAME;
@@ -532,11 +532,31 @@ export function parseSubmission(
  * })
  * ```
  */
+export function report(
+	submission: Submission,
+	options?: {
+		keepFiles?: false;
+		error?: null;
+		value?: Record<string, FormValue> | null;
+		hideFields?: string[];
+		reset?: boolean;
+	},
+): SubmissionResult<never, Exclude<JsonPrimitive | FormDataEntryValue, File>>;
+export function report(
+	submission: Submission,
+	options: {
+		keepFiles: true;
+		error?: null;
+		value?: Record<string, FormValue> | null;
+		hideFields?: string[];
+		reset?: boolean;
+	},
+): SubmissionResult<never>;
 export function report<ErrorShape>(
 	submission: Submission,
 	options: {
 		keepFiles?: false;
-		error: CustomError<ErrorShape>;
+		error: CustomError<ErrorShape> | null;
 		value?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
@@ -549,7 +569,7 @@ export function report<ErrorShape>(
 	submission: Submission,
 	options: {
 		keepFiles: true;
-		error: CustomError<ErrorShape>;
+		error: CustomError<ErrorShape> | null;
 		value?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
@@ -578,26 +598,6 @@ export function report(
 		reset?: boolean;
 	},
 ): SubmissionResult<string[]>;
-export function report(
-	submission: Submission,
-	options?: {
-		keepFiles?: false;
-		error?: null;
-		value?: Record<string, FormValue> | null;
-		hideFields?: string[];
-		reset?: boolean;
-	},
-): SubmissionResult<never, Exclude<JsonPrimitive | FormDataEntryValue, File>>;
-export function report(
-	submission: Submission,
-	options: {
-		keepFiles: true;
-		error?: null;
-		value?: Record<string, FormValue> | null;
-		hideFields?: string[];
-		reset?: boolean;
-	},
-): SubmissionResult<never>;
 export function report<ErrorShape>(
 	submission: Submission,
 	options?: {
@@ -713,12 +713,12 @@ export function isDirty(
 		 * An object representing the default values of the form to compare against.
 		 * Defaults to an empty object if not provided.
 		 */
-		defaultValue?: unknown;
+		defaultValue?: unknown | undefined;
 		/**
 		 * The name of the submit button that triggered the submission.
 		 * It will be excluded from the dirty comparison.
 		 */
-		intentName?: string;
+		intentName?: string | undefined;
 		/**
 		 * A function to serialize values in defaultValue before comparing them to the form data.
 		 * If not provided, a default serializer is used that behaves as follows:
@@ -733,7 +733,7 @@ export function isDirty(
 		 * - Date:
 		 *   - Converted to UTC datetime string without trailing `Z` (e.g. `2026-01-01T12:00:00.000`)
 		 */
-		serialize?: CustomSerialize;
+		serialize?: CustomSerialize | undefined;
 		/**
 		 * A function to exclude specific fields from the comparison.
 		 * Useful for ignoring hidden inputs like CSRF tokens or internal fields added by frameworks
@@ -746,7 +746,7 @@ export function isDirty(
 		 * });
 		 * ```
 		 */
-		skipEntry?: (name: string) => boolean;
+		skipEntry?: ((name: string) => boolean) | undefined;
 	},
 ): boolean | undefined {
 	if (!formData) {

--- a/packages/conform-dom/tests/types.test-d.ts
+++ b/packages/conform-dom/tests/types.test-d.ts
@@ -1,6 +1,13 @@
 import { assertType, test, expectTypeOf } from 'vitest';
-import type { FieldName, ValidationAttributes } from '@conform-to/dom/future';
-import { getFieldValue } from '@conform-to/dom/future';
+import type {
+	FieldName,
+	FormError,
+	FormValue,
+	Submission,
+	SubmissionResult,
+	ValidationAttributes,
+} from '../future';
+import { getFieldValue, isDirty, parseSubmission, report } from '../future';
 
 test('ValidationAttributes', () => {
 	assertType<ValidationAttributes>({});
@@ -137,4 +144,138 @@ test('getFieldValue', () => {
 			optional: true,
 		}),
 	).toEqualTypeOf<string[] | undefined>();
+});
+
+test('parseSubmission', () => {
+	expectTypeOf(
+		parseSubmission(new FormData(), {
+			intentName: undefined,
+			skipEntry: undefined,
+			stripEmptyValues: undefined,
+		}),
+	).toEqualTypeOf<Submission>();
+});
+
+test('isDirty', () => {
+	expectTypeOf(
+		isDirty(new FormData(), {
+			defaultValue: undefined,
+			intentName: undefined,
+			serialize: undefined,
+			skipEntry: undefined,
+		}),
+	).toEqualTypeOf<boolean | undefined>();
+});
+
+const submission = {
+	payload: {
+		lorem: '',
+		file: new File(['content'], 'test.txt'),
+	},
+	fields: ['lorem', 'file'],
+	intent: null,
+};
+
+const updatedValue = {
+	lorem: 'ipsum',
+	file: new File(['updated'], 'updated.txt'),
+};
+
+test('report', () => {
+	/** Default behavior strips files from the submission payload and target value. */
+	const defaultResult = report(submission);
+	const explicitStripResult = report(submission, { keepFiles: false });
+	const defaultResultWithValue = report(submission, { value: updatedValue });
+
+	expectTypeOf(defaultResult).toEqualTypeOf<
+		SubmissionResult<never, string | number | boolean | null>
+	>();
+	expectTypeOf(explicitStripResult).toEqualTypeOf<
+		SubmissionResult<never, string | number | boolean | null>
+	>();
+	expectTypeOf(defaultResult.submission.payload.file).toEqualTypeOf<
+		FormValue<string | number | boolean | null> | undefined
+	>();
+	expectTypeOf(defaultResultWithValue.targetValue).toEqualTypeOf<
+		Record<string, FormValue<string | number | boolean | null>> | undefined
+	>();
+
+	/** `keepFiles: true` preserves file values in both payload and target value. */
+	const keepFilesResult = report(submission, {
+		keepFiles: true,
+		value: updatedValue,
+	});
+
+	expectTypeOf(keepFilesResult).toEqualTypeOf<SubmissionResult<never>>();
+	expectTypeOf(keepFilesResult.submission.payload.file).toEqualTypeOf<
+		FormValue<string | number | boolean | File | null> | undefined
+	>();
+	expectTypeOf(keepFilesResult.targetValue).toEqualTypeOf<
+		| Record<string, FormValue<string | number | boolean | File | null>>
+		| undefined
+	>();
+
+	/** Literal `null` should keep the dedicated `SubmissionResult<never>` overload. */
+	expectTypeOf(report(submission, { error: null })).toEqualTypeOf<
+		SubmissionResult<never, string | number | boolean | null>
+	>();
+	expectTypeOf(
+		report(submission, { keepFiles: true, error: null }),
+	).toEqualTypeOf<SubmissionResult<never>>();
+
+	/** Custom errors should infer the provided error shape. */
+	const stringResult = report(submission, {
+		error: {
+			fieldErrors: {
+				lorem: 'Required',
+			},
+		},
+	});
+	const objectResult = report(submission, {
+		keepFiles: true,
+		error: {
+			formErrors: { message: 'Invalid' },
+			fieldErrors: {
+				lorem: { message: 'Required' },
+			},
+		},
+	});
+
+	expectTypeOf(stringResult).toEqualTypeOf<
+		SubmissionResult<string, string | number | boolean | null>
+	>();
+	expectTypeOf(objectResult).toEqualTypeOf<
+		SubmissionResult<{ message: string }>
+	>();
+
+	/** Standard schema issues should normalize to `string[]` errors. */
+	const standardSchemaResult = report(submission, {
+		error: {
+			issues: [{ path: ['lorem'], message: 'Required' }],
+		},
+	});
+
+	expectTypeOf(standardSchemaResult).toEqualTypeOf<
+		SubmissionResult<string[], string | number | boolean | null>
+	>();
+
+	/** Nullable normalized form errors should still use the file-stripping overloads. */
+	const error: FormError<string[]> | null =
+		Math.random() > 0.5
+			? {
+					formErrors: null,
+					fieldErrors: {
+						lorem: ['Required'],
+					},
+				}
+			: null;
+	expectTypeOf(report(submission, { error })).toEqualTypeOf<
+		SubmissionResult<string[], string | number | boolean | null>
+	>();
+	expectTypeOf(
+		report(submission, {
+			keepFiles: true,
+			error,
+		}),
+	).toEqualTypeOf<SubmissionResult<string[]>>();
 });

--- a/packages/conform-dom/tests/types.test-d.ts
+++ b/packages/conform-dom/tests/types.test-d.ts
@@ -206,7 +206,9 @@ test('report', () => {
 		value: updatedValue,
 	});
 
-	expectTypeOf(keepFilesResult).toEqualTypeOf<SubmissionResult<never>>();
+	expectTypeOf(keepFilesResult).toEqualTypeOf<
+		SubmissionResult<never, string | number | boolean | File | null>
+	>();
 	expectTypeOf(keepFilesResult.submission.payload.file).toEqualTypeOf<
 		FormValue<string | number | boolean | File | null> | undefined
 	>();
@@ -221,7 +223,9 @@ test('report', () => {
 	>();
 	expectTypeOf(
 		report(submission, { keepFiles: true, error: null }),
-	).toEqualTypeOf<SubmissionResult<never>>();
+	).toEqualTypeOf<
+		SubmissionResult<never, string | number | boolean | File | null>
+	>();
 
 	/** Custom errors should infer the provided error shape. */
 	const stringResult = report(submission, {
@@ -245,7 +249,10 @@ test('report', () => {
 		SubmissionResult<string, string | number | boolean | null>
 	>();
 	expectTypeOf(objectResult).toEqualTypeOf<
-		SubmissionResult<{ message: string }>
+		SubmissionResult<
+			{ message: string },
+			string | number | boolean | File | null
+		>
 	>();
 
 	/** Standard schema issues should normalize to `string[]` errors. */
@@ -277,5 +284,7 @@ test('report', () => {
 			keepFiles: true,
 			error,
 		}),
-	).toEqualTypeOf<SubmissionResult<string[]>>();
+	).toEqualTypeOf<
+		SubmissionResult<string[], string | number | boolean | File | null>
+	>();
 });

--- a/packages/conform-dom/types.ts
+++ b/packages/conform-dom/types.ts
@@ -102,15 +102,15 @@ export type SubmissionResult<
 	/**
 	 * The target value of the submission. Defined only when the target value is different from the submitted value.
 	 */
-	targetValue?: Record<string, FormValue<ValueType>>;
+	targetValue?: Record<string, FormValue<ValueType>> | undefined;
 	/**
 	 * Validation errors for `targetValue` when present, otherwise for the original payload.
 	 */
-	error?: FormError<ErrorShape> | null;
+	error?: FormError<ErrorShape> | null | undefined;
 	/**
 	 * Indicates whether the form should be reset to its initial state.
 	 */
-	reset?: boolean;
+	reset?: boolean | undefined;
 };
 
 /** The name of an input field with type information for TypeScript inference. */


### PR DESCRIPTION
Fix https://github.com/edmundhung/conform/discussions/1207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

## Implementation Details

This PR updates typings and tests so that report infers a SubmissionResult which strips File values by default (and preserves them only when keepFiles: true):

- Adds a changeset declaring a patch for @conform-to/dom and @conform-to/react describing the fix.
- Adjusts report/parseSubmission/isDirty overloads and option optionality to better reflect undefined unions and control-flow for error overloads.
- Updates SubmissionResult to explicitly include undefined in optional fields: targetValue, error, and reset.
- Introduces Serializable helper to support stripping File types from serializable shapes.
- Adds comprehensive type tests (packages/conform-dom/tests/types.test-d.ts) covering:
  - Default file-stripping behavior and keepFiles: true preservation
  - Overload selection for literal null error vs custom error shapes
  - Schema issue normalization and nullable error handling

The change ensures loader-serialized submission results (with runtime file-like objects) are compatible with components expecting a SubmissionResult without requiring explicit generics by stripping File values by default.
</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->