### PR TITLE
fix(conform-zod): avoid cjs paths in zod v4 declarations

### DIFF
--- a/.changeset/selfish-wasps-confess.md
+++ b/.changeset/selfish-wasps-confess.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/zod': patch
+---
+
+fix(conform-zod): avoid cjs paths in zod v4 declarations

--- a/packages/conform-zod/tsconfig.build.json
+++ b/packages/conform-zod/tsconfig.build.json
@@ -4,7 +4,9 @@
 		"outDir": "./dist",
 		"emitDeclarationOnly": true,
 		"noEmit": false,
-		"paths": {}
+		"paths": {
+			// Do not inherit zod-v4 path aliases.
+		}
 	},
 	"exclude": ["**/tests", "dist"]
 }

--- a/packages/conform-zod/tsconfig.build.json
+++ b/packages/conform-zod/tsconfig.build.json
@@ -3,7 +3,8 @@
 	"compilerOptions": {
 		"outDir": "./dist",
 		"emitDeclarationOnly": true,
-		"noEmit": false
+		"noEmit": false,
+		"paths": {}
 	},
 	"exclude": ["**/tests", "dist"]
 }


### PR DESCRIPTION
## Overview

#1216 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

This patch prevents Zod v4 path aliases from leaking into the built TypeScript declarations for the `@conform-to/zod` package by clearing compilerOptions.paths in the package build tsconfig. The package-level tsconfig still keeps the "zod/v4" path alias for editor/test resolution; the build config explicitly resets paths so declaration emission doesn't use the aliased (CJS) import paths.

Example of the added build config:

```json
{
  "extends": "./tsconfig",
  "compilerOptions": {
    "outDir": "./dist",
    "emitDeclarationOnly": true,
    "noEmit": false,
    "paths": {
      // Do not inherit zod-v4 path aliases.
    }
  },
  "exclude": ["**/tests", "dist"]
}
```

</details>

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/edmundhung/conform/pull/1217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->