### PR TITLE
Preserve lastResult errors without initialValue

### DIFF
--- a/.changeset/quiet-errors-flow.md
+++ b/.changeset/quiet-errors-flow.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/dom': patch
+---
+
+Preserve `lastResult` errors when `initialValue` is omitted.

--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -944,7 +944,10 @@ export function createFormContext<
 			return;
 		}
 
-		const initialValue = result.initialValue ?? meta.initialValue;
+		const initialValue =
+			typeof result.initialValue !== 'undefined'
+				? result.initialValue
+				: meta.initialValue;
 		const error = Object.entries(result.error ?? {}).reduce<
 			Record<string, FormError>
 		>((result, [name, newError]) => {
@@ -966,7 +969,8 @@ export function createFormContext<
 			pendingIntents,
 			isValueUpdated: false,
 			submissionStatus: result.status,
-			value: initialValue,
+			value:
+				typeof result.initialValue !== 'undefined' ? initialValue : meta.value,
 			validated: {
 				...meta.validated,
 				...result.state?.validated,

--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -939,11 +939,12 @@ export function createFormContext<
 	function report(result: SubmissionResult<FormError>) {
 		const formElement = getFormElement();
 
-		if (!result.initialValue) {
+		if (result.initialValue === null) {
 			reset();
 			return;
 		}
 
+		const initialValue = result.initialValue ?? meta.initialValue;
 		const error = Object.entries(result.error ?? {}).reduce<
 			Record<string, FormError>
 		>((result, [name, newError]) => {
@@ -965,7 +966,7 @@ export function createFormContext<
 			pendingIntents,
 			isValueUpdated: false,
 			submissionStatus: result.status,
-			value: result.initialValue,
+			value: initialValue,
 			validated: {
 				...meta.validated,
 				...result.state?.validated,

--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -944,10 +944,6 @@ export function createFormContext<
 			return;
 		}
 
-		const initialValue =
-			typeof result.initialValue !== 'undefined'
-				? result.initialValue
-				: meta.initialValue;
 		const error = Object.entries(result.error ?? {}).reduce<
 			Record<string, FormError>
 		>((result, [name, newError]) => {
@@ -970,7 +966,9 @@ export function createFormContext<
 			isValueUpdated: false,
 			submissionStatus: result.status,
 			value:
-				typeof result.initialValue !== 'undefined' ? initialValue : meta.value,
+				typeof result.initialValue !== 'undefined'
+					? result.initialValue
+					: meta.value,
 			validated: {
 				...meta.validated,
 				...result.state?.validated,

--- a/packages/conform-dom/tests/form.node.test.ts
+++ b/packages/conform-dom/tests/form.node.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createFormContext } from '../form';
+
+describe('createFormContext', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('keeps last submission errors when initialValue is omitted', () => {
+		vi.stubGlobal('document', {
+			forms: {
+				namedItem: () => null,
+			},
+		});
+
+		const context = createFormContext({
+			formId: 'test-form',
+			lastResult: null,
+		});
+
+		context.onUpdate({
+			lastResult: {
+				status: 'error',
+				error: {
+					name: ['some error message'],
+				},
+				fields: ['name'],
+			},
+		});
+
+		expect(context.getState().submissionStatus).toBe('error');
+		expect(context.getState().error.name).toEqual(['some error message']);
+	});
+});

--- a/packages/conform-dom/tests/form.node.test.ts
+++ b/packages/conform-dom/tests/form.node.test.ts
@@ -6,6 +6,49 @@ describe('createFormContext', () => {
 		vi.unstubAllGlobals();
 	});
 
+	function setupFormData(value: string) {
+		class TestElement {}
+
+		const form = {
+			elements: [] as unknown[],
+			isConnected: true,
+		};
+		const input = Object.assign(new TestElement(), {
+			tagName: 'INPUT',
+			type: 'text',
+			name: 'name',
+			form,
+			focus: vi.fn(),
+		});
+
+		form.elements = [input];
+
+		vi.stubGlobal('Element', TestElement);
+		vi.stubGlobal(
+			'FormData',
+			class {
+				get(name: string) {
+					if (name === '__intent__' || name === '__state__') {
+						return null;
+					}
+
+					return name === 'name' ? value : null;
+				}
+
+				entries() {
+					return [['name', value]][Symbol.iterator]();
+				}
+			},
+		);
+		vi.stubGlobal('document', {
+			forms: {
+				namedItem: () => form,
+			},
+		});
+
+		return { input };
+	}
+
 	it('keeps last submission errors when initialValue is omitted', () => {
 		vi.stubGlobal('document', {
 			forms: {
@@ -30,5 +73,73 @@ describe('createFormContext', () => {
 
 		expect(context.getState().submissionStatus).toBe('error');
 		expect(context.getState().error.name).toEqual(['some error message']);
+	});
+
+	it('keeps current values when lastResult omits initialValue', () => {
+		const { input } = setupFormData('typed value');
+
+		const context = createFormContext({
+			formId: 'test-form',
+			defaultValue: {
+				name: 'initial value',
+			},
+			lastResult: null,
+		});
+
+		context.onInput({
+			target: input,
+			defaultPrevented: false,
+		} as unknown as Event);
+
+		expect(context.getState().initialValue.name).toBe('initial value');
+		expect(context.getState().value.name).toBe('typed value');
+
+		context.onUpdate({
+			lastResult: {
+				status: 'error',
+				error: {
+					name: ['some error message'],
+				},
+				fields: ['name'],
+			},
+		});
+
+		expect(context.getState().submissionStatus).toBe('error');
+		expect(context.getState().value.name).toBe('typed value');
+		expect(context.getState().error.name).toEqual(['some error message']);
+	});
+
+	it('resets current values when lastResult initialValue is null', () => {
+		const { input } = setupFormData('typed value');
+
+		const context = createFormContext({
+			formId: 'test-form',
+			defaultValue: {
+				name: 'initial value',
+			},
+			lastResult: null,
+		});
+
+		context.onInput({
+			target: input,
+			defaultPrevented: false,
+		} as unknown as Event);
+
+		expect(context.getState().value.name).toBe('typed value');
+
+		context.onUpdate({
+			lastResult: {
+				status: 'error',
+				initialValue: null,
+				error: {
+					name: ['some error message'],
+				},
+				fields: ['name'],
+			},
+		});
+
+		expect(context.getState().submissionStatus).toBeUndefined();
+		expect(context.getState().value.name).toBe('initial value');
+		expect(context.getState().error.name).toBeUndefined();
 	});
 });


### PR DESCRIPTION
`lastResult` errors could be missed when `initialValue` was omitted.
This keeps `null` as the explicit reset case, while letting `undefined` continue through the existing initial-state path so returned errors are still picked up. I checked it with the focused repro, the `@conform-to/dom` node tests passing 49/49, typecheck, oxlint, oxfmt, and `git diff --check`.
Fixes #1003

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

## Changes

- **Core fix** (`packages/conform-dom/form.ts`): Updated `report` reset handling to treat **`initialValue: null`** as the explicit reset signal, while **`initialValue: undefined`** (omitted) follows the existing initial-state path—so **`lastResult` errors aren’t dropped**.
  ```ts
  // conceptual change
  if (result.initialValue === null) reset();
  // otherwise preserve prior lastResult error path behavior
  ```
- **Tests** (`packages/conform-dom/tests/form.node.test.ts`): Added node/DOM-focused coverage to verify error preservation when `initialValue` is omitted, correct `submissionStatus`/`error` updates from `onUpdate` `lastResult`, and reset/clearing when `lastResult.initialValue` is `null`.
- **Release note** (`.changeset/quiet-errors-flow.md`): Patch Changesets entry documenting that `lastResult` errors are preserved when `initialValue` is omitted.

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->