### PR TITLE
chore: update test setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,9 +111,7 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps ${{ matrix.browser }}
       - name: Run Vitest tests
-        run: pnpm run test:future
-        env:
-          BROWSER: ${{ matrix.browser }}
+        run: pnpm run test:future --browser.name=${{ matrix.browser }}
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps ${{ matrix.browser }}
       - name: Run Vitest tests
-        run: pnpm exec vitest --project='conform-*'
+        run: pnpm run test:future
         env:
           BROWSER: ${{ matrix.browser }}
   typecheck:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"dev:playground": "pnpm --filter ./playground run dev",
 		"guide": "pnpm --filter ./guide run dev ",
 		"test": "pnpm run \"/^test:.*/\"",
-		"test:future": "vitest --project='conform-*'",
+		"test:future": "pnpm --filter \"./packages/*\" run --if-present test",
 		"test:api": "vitest --project=browser --project=node",
 		"test:e2e": "playwright test",
 		"version": "changeset version && pnpm install --lockfile-only && .github/version.sh",

--- a/packages/conform-dom/package.json
+++ b/packages/conform-dom/package.json
@@ -68,6 +68,7 @@
 		"@rollup/plugin-babel": "^5.3.1",
 		"@rollup/plugin-node-resolve": "^13.3.0",
 		"@vitest/browser-playwright": "^4.1.5",
+		"playwright": "^1.49.1",
 		"rollup-plugin-copy": "^3.4.0",
 		"rollup": "^2.79.1",
 		"vitest": "^4.1.5"

--- a/packages/conform-dom/package.json
+++ b/packages/conform-dom/package.json
@@ -34,6 +34,7 @@
 		"dev:js": "pnpm run build:js --watch",
 		"dev:ts": "pnpm run build:ts --watch",
 		"dev": "pnpm run \"/^dev:.*/\"",
+		"test": "vitest",
 		"typecheck": "tsc",
 		"prepare": "pnpm run build"
 	},
@@ -66,7 +67,9 @@
 		"@babel/preset-typescript": "^7.20.2",
 		"@rollup/plugin-babel": "^5.3.1",
 		"@rollup/plugin-node-resolve": "^13.3.0",
+		"@vitest/browser-playwright": "^4.1.5",
 		"rollup-plugin-copy": "^3.4.0",
-		"rollup": "^2.79.1"
+		"rollup": "^2.79.1",
+		"vitest": "^4.1.5"
 	}
 }

--- a/packages/conform-dom/vitest.config.ts
+++ b/packages/conform-dom/vitest.config.ts
@@ -2,11 +2,6 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig, defineProject } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
-const defaultBrowsers = ['chromium', 'firefox', 'webkit'] as const;
-const browsers = process.env.BROWSER
-	? [process.env.BROWSER as (typeof defaultBrowsers)[number]]
-	: [...defaultBrowsers];
-const runMultipleBrowsers = browsers.length > 1;
 const root = fileURLToPath(new URL('.', import.meta.url));
 
 export const projects = [
@@ -17,27 +12,21 @@ export const projects = [
 			browser: {
 				enabled: true,
 				headless: true,
-				provider: playwright(
-					runMultipleBrowsers ? { actionTimeout: 1_000 } : undefined,
-				),
+				provider: playwright(),
 				api: 63316,
 				fileParallelism: false,
-				instances: browsers.map((browser) => ({ browser })),
+				instances: [
+					{ browser: 'chromium' },
+					{ browser: 'firefox' },
+					{ browser: 'webkit' },
+				],
 			},
 			include: ['**/tests/**/*.test.{ts,tsx}'],
 			exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
-			testTimeout: process.env.CI
-				? 30_000
-				: runMultipleBrowsers
-					? 15_000
-					: 5_000,
+			testTimeout: process.env.CI ? 30_000 : 5_000,
 			expect: {
 				poll: {
-					timeout: process.env.CI
-						? 10_000
-						: runMultipleBrowsers
-							? 5_000
-							: 1_000,
+					timeout: process.env.CI ? 10_000 : 1_000,
 				},
 			},
 		},

--- a/packages/conform-dom/vitest.config.ts
+++ b/packages/conform-dom/vitest.config.ts
@@ -1,0 +1,66 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig, defineProject } from 'vitest/config';
+import { playwright } from '@vitest/browser-playwright';
+
+const defaultBrowsers = ['chromium', 'firefox', 'webkit'] as const;
+const browsers = process.env.BROWSER
+	? [process.env.BROWSER as (typeof defaultBrowsers)[number]]
+	: [...defaultBrowsers];
+const runMultipleBrowsers = browsers.length > 1;
+const root = fileURLToPath(new URL('.', import.meta.url));
+
+export const projects = [
+	defineProject({
+		root,
+		test: {
+			name: 'conform-dom',
+			browser: {
+				enabled: true,
+				headless: true,
+				provider: playwright(
+					runMultipleBrowsers ? { actionTimeout: 1_000 } : undefined,
+				),
+				api: 63316,
+				fileParallelism: false,
+				instances: browsers.map((browser) => ({ browser })),
+			},
+			include: ['**/tests/**/*.test.{ts,tsx}'],
+			exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
+			testTimeout: process.env.CI
+				? 30_000
+				: runMultipleBrowsers
+					? 15_000
+					: 5_000,
+			expect: {
+				poll: {
+					timeout: process.env.CI
+						? 10_000
+						: runMultipleBrowsers
+							? 5_000
+							: 1_000,
+				},
+			},
+		},
+	}),
+	defineProject({
+		root,
+		test: {
+			name: 'conform-dom (node)',
+			environment: 'node',
+			typecheck: {
+				enabled: true,
+				tsconfig: './tests/tsconfig.json',
+				include: ['**/tests/**/*.test-d.ts'],
+			},
+			include: ['**/tests/**/*.test.{ts,tsx}'],
+			exclude: ['**/node_modules/**', '**/tests/**/*.browser.test.{ts,tsx}'],
+			testTimeout: 1_000,
+		},
+	}),
+];
+
+export default defineConfig({
+	test: {
+		projects,
+	},
+});

