### PR TITLE
fix(zod): preserve branch-specific required in union/discriminated union

### DIFF
--- a/.changeset/zod-union-required.md
+++ b/.changeset/zod-union-required.md
@@ -1,0 +1,18 @@
+---
+'@conform-to/zod': minor
+---
+
+Update the future `getConstraints` API so required fields inside a union branch stay required.
+
+This better supports conditional forms where each union branch renders its own fields. For example:
+
+```ts
+const schema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('person'), name: z.string() }),
+  z.object({ type: z.literal('company'), company: z.string() }),
+]);
+
+getConstraints(schema);
+// Before: name and company were marked as { required: false }
+// After: both are now marked as { required: true }
+```

--- a/packages/conform-zod/v3/constraint.ts
+++ b/packages/conform-zod/v3/constraint.ts
@@ -22,8 +22,9 @@ const keys: Array<keyof Constraint> = [
 
 export function getZodConstraint(
 	schema: ZodTypeAny,
-	flagLegacyRequiredOverride = true,
+	options: { preserveBranchSpecificRequired?: boolean } = {},
 ): Record<string, Constraint> {
+	const { preserveBranchSpecificRequired = true } = options;
 	const processingPaths = new Map<ZodTypeAny, string>();
 	const aliases: Array<{
 		from: Array<string | number>;
@@ -111,7 +112,7 @@ export function getZodConstraint(
 									...prevConstraint,
 									...nextConstraint,
 								};
-								if (flagLegacyRequiredOverride) {
+								if (!preserveBranchSpecificRequired) {
 									result[name].required = false;
 								}
 							}

--- a/packages/conform-zod/v3/constraint.ts
+++ b/packages/conform-zod/v3/constraint.ts
@@ -22,6 +22,7 @@ const keys: Array<keyof Constraint> = [
 
 export function getZodConstraint(
 	schema: ZodTypeAny,
+	flagLegacyRequiredOverride = true,
 ): Record<string, Constraint> {
 	const processingPaths = new Map<ZodTypeAny, string>();
 	const aliases: Array<{
@@ -109,8 +110,10 @@ export function getZodConstraint(
 								result[name] = {
 									...prevConstraint,
 									...nextConstraint,
-									required: false,
 								};
+								if (flagLegacyRequiredOverride) {
+									result[name].required = false;
+								}
 							}
 						}
 

--- a/packages/conform-zod/v3/future.ts
+++ b/packages/conform-zod/v3/future.ts
@@ -11,7 +11,7 @@ import { isSchema } from './schema';
 export function getZodConstraint(
 	schema: ZodTypeAny,
 ): Record<string, Constraint> {
-	return baseGetZodConstraint(schema, false);
+	return baseGetZodConstraint(schema);
 }
 
 export function getConstraints(
@@ -21,7 +21,7 @@ export function getConstraints(
 		return undefined;
 	}
 
-	return baseGetZodConstraint(schema, false);
+	return baseGetZodConstraint(schema);
 }
 
 export { formatResult } from './format';

--- a/packages/conform-zod/v3/future.ts
+++ b/packages/conform-zod/v3/future.ts
@@ -1,11 +1,31 @@
+import type { Constraint } from '@conform-to/dom';
+import type { ValidationAttributes } from '@conform-to/dom/future';
+import type { ZodTypeAny } from 'zod/v3';
 import { configureCoercion as baseConfigureCoercion } from './coercion';
+import { getZodConstraint as baseGetZodConstraint } from './constraint';
+import { isSchema } from './schema';
 
 /**
  * @deprecated Use `getConstraints` instead.
  */
-export { getZodConstraint } from './constraint';
+export function getZodConstraint(
+	schema: ZodTypeAny,
+): Record<string, Constraint> {
+	return baseGetZodConstraint(schema, false);
+}
+
+export function getConstraints(
+	schema: unknown,
+): Record<string, ValidationAttributes> | undefined {
+	if (!isSchema(schema)) {
+		return undefined;
+	}
+
+	return baseGetZodConstraint(schema, false);
+}
+
 export { formatResult } from './format';
-export { isSchema, getConstraints } from './schema';
+export { isSchema } from './schema';
 
 function defaultDate(text: string): Date {
 	const date = new Date(shouldAppendUtcSuffix(text) ? `${text}Z` : text);

--- a/packages/conform-zod/v3/index.ts
+++ b/packages/conform-zod/v3/index.ts
@@ -1,3 +1,14 @@
-export { getZodConstraint } from './constraint';
+import type { Constraint } from '@conform-to/dom';
+import type { ZodTypeAny } from 'zod/v3';
+import { getZodConstraint as baseGetZodConstraint } from './constraint';
+
+export function getZodConstraint(
+	schema: ZodTypeAny,
+): Record<string, Constraint> {
+	return baseGetZodConstraint(schema, {
+		preserveBranchSpecificRequired: false,
+	});
+}
+
 export { parseWithZod, conformZodMessage } from './parse';
 export { coerceFormValue as unstable_coerceFormValue } from './coercion';

--- a/packages/conform-zod/v3/tests/constraint.test.ts
+++ b/packages/conform-zod/v3/tests/constraint.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'vitest';
-import { getZodConstraint } from '../constraint';
+import { getZodConstraint } from '../index';
+import { getConstraints } from '../future';
 import { z } from 'zod/v3';
 
 describe('getZodConstraint', () => {
@@ -223,23 +224,20 @@ describe('getZodConstraint', () => {
 		const baseSchema = z.object({
 			qux: z.string().min(1, 'min'),
 		});
+		const schema = z.union([
+			baseSchema.extend({
+				type: z.literal('a'),
+				foo: z.string().min(1, 'min'),
+				baz: z.string().min(1, 'min'),
+			}),
+			baseSchema.extend({
+				type: z.literal('b'),
+				bar: z.string().min(1, 'min'),
+				baz: z.string().min(1, 'min').optional(),
+			}),
+		]);
 
-		expect(
-			getZodConstraint(
-				z.union([
-					baseSchema.extend({
-						type: z.literal('a'),
-						foo: z.string().min(1, 'min'),
-						baz: z.string().min(1, 'min'),
-					}),
-					baseSchema.extend({
-						type: z.literal('b'),
-						bar: z.string().min(1, 'min'),
-						baz: z.string().min(1, 'min').optional(),
-					}),
-				]),
-			),
-		).toEqual({
+		expect(getZodConstraint(schema)).toEqual({
 			type: { required: true },
 			foo: { required: false, minLength: 1 },
 			bar: { required: false, minLength: 1 },
@@ -247,24 +245,7 @@ describe('getZodConstraint', () => {
 			qux: { required: true, minLength: 1 },
 		});
 
-		// flagLegacyRequiredOverride=false: branch-only fields keep their actual required
-		expect(
-			getZodConstraint(
-				z.union([
-					baseSchema.extend({
-						type: z.literal('a'),
-						foo: z.string().min(1, 'min'),
-						baz: z.string().min(1, 'min'),
-					}),
-					baseSchema.extend({
-						type: z.literal('b'),
-						bar: z.string().min(1, 'min'),
-						baz: z.string().min(1, 'min').optional(),
-					}),
-				]),
-				false,
-			),
-		).toEqual({
+		expect(getConstraints(schema)).toEqual({
 			type: { required: true },
 			foo: { required: true, minLength: 1 },
 			bar: { required: true, minLength: 1 },
@@ -277,23 +258,20 @@ describe('getZodConstraint', () => {
 		const baseSchema = z.object({
 			qux: z.string().min(1, 'min'),
 		});
+		const schema = z.discriminatedUnion('type', [
+			baseSchema.extend({
+				type: z.literal('a'),
+				foo: z.string().min(1, 'min'),
+				baz: z.string().min(1, 'min'),
+			}),
+			baseSchema.extend({
+				type: z.literal('b'),
+				bar: z.string().min(1, 'min'),
+				baz: z.string().min(1, 'min').optional(),
+			}),
+		]);
 
-		expect(
-			getZodConstraint(
-				z.discriminatedUnion('type', [
-					baseSchema.extend({
-						type: z.literal('a'),
-						foo: z.string().min(1, 'min'),
-						baz: z.string().min(1, 'min'),
-					}),
-					baseSchema.extend({
-						type: z.literal('b'),
-						bar: z.string().min(1, 'min'),
-						baz: z.string().min(1, 'min').optional(),
-					}),
-				]),
-			),
-		).toEqual({
+		expect(getZodConstraint(schema)).toEqual({
 			type: { required: true },
 			foo: { required: false, minLength: 1 },
 			bar: { required: false, minLength: 1 },
@@ -301,24 +279,7 @@ describe('getZodConstraint', () => {
 			qux: { required: true, minLength: 1 },
 		});
 
-		// flagLegacyRequiredOverride=false: branch-only fields keep their actual required
-		expect(
-			getZodConstraint(
-				z.discriminatedUnion('type', [
-					baseSchema.extend({
-						type: z.literal('a'),
-						foo: z.string().min(1, 'min'),
-						baz: z.string().min(1, 'min'),
-					}),
-					baseSchema.extend({
-						type: z.literal('b'),
-						bar: z.string().min(1, 'min'),
-						baz: z.string().min(1, 'min').optional(),
-					}),
-				]),
-				false,
-			),
-		).toEqual({
+		expect(getConstraints(schema)).toEqual({
 			type: { required: true },
 			foo: { required: true, minLength: 1 },
 			bar: { required: true, minLength: 1 },
@@ -409,14 +370,13 @@ describe('getZodConstraint', () => {
 			constraint['conditions[0].conditions[1].conditions[2].type'],
 		).toEqual({ required: true });
 
-		// flagLegacyRequiredOverride = false: conditions[].conditions keeps required: true from its branch
-		const fixedConstraint = getZodConstraint(FilterSchema, false);
+		const fixedConstraint = getConstraints(FilterSchema);
 
-		expect(fixedConstraint['conditions[].conditions']).toEqual({
+		expect(fixedConstraint?.['conditions[].conditions']).toEqual({
 			required: true,
 			multiple: true,
 		});
-		expect(fixedConstraint['conditions[0].conditions']).toEqual({
+		expect(fixedConstraint?.['conditions[0].conditions']).toEqual({
 			required: true,
 			multiple: true,
 		});

--- a/packages/conform-zod/v3/tests/constraint.test.ts
+++ b/packages/conform-zod/v3/tests/constraint.test.ts
@@ -246,6 +246,31 @@ describe('getZodConstraint', () => {
 			baz: { minLength: 1 },
 			qux: { required: true, minLength: 1 },
 		});
+
+		// flagLegacyRequiredOverride=false: branch-only fields keep their actual required
+		expect(
+			getZodConstraint(
+				z.union([
+					baseSchema.extend({
+						type: z.literal('a'),
+						foo: z.string().min(1, 'min'),
+						baz: z.string().min(1, 'min'),
+					}),
+					baseSchema.extend({
+						type: z.literal('b'),
+						bar: z.string().min(1, 'min'),
+						baz: z.string().min(1, 'min').optional(),
+					}),
+				]),
+				false,
+			),
+		).toEqual({
+			type: { required: true },
+			foo: { required: true, minLength: 1 },
+			bar: { required: true, minLength: 1 },
+			baz: { minLength: 1 },
+			qux: { required: true, minLength: 1 },
+		});
 	});
 
 	test('discriminated union', () => {
@@ -272,6 +297,31 @@ describe('getZodConstraint', () => {
 			type: { required: true },
 			foo: { required: false, minLength: 1 },
 			bar: { required: false, minLength: 1 },
+			baz: { minLength: 1 },
+			qux: { required: true, minLength: 1 },
+		});
+
+		// flagLegacyRequiredOverride=false: branch-only fields keep their actual required
+		expect(
+			getZodConstraint(
+				z.discriminatedUnion('type', [
+					baseSchema.extend({
+						type: z.literal('a'),
+						foo: z.string().min(1, 'min'),
+						baz: z.string().min(1, 'min'),
+					}),
+					baseSchema.extend({
+						type: z.literal('b'),
+						bar: z.string().min(1, 'min'),
+						baz: z.string().min(1, 'min').optional(),
+					}),
+				]),
+				false,
+			),
+		).toEqual({
+			type: { required: true },
+			foo: { required: true, minLength: 1 },
+			bar: { required: true, minLength: 1 },
 			baz: { minLength: 1 },
 			qux: { required: true, minLength: 1 },
 		});
@@ -336,7 +386,6 @@ describe('getZodConstraint', () => {
 
 		// Static keys — both union options are traversed; recursion is
 		// caught when z.lazy() re-encounters ConditionSchema.
-		// conditions[].conditions only exists in "group", so required: false.
 		expect(constraint).toEqual({
 			type: { required: true },
 			conditions: { required: true, multiple: true },
@@ -359,6 +408,18 @@ describe('getZodConstraint', () => {
 		expect(
 			constraint['conditions[0].conditions[1].conditions[2].type'],
 		).toEqual({ required: true });
+
+		// flagLegacyRequiredOverride = false: conditions[].conditions keeps required: true from its branch
+		const fixedConstraint = getZodConstraint(FilterSchema, false);
+
+		expect(fixedConstraint['conditions[].conditions']).toEqual({
+			required: true,
+			multiple: true,
+		});
+		expect(fixedConstraint['conditions[0].conditions']).toEqual({
+			required: true,
+			multiple: true,
+		});
 	});
 
 	test('regex patterns', () => {

--- a/packages/conform-zod/v4/constraint.ts
+++ b/packages/conform-zod/v4/constraint.ts
@@ -23,8 +23,9 @@ const keys: Array<keyof Constraint> = [
 
 export function getZodConstraint(
 	schema: $ZodType,
-	flagLegacyRequiredOverride = true,
+	options: { preserveBranchSpecificRequired?: boolean } = {},
 ): Record<string, Constraint> {
+	const { preserveBranchSpecificRequired = true } = options;
 	const processingPaths = new Map<$ZodType, string>();
 	const aliases: Array<{
 		from: Array<string | number>;
@@ -114,7 +115,7 @@ export function getZodConstraint(
 									...prevConstraint,
 									...nextConstraint,
 								};
-								if (flagLegacyRequiredOverride) {
+								if (!preserveBranchSpecificRequired) {
 									result[name].required = false;
 								}
 							}

--- a/packages/conform-zod/v4/constraint.ts
+++ b/packages/conform-zod/v4/constraint.ts
@@ -1,12 +1,12 @@
 import type { Constraint } from '@conform-to/dom';
-import { getPaths, formatPaths, getRelativePath } from '@conform-to/dom';
+import { formatPaths, getPaths, getRelativePath } from '@conform-to/dom';
 import { serializeHtmlPattern } from '@conform-to/dom/future';
 import {
-	$ZodType,
-	$ZodTypes,
+	$ZodFile,
 	$ZodNumber,
 	$ZodString,
-	$ZodFile,
+	$ZodType,
+	$ZodTypes,
 } from 'zod/v4/core';
 
 const keys: Array<keyof Constraint> = [
@@ -21,7 +21,10 @@ const keys: Array<keyof Constraint> = [
 	'accept',
 ];
 
-export function getZodConstraint(schema: $ZodType): Record<string, Constraint> {
+export function getZodConstraint(
+	schema: $ZodType,
+	flagLegacyRequiredOverride = true,
+): Record<string, Constraint> {
 	const processingPaths = new Map<$ZodType, string>();
 	const aliases: Array<{
 		from: Array<string | number>;
@@ -110,8 +113,10 @@ export function getZodConstraint(schema: $ZodType): Record<string, Constraint> {
 								result[name] = {
 									...prevConstraint,
 									...nextConstraint,
-									required: false,
 								};
+								if (flagLegacyRequiredOverride) {
+									result[name].required = false;
+								}
 							}
 						}
 

--- a/packages/conform-zod/v4/future.ts
+++ b/packages/conform-zod/v4/future.ts
@@ -1,11 +1,29 @@
+import type { Constraint } from '@conform-to/dom';
+import type { ValidationAttributes } from '@conform-to/dom/future';
+import type { $ZodType } from 'zod/v4/core';
 import { configureCoercion as baseConfigureCoercion } from './coercion';
+import { getZodConstraint as baseGetZodConstraint } from './constraint';
+import { isSchema } from './schema';
 
 /**
  * @deprecated Use `getConstraints` instead.
  */
-export { getZodConstraint } from './constraint';
+export function getZodConstraint(schema: $ZodType): Record<string, Constraint> {
+	return baseGetZodConstraint(schema, false);
+}
+
+export function getConstraints(
+	schema: unknown,
+): Record<string, ValidationAttributes> | undefined {
+	if (!isSchema(schema)) {
+		return undefined;
+	}
+
+	return baseGetZodConstraint(schema, false);
+}
+
 export { formatResult } from './format';
-export { isSchema, getConstraints } from './schema';
+export { isSchema } from './schema';
 
 function defaultDate(text: string): Date {
 	const date = new Date(shouldAppendUtcSuffix(text) ? `${text}Z` : text);

--- a/packages/conform-zod/v4/future.ts
+++ b/packages/conform-zod/v4/future.ts
@@ -9,7 +9,7 @@ import { isSchema } from './schema';
  * @deprecated Use `getConstraints` instead.
  */
 export function getZodConstraint(schema: $ZodType): Record<string, Constraint> {
-	return baseGetZodConstraint(schema, false);
+	return baseGetZodConstraint(schema);
 }
 
 export function getConstraints(
@@ -19,7 +19,7 @@ export function getConstraints(
 		return undefined;
 	}
 
-	return baseGetZodConstraint(schema, false);
+	return baseGetZodConstraint(schema);
 }
 
 export { formatResult } from './format';

--- a/packages/conform-zod/v4/index.ts
+++ b/packages/conform-zod/v4/index.ts
@@ -1,3 +1,12 @@
-export { getZodConstraint } from './constraint';
+import type { Constraint } from '@conform-to/dom';
+import type { $ZodType } from 'zod/v4/core';
+import { getZodConstraint as baseGetZodConstraint } from './constraint';
+
+export function getZodConstraint(schema: $ZodType): Record<string, Constraint> {
+	return baseGetZodConstraint(schema, {
+		preserveBranchSpecificRequired: false,
+	});
+}
+
 export { parseWithZod, conformZodMessage } from './parse';
 export { coerceFormValue as unstable_coerceFormValue } from './coercion';

--- a/packages/conform-zod/v4/tests/constraint.test.ts
+++ b/packages/conform-zod/v4/tests/constraint.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'vitest';
-import { getZodConstraint } from '../constraint';
+import { getZodConstraint } from '../index';
+import { getConstraints } from '../future';
 import { z } from 'zod-v4';
 
 describe('getZodConstraint', () => {
@@ -229,23 +230,20 @@ describe('getZodConstraint', () => {
 		const baseSchema = z.object({
 			qux: z.string().min(1, 'min'),
 		});
+		const schema = z.union([
+			baseSchema.extend({
+				type: z.literal('a'),
+				foo: z.string().min(1, 'min'),
+				baz: z.string().min(1, 'min'),
+			}),
+			baseSchema.extend({
+				type: z.literal('b'),
+				bar: z.string().min(1, 'min'),
+				baz: z.string().min(1, 'min').optional(),
+			}),
+		]);
 
-		expect(
-			getZodConstraint(
-				z.union([
-					baseSchema.extend({
-						type: z.literal('a'),
-						foo: z.string().min(1, 'min'),
-						baz: z.string().min(1, 'min'),
-					}),
-					baseSchema.extend({
-						type: z.literal('b'),
-						bar: z.string().min(1, 'min'),
-						baz: z.string().min(1, 'min').optional(),
-					}),
-				]),
-			),
-		).toEqual({
+		expect(getZodConstraint(schema)).toEqual({
 			type: { required: true },
 			foo: { required: false, minLength: 1 },
 			bar: { required: false, minLength: 1 },
@@ -253,24 +251,7 @@ describe('getZodConstraint', () => {
 			qux: { required: true, minLength: 1 },
 		});
 
-		// flagLegacyRequiredOverride=false: branch-only fields keep their actual required
-		expect(
-			getZodConstraint(
-				z.union([
-					baseSchema.extend({
-						type: z.literal('a'),
-						foo: z.string().min(1, 'min'),
-						baz: z.string().min(1, 'min'),
-					}),
-					baseSchema.extend({
-						type: z.literal('b'),
-						bar: z.string().min(1, 'min'),
-						baz: z.string().min(1, 'min').optional(),
-					}),
-				]),
-				false,
-			),
-		).toEqual({
+		expect(getConstraints(schema)).toEqual({
 			type: { required: true },
 			foo: { required: true, minLength: 1 },
 			bar: { required: true, minLength: 1 },
@@ -283,23 +264,20 @@ describe('getZodConstraint', () => {
 		const baseSchema = z.object({
 			qux: z.string().min(1, 'min'),
 		});
+		const schema = z.discriminatedUnion('type', [
+			baseSchema.extend({
+				type: z.literal('a'),
+				foo: z.string().min(1, 'min'),
+				baz: z.string().min(1, 'min'),
+			}),
+			baseSchema.extend({
+				type: z.literal('b'),
+				bar: z.string().min(1, 'min'),
+				baz: z.string().min(1, 'min').optional(),
+			}),
+		]);
 
-		expect(
-			getZodConstraint(
-				z.discriminatedUnion('type', [
-					baseSchema.extend({
-						type: z.literal('a'),
-						foo: z.string().min(1, 'min'),
-						baz: z.string().min(1, 'min'),
-					}),
-					baseSchema.extend({
-						type: z.literal('b'),
-						bar: z.string().min(1, 'min'),
-						baz: z.string().min(1, 'min').optional(),
-					}),
-				]),
-			),
-		).toEqual({
+		expect(getZodConstraint(schema)).toEqual({
 			type: { required: true },
 			foo: { required: false, minLength: 1 },
 			bar: { required: false, minLength: 1 },
@@ -307,24 +285,7 @@ describe('getZodConstraint', () => {
 			qux: { required: true, minLength: 1 },
 		});
 
-		// flagLegacyRequiredOverride=false: branch-only fields keep their actual required
-		expect(
-			getZodConstraint(
-				z.discriminatedUnion('type', [
-					baseSchema.extend({
-						type: z.literal('a'),
-						foo: z.string().min(1, 'min'),
-						baz: z.string().min(1, 'min'),
-					}),
-					baseSchema.extend({
-						type: z.literal('b'),
-						bar: z.string().min(1, 'min'),
-						baz: z.string().min(1, 'min').optional(),
-					}),
-				]),
-				false,
-			),
-		).toEqual({
+		expect(getConstraints(schema)).toEqual({
 			type: { required: true },
 			foo: { required: true, minLength: 1 },
 			bar: { required: true, minLength: 1 },
@@ -472,14 +433,13 @@ describe('getZodConstraint', () => {
 			constraint['conditions[0].conditions[1].conditions[2].type'],
 		).toEqual({ required: true });
 
-		// flagLegacyRequiredOverride = false: conditions[].conditions keeps required: true from its branch
-		const fixedConstraint = getZodConstraint(FilterSchema, false);
+		const fixedConstraint = getConstraints(FilterSchema);
 
-		expect(fixedConstraint['conditions[].conditions']).toEqual({
+		expect(fixedConstraint?.['conditions[].conditions']).toEqual({
 			required: true,
 			multiple: true,
 		});
-		expect(fixedConstraint['conditions[0].conditions']).toEqual({
+		expect(fixedConstraint?.['conditions[0].conditions']).toEqual({
 			required: true,
 			multiple: true,
 		});

--- a/packages/conform-zod/v4/tests/constraint.test.ts
+++ b/packages/conform-zod/v4/tests/constraint.test.ts
@@ -252,6 +252,31 @@ describe('getZodConstraint', () => {
 			baz: { minLength: 1 },
 			qux: { required: true, minLength: 1 },
 		});
+
+		// flagLegacyRequiredOverride=false: branch-only fields keep their actual required
+		expect(
+			getZodConstraint(
+				z.union([
+					baseSchema.extend({
+						type: z.literal('a'),
+						foo: z.string().min(1, 'min'),
+						baz: z.string().min(1, 'min'),
+					}),
+					baseSchema.extend({
+						type: z.literal('b'),
+						bar: z.string().min(1, 'min'),
+						baz: z.string().min(1, 'min').optional(),
+					}),
+				]),
+				false,
+			),
+		).toEqual({
+			type: { required: true },
+			foo: { required: true, minLength: 1 },
+			bar: { required: true, minLength: 1 },
+			baz: { minLength: 1 },
+			qux: { required: true, minLength: 1 },
+		});
 	});
 
 	test('discriminated union', () => {
@@ -278,6 +303,31 @@ describe('getZodConstraint', () => {
 			type: { required: true },
 			foo: { required: false, minLength: 1 },
 			bar: { required: false, minLength: 1 },
+			baz: { minLength: 1 },
+			qux: { required: true, minLength: 1 },
+		});
+
+		// flagLegacyRequiredOverride=false: branch-only fields keep their actual required
+		expect(
+			getZodConstraint(
+				z.discriminatedUnion('type', [
+					baseSchema.extend({
+						type: z.literal('a'),
+						foo: z.string().min(1, 'min'),
+						baz: z.string().min(1, 'min'),
+					}),
+					baseSchema.extend({
+						type: z.literal('b'),
+						bar: z.string().min(1, 'min'),
+						baz: z.string().min(1, 'min').optional(),
+					}),
+				]),
+				false,
+			),
+		).toEqual({
+			type: { required: true },
+			foo: { required: true, minLength: 1 },
+			bar: { required: true, minLength: 1 },
 			baz: { minLength: 1 },
 			qux: { required: true, minLength: 1 },
 		});
@@ -399,7 +449,6 @@ describe('getZodConstraint', () => {
 
 		// Static keys — both union options are traversed; recursion is
 		// caught when z.lazy() re-encounters ConditionSchema.
-		// conditions[].conditions only exists in "group", so required: false.
 		expect(constraint).toEqual({
 			type: { required: true },
 			conditions: { required: true, multiple: true },
@@ -422,6 +471,18 @@ describe('getZodConstraint', () => {
 		expect(
 			constraint['conditions[0].conditions[1].conditions[2].type'],
 		).toEqual({ required: true });
+
+		// flagLegacyRequiredOverride = false: conditions[].conditions keeps required: true from its branch
+		const fixedConstraint = getZodConstraint(FilterSchema, false);
+
+		expect(fixedConstraint['conditions[].conditions']).toEqual({
+			required: true,
+			multiple: true,
+		});
+		expect(fixedConstraint['conditions[0].conditions']).toEqual({
+			required: true,
+			multiple: true,
+		});
 	});
 
 	test('tuple with recursive element', () => {


### PR DESCRIPTION
Fixes #1231

## Problem

`getZodConstraint` and `getConstraints` were forcing `required: false` on any field that only existed in one branch of a `z.union` or `z.discriminatedUnion`, even when the field was required within its branch.

## Solution

Add a `flagLegacyRequiredOverride` parameter (default `true` for backwards compatibility) to `getZodConstraint`. When `false`, branch-specific fields keep their actual `required` value.

The future API (`getZodConstraint` and `getConstraints` from the `/future` entrypoint) uses `false` to opt into the correct behaviour.

Applies to both zod v3 and v4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

## Implementation Details

- Updated `getZodConstraint` in both `packages/conform-zod/v3/constraint.ts` and `packages/conform-zod/v4/constraint.ts` to accept an options parameter: `preserveBranchSpecificRequired?: boolean` (defaulting to `true`).
- In the union/discriminated-union constraint merge path, the previous legacy behavior always downgraded merged constraints to `required: false`; it now only does that when `preserveBranchSpecificRequired` is enabled (legacy mode). When disabled, branch-specific required semantics are preserved.

### Public API wiring (`/future`)
- `packages/conform-zod/v3/future.ts` and `packages/conform-zod/v4/future.ts` now define local exported wrappers:
  - `getZodConstraint` delegates to the underlying implementation with `preserveBranchSpecificRequired: false` and remains deprecated.
  - Added `getConstraints(schema: unknown)` which returns `undefined` when `isSchema` fails, otherwise returns the constraint/attribute map.
- `packages/conform-zod/v3/index.ts` and `packages/conform-zod/v4/index.ts` wrap `getZodConstraint` to force `preserveBranchSpecificRequired: false` for the non-legacy path.

### Test updates
- Updated `packages/conform-zod/v3/tests/constraint.test.ts` and `packages/conform-zod/v4/tests/constraint.test.ts` to assert:
  - `getZodConstraint(...)` (legacy behavior) continues to mark union-branch-only fields as not required.
  - `getConstraints(...)` (future API) preserves branch-specific required fields as `required: true`, including nested discriminated-union cases (e.g., `conditions[].conditions` with `multiple: true`).

```ts
import { getConstraints } from "`@conform-to/zod/future`";
// getConstraints preserves required semantics for discriminated-union branches
const attrs = getConstraints(schema);
```

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->