### PR TITLE
docs: fix document for getInputProps

### DIFF
--- a/packages/conform-react/helpers.ts
+++ b/packages/conform-react/helpers.ts
@@ -230,8 +230,8 @@ export function getFormControlProps<Schema>(
  * Derives the properties of an input element based on the field metadata,
  * including common form control attributes like `key`, `id`, `name`, `form`, `autoFocus`, `aria-invalid`, `aria-describedby`
  * and constraint attributes such as `type`, `required`, `minLength`, `maxLength`, `min`, `max`, `step`, `pattern`, `multiple`.
- * Depends on the provided options, it will also set `defaultChecked` / `checked` if it is a checkbox or radio button,
- * or otherwise `defaultValue` / `value`.
+ * Depends on the provided options, it will also set `defaultChecked` / `value` if it is a checkbox or radio button,
+ * or otherwise `defaultValue`.
  *
  * See https://conform.guide/api/react/getInputProps
  *


### PR DESCRIPTION
The document for `getInputProps` describes the wrong result:
* For `checkbox` or `radio`, it returns `value` instead of `checked`.
* Otherwise, it actually doesn't return `value` property.

This PR fixes the document.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

Updated JSDoc for `getInputProps` in `packages/conform-react/helpers.ts` to accurately document the returned properties:
- **Checkbox/radio inputs**: Returns `defaultChecked` and `value` properties
- **Other input types**: Returns `defaultValue` property only

The documentation now correctly reflects the actual behavior of the function.

</details>

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/edmundhung/conform/pull/1227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->