--- a/packages/conform-react/package.json
+++ b/packages/conform-react/package.json
@@ -34,6 +34,7 @@
 		"dev:js": "pnpm run build:js --watch",
 		"dev:ts": "pnpm run build:ts --watch",
 		"dev": "pnpm run \"/^dev:.*/\"",
+		"test": "vitest",
 		"typecheck": "tsc",
 		"prepare": "pnpm run build"
 	},
@@ -62,11 +63,13 @@
 		"@rollup/plugin-node-resolve": "^13.3.0",
 		"@types/react": "^18.2.43",
 		"@types/react-dom": "^18.3.5",
+		"@vitest/browser-playwright": "^4.1.5",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"rollup-plugin-copy": "^3.4.0",
 		"rollup": "^2.79.1",
 		"typescript": "^5.8.3",
+		"vitest": "^4.1.5",
 		"vitest-browser-react": "^1.0.1"
 	},
 	"peerDependencies": {

--- a/packages/conform-react/package.json
+++ b/packages/conform-react/package.json
@@ -64,6 +64,7 @@
 		"@types/react": "^18.2.43",
 		"@types/react-dom": "^18.3.5",
 		"@vitest/browser-playwright": "^4.1.5",
+		"playwright": "^1.49.1",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"rollup-plugin-copy": "^3.4.0",

--- a/packages/conform-react/vitest.config.ts
+++ b/packages/conform-react/vitest.config.ts
@@ -2,11 +2,6 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig, defineProject } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
-const defaultBrowsers = ['chromium', 'firefox', 'webkit'] as const;
-const browsers = process.env.BROWSER
-	? [process.env.BROWSER as (typeof defaultBrowsers)[number]]
-	: [...defaultBrowsers];
-const runMultipleBrowsers = browsers.length > 1;
 const root = fileURLToPath(new URL('.', import.meta.url));
 
 export const projects = [
@@ -24,27 +19,21 @@ export const projects = [
 			browser: {
 				enabled: true,
 				headless: true,
-				provider: playwright(
-					runMultipleBrowsers ? { actionTimeout: 1_000 } : undefined,
-				),
+				provider: playwright(),
 				api: 63317,
 				fileParallelism: false,
-				instances: browsers.map((browser) => ({ browser })),
+				instances: [
+					{ browser: 'chromium' },
+					{ browser: 'firefox' },
+					{ browser: 'webkit' },
+				],
 			},
 			include: ['**/tests/**/*.test.{ts,tsx}'],
 			exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
-			testTimeout: process.env.CI
-				? 30_000
-				: runMultipleBrowsers
-					? 15_000
-					: 5_000,
+			testTimeout: process.env.CI ? 30_000 : 5_000,
 			expect: {
 				poll: {
-					timeout: process.env.CI
-						? 10_000
-						: runMultipleBrowsers
-							? 5_000
-							: 1_000,
+					timeout: process.env.CI ? 10_000 : 1_000,
 				},
 			},
 		},

--- a/packages/conform-react/vitest.config.ts
+++ b/packages/conform-react/vitest.config.ts
@@ -1,0 +1,76 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig, defineProject } from 'vitest/config';
+import { playwright } from '@vitest/browser-playwright';
+
+const defaultBrowsers = ['chromium', 'firefox', 'webkit'] as const;
+const browsers = process.env.BROWSER
+	? [process.env.BROWSER as (typeof defaultBrowsers)[number]]
+	: [...defaultBrowsers];
+const runMultipleBrowsers = browsers.length > 1;
+const root = fileURLToPath(new URL('.', import.meta.url));
+
+export const projects = [
+	defineProject({
+		root,
+		optimizeDeps: {
+			/**
+			 * Prebundle the React dev JSX runtime so Vitest doesn't re-optimize it
+			 * mid-run and reload large browser suites while they are being collected.
+			 */
+			include: ['react/jsx-dev-runtime'],
+		},
+		test: {
+			name: 'conform-react',
+			browser: {
+				enabled: true,
+				headless: true,
+				provider: playwright(
+					runMultipleBrowsers ? { actionTimeout: 1_000 } : undefined,
+				),
+				api: 63317,
+				fileParallelism: false,
+				instances: browsers.map((browser) => ({ browser })),
+			},
+			include: ['**/tests/**/*.test.{ts,tsx}'],
+			exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
+			testTimeout: process.env.CI
+				? 30_000
+				: runMultipleBrowsers
+					? 15_000
+					: 5_000,
+			expect: {
+				poll: {
+					timeout: process.env.CI
+						? 10_000
+						: runMultipleBrowsers
+							? 5_000
+							: 1_000,
+				},
+			},
+		},
+	}),
+	defineProject({
+		root,
+		optimizeDeps: {
+			include: ['react/jsx-dev-runtime'],
+		},
+		test: {
+			name: 'conform-react (node)',
+			environment: 'node',
+			typecheck: {
+				enabled: true,
+				tsconfig: './tests/tsconfig.json',
+				include: ['**/tests/**/*.test-d.ts'],
+			},
+			include: ['**/tests/**/*.test.{ts,tsx}'],
+			exclude: ['**/node_modules/**', '**/tests/**/*.browser.test.{ts,tsx}'],
+			testTimeout: 1_000,
+		},
+	}),
+];
+
+export default defineConfig({
+	test: {
+		projects,
+	},
+});

