### PR TITLE
fix(conform-zod): Zod 4.4 coercion optionality handling

### DIFF
--- a/.changeset/new-peaches-rest.md
+++ b/.changeset/new-peaches-rest.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/zod': patch
+---
+
+Fix Zod 4.4 coercion optionality handling

--- a/packages/conform-zod/package.json
+++ b/packages/conform-zod/package.json
@@ -82,7 +82,7 @@
 		"rollup": "^2.79.1",
 		"rollup-plugin-copy": "^3.4.0",
 		"zod": "^3.25.75",
-		"zod-v4": "npm:zod@^4.0.0"
+		"zod-v4": "npm:zod@^4.4.3"
 	},
 	"keywords": [
 		"constraint-validation",

--- a/packages/conform-zod/tsconfig.json
+++ b/packages/conform-zod/tsconfig.json
@@ -4,6 +4,11 @@
 		"target": "ES2022",
 		"module": "ES2022",
 		"moduleResolution": "Bundler",
+		"baseUrl": ".",
+		"paths": {
+			"zod/v4": ["./node_modules/zod-v4/v4"],
+			"zod/v4/*": ["./node_modules/zod-v4/v4/*"]
+		},
 		"allowSyntheticDefaultImports": true,
 		"noUncheckedIndexedAccess": true,
 		"strict": true,

--- a/packages/conform-zod/tsconfig.json
+++ b/packages/conform-zod/tsconfig.json
@@ -6,6 +6,10 @@
 		"moduleResolution": "Bundler",
 		"baseUrl": ".",
 		"paths": {
+			// Keep v4 sources and tests on the zod-v4 alias. The zod devDependency is
+			// still v3 for v3 support, so resolving zod/v4 normally would use the v4
+			// compatibility types bundled with zod@3. This alias can be removed when
+			// v3 support is dropped and zod itself is upgraded to v4.
 			"zod/v4": ["./node_modules/zod-v4/v4"],
 			"zod/v4/*": ["./node_modules/zod-v4/v4/*"]
 		},

--- a/packages/conform-zod/v4/coercion.ts
+++ b/packages/conform-zod/v4/coercion.ts
@@ -248,9 +248,7 @@ function materializesMissingValue(type: $ZodType): boolean {
 			return materializesMissingValue(pipeDef.out);
 		}
 
-		if (pipeDef.out._zod.def.type === 'transform') {
-			return materializesMissingValue(pipeDef.in);
-		}
+		return materializesMissingValue(pipeDef.in);
 	}
 
 	return def.type === 'array' || def.type === 'object';

--- a/packages/conform-zod/v4/coercion.ts
+++ b/packages/conform-zod/v4/coercion.ts
@@ -230,6 +230,23 @@ function materializesMissingValue(type: $ZodType): boolean {
 	return def.type === 'array' || def.type === 'object';
 }
 
