### PR TITLE
chore: update changeset as patch

### DIFF
--- a/.changeset/pattern-constraint-regex.md
+++ b/.changeset/pattern-constraint-regex.md
@@ -1,8 +1,8 @@
 ---
-'@conform-to/dom': minor
-'@conform-to/react': minor
-'@conform-to/valibot': minor
-'@conform-to/zod': minor
+'@conform-to/dom': patch
+'@conform-to/react': patch
+'@conform-to/valibot': patch
+'@conform-to/zod': patch
 ---
 
 `getZodConstraint`, `getValibotConstraint`, and the future `getConstraints` helpers can now derive HTML `pattern` constraints from Zod and Valibot schemas. When a field uses multiple regex validators, Conform combines them into a single `pattern` when possible.


### PR DESCRIPTION
Don't wanna do a minor bump yet. I think this change can also be considered a patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

Updated the changeset for the pattern constraint change to specify `patch` version bumps for `@conform-to/dom`, `@conform-to/react`, `@conform-to/valibot`, and `@conform-to/zod` packages. This reflects the classification of the underlying changes as requiring only a patch release rather than a minor release.
</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->