--- a/packages/conform-valibot/package.json
+++ b/packages/conform-valibot/package.json
@@ -59,6 +59,7 @@
 		"@rollup/plugin-babel": "^5.3.1",
 		"@rollup/plugin-node-resolve": "^13.3.0",
 		"@vitest/browser-playwright": "^4.1.5",
+		"playwright": "^1.49.1",
 		"rollup-plugin-copy": "^3.4.0",
 		"rollup": "^2.79.1",
 		"typescript": "^5.8.3",

--- a/packages/conform-valibot/package.json
+++ b/packages/conform-valibot/package.json
@@ -58,9 +58,11 @@
 		"@babel/preset-typescript": "^7.20.2",
 		"@rollup/plugin-babel": "^5.3.1",
 		"@rollup/plugin-node-resolve": "^13.3.0",
+		"@vitest/browser-playwright": "^4.1.5",
 		"rollup-plugin-copy": "^3.4.0",
 		"rollup": "^2.79.1",
 		"typescript": "^5.8.3",
+		"vitest": "^4.1.5",
 		"valibot": "^1.0.0"
 	},
 	"keywords": [

--- a/packages/conform-valibot/vitest.config.ts
+++ b/packages/conform-valibot/vitest.config.ts
@@ -1,0 +1,66 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig, defineProject } from 'vitest/config';
+import { playwright } from '@vitest/browser-playwright';
+
+const defaultBrowsers = ['chromium', 'firefox', 'webkit'] as const;
+const browsers = process.env.BROWSER
+	? [process.env.BROWSER as (typeof defaultBrowsers)[number]]
+	: [...defaultBrowsers];
+const runMultipleBrowsers = browsers.length > 1;
+const root = fileURLToPath(new URL('.', import.meta.url));
+
+export const projects = [
+	defineProject({
+		root,
+		test: {
+			name: 'conform-valibot',
+			browser: {
+				enabled: true,
+				headless: true,
+				provider: playwright(
+					runMultipleBrowsers ? { actionTimeout: 1_000 } : undefined,
+				),
+				api: 63319,
+				fileParallelism: false,
+				instances: browsers.map((browser) => ({ browser })),
+			},
+			include: ['**/tests/**/*.test.{ts,tsx}'],
+			exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
+			testTimeout: process.env.CI
+				? 30_000
+				: runMultipleBrowsers
+					? 15_000
+					: 5_000,
+			expect: {
+				poll: {
+					timeout: process.env.CI
+						? 10_000
+						: runMultipleBrowsers
+							? 5_000
+							: 1_000,
+				},
+			},
+		},
+	}),
+	defineProject({
+		root,
+		test: {
+			name: 'conform-valibot (node)',
+			environment: 'node',
+			typecheck: {
+				enabled: true,
+				tsconfig: './tests/tsconfig.json',
+				include: ['**/tests/**/*.test-d.ts'],
+			},
+			include: ['**/tests/**/*.test.{ts,tsx}'],
+			exclude: ['**/node_modules/**', '**/tests/**/*.browser.test.{ts,tsx}'],
+			testTimeout: 1_000,
+		},
+	}),
+];
+
+export default defineConfig({
+	test: {
+		projects,
+	},
+});

--- a/packages/conform-valibot/vitest.config.ts
+++ b/packages/conform-valibot/vitest.config.ts
@@ -2,11 +2,6 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig, defineProject } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
-const defaultBrowsers = ['chromium', 'firefox', 'webkit'] as const;
-const browsers = process.env.BROWSER
-	? [process.env.BROWSER as (typeof defaultBrowsers)[number]]
-	: [...defaultBrowsers];
-const runMultipleBrowsers = browsers.length > 1;
 const root = fileURLToPath(new URL('.', import.meta.url));
 
 export const projects = [
@@ -17,27 +12,21 @@ export const projects = [
 			browser: {
 				enabled: true,
 				headless: true,
-				provider: playwright(
-					runMultipleBrowsers ? { actionTimeout: 1_000 } : undefined,
-				),
+				provider: playwright(),
 				api: 63319,
 				fileParallelism: false,
-				instances: browsers.map((browser) => ({ browser })),
+				instances: [
+					{ browser: 'chromium' },
+					{ browser: 'firefox' },
+					{ browser: 'webkit' },
+				],
 			},
 			include: ['**/tests/**/*.test.{ts,tsx}'],
 			exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
-			testTimeout: process.env.CI
-				? 30_000
-				: runMultipleBrowsers
-					? 15_000
-					: 5_000,
+			testTimeout: process.env.CI ? 30_000 : 5_000,
 			expect: {
 				poll: {
-					timeout: process.env.CI
-						? 10_000
-						: runMultipleBrowsers
-							? 5_000
-							: 1_000,
+					timeout: process.env.CI ? 10_000 : 1_000,
 				},
 			},
 		},

--- a/packages/conform-zod/default/tests/parse.test.ts
+++ b/packages/conform-zod/default/tests/parse.test.ts
@@ -163,13 +163,14 @@ describe('parse', () => {
 				date: z.date({ invalid_type_error: 'invalid' }),
 				file: z.instanceof(File, { message: 'invalid' }),
 			});
+			const file = new File([], '');
 			const formData = createFormData([
 				['text', 'abc'],
 				['number', '1'],
 				['boolean', 'on'],
 				['bigint', '1'],
 				['date', '1970-01-01'],
-				['file', new File([], '')],
+				['file', file],
 			]);
 
 			expect(
@@ -185,7 +186,7 @@ describe('parse', () => {
 					boolean: 'on',
 					bigint: '1',
 					date: '1970-01-01',
-					file: new File([], ''),
+					file,
 				},
 				error: {
 					number: ['invalid'],

--- a/packages/conform-zod/package.json
+++ b/packages/conform-zod/package.json
@@ -80,6 +80,7 @@
 		"@rollup/plugin-babel": "^5.3.1",
 		"@rollup/plugin-node-resolve": "^13.3.0",
 		"@vitest/browser-playwright": "^4.1.5",
+		"playwright": "^1.49.1",
 		"rollup": "^2.79.1",
 		"rollup-plugin-copy": "^3.4.0",
 		"vitest": "^4.1.5",

--- a/packages/conform-zod/package.json
+++ b/packages/conform-zod/package.json
@@ -79,8 +79,10 @@
 		"@babel/preset-typescript": "^7.20.2",
 		"@rollup/plugin-babel": "^5.3.1",
 		"@rollup/plugin-node-resolve": "^13.3.0",
+		"@vitest/browser-playwright": "^4.1.5",
 		"rollup": "^2.79.1",
 		"rollup-plugin-copy": "^3.4.0",
+		"vitest": "^4.1.5",
 		"zod": "^3.25.75",
 		"zod-v4": "npm:zod@^4.4.3"
 	},

--- a/packages/conform-zod/tsconfig.json
+++ b/packages/conform-zod/tsconfig.json
@@ -21,5 +21,6 @@
 		"composite": true,
 		"noEmit": true,
 		"skipLibCheck": true
-	}
+	},
+	"exclude": ["**/*.test-d.ts"]
 }