+function withOptionalInput(type: $ZodType): $ZodType {
+	const schema = Object.create(Object.getPrototypeOf(type)) as $ZodType;
+	const descriptors = Object.getOwnPropertyDescriptors(type);
+
+	delete descriptors._zod;
+	Object.defineProperties(schema, descriptors);
+	Object.defineProperty(schema, '_zod', {
+		value: Object.create(type._zod, {
+			optin: {
+				value: 'optional',
+			},
+		}),
+	});
+
+	return schema;
+}
+
 function coerceObjectShapeEntry(
 	type: $ZodType,
 	options: CoerceTypeOptions,
@@ -237,7 +254,7 @@ function coerceObjectShapeEntry(
 	const schema = coerceType(type, options);
 
 	if (type._zod.optin !== 'optional' && materializesMissingValue(type)) {
-		(schema as $ZodTypes)._zod.optin = 'optional';
+		return withOptionalInput(schema);
 	}
 
 	return schema;

--- a/packages/conform-zod/v4/coercion.ts
+++ b/packages/conform-zod/v4/coercion.ts
@@ -226,9 +226,9 @@ function pipeWithOptionality(
 }
 
 function materializesMissingValue(type: $ZodType): boolean {
-	let def = type._zod.def;
+	const def = type._zod.def;
 
-	while (
+	if (
 		def.type === 'optional' ||
 		def.type === 'nonoptional' ||
 		def.type === 'default' ||
@@ -236,7 +236,21 @@ function materializesMissingValue(type: $ZodType): boolean {
 		def.type === 'catch' ||
 		def.type === 'nullable'
 	) {
-		def = (def as unknown as { innerType: $ZodType }).innerType._zod.def;
+		return materializesMissingValue(
+			(def as unknown as { innerType: $ZodType }).innerType,
+		);
+	}
+
+	if (def.type === 'pipe') {
+		const pipeDef = def as unknown as { in: $ZodType; out: $ZodType };
+
+		if (pipeDef.in._zod.def.type === 'transform') {
+			return materializesMissingValue(pipeDef.out);
+		}
+
+		if (pipeDef.out._zod.def.type === 'transform') {
+			return materializesMissingValue(pipeDef.in);
+		}
 	}
 
 	return def.type === 'array' || def.type === 'object';

--- a/packages/conform-zod/v4/coercion.ts
+++ b/packages/conform-zod/v4/coercion.ts
@@ -191,6 +191,28 @@ function typeCheckTransform(defType: string): $ZodType {
 	});
 }
 
+function pipeWithOptionality(
+	coercion: CoercionFunction,
+	target: $ZodType,
+): $ZodType {
+	const schema = pipe(transform(coercion), target) as $ZodType;
+
+	if (target._zod.optin) {
+		(schema as $ZodTypes)._zod.optin = target._zod.optin;
+	}
+
+	if (target._zod.optout) {
+		(schema as $ZodTypes)._zod.optout = target._zod.optout;
+	}
+
+	return schema;
+}
+
+function materializesMissingValue(type: $ZodType): boolean {
+	const def = type._zod.def;
+	return def.type === 'array' || def.type === 'object';
+}
+
 /**
  * Reconstruct the provided schema with additional preprocessing steps
  * that strip empty values and coerce strings to the correct type.
@@ -243,7 +265,7 @@ function coerceType(
 			: type;
 
 	if (coercion) {
-		schema = pipe(transform(coercion), target);
+		schema = pipeWithOptionality(coercion, target);
 	} else if (target !== type) {
 		schema = target;
 	} else if (def.type === 'array') {
@@ -251,8 +273,8 @@ function coerceType(
 			? { ...def, checks: undefined }
 			: def;
 
-		schema = pipe(
-			transform((value) => {
+		schema = pipeWithOptionality(
+			(value) => {
 				if (Array.isArray(value)) {
 					return value;
 				}
@@ -266,7 +288,7 @@ function coerceType(
 				}
 
 				return [value];
-			}),
+			},
 			new constr({
 				...arrayDef,
 				element: coerceType(def.element, options),
@@ -277,21 +299,29 @@ function coerceType(
 			? { ...def, catchall: undefined }
 			: def;
 
-		schema = pipe(
-			transform((value) => {
+		schema = pipeWithOptionality(
+			(value) => {
 				if (typeof value === 'undefined') {
 					return {};
 				}
 
 				return value;
-			}),
+			},
 			new constr({
 				...objectDef,
 				shape: Object.fromEntries(
-					Object.entries(def.shape).map(([key, def]) => [
-						key,
-						coerceType(def, options),
-					]),
+					Object.entries(def.shape).map(([key, def]) => {
+						const schema = coerceType(def, options);
+
+						if (
+							def._zod.optin !== 'optional' &&
+							materializesMissingValue(def)
+						) {
+							(schema as $ZodTypes)._zod.optin = 'optional';
+						}
+
+						return [key, schema];
+					}),
 				),
 			}) as $ZodType<unknown, {}>,
 		);
@@ -300,7 +330,7 @@ function coerceType(
 		const wrapped = new constr({ ...def, innerType });
 
 		schema = options.stripEmptyValue
-			? pipe(transform(options.stripEmptyValue), wrapped)
+			? pipeWithOptionality(options.stripEmptyValue, wrapped)
 			: wrapped;
 	} else if (def.type === 'default' || def.type === 'prefault') {
 		if (options.skipDefaults) {
@@ -314,7 +344,7 @@ function coerceType(
 			const wrapped = new constr({ ...def, innerType });
 
 			schema = options.stripEmptyValue
-				? pipe(transform(options.stripEmptyValue), wrapped)
+				? pipeWithOptionality(options.stripEmptyValue, wrapped)
 				: wrapped;
 		}
 	} else if (def.type === 'catch') {

--- a/packages/conform-zod/v4/coercion.ts
+++ b/packages/conform-zod/v4/coercion.ts
@@ -226,7 +226,19 @@ function pipeWithOptionality(
 }
 
 function materializesMissingValue(type: $ZodType): boolean {
-	const def = type._zod.def;
+	let def = type._zod.def;
+
+	while (
+		def.type === 'optional' ||
+		def.type === 'nonoptional' ||
+		def.type === 'default' ||
+		def.type === 'prefault' ||
+		def.type === 'catch' ||
+		def.type === 'nullable'
+	) {
+		def = (def as unknown as { innerType: $ZodType }).innerType._zod.def;
+	}
+
 	return def.type === 'array' || def.type === 'object';
 }
 

--- a/packages/conform-zod/v4/coercion.ts
+++ b/packages/conform-zod/v4/coercion.ts
@@ -232,9 +232,8 @@ function materializesMissingValue(type: $ZodType): boolean {
 
 function withOptionalInput(type: $ZodType): $ZodType {
 	const schema = Object.create(Object.getPrototypeOf(type)) as $ZodType;
-	const descriptors = Object.getOwnPropertyDescriptors(type);
+	const { _zod, ...descriptors } = Object.getOwnPropertyDescriptors(type);
 
-	delete descriptors._zod;
 	Object.defineProperties(schema, descriptors);
 	Object.defineProperty(schema, '_zod', {
 		value: Object.create(type._zod, {

--- a/packages/conform-zod/v4/coercion.ts
+++ b/packages/conform-zod/v4/coercion.ts
@@ -13,6 +13,23 @@ type CoercionFunction = (value: unknown) => unknown;
 
 type CoercionKey = 'string' | 'file' | 'number' | 'boolean' | 'date' | 'bigint';
 
+type CoerceTypeOptions = {
+	/** Map of original schema to its coerced version. Prevents re-processing and infinite recursion from z.lazy(). */
+	resolved: Map<$ZodType, $ZodType>;
+	/** Schemas currently being resolved. Detects re-entrant calls from getter-based recursive schemas. */
+	resolving: Set<$ZodType>;
+	/** Returns a coercion function for the given schema type, or null to skip. */
+	coerce: (type: $ZodType) => CoercionFunction | null;
+	/** Strip function for optional/nonoptional/array. `undefined` = no stripping. */
+	stripEmptyValue?: CoercionFunction;
+	/** Whether to replace the original schema with a type check for non-constrained leaves. */
+	skipValidation?: boolean;
+	/** Whether to skip default/prefault wrappers (recurse into inner). */
+	skipDefaults?: boolean;
+	/** Whether to skip transforms in pipe (only process `def.in`). */
+	skipTransforms?: boolean;
+};
+
 function coerceFile(file: unknown): unknown {
 	if (
 		typeof File !== 'undefined' &&
@@ -213,29 +230,24 @@ function materializesMissingValue(type: $ZodType): boolean {
 	return def.type === 'array' || def.type === 'object';
 }
 
+function coerceObjectShapeEntry(
+	type: $ZodType,
+	options: CoerceTypeOptions,
+): $ZodType {
+	const schema = coerceType(type, options);
+
+	if (type._zod.optin !== 'optional' && materializesMissingValue(type)) {
+		(schema as $ZodTypes)._zod.optin = 'optional';
+	}
+
+	return schema;
+}
+
 /**
  * Reconstruct the provided schema with additional preprocessing steps
  * that strip empty values and coerce strings to the correct type.
  */
-function coerceType(
-	type: $ZodType,
-	options: {
-		/** Map of original schema to its coerced version. Prevents re-processing and infinite recursion from z.lazy(). */
-		resolved: Map<$ZodType, $ZodType>;
-		/** Schemas currently being resolved. Detects re-entrant calls from getter-based recursive schemas. */
-		resolving: Set<$ZodType>;
-		/** Returns a coercion function for the given schema type, or null to skip. */
-		coerce: (type: $ZodType) => CoercionFunction | null;
-		/** Strip function for optional/nonoptional/array. `undefined` = no stripping. */
-		stripEmptyValue?: CoercionFunction;
-		/** Whether to replace the original schema with a type check for non-constrained leaves. */
-		skipValidation?: boolean;
-		/** Whether to skip default/prefault wrappers (recurse into inner). */
-		skipDefaults?: boolean;
-		/** Whether to skip transforms in pipe (only process `def.in`). */
-		skipTransforms?: boolean;
-	},
-): $ZodType {
+function coerceType(type: $ZodType, options: CoerceTypeOptions): $ZodType {
 	const result = options.resolved.get(type);
 
 	if (result) {
@@ -310,18 +322,10 @@ function coerceType(
 			new constr({
 				...objectDef,
 				shape: Object.fromEntries(
-					Object.entries(def.shape).map(([key, def]) => {
-						const schema = coerceType(def, options);
-
-						if (
-							def._zod.optin !== 'optional' &&
-							materializesMissingValue(def)
-						) {
-							(schema as $ZodTypes)._zod.optin = 'optional';
-						}
-
-						return [key, schema];
-					}),
+					Object.entries(def.shape).map(([key, def]) => [
+						key,
+						coerceObjectShapeEntry(def, options),
+					]),
 				),
 			}) as $ZodType<unknown, {}>,
 		);
@@ -397,9 +401,10 @@ function coerceType(
 					const object = new item._zod.constr({
 						...innerDef,
 						shape: Object.fromEntries(
-							Object.entries(objectDef.shape).map(([key, def]) => {
-								return [key, coerceType(def, options)];
-							}),
+							Object.entries(objectDef.shape).map(([key, def]) => [
+								key,
+								coerceObjectShapeEntry(def, options),
+							]),
 						),
 					}) as $ZodType<unknown, {}>;
 

--- a/packages/conform-zod/v4/tests/coercion/schema/discriminatedUnion.test.ts
+++ b/packages/conform-zod/v4/tests/coercion/schema/discriminatedUnion.test.ts
@@ -8,6 +8,8 @@ import {
 	number,
 	boolean,
 	extend,
+	array,
+	string,
 } from 'zod-v4/mini';
 import { getResult } from '../../../../tests/helpers/zod';
 
@@ -232,6 +234,64 @@ describe('coercion', () => {
 				success: false,
 				error: {
 					status: ['Invalid input'],
+				},
+			});
+		});
+
+		test('should materialize missing array and object fields in members', () => {
+			const schema = z.discriminatedUnion('type', [
+				z.object({
+					type: z.literal('a'),
+					items: z.array(z.string()),
+					nested: z.object({
+						value: z.string().optional(),
+					}),
+				}),
+				z.object({
+					type: z.literal('b'),
+					enabled: z.boolean(),
+				}),
+			]);
+			const schemaWithMini = discriminatedUnion('type', [
+				object({
+					type: literal('a'),
+					items: array(string()),
+					nested: object({
+						value: z.string().optional(),
+					}),
+				}),
+				object({
+					type: literal('b'),
+					enabled: boolean(),
+				}),
+			]);
+
+			expect(
+				getResult(
+					coerceFormValue(schema).safeParse({
+						type: 'a',
+					}),
+				),
+			).toEqual({
+				success: true,
+				data: {
+					type: 'a',
+					items: [],
+					nested: {},
+				},
+			});
+			expect(
+				getResult(
+					coerceFormValue(schemaWithMini).safeParse({
+						type: 'a',
+					}),
+				),
+			).toEqual({
+				success: true,
+				data: {
+					type: 'a',
+					items: [],
+					nested: {},
 				},
 			});
 		});

--- a/packages/conform-zod/v4/tests/coercion/schema/object.test.ts
+++ b/packages/conform-zod/v4/tests/coercion/schema/object.test.ts
@@ -147,5 +147,40 @@ describe('coercion', () => {
 				},
 			});
 		});
+
+		test('should not leak missing-field optionality to reused schemas', () => {
+			const items = z.array(z.string());
+			const schema = z.object({
+				items,
+				union: z.union([z.literal('other'), items]),
+			});
+			const coerced = coerceFormValue(schema);
+			const shape = (
+				coerced as unknown as {
+					_zod: {
+						def: {
+							out: {
+								_zod: {
+									def: {
+										shape: Record<
+											string,
+											{
+												_zod: {
+													optin?: 'optional';
+													def: { options: { _zod: { optin?: 'optional' } }[] };
+												};
+											}
+										>;
+									};
+								};
+							};
+						};
+					};
+				}
+			)._zod.def.out._zod.def.shape;
+
+			expect(shape.items._zod.optin).toBe('optional');
+			expect(shape.union._zod.def.options[1]._zod.optin).toBeUndefined();
+		});
 	});
 });

