### PR TITLE
fix: preserve empty strings in defaultPayload

### DIFF
--- a/.changeset/preserve-default-payload-empty-values.md
+++ b/.changeset/preserve-default-payload-empty-values.md
@@ -1,0 +1,6 @@
+---
+'@conform-to/dom': patch
+'@conform-to/react': patch
+---
+
+Preserve empty values in `defaultPayload` so custom controls can render the full default structure before user interaction.

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -892,8 +892,9 @@ export function defaultSerialize(value: unknown): ReturnType<Serialize> {
 
 /**
  * Recursively serializes a value using the provided serialize function,
- * collapsing empty leaves (`null`, `''`, empty files) to `undefined`
+ * collapsing empty leaves (`null`, empty files) to `undefined`
  * and removing empty containers (objects with no remaining keys, empty arrays).
+ * When `stripEmptyStrings` is true (the default), empty strings `''` are also collapsed.
  *
  * When serialize returns `undefined` for a value (i.e. it can't be represented
  * as form data), the raw value is kept and recursed into if it's an object or array.
@@ -904,6 +905,7 @@ export function defaultSerialize(value: unknown): ReturnType<Serialize> {
 export function normalize(
 	value: unknown,
 	serialize: Serialize = defaultSerialize,
+	stripEmptyStrings: boolean = true,
 	name?: string,
 ): unknown {
 	let data: unknown = serialize(value, {
@@ -914,7 +916,7 @@ export function normalize(
 		data = value;
 	}
 
-	if (data === '' || data === null) {
+	if (data === null || (stripEmptyStrings && data === '')) {
 		return undefined;
 	}
 
@@ -932,7 +934,7 @@ export function normalize(
 		}
 
 		const array = data.map((item, index) =>
-			normalize(item, serialize, appendPath(name, index)),
+			normalize(item, serialize, stripEmptyStrings, appendPath(name, index)),
 		);
 
 		if (
@@ -951,6 +953,7 @@ export function normalize(
 				const normalizedValue = normalize(
 					value,
 					serialize,
+					stripEmptyStrings,
 					appendPath(name, key),
 				);
 

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -800,8 +800,8 @@ export function isDirty(
 	};
 
 	return !deepEqual(
-		normalize(formValue, serialize),
-		normalize(options?.defaultValue, serialize),
+		normalize(formValue, { serialize }),
+		normalize(options?.defaultValue, { serialize }),
 	);
 }
 
@@ -891,23 +891,28 @@ export function defaultSerialize(value: unknown): ReturnType<Serialize> {
 }
 
 /**
- * Recursively serializes a value using the provided serialize function,
- * collapsing empty leaves (`null`, empty files) to `undefined`
- * and removing empty containers (objects with no remaining keys, empty arrays).
- * When `stripEmptyStrings` is true (the default), empty strings `''` are also collapsed.
+ * Recursively serializes a value using the provided serialize function.
+ * When `stripEmptyValue` is true, empty values, empty arrays, and empty objects
+ * are removed, and single-string arrays are unwrapped to match single-value fields.
  *
  * When serialize returns `undefined` for a value (i.e. it can't be represented
  * as form data), the raw value is kept and recursed into if it's an object or array.
  *
- * Single-element arrays where the element is a string or undefined are unwrapped
- * to handle the case where a multi-value field (e.g. checkboxes) has only one value.
  */
 export function normalize(
 	value: unknown,
-	serialize: Serialize = defaultSerialize,
-	stripEmptyStrings: boolean = true,
-	name?: string,
+	options: {
+		serialize?: Serialize;
+		stripEmptyValue?: boolean;
+		name?: string;
+	} = {},
 ): unknown {
+	const {
+		serialize = defaultSerialize,
+		stripEmptyValue = true,
+		name,
+	} = options;
+
 	let data: unknown = serialize(value, {
 		name,
 	});
@@ -916,12 +921,12 @@ export function normalize(
 		data = value;
 	}
 
-	if (data === null || (stripEmptyStrings && data === '')) {
+	if (stripEmptyValue && (data === null || data === '')) {
 		return undefined;
 	}
 
 	if (isGlobalInstance(data, 'File')) {
-		if (data.name === '' && data.size === 0) {
+		if (stripEmptyValue && data.name === '' && data.size === 0) {
 			return undefined;
 		}
 
@@ -929,15 +934,16 @@ export function normalize(
 	}
 
 	if (Array.isArray(data)) {
-		if (data.length === 0) {
+		if (stripEmptyValue && data.length === 0) {
 			return undefined;
 		}
 
 		const array = data.map((item, index) =>
-			normalize(item, serialize, stripEmptyStrings, appendPath(name, index)),
+			normalize(item, { ...options, name: appendPath(name, index) }),
 		);
 
 		if (
+			stripEmptyValue &&
 			array.length === 1 &&
 			(typeof array[0] === 'string' || array[0] === undefined)
 		) {
@@ -950,12 +956,10 @@ export function normalize(
 	if (isPlainObject(data)) {
 		const entries = Object.entries(data).reduce<Array<[string, unknown]>>(
 			(list, [key, value]) => {
-				const normalizedValue = normalize(
-					value,
-					serialize,
-					stripEmptyStrings,
-					appendPath(name, key),
-				);
+				const normalizedValue = normalize(value, {
+					...options,
+					name: appendPath(name, key),
+				});
 
 				if (typeof normalizedValue !== 'undefined') {
 					list.push([key, normalizedValue]);
@@ -966,7 +970,7 @@ export function normalize(
 			[],
 		);
 
-		if (entries.length === 0) {
+		if (stripEmptyValue && entries.length === 0) {
 			return undefined;
 		}
 

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -511,7 +511,11 @@ export function getDefaultPayload(
 		return null;
 	}
 
-	return normalize(value, context.serialize, false, name);
+	return normalize(value, {
+		serialize: context.serialize,
+		stripEmptyValue: false,
+		name,
+	});
 }
 
 export function getDefaultValue(

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -511,7 +511,7 @@ export function getDefaultPayload(
 		return null;
 	}
 
-	return normalize(value, context.serialize, name);
+	return normalize(value, context.serialize, false, name);
 }
 
 export function getDefaultValue(

--- a/packages/conform-react/tests/state.test.ts
+++ b/packages/conform-react/tests/state.test.ts
@@ -1388,7 +1388,7 @@ describe('form state', () => {
 
 		expect(getListKey(context, 'tasks')).toEqual(['0-tasks[0]']);
 		expect(getDefaultOptions(context, 'tasks')).toEqual(['Final 1']);
-		expect(getDefaultPayload(context, 'tasks')).toBe('Final 1');
+		expect(getDefaultPayload(context, 'tasks')).toEqual(['Final 1']);
 		expect(isTouched(context.state)).toBe(true);
 
 		context.state = updateState(
@@ -1603,49 +1603,32 @@ test('field metadata serialize override updates default values', () => {
 	expect(field.defaultPayload).toBe('{"foo":"bar"}');
 });
 
-test('getDefaultPayload preserves empty strings', () => {
-	// Nested object where some fields are empty strings
+test('getDefaultPayload', () => {
 	const context = createContext({
 		state: initializeState({
 			defaultValue: {
 				address: {
 					street: '',
+					postcode: null,
 					city: 'London',
 				},
+				tasks: ['', 'Buy groceries', ''],
+				username: '',
 			},
 		}),
 	});
 
 	expect(getDefaultPayload(context, 'address')).toEqual({
 		street: '',
+		postcode: null,
 		city: 'London',
 	});
-
-	// Array where some items are empty strings
-	const contextWithArray = createContext({
-		state: initializeState({
-			defaultValue: {
-				tasks: ['', 'Buy groceries', ''],
-			},
-		}),
-	});
-
-	expect(getDefaultPayload(contextWithArray, 'tasks')).toEqual([
+	expect(getDefaultPayload(context, 'tasks')).toEqual([
 		'',
 		'Buy groceries',
 		'',
 	]);
-
-	// Single field with an empty string value
-	const contextWithEmptyString = createContext({
-		state: initializeState({
-			defaultValue: {
-				username: '',
-			},
-		}),
-	});
-
-	expect(getDefaultPayload(contextWithEmptyString, 'username')).toBe('');
+	expect(getDefaultPayload(context, 'username')).toBe('');
 });
 
 test('getDefaultListKey', () => {

--- a/packages/conform-react/tests/state.test.ts
+++ b/packages/conform-react/tests/state.test.ts
@@ -1603,6 +1603,51 @@ test('field metadata serialize override updates default values', () => {
 	expect(field.defaultPayload).toBe('{"foo":"bar"}');
 });
 
+test('getDefaultPayload preserves empty strings', () => {
+	// Nested object where some fields are empty strings
+	const context = createContext({
+		state: initializeState({
+			defaultValue: {
+				address: {
+					street: '',
+					city: 'London',
+				},
+			},
+		}),
+	});
+
+	expect(getDefaultPayload(context, 'address')).toEqual({
+		street: '',
+		city: 'London',
+	});
+
+	// Array where some items are empty strings
+	const contextWithArray = createContext({
+		state: initializeState({
+			defaultValue: {
+				tasks: ['', 'Buy groceries', ''],
+			},
+		}),
+	});
+
+	expect(getDefaultPayload(contextWithArray, 'tasks')).toEqual([
+		'',
+		'Buy groceries',
+		'',
+	]);
+
+	// Single field with an empty string value
+	const contextWithEmptyString = createContext({
+		state: initializeState({
+			defaultValue: {
+				username: '',
+			},
+		}),
+	});
+
+	expect(getDefaultPayload(contextWithEmptyString, 'username')).toBe('');
+});
+
 test('getDefaultListKey', () => {
 	const prefix = 'test-prefix';
 	const initialValue = {


### PR DESCRIPTION
Fixes #1234 · Closes discussion #1232

## Problem

`normalize()` in `packages/conform-dom/formdata.ts` collapses empty strings to `undefined`. This is intentional for `isDirty` (where `''` and missing should compare equal), but `defaultPayload` uses the same function and therefore silently drops empty-string fields from the returned value.

## Solution

Add a `stripEmptyStrings` parameter to `normalize()` (defaults to `true`, preserving existing behaviour everywhere):

```ts
export function normalize(
    value: unknown,
    serialize: Serialize = defaultSerialize,
    stripEmptyStrings: boolean = true,
    name?: string,
): unknown
```

`getDefaultPayload()` in `packages/conform-react/future/state.ts` now calls `normalize(..., false)`, preserving empty strings in the returned payload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

**Changes Made:**
- Updated `normalize()` in `packages/conform-dom/formdata.ts` to accept a new `stripEmptyStrings` boolean parameter (default `true`). When enabled, `''` is normalized to `undefined`; when disabled, empty strings are preserved (while `null` still collapses to `undefined`). The flag is forwarded through recursive normalization.
- Updated `getDefaultPayload()` in `packages/conform-react/future/state.ts` to call `normalize(..., false, name)` so default payloads retain empty-string values.
- Added a unit test in `packages/conform-react/tests/state.test.ts` verifying `getDefaultPayload` preserves empty strings for nested objects, arrays, and single fields.

**Example:**
```js
// Nested empty string is preserved in defaultPayload
getDefaultPayload(context, 'address', {
  defaultValue: { address: { street: '', city: 'London' } }
});
// => { street: '', city: 'London' }
```

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->