--- a/packages/conform-zod/v3/tests/parse.test.ts
+++ b/packages/conform-zod/v3/tests/parse.test.ts
@@ -163,13 +163,14 @@ describe('parse', () => {
 				date: z.date({ invalid_type_error: 'invalid' }),
 				file: z.instanceof(File, { message: 'invalid' }),
 			});
+			const file = new File([], '');
 			const formData = createFormData([
 				['text', 'abc'],
 				['number', '1'],
 				['boolean', 'on'],
 				['bigint', '1'],
 				['date', '1970-01-01'],
-				['file', new File([], '')],
+				['file', file],
 			]);
 
 			expect(
@@ -185,7 +186,7 @@ describe('parse', () => {
 					boolean: 'on',
 					bigint: '1',
 					date: '1970-01-01',
-					file: new File([], ''),
+					file,
 				},
 				error: {
 					number: ['invalid'],

--- a/packages/conform-zod/v3/tests/tsconfig.json
+++ b/packages/conform-zod/v3/tests/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"target": "ES2022",
+		"module": "ES2022",
+		"moduleResolution": "Bundler",
+		"strict": true,
+		"exactOptionalPropertyTypes": true,
+		"noUncheckedIndexedAccess": true,
+		"skipLibCheck": false,
+		"noEmit": true
+	},
+	"include": ["types.test-d.ts"]
+}

--- a/packages/conform-zod/v3/tests/types.test-d.ts
+++ b/packages/conform-zod/v3/tests/types.test-d.ts
@@ -1,0 +1,139 @@
+import type { Constraint, Submission } from '@conform-to/dom';
+import type { FormError, ValidationAttributes } from '@conform-to/dom/future';
+import { expectTypeOf, test } from 'vitest';
+import { z, type ZodTypeAny } from 'zod';
+import { getZodConstraint, parseWithZod } from '@conform-to/zod/v3';
+import {
+	coerceFormValue,
+	coerceStructure,
+	configureCoercion,
+	formatResult,
+	getConstraints,
+	isSchema,
+} from '@conform-to/zod/v3/future';
+
+const schema = z.object({
+	age: z.number().optional(),
+	subscribed: z.boolean(),
+	publishedAt: z.date(),
+});
+
+const transformedSchema = z.object({
+	age: z.string().transform((value) => Number(value)),
+});
+
+test('getZodConstraint', () => {
+	expectTypeOf(getZodConstraint(schema)).toEqualTypeOf<
+		Record<string, Constraint>
+	>();
+});
+
+test('parseWithZod', () => {
+	const submission = parseWithZod(new FormData(), {
+		schema: transformedSchema,
+	});
+	const asyncSubmission = parseWithZod(new FormData(), {
+		schema: transformedSchema,
+		async: true,
+	});
+
+	expectTypeOf(submission).toEqualTypeOf<
+		Submission<
+			z.input<typeof transformedSchema>,
+			string[],
+			z.output<typeof transformedSchema>
+		>
+	>();
+	expectTypeOf(asyncSubmission).toEqualTypeOf<
+		Promise<
+			Submission<
+				z.input<typeof transformedSchema>,
+				string[],
+				z.output<typeof transformedSchema>
+			>
+		>
+	>();
+});
+
+test('configureCoercion', () => {
+	const custom = configureCoercion({
+		type: {
+			date(text) {
+				return new Date(text);
+			},
+		},
+	});
+	const coerced = custom.coerceFormValue(transformedSchema);
+	const structured = custom.coerceStructure(transformedSchema);
+
+	expectTypeOf<z.output<typeof coerced>>().toEqualTypeOf<
+		z.output<typeof transformedSchema>
+	>();
+	expectTypeOf<z.input<typeof coerced>>().toEqualTypeOf<
+		z.input<typeof transformedSchema>
+	>();
+	expectTypeOf<z.output<typeof structured>>().toEqualTypeOf<
+		z.input<typeof transformedSchema>
+	>();
+	expectTypeOf<z.input<typeof structured>>().toEqualTypeOf<
+		z.input<typeof transformedSchema>
+	>();
+});
+
+test('coerceFormValue', () => {
+	const coerced = coerceFormValue(transformedSchema);
+
+	expectTypeOf<z.output<typeof coerced>>().toEqualTypeOf<
+		z.output<typeof transformedSchema>
+	>();
+	expectTypeOf<z.input<typeof coerced>>().toEqualTypeOf<
+		z.input<typeof transformedSchema>
+	>();
+});
+
+test('coerceStructure', () => {
+	const structured = coerceStructure(transformedSchema);
+
+	expectTypeOf<z.output<typeof structured>>().toEqualTypeOf<
+		z.input<typeof transformedSchema>
+	>();
+	expectTypeOf<z.input<typeof structured>>().toEqualTypeOf<
+		z.input<typeof transformedSchema>
+	>();
+});
+
+test('formatResult', () => {
+	const result = transformedSchema.safeParse({ age: '1' });
+	const formatted = formatResult(result);
+	const formattedWithValue = formatResult(result, { includeValue: true });
+	const formattedWithCustomIssues = formatResult(result, {
+		formatIssues(issues, name) {
+			return {
+				count: issues.length,
+				name,
+			};
+		},
+	});
+
+	expectTypeOf(formatted).toEqualTypeOf<FormError<string[]> | null>();
+	expectTypeOf(formattedWithValue).toEqualTypeOf<{
+		error: FormError<string[]> | null;
+		value: z.output<typeof transformedSchema> | undefined;
+	}>();
+	expectTypeOf(formattedWithCustomIssues).toEqualTypeOf<FormError<{
+		count: number;
+		name: string;
+	}> | null>();
+});
+
+test('getConstraints', () => {
+	expectTypeOf(getConstraints(schema)).toEqualTypeOf<
+		Record<string, ValidationAttributes> | undefined
+	>();
+});
+
+test('isSchema', () => {
+	expectTypeOf(isSchema).toEqualTypeOf<
+		(schema: unknown) => schema is ZodTypeAny
+	>();
+});

--- a/packages/conform-zod/v4/tests/parse.test.ts
+++ b/packages/conform-zod/v4/tests/parse.test.ts
@@ -191,13 +191,14 @@ describe('parse', () => {
 				date: z.date({ message: 'invalid' }),
 				file: z.file({ message: 'invalid' }),
 			});
+			const file = new File([], '');
 			const formData = createFormData([
 				['text', 'abc'],
 				['number', '1'],
 				['boolean', 'on'],
 				['bigint', '1'],
 				['date', '1970-01-01'],
-				['file', new File([], '')],
+				['file', file],
 			]);
 
 			expect(
@@ -213,7 +214,7 @@ describe('parse', () => {
 					boolean: 'on',
 					bigint: '1',
 					date: '1970-01-01',
-					file: new File([], ''),
+					file,
 				},
 				error: {
 					number: ['invalid'],

--- a/packages/conform-zod/v4/tests/tsconfig.json
+++ b/packages/conform-zod/v4/tests/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"target": "ES2022",
+		"module": "ES2022",
+		"moduleResolution": "Bundler",
+		"baseUrl": "../..",
+		"paths": {
+			"zod": ["./node_modules/zod-v4"],
+			"zod/*": ["./node_modules/zod-v4/*"]
+		},
+		"strict": true,
+		"exactOptionalPropertyTypes": true,
+		"noUncheckedIndexedAccess": true,
+		"skipLibCheck": false,
+		"noEmit": true
+	},
+	"include": ["types.test-d.ts"]
+}

--- a/packages/conform-zod/v4/tests/types.test-d.ts
+++ b/packages/conform-zod/v4/tests/types.test-d.ts
@@ -1,0 +1,137 @@
+import type { Constraint, Submission } from '@conform-to/dom';
+import type { FormError, ValidationAttributes } from '@conform-to/dom/future';
+import { expectTypeOf, test } from 'vitest';
+import { z, type ZodAny } from 'zod';
+import { getZodConstraint, parseWithZod } from '@conform-to/zod/v4';
+import {
+	coerceFormValue,
+	coerceStructure,
+	configureCoercion,
+	formatResult,
+	getConstraints,
+	isSchema,
+} from '@conform-to/zod/v4/future';
+
+const schema = z.object({
+	age: z.number().optional(),
+	subscribed: z.boolean(),
+	publishedAt: z.date(),
+});
+
+const transformedSchema = z.object({
+	age: z.string().transform((value) => Number(value)),
+});
+
+test('getZodConstraint', () => {
+	expectTypeOf(getZodConstraint(schema)).toEqualTypeOf<
+		Record<string, Constraint>
+	>();
+});
+
+test('parseWithZod', () => {
+	const submission = parseWithZod(new FormData(), {
+		schema: transformedSchema,
+	});
+	const asyncSubmission = parseWithZod(new FormData(), {
+		schema: transformedSchema,
+		async: true,
+	});
+
+	expectTypeOf(submission).toEqualTypeOf<
+		Submission<
+			z.input<typeof transformedSchema>,
+			string[],
+			z.output<typeof transformedSchema>
+		>
+	>();
+	expectTypeOf(asyncSubmission).toEqualTypeOf<
+		Promise<
+			Submission<
+				z.input<typeof transformedSchema>,
+				string[],
+				z.output<typeof transformedSchema>
+			>
+		>
+	>();
+});
+
+test('configureCoercion', () => {
+	const custom = configureCoercion({
+		type: {
+			date(text) {
+				return new Date(text);
+			},
+		},
+	});
+	const coerced = custom.coerceFormValue(transformedSchema);
+	const structured = custom.coerceStructure(transformedSchema);
+
+	expectTypeOf<z.output<typeof coerced>>().toEqualTypeOf<
+		z.output<typeof transformedSchema>
+	>();
+	expectTypeOf<z.input<typeof coerced>>().toEqualTypeOf<
+		z.input<typeof transformedSchema>
+	>();
+	expectTypeOf<z.output<typeof structured>>().toEqualTypeOf<
+		z.input<typeof transformedSchema>
+	>();
+	expectTypeOf<z.input<typeof structured>>().toEqualTypeOf<
+		z.input<typeof transformedSchema>
+	>();
+});
+
+test('coerceFormValue', () => {
+	const coerced = coerceFormValue(transformedSchema);
+
+	expectTypeOf<z.output<typeof coerced>>().toEqualTypeOf<
+		z.output<typeof transformedSchema>
+	>();
+	expectTypeOf<z.input<typeof coerced>>().toEqualTypeOf<
+		z.input<typeof transformedSchema>
+	>();
+});
+
+test('coerceStructure', () => {
+	const structured = coerceStructure(transformedSchema);
+
+	expectTypeOf<z.output<typeof structured>>().toEqualTypeOf<
+		z.input<typeof transformedSchema>
+	>();
+	expectTypeOf<z.input<typeof structured>>().toEqualTypeOf<
+		z.input<typeof transformedSchema>
+	>();
+});
+
+test('formatResult', () => {
+	const result = transformedSchema.safeParse({ age: '1' });
+	const formatted = formatResult(result);
+	const formattedWithValue = formatResult(result, { includeValue: true });
+	const formattedWithCustomIssues = formatResult(result, {
+		formatIssues(issues, name) {
+			return {
+				count: issues.length,
+				name,
+			};
+		},
+	});
+
+	expectTypeOf(formatted).toEqualTypeOf<FormError<string[]> | null>();
+	expectTypeOf(formattedWithValue).toEqualTypeOf<{
+		error: FormError<string[]> | null;
+		value: z.output<typeof transformedSchema> | undefined;
+	}>();
+	expectTypeOf(formattedWithCustomIssues).toEqualTypeOf<FormError<{
+		count: number;
+		name: string;
+	}> | null>();
+});
+
+test('getConstraints', () => {
+	expectTypeOf(getConstraints(schema)).toEqualTypeOf<
+		Record<string, ValidationAttributes> | undefined
+	>();
+});
+
+test('isSchema', () => {
+	expectTypeOf(isSchema).toEqualTypeOf<(schema: unknown) => schema is ZodAny>();
+});

--- a/packages/conform-zod/vitest.config.ts
+++ b/packages/conform-zod/vitest.config.ts
@@ -1,0 +1,84 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig, defineProject } from 'vitest/config';
+import { playwright } from '@vitest/browser-playwright';
+
+const defaultBrowsers = ['chromium', 'firefox', 'webkit'] as const;
+const browsers = process.env.BROWSER
+	? [process.env.BROWSER as (typeof defaultBrowsers)[number]]
+	: [...defaultBrowsers];
+const runMultipleBrowsers = browsers.length > 1;
+const root = fileURLToPath(new URL('.', import.meta.url));
+
+export const projects = [
+	defineProject({
+		root,
+		test: {
+			name: 'conform-zod',
+			browser: {
+				enabled: true,
+				headless: true,
+				provider: playwright(
+					runMultipleBrowsers ? { actionTimeout: 1_000 } : undefined,
+				),
+				api: 63318,
+				fileParallelism: false,
+				instances: browsers.map((browser) => ({ browser })),
+			},
+			include: ['**/tests/**/*.test.{ts,tsx}'],
+			exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
+			testTimeout: process.env.CI
+				? 30_000
+				: runMultipleBrowsers
+					? 15_000
+					: 5_000,
+			expect: {
+				poll: {
+					timeout: process.env.CI
+						? 10_000
+						: runMultipleBrowsers
+							? 5_000
+							: 1_000,
+				},
+			},
+		},
+	}),
+	defineProject({
+		root,
+		test: {
+			name: 'conform-zod (node, zod v3)',
+			environment: 'node',
+			typecheck: {
+				enabled: true,
+				tsconfig: './v3/tests/tsconfig.json',
+				include: ['v3/tests/types.test-d.ts'],
+			},
+			include: [
+				'default/tests/**/*.test.{ts,tsx}',
+				'v3/tests/**/*.test.{ts,tsx}',
+			],
+			exclude: ['**/node_modules/**', '**/tests/**/*.browser.test.{ts,tsx}'],
+			testTimeout: 1_000,
+		},
+	}),
+	defineProject({
+		root,
+		test: {
+			name: 'conform-zod (node, zod v4)',
+			environment: 'node',
+			typecheck: {
+				enabled: true,
+				tsconfig: './v4/tests/tsconfig.json',
+				include: ['v4/tests/types.test-d.ts'],
+			},
+			include: ['v4/tests/**/*.test.{ts,tsx}'],
+			exclude: ['**/node_modules/**', '**/tests/**/*.browser.test.{ts,tsx}'],
+			testTimeout: 1_000,
+		},
+	}),
+];
+
+export default defineConfig({
+	test: {
+		projects,
+	},
+});

--- a/packages/conform-zod/vitest.config.ts
+++ b/packages/conform-zod/vitest.config.ts
@@ -2,11 +2,6 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig, defineProject } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
-const defaultBrowsers = ['chromium', 'firefox', 'webkit'] as const;
-const browsers = process.env.BROWSER
-	? [process.env.BROWSER as (typeof defaultBrowsers)[number]]
-	: [...defaultBrowsers];
-const runMultipleBrowsers = browsers.length > 1;
 const root = fileURLToPath(new URL('.', import.meta.url));
 
 export const projects = [
@@ -17,27 +12,21 @@ export const projects = [
 			browser: {
 				enabled: true,
 				headless: true,
-				provider: playwright(
-					runMultipleBrowsers ? { actionTimeout: 1_000 } : undefined,
-				),
+				provider: playwright(),
 				api: 63318,
 				fileParallelism: false,
-				instances: browsers.map((browser) => ({ browser })),
+				instances: [
+					{ browser: 'chromium' },
+					{ browser: 'firefox' },
+					{ browser: 'webkit' },
+				],
 			},
 			include: ['**/tests/**/*.test.{ts,tsx}'],
 			exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
-			testTimeout: process.env.CI
-				? 30_000
-				: runMultipleBrowsers
-					? 15_000
-					: 5_000,
+			testTimeout: process.env.CI ? 30_000 : 5_000,
 			expect: {
 				poll: {
-					timeout: process.env.CI
-						? 10_000
-						: runMultipleBrowsers
-							? 5_000
-							: 1_000,
+					timeout: process.env.CI ? 10_000 : 1_000,
 				},
 			},
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -854,6 +854,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.1.5
         version: 4.1.5(msw@2.11.6(@types/node@25.5.0)(typescript@5.8.3))(playwright@1.49.1)(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3))(vitest@4.1.5)
+      playwright:
+        specifier: ^1.49.1
+        version: 1.49.1
       rollup:
         specifier: ^2.79.1
         version: 2.79.1
@@ -897,6 +900,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.1.5
         version: 4.1.5(msw@2.11.6(@types/node@25.5.0)(typescript@5.8.3))(playwright@1.49.1)(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3))(vitest@4.1.5)