--- a/packages/conform-zod/v4/tests/coercion/schema/object.test.ts
+++ b/packages/conform-zod/v4/tests/coercion/schema/object.test.ts
@@ -204,5 +204,20 @@ describe('coercion', () => {
 			expect(shape.caughtItems._zod.optin).toBe('optional');
 			expect(shape.union._zod.def.options[1]._zod.optin).toBeUndefined();
 		});
+
+		test('should materialize missing pipe-wrapped collection fields', () => {
+			const schema = z.object({
+				preprocessed: z.preprocess((value) => value, z.array(z.string())),
+				transformed: z.array(z.string()).transform((value) => value),
+			});
+
+			expect(getResult(coerceFormValue(schema).safeParse({}))).toEqual({
+				success: true,
+				data: {
+					preprocessed: [],
+					transformed: [],
+				},
+			});
+		});
 	});
 });

--- a/packages/conform-zod/v4/tests/coercion/schema/object.test.ts
+++ b/packages/conform-zod/v4/tests/coercion/schema/object.test.ts
@@ -162,15 +162,23 @@ describe('coercion', () => {
 							out: {
 								_zod: {
 									def: {
-										shape: Record<
-											string,
-											{
+										shape: {
+											items: {
 												_zod: {
 													optin?: 'optional';
-													def: { options: { _zod: { optin?: 'optional' } }[] };
 												};
-											}
-										>;
+											};
+											union: {
+												_zod: {
+													def: {
+														options: [
+															{ _zod: { optin?: 'optional' } },
+															{ _zod: { optin?: 'optional' } },
+														];
+													};
+												};
+											};
+										};
 									};
 								};
 							};

--- a/packages/conform-zod/v4/tests/coercion/schema/object.test.ts
+++ b/packages/conform-zod/v4/tests/coercion/schema/object.test.ts
@@ -152,6 +152,8 @@ describe('coercion', () => {
 			const items = z.array(z.string());
 			const schema = z.object({
 				items,
+				nonoptionalItems: items.nonoptional(),
+				caughtItems: items.catch([]),
 				union: z.union([z.literal('other'), items]),
 			});
 			const coerced = coerceFormValue(schema);
@@ -164,6 +166,16 @@ describe('coercion', () => {
 									def: {
 										shape: {
 											items: {
+												_zod: {
+													optin?: 'optional';
+												};
+											};
+											nonoptionalItems: {
+												_zod: {
+													optin?: 'optional';
+												};
+											};
+											caughtItems: {
 												_zod: {
 													optin?: 'optional';
 												};
@@ -188,6 +200,8 @@ describe('coercion', () => {
 			)._zod.def.out._zod.def.shape;
 
 			expect(shape.items._zod.optin).toBe('optional');
+			expect(shape.nonoptionalItems._zod.optin).toBe('optional');
+			expect(shape.caughtItems._zod.optin).toBe('optional');
 			expect(shape.union._zod.def.options[1]._zod.optin).toBeUndefined();
 		});
 	});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1027,8 +1027,8 @@ importers:
         specifier: ^3.25.75
         version: 3.25.76
       zod-v4:
-        specifier: npm:zod@^4.0.0
-        version: zod@4.0.5
+        specifier: npm:zod@^4.4.3
+        version: zod@4.4.3
 
   playground:
     dependencies:
@@ -13389,11 +13389,11 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.0.5:
-    resolution: {integrity: sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==}
-
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -28429,8 +28429,8 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.0.5: {}
-
   zod@4.3.6: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Overview

Fix #1210

Fixes Zod v4 coercion so schemas wrapped with preprocessing pipes preserve their input/output optionality metadata.

Zod 4.4 tightened object property handling around missing keys. Because Conform wraps schemas with `pipe(transform(...), target)` during coercion, optional/default metadata could be lost on the outer schema, causing missing optional/defaulted object fields to be reported as nonoptional.

This change copies `_zod.optin` and `_zod.optout` from the wrapped target schema to the generated pipe schema, and preserves the existing behavior for required arrays/objects that materialize missing values as `[]` or `{}`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

This PR preserves Zod v4.4 input/output optionality metadata when Conform wraps schemas for coercion, preventing optional/defaulted object and array fields from being reported as required.

Key changes:
- Introduces pipeWithOptionality() to compose pipe(transform(...), target) while copying target._zod.optin/_zod.optout onto the pipe schema.
- Refactors coerceType() to use a CoerceTypeOptions object and apply pipeWithOptionality across coercion paths.
- Adds coerceObjectShapeEntry() to mark per-property coerced schemas optional when the underlying type can materialize missing arrays/objects, ensuring omitted fields materialize as [] or {}.
- Applies optionality handling to discriminated-union variants and avoids leaking optionality metadata to reused schema instances.
- Adds tests for discriminated unions and object reuse scenarios and includes a small type fix and a changeset for a patch release of @conform-to/zod.

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->