### PR TITLE
fix(zod): support z.readonly() in coerceFormValue and getZodConstraint

### DIFF
--- a/.changeset/coerce-readonly-schema.md
+++ b/.changeset/coerce-readonly-schema.md
@@ -1,0 +1,7 @@
+---
+'@conform-to/zod': patch
+---
+
+Support `z.readonly()` schemas in `coerceFormValue` and `getZodConstraint`.
+
+Previously, the `readonly` wrapper was treated as an opaque type, so coercion was skipped for any field defined with `.readonly()` (e.g. `z.number().readonly()` would fail with `expected number, received string`) and `getZodConstraint` dropped the field's validation attributes (such as `minLength`). The wrapper is now unwrapped like other transparent wrappers (`.nullable()`, `.brand()`), so its inner type is coerced and its constraints are derived correctly. This applies to the default, `/v3`, and `/v4` adapters.

--- a/packages/conform-zod/default/coercion.ts
+++ b/packages/conform-zod/default/coercion.ts
@@ -13,7 +13,6 @@ import {
 	any,
 	ZodCatch,
 	ZodBranded,
-	ZodReadonly,
 	ZodDefault,
 } from 'zod';
 import type {
@@ -356,7 +355,11 @@ export function enableTypeCoercion<Schema extends ZodTypeAny>(
 			type: enableTypeCoercion(def.type, options),
 		});
 	} else if (def.typeName === 'ZodReadonly') {
-		schema = new ZodReadonly({
+		const constr = type.constructor as new (
+			definition: typeof def,
+		) => ZodTypeAny;
+
+		schema = new constr({
 			...def,
 			innerType: enableTypeCoercion(def.innerType, options),
 		});

--- a/packages/conform-zod/default/coercion.ts
+++ b/packages/conform-zod/default/coercion.ts
@@ -13,6 +13,7 @@ import {
 	any,
 	ZodCatch,
 	ZodBranded,
+	ZodReadonly,
 	ZodDefault,
 } from 'zod';
 import type {
@@ -353,6 +354,11 @@ export function enableTypeCoercion<Schema extends ZodTypeAny>(
 		schema = new ZodBranded({
 			...def,
 			type: enableTypeCoercion(def.type, options),
+		});
+	} else if (def.typeName === 'ZodReadonly') {
+		schema = new ZodReadonly({
+			...def,
+			innerType: enableTypeCoercion(def.innerType, options),
 		});
 	} else if (def.typeName === 'ZodTuple') {
 		schema = new ZodTuple({

--- a/packages/conform-zod/default/constraint.ts
+++ b/packages/conform-zod/default/constraint.ts
@@ -57,6 +57,8 @@ export function getZodConstraint(
 			}
 		} else if (def.typeName === 'ZodEffects') {
 			updateConstraint(def.schema, data, name);
+		} else if (def.typeName === 'ZodReadonly') {
+			updateConstraint(def.innerType, data, name);
 		} else if (def.typeName === 'ZodPipeline') {
 			// FIXME: What to do with .pipe()?
 			updateConstraint(def.out, data, name);

--- a/packages/conform-zod/default/tests/coercion/schema/readonly.test.ts
+++ b/packages/conform-zod/default/tests/coercion/schema/readonly.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from 'vitest';
+import { coerceFormValue } from '../../../coercion';
+import { z } from 'zod';
+import { getResult } from '../../../../tests/helpers/zod';
+
+describe('coercion', () => {
+	describe('z.readonly', () => {
+		test('should coerce values wrapped with readonly', () => {
+			const schema = z
+				.object({
+					a: z.string().readonly(),
+					b: z.number().readonly(),
+					c: z.boolean().readonly(),
+					d: z.date().readonly(),
+					e: z.bigint().readonly(),
+					f: z.instanceof(File).readonly(),
+					g: z.string().optional().readonly(),
+					h: z.string().readonly().optional(),
+					i: z.object({ value: z.number() }).readonly(),
+				})
+				.readonly();
+			const defaultFile = new File(['hello', 'world'], 'example.txt');
+
+			expect(
+				getResult(
+					coerceFormValue(schema).safeParse({
+						a: '',
+						b: '',
+						c: '',
+						d: '',
+						e: '',
+						f: '',
+						g: '',
+						h: '',
+						i: { value: '' },
+					}),
+				),
+			).toEqual({
+				success: false,
+				error: {
+					a: ['Required'],
+					b: ['Required'],
+					c: ['Required'],
+					d: ['Required'],
+					e: ['Required'],
+					f: ['Input not instance of File'],
+					'i.value': ['Required'],
+				},
+			});
+			expect(
+				getResult(
+					coerceFormValue(schema).safeParse({
+						a: 'hello world',
+						b: '42',
+						c: 'on',
+						d: '1970-01-01',
+						e: '0x1fffffffffffff',
+						f: defaultFile,
+						g: '',
+						h: '',
+						i: { value: '7' },
+					}),
+				),
+			).toEqual({
+				success: true,
+				data: {
+					a: 'hello world',
+					b: 42,
+					c: true,
+					d: new Date('1970-01-01'),
+					e: BigInt('0x1fffffffffffff'),
+					f: defaultFile,
+					g: undefined,
+					h: undefined,
+					i: { value: 7 },
+				},
+			});
+		});
+	});
+});

--- a/packages/conform-zod/default/tests/constraint.test.ts
+++ b/packages/conform-zod/default/tests/constraint.test.ts
@@ -200,6 +200,25 @@ describe('getZodConstraint', () => {
 		expect(() => getZodConstraint(z.array(z.string()))).toThrow();
 	});
 
+	test('readonly', () => {
+		const schema = z
+			.object({
+				text: z.string().min(1, 'min').max(100, 'max').readonly(),
+				number: z.number().min(1, 'min').readonly(),
+				optionalText: z.string().min(1, 'min').readonly().optional(),
+				nested: z.object({ value: z.string().min(1, 'min') }).readonly(),
+			})
+			.readonly();
+
+		expect(getZodConstraint(schema)).toEqual({
+			text: { required: true, minLength: 1, maxLength: 100 },
+			number: { required: true, min: 1 },
+			optionalText: { required: false, minLength: 1 },
+			nested: { required: true },
+			'nested.value': { required: true, minLength: 1 },
+		});
+	});
+
 	test('intersection', () => {
 		const schema = z.object({
 			text: z.string().min(10, 'min').max(100, 'max'),

--- a/packages/conform-zod/v3/coercion.ts
+++ b/packages/conform-zod/v3/coercion.ts
@@ -13,6 +13,7 @@ import {
 	any,
 	ZodCatch,
 	ZodBranded,
+	ZodReadonly,
 	ZodDefault,
 } from 'zod/v3';
 import type {
@@ -412,6 +413,11 @@ function coerceType<Schema extends ZodTypeAny>(
 		schema = new ZodBranded({
 			...def,
 			type: coerceType(def.type, options),
+		});
+	} else if (def.typeName === 'ZodReadonly') {
+		schema = new ZodReadonly({
+			...def,
+			innerType: coerceType(def.innerType, options),
 		});
 	} else if (def.typeName === 'ZodTuple') {
 		schema = new ZodTuple({

--- a/packages/conform-zod/v3/constraint.ts
+++ b/packages/conform-zod/v3/constraint.ts
@@ -57,6 +57,8 @@ export function getZodConstraint(
 			}
 		} else if (def.typeName === 'ZodEffects') {
 			updateConstraint(def.schema, data, name);
+		} else if (def.typeName === 'ZodReadonly') {
+			updateConstraint(def.innerType, data, name);
 		} else if (def.typeName === 'ZodPipeline') {
 			// FIXME: What to do with .pipe()?
 			updateConstraint(def.out, data, name);

--- a/packages/conform-zod/v3/tests/coercion/schema/readonly.test.ts
+++ b/packages/conform-zod/v3/tests/coercion/schema/readonly.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from 'vitest';
+import { coerceFormValue } from '../../../coercion';
+import { z } from 'zod/v3';
+import { getResult } from '../../../../tests/helpers/zod';
+
+describe('coercion', () => {
+	describe('z.readonly', () => {
+		test('should coerce values wrapped with readonly', () => {
+			const schema = z
+				.object({
+					a: z.string().readonly(),
+					b: z.number().readonly(),
+					c: z.boolean().readonly(),
+					d: z.date().readonly(),
+					e: z.bigint().readonly(),
+					f: z.instanceof(File).readonly(),
+					g: z.string().optional().readonly(),
+					h: z.string().readonly().optional(),
+					i: z.object({ value: z.number() }).readonly(),
+				})
+				.readonly();
+			const defaultFile = new File(['hello', 'world'], 'example.txt');
+
+			expect(
+				getResult(
+					coerceFormValue(schema).safeParse({
+						a: '',
+						b: '',
+						c: '',
+						d: '',
+						e: '',
+						f: '',
+						g: '',
+						h: '',
+						i: { value: '' },
+					}),
+				),
+			).toEqual({
+				success: false,
+				error: {
+					a: ['Required'],
+					b: ['Required'],
+					c: ['Required'],
+					d: ['Required'],
+					e: ['Required'],
+					f: ['Input not instance of File'],
+					'i.value': ['Required'],
+				},
+			});
+			expect(
+				getResult(
+					coerceFormValue(schema).safeParse({
+						a: 'hello world',
+						b: '42',
+						c: 'on',
+						d: '1970-01-01',
+						e: '0x1fffffffffffff',
+						f: defaultFile,
+						g: '',
+						h: '',
+						i: { value: '7' },
+					}),
+				),
+			).toEqual({
+				success: true,
+				data: {
+					a: 'hello world',
+					b: 42,
+					c: true,
+					d: new Date('1970-01-01'),
+					e: BigInt('0x1fffffffffffff'),
+					f: defaultFile,
+					g: undefined,
+					h: undefined,
+					i: { value: 7 },
+				},
+			});
+		});
+	});
+});

--- a/packages/conform-zod/v3/tests/constraint.test.ts
+++ b/packages/conform-zod/v3/tests/constraint.test.ts
@@ -200,6 +200,25 @@ describe('getZodConstraint', () => {
 		expect(() => getZodConstraint(z.array(z.string()))).toThrow();
 	});
 
+	test('readonly', () => {
+		const schema = z
+			.object({
+				text: z.string().min(1, 'min').max(100, 'max').readonly(),
+				number: z.number().min(1, 'min').readonly(),
+				optionalText: z.string().min(1, 'min').readonly().optional(),
+				nested: z.object({ value: z.string().min(1, 'min') }).readonly(),
+			})
+			.readonly();
+
+		expect(getZodConstraint(schema)).toEqual({
+			text: { required: true, minLength: 1, maxLength: 100 },
+			number: { required: true, min: 1 },
+			optionalText: { required: false, minLength: 1 },
+			nested: { required: true },
+			'nested.value': { required: true, minLength: 1 },
+		});
+	});
+
 	test('intersection', () => {
 		const schema = z.object({
 			text: z.string().min(10, 'min').max(100, 'max'),

--- a/packages/conform-zod/v4/coercion.ts
+++ b/packages/conform-zod/v4/coercion.ts
@@ -467,6 +467,11 @@ function coerceType(type: $ZodType, options: CoerceTypeOptions): $ZodType {
 			...def,
 			innerType: coerceType(def.innerType, options),
 		});
+	} else if (def.type === 'readonly') {
+		schema = new constr({
+			...def,
+			innerType: coerceType(def.innerType, options),
+		});
 	} else if (def.type === 'pipe') {
 		if (options.skipTransforms) {
 			schema = coerceType(def.in, options);

--- a/packages/conform-zod/v4/coercion.ts
+++ b/packages/conform-zod/v4/coercion.ts
@@ -234,7 +234,8 @@ function materializesMissingValue(type: $ZodType): boolean {
 		def.type === 'default' ||
 		def.type === 'prefault' ||
 		def.type === 'catch' ||
-		def.type === 'nullable'
+		def.type === 'nullable' ||
+		def.type === 'readonly'
 	) {
 		return materializesMissingValue(
 			(def as unknown as { innerType: $ZodType }).innerType,

--- a/packages/conform-zod/v4/constraint.ts
+++ b/packages/conform-zod/v4/constraint.ts
@@ -62,6 +62,8 @@ export function getZodConstraint(schema: $ZodType): Record<string, Constraint> {
 				updateConstraint(def.in, data, name);
 			}
 			updateConstraint(def.out, data, name);
+		} else if (def.type === 'readonly') {
+			updateConstraint(def.innerType, data, name);
 		} else if (def.type === 'intersection') {
 			const leftResult: Record<string, Constraint> = {};
 			const rightResult: Record<string, Constraint> = {};

--- a/packages/conform-zod/v4/tests/coercion/schema/readonly.test.ts
+++ b/packages/conform-zod/v4/tests/coercion/schema/readonly.test.ts
@@ -1,0 +1,157 @@
+import { describe, test, expect } from 'vitest';
+import { coerceFormValue } from '../../../coercion';
+import { z } from 'zod-v4';
+import {
+	object,
+	string,
+	number,
+	boolean,
+	date,
+	bigint,
+	file,
+	optional,
+	readonly,
+} from 'zod-v4/mini';
+import { getResult } from '../../../../tests/helpers/zod';
+
+describe('coercion', () => {
+	describe('z.readonly', () => {
+		test('should coerce values wrapped with readonly', () => {
+			const schema = z
+				.object({
+					a: z.string('Required').readonly(),
+					b: z.number('Required').readonly(),
+					c: z.boolean('Required').readonly(),
+					d: z.date('Required').readonly(),
+					e: z.bigint('Required').readonly(),
+					f: z.file('Required').readonly(),
+					g: z.string().optional().readonly(),
+					h: z.string().readonly().optional(),
+					i: z.object({ value: z.number('Required') }).readonly(),
+				})
+				.readonly();
+			const schemaWithMini = object({
+				a: readonly(string('Required')),
+				b: readonly(number('Required')),
+				c: readonly(boolean('Required')),
+				d: readonly(date('Required')),
+				e: readonly(bigint('Required')),
+				f: readonly(file('Required')),
+				g: readonly(optional(string())),
+				h: optional(readonly(string())),
+				i: readonly(object({ value: number('Required') })),
+			});
+			const defaultFile = new File(['hello', 'world'], 'example.txt');
+
+			expect(
+				getResult(
+					coerceFormValue(schema).safeParse({
+						a: '',
+						b: '',
+						c: '',
+						d: '',
+						e: '',
+						f: '',
+						g: '',
+						h: '',
+						i: { value: '' },
+					}),
+				),
+			).toEqual({
+				success: false,
+				error: {
+					a: ['Required'],
+					b: ['Required'],
+					c: ['Required'],
+					d: ['Required'],
+					e: ['Required'],
+					f: ['Required'],
+					'i.value': ['Required'],
+				},
+			});
+			expect(
+				getResult(
+					coerceFormValue(schemaWithMini).safeParse({
+						a: '',
+						b: '',
+						c: '',
+						d: '',
+						e: '',
+						f: '',
+						g: '',
+						h: '',
+						i: { value: '' },
+					}),
+				),
+			).toEqual({
+				success: false,
+				error: {
+					a: ['Required'],
+					b: ['Required'],
+					c: ['Required'],
+					d: ['Required'],
+					e: ['Required'],
+					f: ['Required'],
+					'i.value': ['Required'],
+				},
+			});
+
+			expect(
+				getResult(
+					coerceFormValue(schema).safeParse({
+						a: 'hello world',
+						b: '42',
+						c: 'on',
+						d: '1970-01-01',
+						e: '0x1fffffffffffff',
+						f: defaultFile,
+						g: '',
+						h: '',
+						i: { value: '7' },
+					}),
+				),
+			).toEqual({
+				success: true,
+				data: {
+					a: 'hello world',
+					b: 42,
+					c: true,
+					d: new Date('1970-01-01'),
+					e: BigInt('0x1fffffffffffff'),
+					f: defaultFile,
+					g: undefined,
+					h: undefined,
+					i: { value: 7 },
+				},
+			});
+			expect(
+				getResult(
+					coerceFormValue(schemaWithMini).safeParse({
+						a: 'hello world',
+						b: '42',
+						c: 'on',
+						d: '1970-01-01',
+						e: '0x1fffffffffffff',
+						f: defaultFile,
+						g: '',
+						h: '',
+						i: { value: '7' },
+					}),
+				),
+			).toEqual({
+				success: true,
+				data: {
+					a: 'hello world',
+					b: 42,
+					c: true,
+					d: new Date('1970-01-01'),
+					e: BigInt('0x1fffffffffffff'),
+					f: defaultFile,
+					g: undefined,
+					h: undefined,
+					i: { value: 7 },
+				},
+			});
+		});
+	});
+});

--- a/packages/conform-zod/v4/tests/coercion/schema/readonly.test.ts
+++ b/packages/conform-zod/v4/tests/coercion/schema/readonly.test.ts
@@ -9,6 +9,7 @@ import {
 	date,
 	bigint,
 	file,
+	array,
 	optional,
 	readonly,
 } from 'zod-v4/mini';
@@ -150,6 +151,32 @@ describe('coercion', () => {
 					g: undefined,
 					h: undefined,
 					i: { value: 7 },
+				},
+			});
+		});
+
+		test('should materialize missing collections wrapped with readonly', () => {
+			const schema = z.object({
+				list: z.array(z.string()).readonly(),
+				nested: z.object({ value: z.string().optional() }).readonly(),
+			});
+			const schemaWithMini = object({
+				list: readonly(array(string())),
+				nested: readonly(object({ value: optional(string()) })),
+			});
+
+			expect(getResult(coerceFormValue(schema).safeParse({}))).toEqual({
+				success: true,
+				data: {
+					list: [],
+					nested: {},
+				},
+			});
+			expect(getResult(coerceFormValue(schemaWithMini).safeParse({}))).toEqual({
+				success: true,
+				data: {
+					list: [],
+					nested: {},
 				},
 			});
 		});

--- a/packages/conform-zod/v4/tests/constraint.test.ts
+++ b/packages/conform-zod/v4/tests/constraint.test.ts
@@ -208,6 +208,25 @@ describe('getZodConstraint', () => {
 		expect(() => getZodConstraint(z.array(z.string()))).toThrow();
 	});
 
+	test('readonly', () => {
+		const schema = z
+			.object({
+				text: z.string().min(1, 'min').max(100, 'max').readonly(),
+				number: z.number().min(1, 'min').readonly(),
+				optionalText: z.string().min(1, 'min').readonly().optional(),
+				nested: z.object({ value: z.string().min(1, 'min') }).readonly(),
+			})
+			.readonly();
+
+		expect(getZodConstraint(schema)).toEqual({
+			text: { required: true, minLength: 1, maxLength: 100 },
+			number: { required: true, min: 1 },
+			optionalText: { required: false, minLength: 1 },
+			nested: { required: true },
+			'nested.value': { required: true, minLength: 1 },
+		});
+	});
+
 	test('intersection', () => {
 		const schema = z.object({
 			text: z.string().min(10, 'min').max(100, 'max'),


### PR DESCRIPTION
## Problem

Fields wrapped with [`z.readonly()`](https://zod.dev/api?id=readonly) are not handled by the Zod adapter. The `readonly` wrapper is treated as an opaque/unknown type, so:

1. **`coerceFormValue` skips coercion** for the inner type. A form value for `z.number().readonly()` arrives as a string and validation fails:

   ```ts
   const schema = coerceFormValue(z.object({ age: z.number().readonly() }));
   schema.safeParse({ age: '42' });
   // ✗ { code: 'invalid_type', expected: 'number', received: 'string', path: ['age'] }
   ```

   The same happens for a `z.object({ ... }).readonly()` field (the empty-object default and nested coercion are skipped).

2. **`getZodConstraint` drops the field's validation attributes**. A `z.string().min(5).readonly()` field loses its `minLength`:

   ```ts
   getZodConstraint(z.object({ name: z.string().min(5).readonly() }));
   // before: { name: { required: true } }   ← minLength missing
   ```

## Fix

`readonly` is a transparent wrapper, just like `nullable`, `catch`, and `brand`, which the adapter already unwraps. This PR unwraps it the same way in both `coerceFormValue` (rebuilding the wrapper around the coerced inner type) and `getZodConstraint` (recursing into `innerType`).

In the constraint walker the `readonly` branch is placed alongside the other transparent wrappers that run *before* the root-level guard, so a schema whose root is `z.object({ ... }).readonly()` is supported too.

Applied consistently across all three adapters: `default`, `/v3`, and `/v4` (both the chainable `.readonly()` and the `zod-mini` `readonly(...)` form).

## Tests

- New `coercion/schema/readonly.test.ts` for `default`, `v3`, and `v4` (mirrors the existing `brand.test.ts`), covering every primitive, nested objects, optional combinations, and (for v4) the `zod-mini` form.
- New `readonly` case in each `constraint.test.ts`, covering constraint derivation through readonly fields including a readonly root object and a readonly + optional combination.

All tests fail before the change and pass after. The full `@conform-to/zod` node test suite passes (`208 passed | 2 skipped`) with no type errors.

A changeset is included (`@conform-to/zod`, patch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

This PR teaches the Conform Zod adapters to treat `z.readonly()` as a transparent wrapper rather than an opaque schema.

- **Coercion:** adapters now detect `ZodReadonly`, recursively coerce its `innerType`, and then re-wrap with `readonly`.
- **Constraints:** `getZodConstraint` now derives constraint attributes from the wrapped `innerType` (so they aren’t dropped).
- **v4 missing-value behavior:** readonly participates in the existing “materialize missing values” logic (important for empty-object/empty-array coercion paths).
- **Adapter coverage:** implemented in **default**, **/v3**, and **/v4** (including `zod-mini` readonly forms).

Example of preserved constraints:
```ts
z.string().min(5).readonly() // keeps minLength constraint in generated constraints
```

Tests added across default/v3/v4 validate readonly coercion and constraint extraction for primitives, nested objects, readonly root objects, readonly/optional combinations, and constraint preservation (including `File`-instance handling where applicable). A changeset updates `@conform-to/zod`.

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->