+      playwright:
+        specifier: ^1.49.1
+        version: 1.49.1
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -943,6 +949,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.1.5
         version: 4.1.5(msw@2.11.6(@types/node@25.5.0)(typescript@5.8.3))(playwright@1.49.1)(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3))(vitest@4.1.5)
+      playwright:
+        specifier: ^1.49.1
+        version: 1.49.1
       rollup:
         specifier: ^2.79.1
         version: 2.79.1
@@ -1038,6 +1047,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.1.5
         version: 4.1.5(msw@2.11.6(@types/node@25.5.0)(typescript@5.8.3))(playwright@1.49.1)(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3))(vitest@4.1.5)
+      playwright:
+        specifier: ^1.49.1
+        version: 1.49.1
       rollup:
         specifier: ^2.79.1
         version: 2.79.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -851,12 +851,18 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: ^13.3.0
         version: 13.3.0(rollup@2.79.1)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.5
+        version: 4.1.5(msw@2.11.6(@types/node@25.5.0)(typescript@5.8.3))(playwright@1.49.1)(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3))(vitest@4.1.5)
       rollup:
         specifier: ^2.79.1
         version: 2.79.1
       rollup-plugin-copy:
         specifier: ^3.4.0
         version: 3.5.0
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.5.0)(@vitest/browser-playwright@4.1.5)(jsdom@27.0.1)(msw@2.11.6(@types/node@25.5.0)(typescript@5.8.3))(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3))
 
   packages/conform-react:
     dependencies:
