### PR TITLE
chore: optimize vitest config

### DIFF
--- a/packages/conform-dom/vitest.config.ts
+++ b/packages/conform-dom/vitest.config.ts
@@ -1,55 +1,54 @@
 import { fileURLToPath } from 'node:url';
-import { defineConfig, defineProject } from 'vitest/config';
+import { defineConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
 const root = fileURLToPath(new URL('.', import.meta.url));
 
-export const projects = [
-	defineProject({
-		root,
-		test: {
-			name: 'conform-dom',
-			browser: {
-				enabled: true,
-				headless: true,
-				provider: playwright(),
-				api: 63316,
-				fileParallelism: false,
-				instances: [
-					{ browser: 'chromium' },
-					{ browser: 'firefox' },
-					{ browser: 'webkit' },
-				],
-			},
-			include: ['**/tests/**/*.test.{ts,tsx}'],
-			exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
-			testTimeout: process.env.CI ? 30_000 : 5_000,
-			expect: {
-				poll: {
-					timeout: process.env.CI ? 10_000 : 1_000,
+export default defineConfig({
+	root,
+	test: {
+		projects: [
+			{
+				test: {
+					name: 'conform-dom',
+					browser: {
+						enabled: true,
+						headless: true,
+						provider: playwright(),
+						fileParallelism: false,
+						instances: [
+							{ browser: 'chromium' },
+							{ browser: 'firefox' },
+							{ browser: 'webkit' },
+						],
+					},
+					include: ['**/tests/**/*.test.{ts,tsx}'],
+					exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
+					testTimeout: process.env.CI ? 30_000 : 5_000,
+					expect: {
+						poll: {
+							timeout: process.env.CI ? 10_000 : 1_000,
+						},
+					},
 				},
 			},
-		},
-	}),
-	defineProject({
-		root,
-		test: {
-			name: 'conform-dom (node)',
-			environment: 'node',
-			typecheck: {
-				enabled: true,
-				tsconfig: './tests/tsconfig.json',
-				include: ['**/tests/**/*.test-d.ts'],
+			{
+				test: {
+					name: 'conform-dom (node)',
+					environment: 'node',
+					typecheck: {
+						enabled: true,
+						tsconfig: './tests/tsconfig.json',
+						include: ['**/tests/**/*.test-d.ts'],
+					},
+					include: ['**/tests/**/*.test.{ts,tsx}'],
+					exclude: [
+						'**/node_modules/**',
+						'**/tests/**/*.browser.test.{ts,tsx}',
+					],
+					testTimeout: 1_000,
+				},
 			},
-			include: ['**/tests/**/*.test.{ts,tsx}'],
-			exclude: ['**/node_modules/**', '**/tests/**/*.browser.test.{ts,tsx}'],
-			testTimeout: 1_000,
-		},
-	}),
-];
-
-export default defineConfig({
-	test: {
-		projects,
+		],
 	},
 });

--- a/packages/conform-react/vitest.config.ts
+++ b/packages/conform-react/vitest.config.ts
@@ -1,65 +1,61 @@
 import { fileURLToPath } from 'node:url';
-import { defineConfig, defineProject } from 'vitest/config';
+import { defineConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
 const root = fileURLToPath(new URL('.', import.meta.url));
 
-export const projects = [
-	defineProject({
-		root,
-		optimizeDeps: {
-			/**
-			 * Prebundle the React dev JSX runtime so Vitest doesn't re-optimize it
-			 * mid-run and reload large browser suites while they are being collected.
-			 */
-			include: ['react/jsx-dev-runtime'],
-		},
-		test: {
-			name: 'conform-react',
-			browser: {
-				enabled: true,
-				headless: true,
-				provider: playwright(),
-				api: 63317,
-				fileParallelism: false,
-				instances: [
-					{ browser: 'chromium' },
-					{ browser: 'firefox' },
-					{ browser: 'webkit' },
-				],
-			},
-			include: ['**/tests/**/*.test.{ts,tsx}'],
-			exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
-			testTimeout: process.env.CI ? 30_000 : 5_000,
-			expect: {
-				poll: {
-					timeout: process.env.CI ? 10_000 : 1_000,
+export default defineConfig({
+	root,
+	optimizeDeps: {
+		/**
+		 * Prebundle the React dev JSX runtime so Vitest doesn't re-optimize it
+		 * mid-run and reload large browser suites while they are being collected.
+		 */
+		include: ['react/jsx-dev-runtime'],
+	},
+	test: {
+		projects: [
+			{
+				test: {
+					name: 'conform-react',
+					browser: {
+						enabled: true,
+						headless: true,
+						provider: playwright(),
+						fileParallelism: false,
+						instances: [
+							{ browser: 'chromium' },
+							{ browser: 'firefox' },
+							{ browser: 'webkit' },
+						],
+					},
+					include: ['**/tests/**/*.test.{ts,tsx}'],
+					exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
+					testTimeout: process.env.CI ? 30_000 : 5_000,
+					expect: {
+						poll: {
+							timeout: process.env.CI ? 10_000 : 1_000,
+						},
+					},
 				},
 			},
-		},
-	}),
-	defineProject({
-		root,
-		optimizeDeps: {
-			include: ['react/jsx-dev-runtime'],
-		},
-		test: {
-			name: 'conform-react (node)',
-			environment: 'node',
-			typecheck: {
-				enabled: true,
-				tsconfig: './tests/tsconfig.json',
-				include: ['**/tests/**/*.test-d.ts'],
+			{
+				test: {
+					name: 'conform-react (node)',
+					environment: 'node',
+					typecheck: {
+						enabled: true,
+						tsconfig: './tests/tsconfig.json',
+						include: ['**/tests/**/*.test-d.ts'],
+					},
+					include: ['**/tests/**/*.test.{ts,tsx}'],
+					exclude: [
+						'**/node_modules/**',
+						'**/tests/**/*.browser.test.{ts,tsx}',
+					],
+					testTimeout: 1_000,
+				},
 			},
-			include: ['**/tests/**/*.test.{ts,tsx}'],
-			exclude: ['**/node_modules/**', '**/tests/**/*.browser.test.{ts,tsx}'],
-			testTimeout: 1_000,
-		},
-	}),
-];
-
-export default defineConfig({
-	test: {
-		projects,
+		],
 	},
 });

--- a/packages/conform-valibot/vitest.config.ts
+++ b/packages/conform-valibot/vitest.config.ts
@@ -1,55 +1,54 @@
 import { fileURLToPath } from 'node:url';
-import { defineConfig, defineProject } from 'vitest/config';
+import { defineConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
 const root = fileURLToPath(new URL('.', import.meta.url));
 
-export const projects = [
-	defineProject({
-		root,
-		test: {
-			name: 'conform-valibot',
-			browser: {
-				enabled: true,
-				headless: true,
-				provider: playwright(),
-				api: 63319,
-				fileParallelism: false,
-				instances: [
-					{ browser: 'chromium' },
-					{ browser: 'firefox' },
-					{ browser: 'webkit' },
-				],
-			},
-			include: ['**/tests/**/*.test.{ts,tsx}'],
-			exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
-			testTimeout: process.env.CI ? 30_000 : 5_000,
-			expect: {
-				poll: {
-					timeout: process.env.CI ? 10_000 : 1_000,
+export default defineConfig({
+	root,
+	test: {
+		projects: [
+			{
+				test: {
+					name: 'conform-valibot',
+					browser: {
+						enabled: true,
+						headless: true,
+						provider: playwright(),
+						fileParallelism: false,
+						instances: [
+							{ browser: 'chromium' },
+							{ browser: 'firefox' },
+							{ browser: 'webkit' },
+						],
+					},
+					include: ['**/tests/**/*.test.{ts,tsx}'],
+					exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
+					testTimeout: process.env.CI ? 30_000 : 5_000,
+					expect: {
+						poll: {
+							timeout: process.env.CI ? 10_000 : 1_000,
+						},
+					},
 				},
 			},
-		},
-	}),
-	defineProject({
-		root,
-		test: {
-			name: 'conform-valibot (node)',
-			environment: 'node',
-			typecheck: {
-				enabled: true,
-				tsconfig: './tests/tsconfig.json',
-				include: ['**/tests/**/*.test-d.ts'],
+			{
+				test: {
+					name: 'conform-valibot (node)',
+					environment: 'node',
+					typecheck: {
+						enabled: true,
+						tsconfig: './tests/tsconfig.json',
+						include: ['**/tests/**/*.test-d.ts'],
+					},
+					include: ['**/tests/**/*.test.{ts,tsx}'],
+					exclude: [
+						'**/node_modules/**',
+						'**/tests/**/*.browser.test.{ts,tsx}',
+					],
+					testTimeout: 1_000,
+				},
 			},
-			include: ['**/tests/**/*.test.{ts,tsx}'],
-			exclude: ['**/node_modules/**', '**/tests/**/*.browser.test.{ts,tsx}'],
-			testTimeout: 1_000,
-		},
-	}),
-];
-
-export default defineConfig({
-	test: {
-		projects,
+		],
 	},
 });

--- a/packages/conform-zod/vitest.config.ts
+++ b/packages/conform-zod/vitest.config.ts
@@ -1,73 +1,74 @@
 import { fileURLToPath } from 'node:url';
-import { defineConfig, defineProject } from 'vitest/config';
+import { defineConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
 const root = fileURLToPath(new URL('.', import.meta.url));
 
-export const projects = [
-	defineProject({
-		root,
-		test: {
-			name: 'conform-zod',
-			browser: {
-				enabled: true,
-				headless: true,
-				provider: playwright(),
-				api: 63318,
-				fileParallelism: false,
-				instances: [
-					{ browser: 'chromium' },
-					{ browser: 'firefox' },
-					{ browser: 'webkit' },
-				],
-			},
-			include: ['**/tests/**/*.test.{ts,tsx}'],
-			exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
-			testTimeout: process.env.CI ? 30_000 : 5_000,
-			expect: {
-				poll: {
-					timeout: process.env.CI ? 10_000 : 1_000,
+export default defineConfig({
+	root,
+	test: {
+		projects: [
+			{
+				test: {
+					name: 'conform-zod',
+					browser: {
+						enabled: true,
+						headless: true,
+						provider: playwright(),
+						fileParallelism: false,
+						instances: [
+							{ browser: 'chromium' },
+							{ browser: 'firefox' },
+							{ browser: 'webkit' },
+						],
+					},
+					include: ['**/tests/**/*.test.{ts,tsx}'],
+					exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
+					testTimeout: process.env.CI ? 30_000 : 5_000,
+					expect: {
+						poll: {
+							timeout: process.env.CI ? 10_000 : 1_000,
+						},
+					},
 				},
 			},
-		},
-	}),
-	defineProject({
-		root,
-		test: {
-			name: 'conform-zod (node, zod v3)',
-			environment: 'node',
-			typecheck: {
-				enabled: true,
-				tsconfig: './v3/tests/tsconfig.json',
-				include: ['v3/tests/types.test-d.ts'],
+			{
+				test: {
+					name: 'conform-zod (node, zod v3)',
+					environment: 'node',
+					typecheck: {
+						enabled: true,
+						tsconfig: './v3/tests/tsconfig.json',
+						include: ['v3/tests/types.test-d.ts'],
+					},
+					include: [
+						'default/tests/**/*.test.{ts,tsx}',
+						'v3/tests/**/*.test.{ts,tsx}',
+					],
+					exclude: [
+						'**/node_modules/**',
+						'**/tests/**/*.browser.test.{ts,tsx}',
+					],
+					testTimeout: 1_000,
+				},
 			},
-			include: [
-				'default/tests/**/*.test.{ts,tsx}',
-				'v3/tests/**/*.test.{ts,tsx}',
-			],
-			exclude: ['**/node_modules/**', '**/tests/**/*.browser.test.{ts,tsx}'],
-			testTimeout: 1_000,
-		},
-	}),
-	defineProject({
-		root,
-		test: {
-			name: 'conform-zod (node, zod v4)',
-			environment: 'node',
-			typecheck: {
-				enabled: true,
-				tsconfig: './v4/tests/tsconfig.json',
-				include: ['v4/tests/types.test-d.ts'],
+			{
+				test: {
+					name: 'conform-zod (node, zod v4)',
+					environment: 'node',
+					typecheck: {
+						enabled: true,
+						tsconfig: './v4/tests/tsconfig.json',
+						include: ['v4/tests/types.test-d.ts'],
+					},
+					include: ['v4/tests/**/*.test.{ts,tsx}'],
+					exclude: [
+						'**/node_modules/**',
+						'**/tests/**/*.browser.test.{ts,tsx}',
+					],
+					testTimeout: 1_000,
+				},
 			},
-			include: ['v4/tests/**/*.test.{ts,tsx}'],
-			exclude: ['**/node_modules/**', '**/tests/**/*.browser.test.{ts,tsx}'],
-			testTimeout: 1_000,
-		},
-	}),
-];
-
-export default defineConfig({
-	test: {
-		projects,
+		],
 	},
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

Refactors Vitest configurations across four package subdirectories to inline `projects` definitions directly within `defineConfig()` rather than exporting them as a separate named constant. This consolidation simplifies the config structure and eliminates the separate `defineProject()` calls.

**Key changes:**
- Removes `export const projects = [...]` declarations from all four config files
- Projects array is now defined inline within `test: { projects: [...] }`
- Removes custom `browser.api` port assignments that were previously specified
- In `conform-react`, consolidates `optimizeDeps` (React JSX dev runtime prebundle) to the top-level config instead of per-project

All test behavior and coverage patterns remain unchanged—only the structural organization of the configuration is refined.

</details>

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/edmundhung/conform/pull/1222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->