### PR TITLE
Preserve empty string array values in submissions

### DIFF
--- a/.changeset/fix-array-empty-string.md
+++ b/.changeset/fix-array-empty-string.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/dom': patch
+---
+
+Preserve empty string values inside array fields when building submission payloads.

--- a/packages/conform-dom/submission.ts
+++ b/packages/conform-dom/submission.ts
@@ -101,7 +101,7 @@ export function getSubmissionContext(
 			context.payload,
 			name,
 			(prev: unknown) => {
-				if (!prev) {
+				if (prev === undefined) {
 					return next;
 				} else if (Array.isArray(prev)) {
 					return prev.concat(next);

--- a/packages/conform-dom/tests/submission.test.ts
+++ b/packages/conform-dom/tests/submission.test.ts
@@ -281,3 +281,29 @@ test('parse()', () => {
 		},
 	});
 });
+
+test('parse() preserves empty strings in array fields', () => {
+	const submission = parse(
+		createFormData([
+			['animals', ''],
+			['animals', 'dog'],
+			['animals', ''],
+			['animals', 'cat'],
+		]),
+		{
+			resolve(payload) {
+				return { value: payload };
+			},
+		},
+	);
+
+	expect(submission.payload).toEqual({
+		animals: ['', 'dog', '', 'cat'],
+	});
+	expect(submission).toMatchObject({
+		status: 'success',
+		value: {
+			animals: ['', 'dog', '', 'cat'],
+		},
+	});
+});


### PR DESCRIPTION
`parseWithZod` could drop an empty string inside an array field because that value was treated like it was absent. That can lose or shift array entries in the parsed submission payload.

This narrows the presence check so only `undefined` is treated as missing. I checked it with the focused `conform-dom` submission test, changed-file `oxlint`, changed-file `oxfmt --check`, and `git diff --check`.

Closes #839

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

## Changes

Modified the presence check in `packages/conform-dom/submission.ts` to preserve empty string values in array fields. The reducer now treats only `undefined` as missing (previously treated any falsy value as missing):

```typescript
// Before: !prev (treats empty string as missing)
// After: prev === undefined (only undefined is missing)
```

This ensures empty string elements in arrays are not dropped during form submission parsing, maintaining correct array indices and element ordering.

## Additional updates

- Added Changesets entry documenting the behavior change
- Added test verifying empty strings are preserved within array fields during parsing

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->