@@ -888,6 +894,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.5
         version: 18.3.7(@types/react@18.3.1)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.5
+        version: 4.1.5(msw@2.11.6(@types/node@25.5.0)(typescript@5.8.3))(playwright@1.49.1)(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3))(vitest@4.1.5)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -903,6 +912,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.5.0)(@vitest/browser-playwright@4.1.5)(jsdom@27.0.1)(msw@2.11.6(@types/node@25.5.0)(typescript@5.8.3))(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3))
       vitest-browser-react:
         specifier: ^1.0.1
         version: 1.0.1(@types/react-dom@18.3.7(@types/react@18.3.1))(@types/react@18.3.1)(@vitest/browser@4.1.5(msw@2.11.6(@types/node@25.5.0)(typescript@5.8.3))(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3))(vitest@4.1.5(@types/node@25.5.0)(@vitest/browser-playwright@4.1.5)(jsdom@27.0.1)(msw@2.11.6(@types/node@25.5.0)(typescript@5.8.3))(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3))))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@4.1.5(@types/node@25.5.0)(@vitest/browser-playwright@4.1.5)(jsdom@27.0.1)(msw@2.11.6(@types/node@25.5.0)(typescript@5.8.3))(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3)))
@@ -928,6 +940,9 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: ^13.3.0
         version: 13.3.0(rollup@2.79.1)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.5
+        version: 4.1.5(msw@2.11.6(@types/node@25.5.0)(typescript@5.8.3))(playwright@1.49.1)(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3))(vitest@4.1.5)
       rollup:
         specifier: ^2.79.1
         version: 2.79.1
@@ -940,6 +955,9 @@ importers:
       valibot:
         specifier: ^1.0.0
         version: 1.0.0(typescript@5.8.3)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.5.0)(@vitest/browser-playwright@4.1.5)(jsdom@27.0.1)(msw@2.11.6(@types/node@25.5.0)(typescript@5.8.3))(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3))
 
   packages/conform-validitystate:
     devDependencies:
@@ -1017,12 +1035,18 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: ^13.3.0
         version: 13.3.0(rollup@2.79.1)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.5
+        version: 4.1.5(msw@2.11.6(@types/node@25.5.0)(typescript@5.8.3))(playwright@1.49.1)(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3))(vitest@4.1.5)
       rollup:
         specifier: ^2.79.1
         version: 2.79.1
       rollup-plugin-copy:
         specifier: ^3.4.0
         version: 3.5.0
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.5.0)(@vitest/browser-playwright@4.1.5)(jsdom@27.0.1)(msw@2.11.6(@types/node@25.5.0)(typescript@5.8.3))(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3))
       zod:
         specifier: ^3.25.75
         version: 3.25.76
@@ -14062,7 +14086,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.27.1
       '@babel/traverse': 7.28.3
     transitivePeerDependencies:
       - supports-color
@@ -21088,7 +21112,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-    optional: true
 
   '@vitest/browser@4.1.5(msw@2.11.6(@types/node@20.19.39)(typescript@5.8.3))(vite@7.3.3(@types/node@20.19.39)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3))(vitest@4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(jsdom@27.0.1)(msw@2.11.6(@types/node@20.19.39)(typescript@5.8.3))(vite@7.3.3(@types/node@20.19.39)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3)))':
     dependencies:
@@ -21117,7 +21140,7 @@ snapshots:
       sirv: 3.0.2
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@types/node@25.5.0)(@vitest/browser-playwright@4.1.5)(jsdom@27.0.1)(msw@2.11.6(@types/node@25.5.0)(typescript@5.8.3))(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3))
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -28397,16 +28420,16 @@ snapshots:
       '@vitest/snapshot': 4.1.5
       '@vitest/spy': 4.1.5
       '@vitest/utils': 4.1.5
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 7.3.3(@types/node@25.5.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
@@ -28711,8 +28734,7 @@ snapshots:
 
   ws@8.20.0: {}
 
-  ws@8.20.1:
-    optional: true
+  ws@8.20.1: {}
 
   xdm@2.1.0:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,29 +1,9 @@
-import { defineConfig, TestProjectInlineConfiguration } from 'vitest/config';
+import { defineConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
-const defaultBrowsers = ['chromium', 'firefox', 'webkit'] as const;
-const browsers = process.env.BROWSER
-	? [process.env.BROWSER as (typeof defaultBrowsers)[number]]
-	: [...defaultBrowsers];
-const runMultipleBrowsers = browsers.length > 1;
-
-if (runMultipleBrowsers) {
-	// Multi-browser runs add enough process listeners through Vitest/Playwright
-	// startup that Node's default limit warns even though this is expected here.
-	process.setMaxListeners(20);
-}
-
 export default defineConfig({
-	optimizeDeps: {
-		/**
-		 * Prebundle the React dev JSX runtime so Vitest doesn't re-optimize it
-		 * mid-run and reload large browser suites while they are being collected.
-		 */
-		include: ['react/jsx-dev-runtime'],
-	},
 	test: {
 		projects: [
-			// legacy setup to be moved into the packages
 			{
 				test: {
 					name: 'browser',
@@ -43,74 +23,6 @@ export default defineConfig({
 					environment: 'node',
 				},
 			},
-			...defineTests('conform-dom', { browserApiPort: 63316 }),
-			...defineTests('conform-react', { browserApiPort: 63317 }),
-			...defineTests('conform-zod', { browserApiPort: 63318 }),
-			...defineTests('conform-valibot', { browserApiPort: 63319 }),
 		],
 	},
 });
-
-function defineTests(
-	packageName: string,
-	options: {
-		browserApiPort: number;
-	},
-): TestProjectInlineConfiguration[] {
-	return [
-		{
-			test: {
-				// We set the package name only as Vitest will use the browser name as a suffix
-				name: packageName,
-				browser: {
-					enabled: true,
-					headless: true,
-					provider: playwright(
-						runMultipleBrowsers ? { actionTimeout: 1_000 } : undefined,
-					),
-					api: options.browserApiPort,
-					fileParallelism: false,
-					instances: browsers.map((browser) => ({ browser })),
-				},
-				// This covers both .browser.test.ts/tsx and .test.ts/tsx files
-				include: [`packages/${packageName}/**/tests/**/*.test.{ts,tsx}`],
-				exclude: [
-					`**/node_modules/**`,
-					`packages/${packageName}/**/tests/**/*.node.test.{ts,tsx}`,
-				],
-				testTimeout: process.env.CI
-					? 30_000
-					: runMultipleBrowsers
-						? 15_000
-						: 5_000,
-				expect: {
-					poll: {
-						timeout: process.env.CI
-							? 10_000
-							: runMultipleBrowsers
-								? 5_000
-								: 1_000,
-					},
-				},
-			},
-		},
-		{
-			test: {
-				name: `${packageName} (node)`,
-				environment: 'node',
-				typecheck: {
-					enabled: true,
-					tsconfig: `./packages/${packageName}/tests/tsconfig.json`,
-					include: [`packages/${packageName}/**/tests/**/*.test-d.ts`],
-				},
-				// This covers both .node.test.ts/tsx and .test.ts/tsx files
-				include: [`packages/${packageName}/**/tests/**/*.test.{ts,tsx}`],
-				exclude: [
-					`**/node_modules/**`,
-					`packages/${packageName}/**/tests/**/*.browser.test.{ts,tsx}`,
-				],
-				testTimeout: 1_000,
-			},
-		},
-	];
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

This PR moves the test orchestration from a centralized root configuration to per-package Vitest setups and updates CI and scripts to run package-scoped tests.

- CI/workflows: .github/workflows/tests.yml now runs package tests in the "future" job via the root script `pnpm run test:future --browser.name=${{ matrix.browser }}` (instead of invoking vitest directly).
- Root scripts: package.json adds/changes "test:future" to `pnpm --filter "./packages/*" run --if-present test`.
- Root Vitest config: vitest.config.ts simplified to two minimal projects (browser + node), delegating package test suites to package configs.
- Per-package test configs: Added vitest.config.ts files for packages: conform-dom, conform-react, conform-valibot, conform-zod — each exports a projects array with a Playwright-driven browser project and a Node/typecheck project (CI-aware timeouts, fileParallelism disabled, explicit browser instances).
- Package scripts & deps: Added `test` scripts and pinned devDeps for Vitest/browser-Playwright/playwright across relevant packages (conform-dom, conform-react, conform-valibot, conform-zod); root devDependencies also include vitest and browser-playwright.
- Type-level tests: Added/updated .test-d.ts type assertion suites for conform-zod v3 and v4 (expectTypeOf checks for exported helpers).
- Test fixes: Several tests (v3/v4/default parse tests) now reuse a single File instance to stabilize file payload assertions.

</details>

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/edmundhung/conform/pull/1219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->