### PR TITLE
feat: custom state

### DIFF
--- a/.changeset/custom-form-state.md
+++ b/.changeset/custom-form-state.md
@@ -1,0 +1,28 @@
+---
+'@conform-to/react': minor
+---
+
+Add custom form state to the future React APIs.
+
+Use `defineCustomState()` to derive state from form intents and submission results, register it through `configureForms()` or `useForm()`, and read the current value from `form.customState`:
+
+```tsx
+import { defineCustomState, useForm } from '@conform-to/react/future';
+
+const submitCount = defineCustomState({
+  initialize() {
+    return 0;
+  },
+  handleIntent(count, { intent }) {
+    return intent.type === 'submit' ? count + 1 : count;
+  },
+});
+
+const { form } = useForm({
+  customState: {
+    submitCount,
+  },
+});
+
+form.customState.submitCount;
+```

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ CHANGELOG.md
 
 # Vitest
 __screenshots__
+.vitest-attachments

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@
     - [useControl](./api/react/future/useControl.md)
     - [useIntent](./api/react/future/useIntent.md)
     - [defineIntent](./api/react/future/defineIntent.md)
+    - [defineCustomState](./api/react/future/defineCustomState.md)
     - [resolveSubmission](./api/react/future/resolveSubmission.md)
     - [parseSubmission](./api/react/future/parseSubmission.md)
     - [report](./api/react/future/report.md)

--- a/docs/api/react/future/configureForms.md
+++ b/docs/api/react/future/configureForms.md
@@ -54,6 +54,12 @@ Intent handlers available to every form created by this factory.
 
 Use this to add custom methods to [`useIntent`](./useIntent.md), the `intent` object returned by [`useForm`](./useForm.md), and the bound [`resolveSubmission`](./resolveSubmission.md) helper returned from this factory.
 
+### `customState?: Record<string, CustomStateHandler>`
+
+Custom state handlers available to every form created by this factory.
+
+Use [`defineCustomState`](./defineCustomState.md) to define custom state that can be read from `form.customState`.
+
 ### `shouldValidate?: 'onSubmit' | 'onBlur' | 'onInput'`
 
 Determines when validation should run for the first time on a field. Default is `onSubmit`.

--- a/docs/api/react/future/defineCustomState.md
+++ b/docs/api/react/future/defineCustomState.md
@@ -1,0 +1,166 @@
+# defineCustomState
+
+> The `defineCustomState` function is part of Conform's future export. These APIs are experimental and may change in minor versions. [Learn more](https://github.com/edmundhung/conform/discussions/954)
+
+`defineCustomState` lets you keep derived state alongside Conform's built-in form state. Register custom state through [`configureForms`](./configureForms.md) or [`useForm`](./useForm.md), then read it from `form.customState`.
+
+```ts
+import { defineCustomState } from '@conform-to/react/future';
+
+const submitCount = defineCustomState({
+  initialize() {
+    return 0;
+  },
+  handleIntent(count, { intent }) {
+    return intent.type === 'submit' ? count + 1 : count;
+  },
+});
+```
+
+## Parameters
+
+### `definition: CustomStateHandler`
+
+An object that describes how to initialize and update the custom state.
+
+### `definition.initialize({ reset, lastState })`
+
+Creates the initial state value. This method is required.
+
+`reset` is `true` when Conform is resetting the form state. `lastState` contains the previous value for this custom state key when one exists.
+
+```ts
+initialize({ reset, lastState }) {
+  if (reset && lastState) {
+    return lastState;
+  }
+
+  return 'idle';
+}
+```
+
+### `definition.handleIntent(state, ctx)`
+
+Updates state when Conform applies an intent. Use this for state derived from the intent itself, such as submit counts, timestamps, or the last attempted payload.
+
+`ctx` contains:
+
+- `intent`: The resolved intent.
+- `submission`: The parsed submission.
+
+### `definition.handleResult(state, ctx)`
+
+Updates state when Conform applies a validation or submission result. Use this for state derived from success, failure, or errors.
+
+`ctx` contains:
+
+- `intent`: The resolved intent.
+- `submission`: The parsed submission.
+- `error`: The result error. `undefined` means the result is not known yet, `null` means the result has no error, and an object means validation failed.
+- `phase`: Either `'client'` or `'server'`.
+
+`phase: 'client'` is used for client validation results, including async validation. `phase: 'server'` is used for server or application results, including `lastResult` and `onSubmit().update(...)`.
+
+## Returns
+
+The same custom state handler object, with the state and custom intent types wired into TypeScript.
+
+## Examples
+
+### Submit count
+
+Use `handleIntent` when the state should change because the user attempted an intent.
+
+```ts
+const submitCount = defineCustomState({
+  initialize() {
+    return 0;
+  },
+  handleIntent(count, { intent }) {
+    if (intent.type === 'submit') {
+      return count + 1;
+    }
+
+    return count;
+  },
+});
+```
+
+### Failed submit count
+
+Use `handleResult` when the state depends on the result.
+
+```ts
+const failedSubmitCount = defineCustomState({
+  initialize() {
+    return 0;
+  },
+  handleResult(count, { intent, error }) {
+    if (intent.type === 'submit' && error) {
+      return count + 1;
+    }
+
+    return count;
+  },
+});
+```
+
+### Submission status
+
+Use both methods when you want to record that an intent happened, then update based on the result.
+
+```ts
+const submissionStatus = defineCustomState<
+  'idle' | 'submitted' | 'success' | 'error'
+>({
+  initialize() {
+    return 'idle';
+  },
+  handleIntent(status, { intent }) {
+    if (intent.type === 'submit') {
+      return 'submitted';
+    }
+
+    return status;
+  },
+  handleResult(status, { intent, error, phase }) {
+    if (intent.type !== 'submit') {
+      return status;
+    }
+
+    if (error) {
+      return 'error';
+    }
+
+    if (phase === 'server' && error === null) {
+      return 'success';
+    }
+
+    return status;
+  },
+});
+```
+
+## Registering Custom State
+
+Register custom state globally with [`configureForms`](./configureForms.md):
+
+```ts
+const forms = configureForms({
+  customState: {
+    submitCount,
+  },
+});
+```
+
+Or register it for one form with [`useForm`](./useForm.md):
+
+```tsx
+const { form } = useForm({
+  customState: {
+    submitCount,
+  },
+});
+
+form.customState.submitCount;
+```

--- a/docs/api/react/future/defineCustomState.md
+++ b/docs/api/react/future/defineCustomState.md
@@ -2,7 +2,7 @@
 
 > The `defineCustomState` function is part of Conform's future export. These APIs are experimental and may change in minor versions. [Learn more](https://github.com/edmundhung/conform/discussions/954)
 
-`defineCustomState` lets you keep derived state alongside Conform's built-in form state. Register custom state through [`configureForms`](./configureForms.md) or [`useForm`](./useForm.md), then read it from `form.customState`.
+`defineCustomState` lets you add application-specific state to a form. Register the handler with [`configureForms`](./configureForms.md) or [`useForm`](./useForm.md), then read its value from `form.customState`.
 
 ```ts
 import { defineCustomState } from '@conform-to/react/future';
@@ -17,51 +17,64 @@ const submitCount = defineCustomState({
 });
 ```
 
+Custom state is updated as part of the same transition as Conform's built-in state. Use it for form-specific information that Conform does not model directly, such as submission counters, workflow state, or application-specific status.
+
 ## Parameters
 
 ### `definition: CustomStateHandler`
 
-An object that describes how to initialize and update the custom state.
+An object that defines the initial value and how it changes in response to form transitions.
 
 ### `definition.initialize()`
 
-Creates the initial state value. This method is required. It runs when the custom-state slice is first created and again on reset when `reset` is not defined.
+Returns the initial state value. This method is required, and its return value is used to infer the state type.
 
-### `definition.reset: boolean`
+Conform calls `initialize()` when the state is first created. It also calls it again on reset unless `reset` is `false` or a callback.
 
-Controls whether Conform resets the custom state. When omitted or `true`, Conform calls `initialize()` again. Set it to `false` to preserve the current state.
+### `definition.reset: boolean | ((state, ctx) => State)`
+
+Controls what happens to the custom state when the form resets:
+
+- When omitted or `true`, Conform calls `initialize()` again.
+- When `false`, Conform preserves the current state.
+- When a callback is provided, its return value becomes the next state.
+
+The callback receives the current state and a context object with the following property:
+
+- `result`: The `SubmissionResult` that requested the reset. It will be `undefined` when the form resets via the `key` option passed to `useForm`.
 
 ### `definition.handleIntent(state, ctx)`
 
-Updates state when Conform applies an intent. Use this for state derived from the intent itself, such as submit counts, timestamps, or the last attempted payload.
+Updates the state in response to an intent. Use this when the attempted action matters regardless of its validation result, such as counting submit attempts.
 
-`ctx` contains:
+The context contains:
 
 - `intent`: The resolved intent.
-- `submission`: The parsed submission.
+- `submission`: The parsed submission associated with the intent.
 
 ### `definition.handleResult(state, ctx)`
 
-Updates state when Conform applies a validation or submission result with an explicit outcome. Use this for state derived from success, failure, or errors.
+Updates the state when a form transition sets `result.error` to either an error object or `null`. Use this when the next state depends on whether validation or submission succeeded or failed.
 
-`ctx` contains:
+The context contains:
 
 - `intent`: The resolved intent.
-- `submission`: The parsed submission.
-- `error`: The result error. `null` means the result has no error, and an object means validation failed.
-- `phase`: Either `'client'` or `'server'`.
+- `result`: The `SubmissionResult`, including its parsed submission, target value, and error.
+- `phase`: The source of the result, either `'client'` or `'server'`.
 
-`phase: 'client'` is used for client validation results, including async validation. `phase: 'server'` is used for server or application results, including `lastResult` and `onSubmit().update(...)`.
+`result.error` is `null` when the result has no error and an object when validation failed.
+
+The `'client'` phase covers synchronous and asynchronous client validation. The `'server'` phase covers results supplied through `lastResult` or `ctx.update(...)` inside `onSubmit`.
 
 ## Returns
 
-The same custom state handler object, with the state and custom intent types wired into TypeScript.
+Returns the definition unchanged. `defineCustomState` provides type checking and inference for the state value and handler arguments.
 
 ## Examples
 
 ### Submit count
 
-Use `handleIntent` when the state should change because the user attempted an intent.
+Use `handleIntent` to count every submit attempt.
 
 ```ts
 const submitCount = defineCustomState({
@@ -69,26 +82,22 @@ const submitCount = defineCustomState({
     return 0;
   },
   handleIntent(count, { intent }) {
-    if (intent.type === 'submit') {
-      return count + 1;
-    }
-
-    return count;
+    return intent.type === 'submit' ? count + 1 : count;
   },
 });
 ```
 
 ### Failed submit count
 
-Use `handleResult` when the state depends on the result.
+Use `handleResult` when the state depends on the validation result.
 
 ```ts
 const failedSubmitCount = defineCustomState({
   initialize() {
     return 0;
   },
-  handleResult(count, { intent, error }) {
-    if (intent.type === 'submit' && error) {
+  handleResult(count, { intent, result }) {
+    if (intent.type === 'submit' && result.error) {
       return count + 1;
     }
 
@@ -99,32 +108,30 @@ const failedSubmitCount = defineCustomState({
 
 ### Submission status
 
-Use both methods when you want to record that an intent happened, then update based on the result.
+Track the status of the latest submission. The state starts as `undefined`, changes to `'error'` when validation fails, and changes to `'success'` only if the server result is successful. Use the `reset` callback to handle responses that also reset the form, such as a create form that clears its fields after adding an entry.
 
 ```ts
-const submissionStatus = defineCustomState<
-  'idle' | 'submitted' | 'success' | 'error'
->({
+const submissionStatus = defineCustomState<'success' | 'error' | undefined>({
   initialize() {
-    return 'idle';
+    return undefined;
   },
-  handleIntent(status, { intent }) {
-    if (intent.type === 'submit') {
-      return 'submitted';
+  reset(_, { result }) {
+    if (typeof result?.error === 'undefined') {
+      return undefined;
     }
 
-    return status;
+    return result.error ? 'error' : 'success';
   },
-  handleResult(status, { intent, error, phase }) {
+  handleResult(status, { intent, result, phase }) {
     if (intent.type !== 'submit') {
       return status;
     }
 
-    if (error) {
+    if (result.error) {
       return 'error';
     }
 
-    if (phase === 'server' && error === null) {
+    if (phase === 'server') {
       return 'success';
     }
 
@@ -133,26 +140,36 @@ const submissionStatus = defineCustomState<
 });
 ```
 
-## Registering Custom State
+## Tips
 
-Register custom state globally with [`configureForms`](./configureForms.md):
+### Registering custom state
 
-```ts
-const forms = configureForms({
-  customState: {
-    submitCount,
-  },
-});
-```
-
-Or register it for one form with [`useForm`](./useForm.md):
+Register a handler with `configureForms` to make it available to every form created by that factory:
 
 ```tsx
-const { form } = useForm({
+const { useForm } = configureForms({
   customState: {
     submitCount,
   },
 });
 
-form.customState.submitCount;
+function Example() {
+  const { form } = useForm();
+
+  return <output>{form.customState.submitCount}</output>;
+}
+```
+
+Alternatively, register a handler for a single form with `useForm`:
+
+```tsx
+function Example() {
+  const { form } = useForm({
+    customState: {
+      submitCount,
+    },
+  });
+
+  return <output>{form.customState.submitCount}</output>;
+}
 ```

--- a/docs/api/react/future/defineCustomState.md
+++ b/docs/api/react/future/defineCustomState.md
@@ -23,21 +23,13 @@ const submitCount = defineCustomState({
 
 An object that describes how to initialize and update the custom state.
 
-### `definition.initialize({ reset, lastState })`
+### `definition.initialize()`
 
-Creates the initial state value. This method is required.
+Creates the initial state value. This method is required. It runs when the custom-state slice is first created and again on reset when `reset` is not defined.
 
-`reset` is `true` when Conform is resetting the form state. `lastState` contains the previous value for this custom state key when one exists.
+### `definition.reset: boolean`
 
-```ts
-initialize({ reset, lastState }) {
-  if (reset && lastState) {
-    return lastState;
-  }
-
-  return 'idle';
-}
-```
+Controls whether Conform resets the custom state. When omitted or `true`, Conform calls `initialize()` again. Set it to `false` to preserve the current state.
 
 ### `definition.handleIntent(state, ctx)`
 
@@ -50,13 +42,13 @@ Updates state when Conform applies an intent. Use this for state derived from th
 
 ### `definition.handleResult(state, ctx)`
 
-Updates state when Conform applies a validation or submission result. Use this for state derived from success, failure, or errors.
+Updates state when Conform applies a validation or submission result with an explicit outcome. Use this for state derived from success, failure, or errors.
 
 `ctx` contains:
 
 - `intent`: The resolved intent.
 - `submission`: The parsed submission.
-- `error`: The result error. `undefined` means the result is not known yet, `null` means the result has no error, and an object means validation failed.
+- `error`: The result error. `null` means the result has no error, and an object means validation failed.
 - `phase`: Either `'client'` or `'server'`.
 
 `phase: 'client'` is used for client validation results, including async validation. `phase: 'server'` is used for server or application results, including `lastResult` and `onSubmit().update(...)`.

--- a/docs/api/react/future/defineIntent.md
+++ b/docs/api/react/future/defineIntent.md
@@ -56,7 +56,7 @@ If you omit `move`, Conform falls back to invalidating the affected state under 
 
 ## Returns
 
-The same intent handler object, with the dispatcher arguments and payload wired into TypeScript.
+Returns the definition unchanged. `defineIntent` provides type checking for the dispatcher arguments, parsed payload, and handler arguments.
 
 ## Example
 

--- a/docs/api/react/future/useForm.md
+++ b/docs/api/react/future/useForm.md
@@ -57,6 +57,12 @@ Custom intent handlers available only to this form instance.
 
 Use this when you want to add custom methods to the returned `intent` dispatcher without making them global through [`configureForms`](./configureForms.md).
 
+### `customState?: Record<string, CustomStateHandler>`
+
+Custom state handlers available only to this form instance.
+
+Use [`defineCustomState`](./defineCustomState.md) to define custom state that can be read from `form.customState`.
+
 ### `constraint?: Record<string, ValidationAttributes>`
 
 HTML validation attributes for fields (`required`, `minLength`, `pattern`, etc.).

--- a/docs/api/react/future/useForm.md
+++ b/docs/api/react/future/useForm.md
@@ -63,6 +63,8 @@ Custom state handlers available only to this form instance.
 
 Use [`defineCustomState`](./defineCustomState.md) to define custom state that can be read from `form.customState`.
 
+The handler map is captured when the form mounts and does not change when the form is reset.
+
 ### `constraint?: Record<string, ValidationAttributes>`
 
 HTML validation attributes for fields (`required`, `minLength`, `pattern`, etc.).

--- a/docs/api/react/future/useFormMetadata.md
+++ b/docs/api/react/future/useFormMetadata.md
@@ -62,6 +62,10 @@ Object containing validation errors for all touched fields.
 
 Initial form values.
 
+### `customState: Record<string, unknown>`
+
+Current custom state registered through [`configureForms`](./configureForms.md) or [`useForm`](./useForm.md). Define custom state with [`defineCustomState`](./defineCustomState.md).
+
 ### `props: FormProps`
 
 Form props object for spreading onto the `<form>` element:

--- a/guide/app/layout.tsx
+++ b/guide/app/layout.tsx
@@ -72,6 +72,10 @@ const menus: { [code: string]: Menu[] } = {
 				},
 				{ title: 'defineIntent', to: '/api/react/future/defineIntent' },
 				{
+					title: 'defineCustomState',
+					to: '/api/react/future/defineCustomState',
+				},
+				{
 					title: 'resolveSubmission',
 					to: '/api/react/future/resolveSubmission',
 				},

--- a/packages/conform-react/future/forms.tsx
+++ b/packages/conform-react/future/forms.tsx
@@ -5,7 +5,7 @@ import {
 	defaultSerialize,
 	FormValue,
 } from '@conform-to/dom/future';
-import { useContext, useMemo, useId, createContext } from 'react';
+import { useContext, useMemo, useId, useState, createContext } from 'react';
 import {
 	focusFirstInvalidField,
 	createIntentDispatcher,
@@ -376,10 +376,8 @@ export function configureForms<
 			() => resolveSerialize(options.serialize, globalSerialize),
 			[options.serialize],
 		);
-		const customStateHandlers = useMemo(
-			() =>
-				mergeCustomStateHandlers(globalConfig.customState, options.customState),
-			[options.customState],
+		const [customStateHandlers] = useState(() =>
+			mergeCustomStateHandlers(globalConfig.customState, options.customState),
 		);
 		const fallbackId = useId();
 		const formId = options.id ?? `form-${fallbackId}`;

--- a/packages/conform-react/future/forms.tsx
+++ b/packages/conform-react/future/forms.tsx
@@ -13,8 +13,14 @@ import {
 } from './dom';
 import { useLatest, useConform } from './hooks';
 import { StandardSchemaV1 } from './standard-schema';
-import { isTouched, getFieldset, getField, getFormMetadata } from './state';
 import {
+	isTouched,
+	getFieldset,
+	getField,
+	getFormMetadata,
+	mergeCustomStateHandlers,
+} from './state';
+import type {
 	FormRef,
 	FormsConfig,
 	FormContext,
@@ -22,6 +28,7 @@ import {
 	FormOptions,
 	FieldMetadata,
 	FormHandle,
+	FormCustomState,
 	InferOutput,
 	InferFormShape,
 	DefaultIntentHandlers,
@@ -30,6 +37,7 @@ import {
 	RequireKey,
 	ValidateResult,
 	FormIntent,
+	CustomStateHandler,
 } from './types';
 import {
 	isStandardSchemaV1,
@@ -50,7 +58,11 @@ export function configureForms<
 	SchemaErrorShape = string[],
 	CustomFormMetadata extends Record<string, unknown> = {},
 	CustomFieldMetadata extends Record<string, unknown> = {},
-	CustomIntentHandlers extends Record<string, IntentHandler<any, any>> = {},
+	GlobalIntentHandlers extends Record<string, IntentHandler<any, any>> = {},
+	GlobalCustomStateHandlers extends Record<
+		string,
+		CustomStateHandler<any, any, BaseErrorShape>
+	> = {},
 >(
 	config: Partial<
 		FormsConfig<
@@ -59,7 +71,8 @@ export function configureForms<
 			SchemaErrorShape,
 			CustomFormMetadata,
 			CustomFieldMetadata,
-			CustomIntentHandlers
+			GlobalIntentHandlers,
+			GlobalCustomStateHandlers
 		>
 	> = {},
 ) {
@@ -81,10 +94,12 @@ export function configureForms<
 		SchemaErrorShape,
 		CustomFormMetadata,
 		CustomFieldMetadata,
-		CustomIntentHandlers
+		GlobalIntentHandlers,
+		GlobalCustomStateHandlers
 	> = {
 		...config,
 		intents: config.intents,
+		customState: config.customState,
 		intentName: config.intentName ?? DEFAULT_INTENT_NAME,
 		shouldValidate: config.shouldValidate ?? 'onSubmit',
 		shouldRevalidate:
@@ -99,21 +114,27 @@ export function configureForms<
 			SchemaErrorShape,
 			CustomFormMetadata,
 			CustomFieldMetadata,
-			CustomIntentHandlers
+			GlobalIntentHandlers,
+			GlobalCustomStateHandlers
 		>['validateSchema'],
 	};
 
 	/**
 	 * React context
 	 */
-	const ReactFormContext = createContext<FormContext<BaseErrorShape>[]>([]);
+	const ReactFormContext = createContext<
+		FormContext<BaseErrorShape, FormCustomState<GlobalCustomStateHandlers>>[]
+	>([]);
 
 	/**
 	 * Provides form context to child components.
 	 * Stacks contexts to support nested forms, with latest context taking priority.
 	 */
 	function FormProvider(props: {
-		context: FormContext<BaseErrorShape>;
+		context: FormContext<
+			BaseErrorShape,
+			FormCustomState<GlobalCustomStateHandlers>
+		>;
 		children: React.ReactNode;
 	}): React.ReactElement {
 		const stack = useContext(ReactFormContext);
@@ -130,7 +151,9 @@ export function configureForms<
 		);
 	}
 
-	function useFormContext(formId?: string): FormContext<BaseErrorShape> {
+	function useFormContext(
+		formId?: string,
+	): FormContext<BaseErrorShape, FormCustomState<GlobalCustomStateHandlers>> {
 		const contexts = useContext(ReactFormContext);
 		const context = formId
 			? contexts.find((context) => formId === context.formId)
@@ -197,7 +220,11 @@ export function configureForms<
 		Schema extends BaseSchema,
 		ErrorShape extends BaseErrorShape,
 		Value = InferOutput<Schema>,
-		IntentHandlers extends Record<string, IntentHandler<any, any>> = {},
+		CustomIntentHandlers extends Record<string, IntentHandler<any, any>> = {},
+		CustomStateHandlers extends Record<
+			string,
+			CustomStateHandler<any, any, ErrorShape>
+		> = {},
 	>(
 		schema: Schema,
 		options: RequireKey<
@@ -207,8 +234,9 @@ export function configureForms<
 				Value,
 				Schema,
 				SchemaErrorShape,
-				IntentHandlers,
-				CustomIntentHandlers
+				CustomIntentHandlers,
+				GlobalIntentHandlers,
+				CustomStateHandlers
 			>,
 			'onValidate'
 		>,
@@ -217,7 +245,8 @@ export function configureForms<
 		ErrorShape,
 		CustomFormMetadata,
 		CustomFieldMetadata,
-		CustomIntentHandlers & IntentHandlers
+		GlobalIntentHandlers & CustomIntentHandlers,
+		FormCustomState<GlobalCustomStateHandlers & CustomStateHandlers>
 	>;
 	function useForm<
 		Schema extends BaseSchema,
@@ -225,7 +254,11 @@ export function configureForms<
 			? SchemaErrorShape
 			: BaseErrorShape,
 		Value = InferOutput<Schema>,
-		IntentHandlers extends Record<string, IntentHandler<any, any>> = {},
+		CustomIntentHandlers extends Record<string, IntentHandler<any, any>> = {},
+		CustomStateHandlers extends Record<
+			string,
+			CustomStateHandler<any, any, ErrorShape>
+		> = {},
 	>(
 		schema: Schema,
 		options: RequireKey<
@@ -235,8 +268,9 @@ export function configureForms<
 				Value,
 				Schema,
 				SchemaErrorShape,
-				IntentHandlers,
-				CustomIntentHandlers
+				CustomIntentHandlers,
+				GlobalIntentHandlers,
+				CustomStateHandlers
 			>,
 			SchemaErrorShape extends BaseErrorShape ? never : 'onValidate'
 		>,
@@ -245,13 +279,18 @@ export function configureForms<
 		ErrorShape,
 		CustomFormMetadata,
 		CustomFieldMetadata,
-		CustomIntentHandlers & IntentHandlers
+		GlobalIntentHandlers & CustomIntentHandlers,
+		FormCustomState<GlobalCustomStateHandlers & CustomStateHandlers>
 	>;
 	function useForm<
 		FormShape extends Record<string, any> = Record<string, any>,
 		ErrorShape extends BaseErrorShape = BaseErrorShape,
 		Value = undefined,
-		IntentHandlers extends Record<string, IntentHandler<any, any>> = {},
+		CustomIntentHandlers extends Record<string, IntentHandler<any, any>> = {},
+		CustomStateHandlers extends Record<
+			string,
+			CustomStateHandler<any, any, ErrorShape>
+		> = {},
 	>(
 		options: RequireKey<
 			FormOptions<
@@ -260,8 +299,9 @@ export function configureForms<
 				Value,
 				undefined,
 				SchemaErrorShape,
-				IntentHandlers,
-				CustomIntentHandlers
+				CustomIntentHandlers,
+				GlobalIntentHandlers,
+				CustomStateHandlers
 			>,
 			'onValidate'
 		>,
@@ -270,7 +310,8 @@ export function configureForms<
 		ErrorShape,
 		CustomFormMetadata,
 		CustomFieldMetadata,
-		CustomIntentHandlers & IntentHandlers
+		GlobalIntentHandlers & CustomIntentHandlers,
+		FormCustomState<GlobalCustomStateHandlers & CustomStateHandlers>
 	>;
 	function useForm<
 		FormShape extends Record<string, any> = Record<string, any>,
@@ -279,18 +320,46 @@ export function configureForms<
 	>(
 		schemaOrOptions:
 			| BaseSchema
-			| FormOptions<FormShape, ErrorShape, Value, undefined, any, any>,
-		maybeOptions?: FormOptions<any, ErrorShape, Value, undefined, any, any>,
+			| FormOptions<
+					FormShape,
+					ErrorShape,
+					Value,
+					undefined,
+					any,
+					any,
+					any,
+					any
+			  >,
+		maybeOptions?: FormOptions<
+			any,
+			ErrorShape,
+			Value,
+			undefined,
+			any,
+			any,
+			any,
+			any
+		>,
 	): FormHandle<
 		Record<string, any>,
 		ErrorShape,
 		CustomFormMetadata,
 		CustomFieldMetadata,
-		Record<string, IntentHandler>
+		Record<string, IntentHandler>,
+		Record<string, unknown>
 	> {
 		// implementation signature is broader than the public overloads above
 		let schema: BaseSchema | undefined;
-		let options: FormOptions<any, ErrorShape, Value, undefined, any, any>;
+		let options: FormOptions<
+			any,
+			ErrorShape,
+			Value,
+			undefined,
+			any,
+			any,
+			any,
+			any
+		>;
 
 		if (globalConfig.isSchema(schemaOrOptions)) {
 			schema = schemaOrOptions;
@@ -307,6 +376,11 @@ export function configureForms<
 			() => resolveSerialize(options.serialize, globalSerialize),
 			[options.serialize],
 		);
+		const customStateHandlers = useMemo(
+			() =>
+				mergeCustomStateHandlers(globalConfig.customState, options.customState),
+			[options.customState],
+		);
 		const fallbackId = useId();
 		const formId = options.id ?? `form-${fallbackId}`;
 		const [state, handleSubmit] = useConform<
@@ -314,13 +388,15 @@ export function configureForms<
 			ErrorShape,
 			Value,
 			any,
-			SchemaErrorShape
+			SchemaErrorShape,
+			GlobalCustomStateHandlers
 		>(formId, {
 			...options,
 			intentHandlers: mergeIntentHandlers(
 				globalIntentHandlers,
 				options.intents,
 			),
+			customStateHandlers,
 			serialize,
 			intentName: globalConfig.intentName,
 			onError: options.onError ?? focusFirstInvalidField,
@@ -361,14 +437,30 @@ export function configureForms<
 						options.onValidate(ctx as any),
 					);
 
-					if (validateResult.syncResult) {
-						validateResult.syncResult.value ??= schemaValue;
+					if (
+						validateResult.syncResult &&
+						typeof schemaValue !== 'undefined' &&
+						typeof validateResult.syncResult.value === 'undefined'
+					) {
+						validateResult.syncResult = {
+							...validateResult.syncResult,
+							value: schemaValue,
+						};
 					}
 
 					if (validateResult.asyncResult) {
 						validateResult.asyncResult = validateResult.asyncResult.then(
 							(result) => {
-								result.value ??= schemaValue;
+								if (
+									typeof schemaValue !== 'undefined' &&
+									typeof result.value === 'undefined'
+								) {
+									return {
+										...result,
+										value: schemaValue,
+									};
+								}
+
 								return result;
 							},
 						);
@@ -387,8 +479,10 @@ export function configureForms<
 				);
 			},
 		});
-		const intent = useIntent<FormShape, CustomIntentHandlers>(formId);
-		const context = useMemo<FormContext<ErrorShape>>(
+		const intent = useIntent<FormShape, GlobalIntentHandlers>(formId);
+		const context = useMemo<
+			FormContext<ErrorShape, FormCustomState<GlobalCustomStateHandlers>>
+		>(
 			() => ({
 				formId,
 				state,
@@ -520,7 +614,12 @@ export function configureForms<
 		options: {
 			formId?: string;
 		} = {},
-	): FormMetadata<BaseErrorShape, CustomFormMetadata, CustomFieldMetadata> {
+	): FormMetadata<
+		BaseErrorShape,
+		CustomFormMetadata,
+		CustomFieldMetadata,
+		FormCustomState<GlobalCustomStateHandlers>
+	> {
 		const context = useFormContext(options.formId);
 		const formMetadata = useMemo(
 			() =>
@@ -534,7 +633,8 @@ export function configureForms<
 		return formMetadata as FormMetadata<
 			BaseErrorShape,
 			CustomFormMetadata,
-			CustomFieldMetadata
+			CustomFieldMetadata,
+			FormCustomState<GlobalCustomStateHandlers>
 		>;
 	}
 
@@ -607,7 +707,7 @@ export function configureForms<
 		formRef: FormRef,
 	): IntentDispatcher<
 		Record<string, any>,
-		DefaultIntentHandlers & CustomIntentHandlers
+		DefaultIntentHandlers & GlobalIntentHandlers
 	>;
 	function useIntent<
 		IntentHandlers extends Record<string, IntentHandler<any, any>>,
@@ -615,11 +715,11 @@ export function configureForms<
 		formRef: FormRef,
 	): IntentDispatcher<
 		Record<string, any>,
-		DefaultIntentHandlers & CustomIntentHandlers & IntentHandlers
+		DefaultIntentHandlers & GlobalIntentHandlers & IntentHandlers
 	>;
 	function useIntent<FormShape extends Record<string, any>>(
 		formRef: FormRef,
-	): IntentDispatcher<FormShape, DefaultIntentHandlers & CustomIntentHandlers>;
+	): IntentDispatcher<FormShape, DefaultIntentHandlers & GlobalIntentHandlers>;
 	function useIntent<
 		FormShape extends Record<string, any>,
 		IntentHandlers extends Record<string, IntentHandler<any, any>>,
@@ -627,7 +727,7 @@ export function configureForms<
 		formRef: FormRef,
 	): IntentDispatcher<
 		FormShape,
-		DefaultIntentHandlers & CustomIntentHandlers & IntentHandlers
+		DefaultIntentHandlers & GlobalIntentHandlers & IntentHandlers
 	>;
 	function useIntent(formRef: FormRef) {
 		return useMemo(
@@ -655,7 +755,7 @@ export function configureForms<
 		intent:
 			| FormIntent<
 					Record<string, any>,
-					DefaultIntentHandlers & CustomIntentHandlers & IntentHandlers
+					DefaultIntentHandlers & GlobalIntentHandlers & IntentHandlers
 			  >
 			| { type: 'submit'; payload: undefined }
 			| undefined;

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -49,6 +49,8 @@ import type {
 	CustomControlOptions,
 	ControlOptions,
 	IntentHandler,
+	FormCustomState,
+	CustomStateHandler,
 } from './types';
 import { parseIntent, resolveIntent, applyIntent } from './intent';
 import {
@@ -168,6 +170,10 @@ export function useConform<
 	Value = undefined,
 	SchemaValue = undefined,
 	SchemaErrorShape = unknown,
+	CustomStateHandlers extends Record<
+		string,
+		CustomStateHandler<any, any, ErrorShape>
+	> = {},
 >(
 	formRef: FormRef,
 	options: {
@@ -176,6 +182,7 @@ export function useConform<
 		serialize: Serialize;
 		intentName: string;
 		intentHandlers: Record<string, IntentHandler<any, any>>;
+		customStateHandlers?: CustomStateHandlers | undefined;
 		lastResult?: SubmissionResult<NoInfer<ErrorShape>> | null | undefined;
 		onValidate?:
 			| ValidateHandler<ErrorShape, Value, SchemaValue, SchemaErrorShape>
@@ -185,11 +192,17 @@ export function useConform<
 			| SubmitHandler<FormShape, NoInfer<ErrorShape>, NoInfer<Value>>
 			| undefined;
 	},
-): [FormState<ErrorShape>, (event: React.FormEvent<HTMLFormElement>) => void] {
+): [
+	FormState<ErrorShape, FormCustomState<CustomStateHandlers>>,
+	(event: React.FormEvent<HTMLFormElement>) => void,
+] {
 	const { lastResult } = options;
-	const [state, setState] = useState<FormState<ErrorShape>>(() => {
-		let state = initializeState<ErrorShape>({
+	const [state, setState] = useState<
+		FormState<ErrorShape, FormCustomState<CustomStateHandlers>>
+	>(() => {
+		let state = initializeState<ErrorShape, CustomStateHandlers>({
 			defaultValue: options.defaultValue,
+			customStateHandlers: options.customStateHandlers,
 			resetKey: INITIAL_KEY,
 		});
 
@@ -197,24 +210,31 @@ export function useConform<
 			const intent = parseIntent(lastResult.submission.intent, {
 				handlers: options.intentHandlers,
 			});
-			const result = applyIntent(lastResult, intent, {
-				handlers: options.intentHandlers,
-			});
 
-			state = updateState(state, {
-				...result,
-				type: 'initialize',
-				intent,
-				ctx: {
+			if (intent) {
+				const result = applyIntent(lastResult, intent, {
 					handlers: options.intentHandlers,
-					status: getApplyStatus(lastResult.targetValue, result.targetValue),
-					reset: (defaultValue) =>
-						initializeState<ErrorShape>({
-							defaultValue: defaultValue ?? options.defaultValue,
-							resetKey: INITIAL_KEY,
-						}),
-				},
-			});
+				});
+
+				state = updateState(state, {
+					...result,
+					type: 'initialize',
+					intent,
+					ctx: {
+						handlers: options.intentHandlers,
+						status: getApplyStatus(lastResult.targetValue, result.targetValue),
+						customStateHandlers: options.customStateHandlers,
+						reset: (defaultValue) =>
+							initializeState<ErrorShape, CustomStateHandlers>({
+								defaultValue: defaultValue ?? options.defaultValue,
+								resetKey: INITIAL_KEY,
+								reset: true,
+								customStateHandlers: options.customStateHandlers,
+								lastCustomState: state.customState,
+							}),
+					},
+				});
+			}
 		}
 
 		return state;
@@ -244,6 +264,13 @@ export function useConform<
 			const intent = parseIntent(result.submission.intent, {
 				handlers: options.intentHandlers,
 			});
+
+			if (!intent) {
+				throw new Error(
+					`Unknown intent found in the submission result; Received intent: ${result.submission.intent}`,
+				);
+			}
+
 			const finalResult = applyIntent(normalizedResult, intent, {
 				handlers: options.intentHandlers,
 			});
@@ -256,8 +283,8 @@ export function useConform<
 				dispatchInternalUpdateEvent(formElement);
 			}
 
-			setState((state) =>
-				updateState(state, {
+			setState((current) => {
+				const action = {
 					...finalResult,
 					type,
 					intent,
@@ -267,14 +294,20 @@ export function useConform<
 							normalizedResult.targetValue,
 							finalResult.targetValue,
 						),
-						reset(defaultValue) {
-							return initializeState<ErrorShape>({
+						customStateHandlers: options.customStateHandlers,
+						reset(defaultValue: Record<string, unknown> | null | undefined) {
+							return initializeState<ErrorShape, CustomStateHandlers>({
 								defaultValue: defaultValue ?? options.defaultValue,
+								reset: true,
+								customStateHandlers: options.customStateHandlers,
+								lastCustomState: current.customState,
 							});
 						},
 					},
-				}),
-			);
+				};
+
+				return updateState(current, action);
+			});
 
 			// TODO: move on error handler to a new effect
 			if (formElement && finalResult.error) {
@@ -299,8 +332,10 @@ export function useConform<
 		}
 
 		setState(
-			initializeState<ErrorShape>({
+			initializeState<ErrorShape, CustomStateHandlers>({
 				defaultValue: options.defaultValue,
+				customStateHandlers: options.customStateHandlers,
+				reset: true,
 			}),
 		);
 	} else if (lastResult && lastResult !== lastResultRef.current) {

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -228,7 +228,6 @@ export function useConform<
 							initializeState<ErrorShape, CustomStateHandlers>({
 								defaultValue: defaultValue ?? options.defaultValue,
 								resetKey: INITIAL_KEY,
-								reset: true,
 								customStateHandlers: options.customStateHandlers,
 								lastCustomState: state.customState,
 							}),
@@ -302,7 +301,6 @@ export function useConform<
 						reset(defaultValue: Record<string, unknown> | null | undefined) {
 							return initializeState<ErrorShape, CustomStateHandlers>({
 								defaultValue: defaultValue ?? options.defaultValue,
-								reset: true,
 								customStateHandlers: options.customStateHandlers,
 								lastCustomState: current.customState,
 							});
@@ -335,11 +333,11 @@ export function useConform<
 			dispatchInternalUpdateEvent(formElement);
 		}
 
-		setState(
+		setState((current) =>
 			initializeState<ErrorShape, CustomStateHandlers>({
 				defaultValue: options.defaultValue,
 				customStateHandlers: options.customStateHandlers,
-				reset: true,
+				lastCustomState: current.customState,
 			}),
 		);
 	} else if (lastResult && lastResult !== lastResultRef.current) {

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -251,7 +251,7 @@ export function useConform<
 	const abortControllerRef = useRef<AbortController | null>(null);
 	const handleSubmission = useCallback(
 		(
-			type: 'server' | 'client',
+			type: 'server' | 'client' | 'client:async',
 			result: SubmissionResult<ErrorShape>,
 			options = optionsRef.current,
 		) => {
@@ -271,13 +271,17 @@ export function useConform<
 				);
 			}
 
-			const finalResult = applyIntent(normalizedResult, intent, {
-				handlers: options.intentHandlers,
-			});
 			const formElement = getFormElement(formRef);
+			const finalResult =
+				type === 'client'
+					? applyIntent(normalizedResult, intent, {
+							handlers: options.intentHandlers,
+						})
+					: normalizedResult;
 
 			if (
 				formElement &&
+				type === 'client' &&
 				(finalResult.reset || typeof finalResult.targetValue !== 'undefined')
 			) {
 				dispatchInternalUpdateEvent(formElement);
@@ -475,7 +479,7 @@ export function useConform<
 						if (!abortController.signal.aborted) {
 							submissionResult.error = error;
 
-							handleSubmission('server', submissionResult);
+							handleSubmission('client:async', submissionResult);
 
 							// If the form is meant to be submitted and there is no error
 							if (

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -217,20 +217,22 @@ export function useConform<
 				});
 
 				state = updateState(state, {
-					...result,
 					type: 'initialize',
 					intent,
+					result,
 					ctx: {
-						handlers: options.intentHandlers,
-						status: getApplyStatus(lastResult.targetValue, result.targetValue),
+						intentHandlers: options.intentHandlers,
 						customStateHandlers: options.customStateHandlers,
-						reset: (defaultValue) =>
-							initializeState<ErrorShape, CustomStateHandlers>({
-								defaultValue: defaultValue ?? options.defaultValue,
+						status: getApplyStatus(lastResult.targetValue, result.targetValue),
+						reset() {
+							return initializeState<ErrorShape, CustomStateHandlers>({
+								defaultValue: result.targetValue ?? options.defaultValue,
 								resetKey: INITIAL_KEY,
 								customStateHandlers: options.customStateHandlers,
 								lastCustomState: state.customState,
-							}),
+								result: result,
+							});
+						},
 					},
 				});
 			}
@@ -286,30 +288,29 @@ export function useConform<
 				dispatchInternalUpdateEvent(formElement);
 			}
 
-			setState((current) => {
-				const action = {
-					...finalResult,
+			setState((current) =>
+				updateState(current, {
 					type,
 					intent,
+					result: finalResult,
 					ctx: {
-						handlers: options.intentHandlers,
+						intentHandlers: options.intentHandlers,
+						customStateHandlers: options.customStateHandlers,
 						status: getApplyStatus(
 							normalizedResult.targetValue,
 							finalResult.targetValue,
 						),
-						customStateHandlers: options.customStateHandlers,
-						reset(defaultValue: Record<string, unknown> | null | undefined) {
+						reset() {
 							return initializeState<ErrorShape, CustomStateHandlers>({
-								defaultValue: defaultValue ?? options.defaultValue,
+								defaultValue: finalResult.targetValue ?? options.defaultValue,
 								customStateHandlers: options.customStateHandlers,
 								lastCustomState: current.customState,
+								result: finalResult,
 							});
 						},
 					},
-				};
-
-				return updateState(current, action);
-			});
+				}),
+			);
 
 			// TODO: move on error handler to a new effect
 			if (formElement && finalResult.error) {

--- a/packages/conform-react/future/index.ts
+++ b/packages/conform-react/future/index.ts
@@ -18,6 +18,7 @@ export type {
 	DefaultValue,
 	BaseFieldMetadata,
 	CustomSchemaTypes,
+	CustomStateHandler,
 	FormsConfig,
 	FormContext,
 	FormMetadata,
@@ -31,6 +32,7 @@ export type {
 	InferBaseErrorShape,
 	InferCustomFormMetadata,
 	InferCustomFieldMetadata,
+	InferCustomState,
 } from './types';
 export {
 	configureForms,
@@ -42,6 +44,7 @@ export {
 	resolveSubmission,
 } from './forms';
 export { defineIntent } from './intent';
+export { defineCustomState } from './state';
 export {
 	BaseControl,
 	PreserveBoundary,

--- a/packages/conform-react/future/intent.ts
+++ b/packages/conform-react/future/intent.ts
@@ -67,19 +67,53 @@ export function mergeIntentHandlers<
 	};
 }
 
-const undefinedArg = '__undefined__';
+function deserializeIntentArgs(value: string): unknown[] {
+	const args: unknown[] = [];
+	let token: string | undefined;
+
+	for (const part of value.split(',')) {
+		token = token === undefined ? part : `${token},${part}`;
+
+		if (token.trim() === '') {
+			args.push(undefined);
+			token = undefined;
+			continue;
+		}
+
+		try {
+			args.push(JSON.parse(token));
+			token = undefined;
+		} catch {
+			// The comma was inside a JSON string, object, or array.
+		}
+	}
+
+	if (token !== undefined) {
+		throw new Error('Invalid intent arguments');
+	}
+
+	return args;
+}
 
 /**
  * Serializes a transport intent to string format.
  */
 export function serializeIntent(intent: TransportIntent): string {
-	if (intent.args.length === 0) {
+	const args = intent.args.slice();
+
+	while (args.length > 0 && args[args.length - 1] === undefined) {
+		args.pop();
+	}
+
+	if (args.length === 0) {
 		return intent.type;
 	}
 
-	return `${intent.type}(${JSON.stringify(intent.args, (_, value) =>
-		value === undefined ? undefinedArg : value,
-	).slice(1, -1)})`;
+	return `${intent.type}(${args
+		.map((value) =>
+			value === undefined ? '' : JSON.stringify([value]).slice(1, -1),
+		)
+		.join(',')})`;
 }
 
 /**
@@ -107,9 +141,7 @@ export function deserializeIntent(
 
 		if (serializedArgs !== '') {
 			try {
-				args = JSON.parse(`[${serializedArgs}]`, (_, value) =>
-					value === undefinedArg ? undefined : value,
-				);
+				args = deserializeIntentArgs(serializedArgs);
 			} catch {
 				return undefined;
 			}

--- a/packages/conform-react/future/intent.ts
+++ b/packages/conform-react/future/intent.ts
@@ -67,32 +67,12 @@ export function mergeIntentHandlers<
 	};
 }
 
+const undefinedArg = '$$__undefined__$$';
+
 function deserializeIntentArgs(value: string): unknown[] {
-	const args: unknown[] = [];
-	let token: string | undefined;
-
-	for (const part of value.split(',')) {
-		token = token === undefined ? part : `${token},${part}`;
-
-		if (token.trim() === '') {
-			args.push(undefined);
-			token = undefined;
-			continue;
-		}
-
-		try {
-			args.push(JSON.parse(token));
-			token = undefined;
-		} catch {
-			// The comma was inside a JSON string, object, or array.
-		}
-	}
-
-	if (token !== undefined) {
-		throw new Error('Invalid intent arguments');
-	}
-
-	return args;
+	return JSON.parse(`[${value}]`, (_, value) =>
+		value === undefinedArg ? undefined : value,
+	);
 }
 
 /**
@@ -109,11 +89,15 @@ export function serializeIntent(intent: TransportIntent): string {
 		return intent.type;
 	}
 
-	return `${intent.type}(${args
-		.map((value) =>
-			value === undefined ? '' : JSON.stringify([value]).slice(1, -1),
-		)
-		.join(',')})`;
+	const serializedArgs = JSON.stringify(args, function (this, _, value) {
+		if (value === undefined && Array.isArray(this)) {
+			return undefinedArg;
+		}
+
+		return value;
+	});
+
+	return `${intent.type}(${serializedArgs.slice(1, -1)})`;
 }
 
 /**

--- a/packages/conform-react/future/intent.ts
+++ b/packages/conform-react/future/intent.ts
@@ -67,6 +67,8 @@ export function mergeIntentHandlers<
 	};
 }
 
+const undefinedArg = '__undefined__';
+
 /**
  * Serializes a transport intent to string format.
  */
@@ -75,7 +77,9 @@ export function serializeIntent(intent: TransportIntent): string {
 		return intent.type;
 	}
 
-	return `${intent.type}(${JSON.stringify(intent.args).slice(1, -1)})`;
+	return `${intent.type}(${JSON.stringify(intent.args, (_, value) =>
+		value === undefined ? undefinedArg : value,
+	).slice(1, -1)})`;
 }
 
 /**
@@ -84,6 +88,10 @@ export function serializeIntent(intent: TransportIntent): string {
 export function deserializeIntent(
 	serializedIntent: string,
 ): TransportIntent | undefined {
+	if (serializedIntent === '') {
+		return undefined;
+	}
+
 	let type = serializedIntent;
 	let args: Array<unknown> = [];
 
@@ -99,7 +107,9 @@ export function deserializeIntent(
 
 		if (serializedArgs !== '') {
 			try {
-				args = JSON.parse(`[${serializedArgs}]`);
+				args = JSON.parse(`[${serializedArgs}]`, (_, value) =>
+					value === undefinedArg ? undefined : value,
+				);
 			} catch {
 				return undefined;
 			}
@@ -123,7 +133,7 @@ export function parseIntent<
 	| FormIntent<Record<string, any>, Handlers>
 	| { type: 'submit'; payload: undefined }
 	| undefined {
-	if (!intentValue) {
+	if (intentValue === null) {
 		return { type: 'submit', payload: undefined };
 	}
 

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -9,6 +9,7 @@ import {
 	deepEqual,
 	FormError,
 	isPlainObject,
+	type SubmissionResult,
 } from '@conform-to/dom/future';
 import type {
 	FieldMetadata,
@@ -45,6 +46,7 @@ export function initializeState<
 	resetKey?: string | undefined;
 	customStateHandlers?: CustomStateHandlers | undefined;
 	lastCustomState?: FormCustomState<CustomStateHandlers> | undefined;
+	result?: SubmissionResult<ErrorShape> | undefined;
 }): FormState<ErrorShape, FormCustomState<CustomStateHandlers>> {
 	return {
 		resetKey: options?.resetKey ?? generateUniqueKey(),
@@ -58,6 +60,7 @@ export function initializeState<
 		customState: initializeCustomState({
 			handlers: options?.customStateHandlers,
 			currentState: options?.lastCustomState,
+			result: options?.result,
 		}),
 	};
 }
@@ -80,20 +83,18 @@ export function updateState<
 		ErrorShape,
 		UnknownIntent,
 		{
-			handlers: Record<string, IntentHandler<any, any>>;
+			intentHandlers: Record<string, IntentHandler<any, any>>;
+			customStateHandlers: CustomStateHandlers | undefined;
 			status: ApplyStatus;
-			customStateHandlers?: CustomStateHandlers | undefined;
-			reset: (
-				defaultValue?: Record<string, unknown> | null | undefined,
-			) => FormState<ErrorShape, FormCustomState<CustomStateHandlers>>;
+			reset: () => FormState<ErrorShape, FormCustomState<CustomStateHandlers>>;
 		}
 	>,
 ): FormState<ErrorShape, FormCustomState<CustomStateHandlers>> {
-	if (action.reset) {
-		return action.ctx.reset(action.targetValue);
+	if (action.result.reset) {
+		return action.ctx.reset();
 	}
 
-	const value = action.targetValue ?? action.submission.payload;
+	const value = action.result.targetValue ?? action.result.submission.payload;
 	const isClientAction =
 		action.type === 'client' || action.type === 'client:async';
 	const hasIntentEffects =
@@ -104,21 +105,21 @@ export function updateState<
 		? merge(state, {
 				targetValue:
 					action.type === 'client'
-						? (action.targetValue ?? state.targetValue)
+						? (action.result.targetValue ?? state.targetValue)
 						: state.targetValue,
 				serverValue:
-					action.type === 'client' && action.targetValue
+					action.type === 'client' && action.result.targetValue
 						? null
 						: state.serverValue,
 				// Update client error only if the error is different from the previous one to minimize unnecessary re-renders
 				clientError:
-					typeof action.error !== 'undefined' &&
-					!deepEqual(state.clientError, action.error)
-						? action.error
+					typeof action.result.error !== 'undefined' &&
+					!deepEqual(state.clientError, action.result.error)
+						? action.result.error
 						: state.clientError,
 				// Reset server error if form value is changed
 				serverError:
-					typeof action.error !== 'undefined' &&
+					typeof action.result.error !== 'undefined' &&
 					!deepEqual(state.serverValue, value)
 						? null
 						: state.serverError,
@@ -129,16 +130,16 @@ export function updateState<
 				// Update server error if the error is defined.
 				// There is no need to check if the error is different as we are updating other states as well
 				serverError:
-					typeof action.error !== 'undefined'
-						? action.error
+					typeof action.result.error !== 'undefined'
+						? action.result.error
 						: state.serverError,
 				listKeys:
-					action.type === 'server' && action.targetValue
-						? pruneListKeys(state.listKeys, action.targetValue)
+					action.type === 'server' && action.result.targetValue
+						? pruneListKeys(state.listKeys, action.result.targetValue)
 						: state.listKeys,
 				targetValue:
-					action.type === 'server' && action.targetValue
-						? action.targetValue
+					action.type === 'server' && action.result.targetValue
+						? action.result.targetValue
 						: state.targetValue,
 				// Keep track of the value that the serverError is based on
 				serverValue: !deepEqual(state.serverValue, value)
@@ -147,21 +148,25 @@ export function updateState<
 			});
 	// Validate the whole form if no intent is provided (default submission)
 	const intent = action.intent ?? { type: 'validate' };
-	const handler = action.ctx.handlers?.[intent.type];
+	const handler = action.ctx.intentHandlers?.[intent.type];
 
 	if (handler && action.type === 'client' && hasIntentEffects) {
 		if (typeof handler.move === 'function') {
 			const handleMove = handler.move;
-			state = moveState(state, action.submission.payload, value, (name) =>
-				handleMove({
-					name,
-					payload: intent.payload,
-					status: action.ctx.status,
-					targetValue: action.targetValue,
-				}),
+			state = moveState(
+				state,
+				action.result.submission.payload,
+				value,
+				(name) =>
+					handleMove({
+						name,
+						payload: intent.payload,
+						status: action.ctx.status,
+						targetValue: action.result.targetValue,
+					}),
 			);
 		} else if (typeof handler.resolve === 'function') {
-			state = invalidateState(state, action.submission.payload, value);
+			state = invalidateState(state, action.result.submission.payload, value);
 		}
 	}
 
@@ -173,7 +178,7 @@ export function updateState<
 	) {
 		let touchedFields = state.touchedFields;
 
-		for (const name of getFields(action)) {
+		for (const name of getFields(action.result)) {
 			if (handler.touch({ name, payload: intent.payload })) {
 				touchedFields = appendUniqueItem(touchedFields, name);
 			}
@@ -192,25 +197,25 @@ export function updateState<
 }
 
 export function getFields<ErrorShape>(
-	action: FormAction<ErrorShape, UnknownIntent>,
+	result: SubmissionResult<ErrorShape>,
 ): string[] {
-	let fields = action.submission.fields;
+	let fields = result.submission.fields;
 
-	if (action.error) {
-		fields = fields.concat(Object.keys(action.error.fieldErrors));
+	if (result.error) {
+		fields = fields.concat(Object.keys(result.error.fieldErrors));
 	}
 
-	const result = new Set(['']);
+	const fieldsSet = new Set(['']);
 
 	for (const field of fields) {
 		const paths = parsePath(field);
 
 		for (let index = 1; index <= paths.length; index++) {
-			result.add(formatPath(paths.slice(0, index)));
+			fieldsSet.add(formatPath(paths.slice(0, index)));
 		}
 	}
 
-	return Array.from(result);
+	return Array.from(fieldsSet);
 }
 
 export function getApplyStatus(
@@ -1088,16 +1093,27 @@ export function initializeCustomState<
 >(options: {
 	handlers: CustomStateHandlers | undefined;
 	currentState?: FormCustomState<CustomStateHandlers> | undefined;
+	result?: SubmissionResult<ErrorShape> | undefined;
 }): FormCustomState<CustomStateHandlers> {
 	return Object.fromEntries(
-		Object.entries(options.handlers ?? {}).map(([key, handler]) => [
-			key,
-			options.currentState &&
-			Object.prototype.hasOwnProperty.call(options.currentState, key) &&
-			handler.reset === false
-				? options.currentState[key]
-				: handler.initialize(),
-		]),
+		Object.entries(options.handlers ?? {}).map(([key, handler]) => {
+			if (
+				!options.currentState ||
+				!Object.prototype.hasOwnProperty.call(options.currentState, key) ||
+				handler.reset === undefined ||
+				handler.reset === true
+			) {
+				return [key, handler.initialize()];
+			}
+
+			const currentState = options.currentState[key];
+
+			if (typeof handler.reset === 'function') {
+				return [key, handler.reset(currentState, { result: options.result })];
+			}
+
+			return [key, currentState];
+		}),
 	) as FormCustomState<CustomStateHandlers>;
 }
 
@@ -1129,15 +1145,14 @@ export function updateCustomState<
 			) {
 				nextState = handler.handleIntent(nextState, {
 					intent: action.intent,
-					submission: action.submission,
+					submission: action.result.submission,
 				});
 			}
 
-			if (handler.handleResult && typeof action.error !== 'undefined') {
+			if (handler.handleResult && typeof action.result.error !== 'undefined') {
 				nextState = handler.handleResult(nextState, {
 					intent: action.intent,
-					submission: action.submission,
-					error: action.error,
+					result: action.result,
 					phase:
 						action.type === 'client' || action.type === 'client:async'
 							? 'client'

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -1,5 +1,6 @@
 import {
 	type FieldName,
+	type SubmissionResult,
 	appendPath,
 	formatPath,
 	parsePath,
@@ -23,6 +24,8 @@ import type {
 	BaseFormMetadata,
 	DefineConditionalField,
 	ApplyStatus,
+	CustomStateHandler,
+	FormCustomState,
 } from './types';
 import {
 	appendUniqueItem,
@@ -32,10 +35,19 @@ import {
 	when,
 } from './util';
 
-export function initializeState<ErrorShape>(options?: {
+export function initializeState<
+	ErrorShape = any,
+	CustomStateHandlers extends Record<
+		string,
+		CustomStateHandler<any, any, ErrorShape>
+	> = {},
+>(options?: {
 	defaultValue?: Record<string, unknown> | null | undefined;
 	resetKey?: string | undefined;
-}): FormState<ErrorShape> {
+	reset?: boolean | undefined;
+	customStateHandlers?: CustomStateHandlers | undefined;
+	lastCustomState?: FormCustomState<CustomStateHandlers> | undefined;
+}): FormState<ErrorShape, FormCustomState<CustomStateHandlers>> {
 	return {
 		resetKey: options?.resetKey ?? generateUniqueKey(),
 		listKeys: {},
@@ -45,6 +57,11 @@ export function initializeState<ErrorShape>(options?: {
 		serverError: null,
 		clientError: null,
 		touchedFields: [],
+		customState: initializeCustomState({
+			handlers: options?.customStateHandlers,
+			lastState: options?.lastCustomState,
+			reset: options?.reset ?? false,
+		}),
 	};
 }
 
@@ -54,20 +71,27 @@ export function initializeState<ErrorShape>(options?: {
  * - Server actions: update server errors and clear client errors, with optional target value
  * - Initialize: set initial server value
  */
-export function updateState<ErrorShape>(
-	state: FormState<ErrorShape>,
+export function updateState<
+	ErrorShape,
+	CustomStateHandlers extends Record<
+		string,
+		CustomStateHandler<any, any, ErrorShape>
+	> = {},
+>(
+	state: FormState<ErrorShape, FormCustomState<CustomStateHandlers>>,
 	action: FormAction<
 		ErrorShape,
-		UnknownIntent | undefined,
+		UnknownIntent,
 		{
 			handlers: Record<string, IntentHandler<any, any>>;
 			status: ApplyStatus;
+			customStateHandlers?: CustomStateHandlers | undefined;
 			reset: (
 				defaultValue?: Record<string, unknown> | null | undefined,
-			) => FormState<ErrorShape>;
+			) => FormState<ErrorShape, FormCustomState<CustomStateHandlers>>;
 		}
 	>,
-): FormState<ErrorShape> {
+): FormState<ErrorShape, FormCustomState<CustomStateHandlers>> {
 	if (action.reset) {
 		return action.ctx.reset(action.targetValue);
 	}
@@ -119,11 +143,7 @@ export function updateState<ErrorShape>(
 	const intent = action.intent ?? { type: 'validate' };
 	const handler = action.ctx.handlers?.[intent.type];
 
-	if (!handler || action.type === 'server') {
-		return state;
-	}
-
-	if (action.type === 'client') {
+	if (handler && action.type === 'client') {
 		if (typeof handler.move === 'function') {
 			const handleMove = handler.move;
 			state = moveState(state, action.submission.payload, value, (name) =>
@@ -139,7 +159,11 @@ export function updateState<ErrorShape>(
 		}
 	}
 
-	if (typeof handler.touch === 'function') {
+	if (
+		handler &&
+		action.type !== 'server' &&
+		typeof handler.touch === 'function'
+	) {
 		let touchedFields = state.touchedFields;
 
 		for (const name of getFields(action)) {
@@ -153,11 +177,15 @@ export function updateState<ErrorShape>(
 		});
 	}
 
-	return state;
+	return merge(state, {
+		customState: updateCustomState(state.customState, action, {
+			handlers: action.ctx.customStateHandlers,
+		}),
+	});
 }
 
 export function getFields<ErrorShape>(
-	action: FormAction<ErrorShape, UnknownIntent | null | undefined>,
+	action: FormAction<ErrorShape, UnknownIntent>,
 ): string[] {
 	let fields = action.submission.fields;
 
@@ -194,11 +222,14 @@ export function getApplyStatus(
  * providing a `move()` mapping. It drops list keys and touched fields under
  * changed paths so stale client state does not point at the wrong fields.
  */
-export function invalidateState<ErrorShape>(
-	state: FormState<ErrorShape>,
+export function invalidateState<
+	ErrorShape,
+	CustomState extends Record<string, unknown> = Record<string, unknown>,
+>(
+	state: FormState<ErrorShape, CustomState>,
 	previousValue: Record<string, unknown>,
 	nextValue: Record<string, unknown>,
-): FormState<ErrorShape> {
+): FormState<ErrorShape, CustomState> {
 	if (previousValue === nextValue) {
 		return state;
 	}
@@ -320,12 +351,15 @@ export function invalidateState<ErrorShape>(
  * Preserves list keys and touched fields for intents that can map old field
  * paths to new ones, such as insert, remove, and reorder.
  */
-export function moveState<ErrorShape>(
-	state: FormState<ErrorShape>,
+export function moveState<
+	ErrorShape,
+	CustomState extends Record<string, unknown> = Record<string, unknown>,
+>(
+	state: FormState<ErrorShape, CustomState>,
 	previousValue: Record<string, unknown>,
 	nextValue: Record<string, unknown>,
 	move: (name: string) => string | null,
-): FormState<ErrorShape> {
+): FormState<ErrorShape, CustomState> {
 	if (previousValue === nextValue) {
 		return state;
 	}
@@ -722,29 +756,40 @@ export function getFormMetadata<
 	ErrorShape,
 	CustomFormMetadata extends Record<string, unknown> = {},
 	CustomFieldMetadata extends Record<string, unknown> = {},
+	CustomState extends Record<string, unknown> = {},
 >(
-	context: FormContext<ErrorShape>,
+	context: FormContext<ErrorShape, CustomState>,
 	options?: {
 		extendFormMetadata?:
-			| ((metadata: BaseFormMetadata<ErrorShape>) => CustomFormMetadata)
+			| ((
+					metadata: BaseFormMetadata<ErrorShape, CustomState>,
+			  ) => CustomFormMetadata)
 			| undefined;
 		extendFieldMetadata?:
 			| (<FieldShape>(
 					metadata: BaseFieldMetadata<FieldShape, ErrorShape>,
 					ctx: {
-						form: BaseFormMetadata<ErrorShape>;
+						form: BaseFormMetadata<ErrorShape, CustomState>;
 						when: DefineConditionalField;
 					},
 			  ) => CustomFieldMetadata)
 			| undefined;
 	},
-): FormMetadata<ErrorShape, CustomFormMetadata, CustomFieldMetadata> {
-	const metadata: BaseFormMetadata<ErrorShape> = {
+): FormMetadata<
+	ErrorShape,
+	CustomFormMetadata,
+	CustomFieldMetadata,
+	CustomState
+> {
+	const metadata: BaseFormMetadata<ErrorShape, CustomState> = {
 		key: context.state.resetKey,
 		id: context.formId,
 		errorId: `${context.formId}-form-error`,
 		descriptionId: `${context.formId}-form-description`,
 		defaultValue: context.state.defaultValue,
+		get customState() {
+			return context.state.customState;
+		},
 		get errors() {
 			return getErrors(context.state);
 		},
@@ -796,7 +841,8 @@ export function getFormMetadata<
 	return extended as FormMetadata<
 		ErrorShape,
 		CustomFormMetadata,
-		CustomFieldMetadata
+		CustomFieldMetadata,
+		CustomState
 	>;
 }
 
@@ -805,19 +851,19 @@ export function getField<
 	ErrorShape = string,
 	CustomFieldMetadata extends Record<string, unknown> = {},
 >(
-	context: FormContext<ErrorShape>,
+	context: FormContext<ErrorShape, any>,
 	options: {
 		name: FieldName<FieldShape>;
 		extendFieldMetadata?:
 			| (<F>(
 					metadata: BaseFieldMetadata<F, ErrorShape>,
 					ctx: {
-						form: BaseFormMetadata<ErrorShape>;
+						form: BaseFormMetadata<ErrorShape, any>;
 						when: DefineConditionalField;
 					},
 			  ) => CustomFieldMetadata)
 			| undefined;
-		form?: BaseFormMetadata<ErrorShape, CustomFieldMetadata> | undefined;
+		form?: BaseFormMetadata<ErrorShape, any> | undefined;
 		key?: string | undefined;
 	},
 ): FieldMetadata<FieldShape, ErrorShape, CustomFieldMetadata> {
@@ -912,19 +958,19 @@ export function getFieldset<
 	ErrorShape = string,
 	CustomFieldMetadata extends Record<string, unknown> = {},
 >(
-	context: FormContext<ErrorShape>,
+	context: FormContext<ErrorShape, any>,
 	options: {
 		name?: FieldName<FieldShape> | undefined;
 		extendFieldMetadata?:
 			| (<F>(
 					metadata: BaseFieldMetadata<F, ErrorShape>,
 					ctx: {
-						form: BaseFormMetadata<ErrorShape>;
+						form: BaseFormMetadata<ErrorShape, any>;
 						when: DefineConditionalField;
 					},
 			  ) => CustomFieldMetadata)
 			| undefined;
-		form?: BaseFormMetadata<ErrorShape, CustomFieldMetadata> | undefined;
+		form?: BaseFormMetadata<ErrorShape, any> | undefined;
 	},
 ): Fieldset<FieldShape, ErrorShape, CustomFieldMetadata> {
 	return new Proxy({} as any, {
@@ -954,14 +1000,14 @@ export function getFieldList<
 	ErrorShape = string,
 	CustomFieldMetadata extends Record<string, unknown> = {},
 >(
-	context: FormContext<ErrorShape>,
+	context: FormContext<ErrorShape, any>,
 	options: {
 		name: FieldName<FieldShape>;
 		extendFieldMetadata?:
 			| (<F>(
 					metadata: BaseFieldMetadata<F, ErrorShape>,
 					ctx: {
-						form: BaseFormMetadata<ErrorShape>;
+						form: BaseFormMetadata<ErrorShape, any>;
 						when: DefineConditionalField;
 					},
 			  ) => CustomFieldMetadata)
@@ -989,4 +1035,112 @@ export function getFieldList<
 			key,
 		});
 	});
+}
+
+export function defineCustomState<
+	State,
+	CustomIntentHandlers extends Record<string, IntentHandler<any, any>> = {},
+	ErrorShape = any,
+>(
+	definition: CustomStateHandler<State, CustomIntentHandlers, ErrorShape>,
+): CustomStateHandler<State, CustomIntentHandlers, ErrorShape> {
+	return definition;
+}
+
+export function mergeCustomStateHandlers<
+	GlobalCustomState extends
+		| Record<string, CustomStateHandler<any, any, any>>
+		| undefined,
+	InlineCustomState extends
+		| Record<string, CustomStateHandler<any, any, any>>
+		| undefined,
+>(
+	globalCustomState: GlobalCustomState,
+	inlineCustomState: InlineCustomState,
+): GlobalCustomState & InlineCustomState {
+	if (globalCustomState && inlineCustomState) {
+		for (const key of Object.keys(inlineCustomState)) {
+			if (key in globalCustomState) {
+				throw new Error(`Duplicate custom state key "${key}"`);
+			}
+		}
+	}
+
+	return {
+		...globalCustomState,
+		...inlineCustomState,
+	};
+}
+
+export function initializeCustomState<
+	ErrorShape,
+	CustomStateHandlers extends Record<
+		string,
+		CustomStateHandler<any, any, ErrorShape>
+	>,
+>(options: {
+	handlers: CustomStateHandlers | undefined;
+	lastState?: FormCustomState<CustomStateHandlers> | undefined;
+	reset: boolean;
+}): FormCustomState<CustomStateHandlers> {
+	return Object.fromEntries(
+		Object.entries(options.handlers ?? {}).map(([key, handler]) => [
+			key,
+			handler.initialize({
+				lastState: options.lastState?.[key],
+				reset: options.reset,
+			}),
+		]),
+	) as FormCustomState<CustomStateHandlers>;
+}
+
+export function updateCustomState<
+	ErrorShape,
+	CustomStateHandlers extends Record<
+		string,
+		CustomStateHandler<any, any, ErrorShape>
+	>,
+>(
+	state: FormCustomState<CustomStateHandlers>,
+	action: FormAction<ErrorShape, UnknownIntent>,
+	options: {
+		handlers: CustomStateHandlers | undefined;
+		lastState?: FormCustomState<CustomStateHandlers> | undefined;
+	},
+): FormCustomState<CustomStateHandlers> {
+	if (!options.handlers) {
+		return state;
+	}
+
+	if (action.reset) {
+		return initializeCustomState({
+			handlers: options.handlers,
+			lastState: options.lastState ?? state,
+			reset: true,
+		});
+	}
+
+	return Object.fromEntries(
+		Object.entries(options.handlers).map(([key, handler]) => {
+			let nextState = state[key];
+
+			if (action.type !== 'server' && handler.handleIntent) {
+				nextState = handler.handleIntent(nextState, {
+					intent: action.intent,
+					submission: action.submission,
+				});
+			}
+
+			if (handler.handleResult) {
+				nextState = handler.handleResult(nextState, {
+					intent: action.intent,
+					submission: action.submission,
+					error: action.error,
+					phase: action.type === 'client' ? 'client' : 'server',
+				});
+			}
+
+			return [key, nextState];
+		}),
+	) as FormCustomState<CustomStateHandlers>;
 }

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -97,53 +97,62 @@ export function updateState<
 	}
 
 	const value = action.targetValue ?? action.submission.payload;
+	const isClientAction =
+		action.type === 'client' || action.type === 'client:async';
+	const hasIntentEffects =
+		action.type !== 'server' && action.type !== 'client:async';
 
 	// Apply the form error and target value from the result first
-	state =
-		action.type === 'client'
-			? merge(state, {
-					targetValue: action.targetValue ?? state.targetValue,
-					serverValue: action.targetValue ? null : state.serverValue,
-					// Update client error only if the error is different from the previous one to minimize unnecessary re-renders
-					clientError:
-						typeof action.error !== 'undefined' &&
-						!deepEqual(state.clientError, action.error)
-							? action.error
-							: state.clientError,
-					// Reset server error if form value is changed
-					serverError:
-						typeof action.error !== 'undefined' &&
-						!deepEqual(state.serverValue, value)
-							? null
-							: state.serverError,
-				})
-			: merge(state, {
-					// Clear client error to avoid showing stale errors
-					clientError: null,
-					// Update server error if the error is defined.
-					// There is no need to check if the error is different as we are updating other states as well
-					serverError:
-						typeof action.error !== 'undefined'
-							? action.error
-							: state.serverError,
-					listKeys:
-						action.type === 'server' && action.targetValue
-							? pruneListKeys(state.listKeys, action.targetValue)
-							: state.listKeys,
-					targetValue:
-						action.type === 'server' && action.targetValue
-							? action.targetValue
-							: state.targetValue,
-					// Keep track of the value that the serverError is based on
-					serverValue: !deepEqual(state.serverValue, value)
-						? value
+	state = isClientAction
+		? merge(state, {
+				targetValue:
+					action.type === 'client'
+						? (action.targetValue ?? state.targetValue)
+						: state.targetValue,
+				serverValue:
+					action.type === 'client' && action.targetValue
+						? null
 						: state.serverValue,
-				});
+				// Update client error only if the error is different from the previous one to minimize unnecessary re-renders
+				clientError:
+					typeof action.error !== 'undefined' &&
+					!deepEqual(state.clientError, action.error)
+						? action.error
+						: state.clientError,
+				// Reset server error if form value is changed
+				serverError:
+					typeof action.error !== 'undefined' &&
+					!deepEqual(state.serverValue, value)
+						? null
+						: state.serverError,
+			})
+		: merge(state, {
+				// Clear client error to avoid showing stale errors
+				clientError: null,
+				// Update server error if the error is defined.
+				// There is no need to check if the error is different as we are updating other states as well
+				serverError:
+					typeof action.error !== 'undefined'
+						? action.error
+						: state.serverError,
+				listKeys:
+					action.type === 'server' && action.targetValue
+						? pruneListKeys(state.listKeys, action.targetValue)
+						: state.listKeys,
+				targetValue:
+					action.type === 'server' && action.targetValue
+						? action.targetValue
+						: state.targetValue,
+				// Keep track of the value that the serverError is based on
+				serverValue: !deepEqual(state.serverValue, value)
+					? value
+					: state.serverValue,
+			});
 	// Validate the whole form if no intent is provided (default submission)
 	const intent = action.intent ?? { type: 'validate' };
 	const handler = action.ctx.handlers?.[intent.type];
 
-	if (handler && action.type === 'client') {
+	if (handler && action.type === 'client' && hasIntentEffects) {
 		if (typeof handler.move === 'function') {
 			const handleMove = handler.move;
 			state = moveState(state, action.submission.payload, value, (name) =>
@@ -162,6 +171,7 @@ export function updateState<
 	if (
 		handler &&
 		action.type !== 'server' &&
+		hasIntentEffects &&
 		typeof handler.touch === 'function'
 	) {
 		let touchedFields = state.touchedFields;
@@ -1124,7 +1134,11 @@ export function updateCustomState<
 		Object.entries(options.handlers).map(([key, handler]) => {
 			let nextState = state[key];
 
-			if (action.type !== 'server' && handler.handleIntent) {
+			if (
+				action.type !== 'server' &&
+				action.type !== 'client:async' &&
+				handler.handleIntent
+			) {
 				nextState = handler.handleIntent(nextState, {
 					intent: action.intent,
 					submission: action.submission,
@@ -1136,7 +1150,10 @@ export function updateCustomState<
 					intent: action.intent,
 					submission: action.submission,
 					error: action.error,
-					phase: action.type === 'client' ? 'client' : 'server',
+					phase:
+						action.type === 'client' || action.type === 'client:async'
+							? 'client'
+							: 'server',
 				});
 			}
 

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -1,6 +1,5 @@
 import {
 	type FieldName,
-	type SubmissionResult,
 	appendPath,
 	formatPath,
 	parsePath,
@@ -44,7 +43,6 @@ export function initializeState<
 >(options?: {
 	defaultValue?: Record<string, unknown> | null | undefined;
 	resetKey?: string | undefined;
-	reset?: boolean | undefined;
 	customStateHandlers?: CustomStateHandlers | undefined;
 	lastCustomState?: FormCustomState<CustomStateHandlers> | undefined;
 }): FormState<ErrorShape, FormCustomState<CustomStateHandlers>> {
@@ -59,8 +57,7 @@ export function initializeState<
 		touchedFields: [],
 		customState: initializeCustomState({
 			handlers: options?.customStateHandlers,
-			lastState: options?.lastCustomState,
-			reset: options?.reset ?? false,
+			currentState: options?.lastCustomState,
 		}),
 	};
 }
@@ -1070,7 +1067,7 @@ export function mergeCustomStateHandlers<
 ): GlobalCustomState & InlineCustomState {
 	if (globalCustomState && inlineCustomState) {
 		for (const key of Object.keys(inlineCustomState)) {
-			if (key in globalCustomState) {
+			if (Object.prototype.hasOwnProperty.call(globalCustomState, key)) {
 				throw new Error(`Duplicate custom state key "${key}"`);
 			}
 		}
@@ -1090,16 +1087,16 @@ export function initializeCustomState<
 	>,
 >(options: {
 	handlers: CustomStateHandlers | undefined;
-	lastState?: FormCustomState<CustomStateHandlers> | undefined;
-	reset: boolean;
+	currentState?: FormCustomState<CustomStateHandlers> | undefined;
 }): FormCustomState<CustomStateHandlers> {
 	return Object.fromEntries(
 		Object.entries(options.handlers ?? {}).map(([key, handler]) => [
 			key,
-			handler.initialize({
-				lastState: options.lastState?.[key],
-				reset: options.reset,
-			}),
+			options.currentState &&
+			Object.prototype.hasOwnProperty.call(options.currentState, key) &&
+			handler.reset === false
+				? options.currentState[key]
+				: handler.initialize(),
 		]),
 	) as FormCustomState<CustomStateHandlers>;
 }
@@ -1115,19 +1112,10 @@ export function updateCustomState<
 	action: FormAction<ErrorShape, UnknownIntent>,
 	options: {
 		handlers: CustomStateHandlers | undefined;
-		lastState?: FormCustomState<CustomStateHandlers> | undefined;
 	},
 ): FormCustomState<CustomStateHandlers> {
 	if (!options.handlers) {
 		return state;
-	}
-
-	if (action.reset) {
-		return initializeCustomState({
-			handlers: options.handlers,
-			lastState: options.lastState ?? state,
-			reset: true,
-		});
 	}
 
 	return Object.fromEntries(
@@ -1145,7 +1133,7 @@ export function updateCustomState<
 				});
 			}
 
-			if (handler.handleResult) {
+			if (handler.handleResult && typeof action.error !== 'undefined') {
 				nextState = handler.handleResult(nextState, {
 					intent: action.intent,
 					submission: action.submission,

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -225,9 +225,10 @@ export type FormAction<
 	ErrorShape = any,
 	Intent extends UnknownIntent = UnknownIntent,
 	Context = {},
-> = SubmissionResult<ErrorShape> & {
+> = {
 	type: 'initialize' | 'server' | 'client' | 'client:async';
 	intent: Intent;
+	result: SubmissionResult<ErrorShape>;
 	ctx: Context;
 };
 
@@ -827,7 +828,12 @@ export type CustomStateHandler<
 	ErrorShape = any,
 > = {
 	initialize(): State;
-	reset?: boolean;
+	reset?:
+		| boolean
+		| ((
+				state: State,
+				ctx: { result: SubmissionResult<ErrorShape> | undefined },
+		  ) => State);
 	handleIntent?(
 		state: State,
 		ctx: {
@@ -839,8 +845,7 @@ export type CustomStateHandler<
 		state: State,
 		ctx: {
 			intent: FormIntent<any, DefaultIntentHandlers & CustomIntentHandlers>;
-			submission: Submission;
-			error: FormError<ErrorShape> | null;
+			result: SubmissionResult<ErrorShape>;
 			phase: 'client' | 'server';
 		},
 	): State;

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -826,7 +826,8 @@ export type CustomStateHandler<
 	CustomIntentHandlers extends Record<string, IntentHandler<any, any>> = {},
 	ErrorShape = any,
 > = {
-	initialize(ctx: { reset: boolean; lastState: State | undefined }): State;
+	initialize(): State;
+	reset?: boolean;
 	handleIntent?(
 		state: State,
 		ctx: {
@@ -839,7 +840,7 @@ export type CustomStateHandler<
 		ctx: {
 			intent: FormIntent<any, DefaultIntentHandlers & CustomIntentHandlers>;
 			submission: Submission;
-			error: FormError<ErrorShape> | null | undefined;
+			error: FormError<ErrorShape> | null;
 			phase: 'client' | 'server';
 		},
 	): State;

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -4,6 +4,7 @@ import type {
 	FormError,
 	FormValue,
 	Serialize,
+	Submission,
 	SubmissionResult,
 	ValidationAttributes,
 } from '@conform-to/dom/future';
@@ -196,7 +197,10 @@ export type DefaultValue<Shape> =
 				? null | undefined // We don't support setting default value for file inputs yet
 				: Shape | string | null | undefined;
 
-export type FormState<ErrorShape = any> = {
+export type FormState<
+	ErrorShape = any,
+	CustomState extends Record<string, unknown> = {},
+> = {
 	/** Unique identifier that changes on form reset to trigger reset side effects */
 	resetKey: string;
 	/** Initial form values */
@@ -213,11 +217,13 @@ export type FormState<ErrorShape = any> = {
 	touchedFields: string[];
 	/** Mapping of array field names to their item keys for React list rendering */
 	listKeys: Record<string, string[]>;
+	/** Current custom state for the form */
+	customState: CustomState;
 };
 
 export type FormAction<
 	ErrorShape = any,
-	Intent extends UnknownIntent | null | undefined = UnknownIntent | null,
+	Intent extends UnknownIntent = UnknownIntent,
 	Context = {},
 > = SubmissionResult<ErrorShape> & {
 	type: 'initialize' | 'server' | 'client';
@@ -339,6 +345,10 @@ export type FormsConfig<
 	CustomFormMetadata extends Record<string, unknown>,
 	CustomFieldMetadata extends Record<string, unknown>,
 	CustomIntentHandlers extends Record<string, IntentHandler<any, any>>,
+	CustomStateHandlers extends Record<
+		string,
+		CustomStateHandler<any, any, BaseErrorShape>
+	>,
 > = {
 	/**
 	 * The name of the submit button field that indicates the submission intent.
@@ -353,6 +363,13 @@ export type FormsConfig<
 	 * Intent handlers available to every form created by this factory.
 	 */
 	intents?: CustomIntentHandlers;
+	/**
+	 * Custom state available to every form created by this factory.
+	 */
+	customState?: CustomStateDefinition<
+		CustomStateHandlers,
+		CustomIntentHandlers
+	>;
 	/**
 	 * Determines when validation should run for the first time on a field.
 	 * @default "onSubmit"
@@ -409,7 +426,10 @@ export type FormsConfig<
 	 * Extends form metadata with custom properties.
 	 */
 	extendFormMetadata?: <ErrorShape extends BaseErrorShape>(
-		metadata: BaseFormMetadata<ErrorShape>,
+		metadata: BaseFormMetadata<
+			ErrorShape,
+			FormCustomState<CustomStateHandlers>
+		>,
 	) => CustomFormMetadata;
 	/**
 	 * Extends field metadata with custom properties.
@@ -418,7 +438,7 @@ export type FormsConfig<
 	extendFieldMetadata?: <FieldShape, ErrorShape extends BaseErrorShape>(
 		metadata: BaseFieldMetadata<FieldShape, ErrorShape>,
 		ctx: {
-			form: BaseFormMetadata<ErrorShape>;
+			form: BaseFormMetadata<ErrorShape, FormCustomState<CustomStateHandlers>>;
 			when: DefineConditionalField;
 		},
 	) => CustomFieldMetadata;
@@ -471,6 +491,10 @@ export type FormOptions<
 	SchemaErrorShape = ErrorShape,
 	CustomIntentHandlers extends Record<string, IntentHandler<any, any>> = {},
 	GlobalIntentHandlers extends Record<string, IntentHandler<any, any>> = {},
+	CustomStateHandlers extends Record<
+		string,
+		CustomStateHandler<any, any, any>
+	> = {},
 > = {
 	/** Optional form identifier. If not provided, a unique ID is automatically generated. */
 	id?: string | undefined;
@@ -493,6 +517,15 @@ export type FormOptions<
 	 * Custom intent handlers available only to this form instance.
 	 */
 	intents?: CustomIntentHandlers | undefined;
+	/**
+	 * Custom state available only to this form instance.
+	 */
+	customState?:
+		| CustomStateDefinition<
+				CustomStateHandlers,
+				GlobalIntentHandlers & CustomIntentHandlers
+		  >
+		| undefined;
 	/** HTML validation attributes for fields (required, minLength, pattern, etc.). */
 	constraint?: Record<string, ValidationAttributes> | undefined;
 	/**
@@ -546,20 +579,29 @@ export type FormHandle<
 	CustomFormMetadata extends Record<string, unknown> = {},
 	CustomFieldMetadata extends Record<string, unknown> = {},
 	CustomIntentHandlers extends Record<string, IntentHandler<any, any>> = {},
+	CustomState extends Record<string, unknown> = {},
 > = {
 	/** Form-level metadata and helpers. */
-	form: FormMetadata<ErrorShape, CustomFormMetadata, CustomFieldMetadata>;
+	form: FormMetadata<
+		ErrorShape,
+		CustomFormMetadata,
+		CustomFieldMetadata,
+		CustomState
+	>;
 	/** Field metadata mapped from the form shape. */
 	fields: Fieldset<FormShape, ErrorShape, CustomFieldMetadata>;
 	/** Intent dispatcher for validate, reset, insert, remove, reorder, and update actions. */
 	intent: IntentDispatcher<FormShape, CustomIntentHandlers>;
 };
 
-export interface FormContext<ErrorShape = any> {
+export interface FormContext<
+	ErrorShape = any,
+	CustomState extends Record<string, unknown> = {},
+> {
 	/** The form's unique identifier */
 	formId: string;
 	/** Internal form state with validation results and field data */
-	state: FormState<ErrorShape>;
+	state: FormState<ErrorShape, CustomState>;
 	/** Serializer used to derive field defaults and sync values for this form. */
 	serialize: Serialize;
 	/** HTML validation attributes for fields */
@@ -574,7 +616,7 @@ export interface FormContext<ErrorShape = any> {
 
 export type UnknownIntent = {
 	type: string;
-	payload?: unknown;
+	payload: unknown;
 };
 
 export type TransportIntent = {
@@ -779,6 +821,62 @@ export type IntentHandler<
 	}): string | null;
 };
 
+export type CustomStateHandler<
+	State,
+	CustomIntentHandlers extends Record<string, IntentHandler<any, any>> = {},
+	ErrorShape = any,
+> = {
+	initialize(ctx: { reset: boolean; lastState: State | undefined }): State;
+	handleIntent?(
+		state: State,
+		ctx: {
+			intent: FormIntent<any, DefaultIntentHandlers & CustomIntentHandlers>;
+			submission: Submission;
+		},
+	): State;
+	handleResult?(
+		state: State,
+		ctx: {
+			intent: FormIntent<any, DefaultIntentHandlers & CustomIntentHandlers>;
+			submission: Submission;
+			error: FormError<ErrorShape> | null | undefined;
+			phase: 'client' | 'server';
+		},
+	): State;
+};
+
+export type FormCustomState<
+	Handlers extends Record<string, CustomStateHandler<any, any, any>>,
+> = {
+	[Key in keyof Handlers]: Handlers[Key] extends CustomStateHandler<
+		infer State,
+		any,
+		any
+	>
+		? State
+		: never;
+};
+
+type CustomStateDefinition<
+	CustomStateHandlers extends Record<string, CustomStateHandler<any, any, any>>,
+	IntentHandlers extends Record<string, IntentHandler<any, any>>,
+> = {
+	[Key in keyof CustomStateHandlers]: CustomStateHandlers[Key] extends CustomStateHandler<
+		any,
+		infer RequiredIntents,
+		any
+	>
+		? Exclude<keyof RequiredIntents, keyof IntentHandlers> extends never
+			? RequiredIntents extends Pick<
+					IntentHandlers,
+					Extract<keyof RequiredIntents, keyof IntentHandlers>
+				>
+				? CustomStateHandlers[Key]
+				: never
+			: never
+		: never;
+};
+
 type BaseCombine<
 	T,
 	K extends PropertyKey = T extends unknown ? keyof T : never,
@@ -904,6 +1002,7 @@ export type FormMetadata<
 	ErrorShape = any,
 	CustomFormMetadata extends Record<string, unknown> = {},
 	CustomFieldMetadata extends Record<string, unknown> = {},
+	CustomState extends Record<string, unknown> = {},
 > = Readonly<
 	{
 		/** Unique identifier that changes on form reset */
@@ -926,6 +1025,8 @@ export type FormMetadata<
 		fieldErrors: Record<string, ErrorShape>;
 		/** The form's initial default values. */
 		defaultValue: Record<string, unknown>;
+		/** Current custom state for the form. */
+		customState: CustomState;
 		/** Form props object for spreading onto the <form> element. */
 		props: Readonly<{
 			id: string;
@@ -935,7 +1036,7 @@ export type FormMetadata<
 			noValidate: boolean;
 		}>;
 		/** The current state of the form */
-		context: FormContext<ErrorShape>;
+		context: FormContext<ErrorShape, CustomState>;
 		/** Method to get metadata for a specific field by name. */
 		getField<FieldShape>(
 			name: FieldName<FieldShape>,
@@ -969,8 +1070,8 @@ export type FormMetadata<
  */
 export type BaseFormMetadata<
 	ErrorShape = any,
-	CustomFieldMetadata extends Record<string, unknown> = {},
-> = FormMetadata<ErrorShape, {}, CustomFieldMetadata>;
+	CustomState extends Record<string, unknown> = {},
+> = FormMetadata<ErrorShape, {}, {}, CustomState>;
 
 export type ValidateResult<ErrorShape, Value> =
 	| FormError<ErrorShape>
@@ -1103,7 +1204,7 @@ export type SubmitHandler<
  * ```
  */
 export type InferBaseErrorShape<Config> =
-	Config extends FormsConfig<infer ErrorShape, any, any, any, any, any>
+	Config extends FormsConfig<infer ErrorShape, any, any, any, any, any, any>
 		? ErrorShape
 		: string;
 
@@ -1124,7 +1225,15 @@ export type InferBaseErrorShape<Config> =
  * ```
  */
 export type InferCustomFormMetadata<Config> =
-	Config extends FormsConfig<any, any, any, infer CustomFormMetadata, any, any>
+	Config extends FormsConfig<
+		any,
+		any,
+		any,
+		infer CustomFormMetadata,
+		any,
+		any,
+		any
+	>
 		? CustomFormMetadata
 		: {};
 
@@ -1142,8 +1251,32 @@ export type InferCustomFormMetadata<Config> =
  * ```
  */
 export type InferCustomFieldMetadata<Config> =
-	Config extends FormsConfig<any, any, any, any, infer CustomFieldMetadata, any>
+	Config extends FormsConfig<
+		any,
+		any,
+		any,
+		any,
+		infer CustomFieldMetadata,
+		any,
+		any
+	>
 		? CustomFieldMetadata
+		: {};
+
+/**
+ * Infer the configured custom-state shape from a FormsConfig.
+ */
+export type InferCustomState<Config> =
+	Config extends FormsConfig<
+		any,
+		any,
+		any,
+		any,
+		any,
+		any,
+		infer CustomStateHandlers
+	>
+		? FormCustomState<CustomStateHandlers>
 		: {};
 
 /**

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -226,7 +226,7 @@ export type FormAction<
 	Intent extends UnknownIntent = UnknownIntent,
 	Context = {},
 > = SubmissionResult<ErrorShape> & {
-	type: 'initialize' | 'server' | 'client';
+	type: 'initialize' | 'server' | 'client' | 'client:async';
 	intent: Intent;
 	ctx: Context;
 };

--- a/packages/conform-react/tests/configureForms.browser.test.tsx
+++ b/packages/conform-react/tests/configureForms.browser.test.tsx
@@ -2,7 +2,7 @@
 import { describe, test, expect } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { userEvent } from 'vitest/browser';
-import { configureForms, defineIntent } from '../future';
+import { configureForms, defineIntent, defineCustomState } from '../future';
 import { expectErrorMessage, expectNoErrorMessages } from './helpers';
 import { useRef } from 'react';
 import { getPathArray, updatePathIndex, updatePathValue } from '../future/util';
@@ -249,6 +249,91 @@ describe('configureForms', () => {
 		await userEvent.click(submitButton);
 		await expectNoErrorMessages(title);
 		await expect.element(title).not.toHaveAttribute('aria-invalid', 'true');
+	});
+
+	test('custom state is available on form metadata and resets', async () => {
+		const submitCount = defineCustomState({
+			initialize() {
+				return 0;
+			},
+			handleIntent(state, ctx) {
+				if (ctx.intent.type === 'submit') {
+					return state + 1;
+				}
+
+				return state;
+			},
+		});
+		const customized = configureForms({
+			customState: {
+				submitCount,
+			},
+			extendFormMetadata(form) {
+				return {
+					submitCount: form.customState.submitCount,
+				};
+			},
+		});
+
+		function Form() {
+			const { form, fields, intent } = customized.useForm<Schema, string[]>({
+				onValidate({ payload, error }) {
+					if (!payload.title) {
+						error.fieldErrors.title = ['Title is required'];
+					}
+
+					return error;
+				},
+				onSubmit(event) {
+					event.preventDefault();
+				},
+			});
+
+			return (
+				<form {...form.props}>
+					<input
+						name={fields.title.name}
+						defaultValue={fields.title.defaultValue}
+						aria-label="Title"
+					/>
+					<div data-testid="submit-count">{form.submitCount}</div>
+					<button>Submit</button>
+					<button type="button" onClick={() => intent.submit()}>
+						Submit via Intent
+					</button>
+					<button
+						type="button"
+						onClick={() => intent.update({ name: 'title', value: 'example' })}
+					>
+						Update
+					</button>
+					<button type="button" onClick={() => intent.reset()}>
+						Reset
+					</button>
+				</form>
+			);
+		}
+
+		const screen = render(<Form />);
+		const count = screen.getByTestId('submit-count');
+
+		await expect.element(count).toHaveTextContent('0');
+		await userEvent.click(
+			screen.getByRole('button', { name: 'Submit', exact: true }),
+		);
+		await expect.element(count).toHaveTextContent('1');
+		await userEvent.click(
+			screen.getByRole('button', { name: 'Submit via Intent', exact: true }),
+		);
+		await expect.element(count).toHaveTextContent('2');
+		await userEvent.click(
+			screen.getByRole('button', { name: 'Update', exact: true }),
+		);
+		await expect.element(count).toHaveTextContent('2');
+		await userEvent.click(
+			screen.getByRole('button', { name: 'Reset', exact: true }),
+		);
+		await expect.element(count).toHaveTextContent('0');
 	});
 
 	test('extendFormMetadata adds custom properties', async () => {

--- a/packages/conform-react/tests/helpers.tsx
+++ b/packages/conform-react/tests/helpers.tsx
@@ -14,7 +14,12 @@ import {
 	parseIntent,
 	resolveIntent,
 } from '../future/intent';
-import { FormAction, IntentHandler } from '../future/types';
+import {
+	CustomStateHandler,
+	FormAction,
+	FormCustomState,
+	IntentHandler,
+} from '../future/types';
 import { getApplyStatus, initializeState } from '../future/state';
 import { expect } from 'vitest';
 import { Locator } from 'vitest/browser';
@@ -77,6 +82,10 @@ export function createAction(options: {
 	targetValue?: Record<string, FormValue> | null;
 	error?: Partial<FormError<any>> | null;
 	handlers?: Record<string, IntentHandler<any, any>>;
+	customStateHandlers?: Record<string, CustomStateHandler<any, any, any>>;
+	lastCustomState?: FormCustomState<
+		Record<string, CustomStateHandler<any, any, any>>
+	>;
 }): FormAction<any, any, any> {
 	const formData = new FormData();
 
@@ -109,15 +118,19 @@ export function createAction(options: {
 			: applyIntent(result, intent, { handlers });
 
 	return {
-		...finalResult,
 		type: options.type,
 		intent,
+		result: finalResult,
 		ctx: {
-			handlers,
+			intentHandlers: handlers,
+			customStateHandlers: options.customStateHandlers,
 			status: getApplyStatus(result.targetValue, finalResult.targetValue),
-			reset(defaultValue?: Record<string, unknown> | null) {
+			reset() {
 				return initializeState({
-					defaultValue: defaultValue ?? options.defaultValue,
+					defaultValue: finalResult.targetValue ?? options.defaultValue,
+					customStateHandlers: options.customStateHandlers,
+					lastCustomState: options.lastCustomState,
+					result: finalResult,
 				});
 			},
 		},

--- a/packages/conform-react/tests/helpers.tsx
+++ b/packages/conform-react/tests/helpers.tsx
@@ -103,7 +103,10 @@ export function createAction(options: {
 		reset: options.reset,
 		error: options.error,
 	});
-	const finalResult = applyIntent(result, intent, { handlers });
+	const finalResult =
+		options.type === 'client:async'
+			? result
+			: applyIntent(result, intent, { handlers });
 
 	return {
 		...finalResult,

--- a/packages/conform-react/tests/intent.test.ts
+++ b/packages/conform-react/tests/intent.test.ts
@@ -43,8 +43,15 @@ test('serializeIntent', () => {
 		'custom(null)',
 	);
 	expect(serializeIntent({ type: 'custom', args: [undefined, 1] })).toBe(
-		'custom("__undefined__",1)',
+		'custom(,1)',
 	);
+	expect(serializeIntent({ type: 'custom', args: [undefined] })).toBe('custom');
+	expect(
+		serializeIntent({
+			type: 'custom',
+			args: [{ a: undefined, b: 123 }, undefined],
+		}),
+	).toBe('custom({"b":123})');
 
 	// Test intent with undefined payload
 	expect(serializeIntent({ type: 'reset', args: [] })).toBe('reset');
@@ -84,10 +91,25 @@ test('deserializeIntent', () => {
 		args: [],
 	});
 
-	// Test serialized undefined argument
-	expect(deserializeIntent('custom("__undefined__",1)')).toEqual({
+	expect(deserializeIntent('custom("__undefined__")')).toEqual({
+		type: 'custom',
+		args: ['__undefined__'],
+	});
+	expect(deserializeIntent('custom(,1)')).toEqual({
 		type: 'custom',
 		args: [undefined, 1],
+	});
+	expect(deserializeIntent('custom({"nested":{"$undefined":true}})')).toEqual({
+		type: 'custom',
+		args: [{ nested: { $undefined: true } }],
+	});
+	expect(deserializeIntent('custom("",1)')).toEqual({
+		type: 'custom',
+		args: ['', 1],
+	});
+	expect(deserializeIntent('custom("a,b",{"items":[1,2]})')).toEqual({
+		type: 'custom',
+		args: ['a,b', { items: [1, 2] }],
 	});
 
 	// Test empty string
@@ -110,11 +132,7 @@ test('parseIntent', () => {
 	expect(
 		parseIntent('validate(null)', { handlers: defaultIntentHandlers }),
 	).toBe(undefined);
-	expect(
-		parseIntent('validate("__undefined__")', {
-			handlers: defaultIntentHandlers,
-		}),
-	).toEqual({
+	expect(parseIntent('validate', { handlers: defaultIntentHandlers })).toEqual({
 		type: 'validate',
 		payload: undefined,
 	});

--- a/packages/conform-react/tests/intent.test.ts
+++ b/packages/conform-react/tests/intent.test.ts
@@ -43,8 +43,14 @@ test('serializeIntent', () => {
 		'custom(null)',
 	);
 	expect(serializeIntent({ type: 'custom', args: [undefined, 1] })).toBe(
-		'custom(,1)',
+		'custom("$$__undefined__$$",1)',
 	);
+	expect(
+		serializeIntent({
+			type: 'custom',
+			args: [undefined, 1, undefined, 2, undefined],
+		}),
+	).toBe('custom("$$__undefined__$$",1,"$$__undefined__$$",2)');
 	expect(serializeIntent({ type: 'custom', args: [undefined] })).toBe('custom');
 	expect(
 		serializeIntent({
@@ -52,6 +58,25 @@ test('serializeIntent', () => {
 			args: [{ a: undefined, b: 123 }, undefined],
 		}),
 	).toBe('custom({"b":123})');
+	// Undefined object properties are omitted while array positions are preserved.
+	expect(
+		serializeIntent({
+			type: 'custom',
+			args: [[undefined, { a: undefined, b: 1 }]],
+		}),
+	).toBe('custom(["$$__undefined__$$",{"b":1}])');
+	expect(
+		serializeIntent({
+			type: 'custom',
+			args: [{ items: [undefined, 1, undefined], missing: undefined }],
+		}),
+	).toBe('custom({"items":["$$__undefined__$$",1,"$$__undefined__$$"]})');
+	expect(
+		serializeIntent({
+			type: 'custom',
+			args: [[1, undefined], undefined],
+		}),
+	).toBe('custom([1,"$$__undefined__$$"])');
 
 	// Test intent with undefined payload
 	expect(serializeIntent({ type: 'reset', args: [] })).toBe('reset');
@@ -95,9 +120,23 @@ test('deserializeIntent', () => {
 		type: 'custom',
 		args: ['__undefined__'],
 	});
-	expect(deserializeIntent('custom(,1)')).toEqual({
+	expect(deserializeIntent('custom("$$__undefined__$$",1)')).toEqual({
 		type: 'custom',
 		args: [undefined, 1],
+	});
+	expect(
+		deserializeIntent('custom("$$__undefined__$$",1,"$$__undefined__$$",2)'),
+	).toEqual({
+		type: 'custom',
+		args: [undefined, 1, undefined, 2],
+	});
+	expect(deserializeIntent('custom( "$$__undefined__$$" ,1)')).toEqual({
+		type: 'custom',
+		args: [undefined, 1],
+	});
+	expect(deserializeIntent('custom("$$__undefined__$$")')).toEqual({
+		type: 'custom',
+		args: [undefined],
 	});
 	expect(deserializeIntent('custom({"nested":{"$undefined":true}})')).toEqual({
 		type: 'custom',
@@ -111,6 +150,64 @@ test('deserializeIntent', () => {
 		type: 'custom',
 		args: ['a,b', { items: [1, 2] }],
 	});
+	expect(deserializeIntent('custom("a\\\"?{},b","c\\\\d",{"?":"?"})')).toEqual({
+		type: 'custom',
+		args: ['a"?{},b', 'c\\d', { '?': '?' }],
+	});
+	expect(
+		deserializeIntent('custom({"items":[1,{"nested":[2,3]}]},[4,[5,6]])'),
+	).toEqual({
+		type: 'custom',
+		args: [{ items: [1, { nested: [2, 3] }] }, [4, [5, 6]]],
+	});
+	expect(deserializeIntent('custom(true,-1.5,1e3)')).toEqual({
+		type: 'custom',
+		args: [true, -1.5, 1000],
+	});
+	expect(
+		deserializeIntent(
+			serializeIntent({
+				type: 'custom',
+				args: [
+					[undefined, { items: [1, undefined] }],
+					{ items: [undefined], missing: undefined },
+				],
+			}),
+		),
+	).toEqual({
+		type: 'custom',
+		args: [[undefined, { items: [1, undefined] }], { items: [undefined] }],
+	});
+	expect(
+		deserializeIntent(
+			serializeIntent({
+				type: 'custom',
+				args: [
+					['$__undefined__$$', '$$__undefined__$', '__undefined__'],
+					{ value: 'prefix$$__undefined__$$suffix' },
+				],
+			}),
+		),
+	).toEqual({
+		type: 'custom',
+		args: [
+			['$__undefined__$$', '$$__undefined__$', '__undefined__'],
+			{ value: 'prefix$$__undefined__$$suffix' },
+		],
+	});
+	expect(
+		deserializeIntent(serializeIntent({ type: 'custom', args: [-0] })),
+	).toEqual({
+		type: 'custom',
+		args: [0],
+	});
+	expect(deserializeIntent('custom(1,)')).toBeUndefined();
+	expect(deserializeIntent('custom({])')).toBeUndefined();
+	expect(deserializeIntent('custom([})')).toBeUndefined();
+	expect(deserializeIntent('custom("unterminated,,,,)')).toBeUndefined();
+	expect(
+		deserializeIntent(`custom("${'\\"?'.repeat(50_000)})`),
+	).toBeUndefined();
 
 	// Test empty string
 	expect(deserializeIntent('')).toBeUndefined();

--- a/packages/conform-react/tests/intent.test.ts
+++ b/packages/conform-react/tests/intent.test.ts
@@ -43,7 +43,7 @@ test('serializeIntent', () => {
 		'custom(null)',
 	);
 	expect(serializeIntent({ type: 'custom', args: [undefined, 1] })).toBe(
-		'custom(null,1)',
+		'custom("__undefined__",1)',
 	);
 
 	// Test intent with undefined payload
@@ -85,10 +85,13 @@ test('deserializeIntent', () => {
 	});
 
 	// Test serialized undefined argument
-	expect(deserializeIntent('custom(null,1)')).toEqual({
+	expect(deserializeIntent('custom("__undefined__",1)')).toEqual({
 		type: 'custom',
-		args: [null, 1],
+		args: [undefined, 1],
 	});
+
+	// Test empty string
+	expect(deserializeIntent('')).toBeUndefined();
 });
 
 test('parseIntent', () => {
@@ -101,10 +104,20 @@ test('parseIntent', () => {
 		type: 'submit',
 		payload: undefined,
 	});
-
 	expect(parseIntent('custom', { handlers: defaultIntentHandlers })).toBe(
 		undefined,
 	);
+	expect(
+		parseIntent('validate(null)', { handlers: defaultIntentHandlers }),
+	).toBe(undefined);
+	expect(
+		parseIntent('validate("__undefined__")', {
+			handlers: defaultIntentHandlers,
+		}),
+	).toEqual({
+		type: 'validate',
+		payload: undefined,
+	});
 
 	const handlers = {
 		custom: {

--- a/packages/conform-react/tests/state.test.ts
+++ b/packages/conform-react/tests/state.test.ts
@@ -943,6 +943,41 @@ describe('form state', () => {
 		expect(isTouched(context.state, 'tasks[1]')).toBe(true);
 		expect(isTouched(context.state, 'tasks[2]')).toBe(false);
 
+		context.state = updateState(
+			context.state,
+			createAction({
+				type: 'client:async',
+				entries: [
+					['title', 'My Tasks'],
+					['tasks[0]', 'Default task 1'],
+					['tasks[1]', 'Default task 2'],
+					['tasks[2]', 'New task'],
+					[
+						DEFAULT_INTENT_NAME,
+						serializeIntent({
+							type: 'insert',
+							args: [
+								{
+									name: 'tasks',
+									index: 0,
+									defaultValue: 'Async task',
+								},
+							],
+						}),
+					],
+				],
+				error: null,
+			}),
+		);
+
+		expect(getDefaultOptions(context, 'tasks')).toEqual([
+			'Default task 1',
+			'Default task 2',
+			'New task',
+		]);
+		expect(isTouched(context.state, 'tasks[1]')).toBe(true);
+		expect(isTouched(context.state, 'tasks[2]')).toBe(false);
+
 		// Test inserting an item at a specific index
 		vi.advanceTimersByTime(1);
 		context.state = updateState(
@@ -2117,22 +2152,24 @@ test('updateCustomState', () => {
 		step: 0,
 	});
 
-	const asyncPassAction = createAction({
-		type: 'server',
-		entries: [['title', 'Example']],
-		error: null,
-	});
-
-	const asyncPassState = updateCustomState(pendingState, asyncPassAction, {
-		handlers,
-	});
+	const asyncPassState = updateCustomState(
+		pendingState,
+		createAction({
+			type: 'client:async',
+			entries: [['title', 'Example']],
+			error: null,
+		}),
+		{
+			handlers,
+		},
+	);
 
 	expect(asyncPassState).toEqual({
 		submitCount: 1,
 		failedSubmitCount: 0,
 		summary: { dismissed: false },
-		status: 'success',
-		step: 0,
+		status: 'submitted',
+		step: 1,
 	});
 
 	const serverPassState = updateCustomState(
@@ -2152,7 +2189,7 @@ test('updateCustomState', () => {
 		failedSubmitCount: 0,
 		summary: { dismissed: false },
 		status: 'success',
-		step: 0,
+		step: 1,
 	});
 
 	const failureState = updateCustomState(

--- a/packages/conform-react/tests/state.test.ts
+++ b/packages/conform-react/tests/state.test.ts
@@ -23,6 +23,9 @@ import {
 	getField,
 	getFieldset,
 	getFieldList,
+	defineCustomState,
+	initializeCustomState,
+	updateCustomState,
 } from '../future/state';
 import { defineIntent, serializeIntent } from '../future/intent';
 import { getPathArray, updatePathValue } from '../future/util';
@@ -1974,4 +1977,247 @@ test('getFieldList', () => {
 	expect(firstUserFieldset?.name?.defaultValue).toBe('John');
 	expect(firstUserFieldset?.age?.name).toBe('users[0].age');
 	expect(firstUserFieldset?.age?.defaultValue).toBe('25');
+});
+
+test('initializeCustomState', () => {
+	const customState = initializeCustomState({
+		handlers: {
+			wizard: defineCustomState({
+				initialize() {
+					return { step: 0 };
+				},
+				handleIntent(state) {
+					return state;
+				},
+			}),
+			summary: defineCustomState({
+				initialize() {
+					return { dismissed: false };
+				},
+				handleIntent(state) {
+					return state;
+				},
+			}),
+		},
+		reset: false,
+	});
+
+	expect(customState).toEqual({
+		wizard: { step: 0 },
+		summary: { dismissed: false },
+	});
+});
+
+test('updateCustomState', () => {
+	const handlers = {
+		submitCount: defineCustomState({
+			initialize() {
+				return 0;
+			},
+			handleIntent(state, ctx) {
+				if (ctx.intent.type === 'submit') {
+					return state + 1;
+				}
+
+				return state;
+			},
+		}),
+		failedSubmitCount: defineCustomState({
+			initialize() {
+				return 0;
+			},
+			handleResult(state, ctx) {
+				if (ctx.intent.type === 'submit' && ctx.error) {
+					return state + 1;
+				}
+
+				return state;
+			},
+		}),
+		summary: defineCustomState({
+			initialize() {
+				return { dismissed: false };
+			},
+			handleIntent(state) {
+				return state;
+			},
+		}),
+		status: defineCustomState<'idle' | 'submitted' | 'success' | 'error'>({
+			initialize(ctx) {
+				if (ctx.reset && ctx.lastState) {
+					return ctx.lastState;
+				}
+
+				return 'idle';
+			},
+			handleIntent(state, ctx) {
+				if (ctx.intent.type === 'submit') {
+					return 'submitted';
+				}
+
+				return state;
+			},
+			handleResult(state, ctx) {
+				if (ctx.intent.type !== 'submit') {
+					return state;
+				}
+
+				if (ctx.error) {
+					return 'error';
+				}
+
+				if (ctx.phase === 'server' && ctx.error === null) {
+					return 'success';
+				}
+
+				return state;
+			},
+		}),
+		step: defineCustomState({
+			initialize() {
+				return 0;
+			},
+			handleResult(state, ctx) {
+				if (
+					ctx.intent.type === 'submit' &&
+					ctx.phase === 'client' &&
+					ctx.error === null
+				) {
+					return state + 1;
+				}
+
+				return state;
+			},
+		}),
+	};
+	const initialState = {
+		submitCount: 0,
+		failedSubmitCount: 0,
+		summary: { dismissed: false },
+		status: 'idle' as const,
+		step: 0,
+	};
+
+	const pendingState = updateCustomState(
+		initialState,
+		createAction({
+			type: 'client',
+			entries: [['title', 'Example']],
+		}),
+		{
+			handlers,
+		},
+	);
+
+	expect(pendingState).toEqual({
+		submitCount: 1,
+		failedSubmitCount: 0,
+		summary: { dismissed: false },
+		status: 'submitted',
+		step: 0,
+	});
+
+	const asyncPassAction = createAction({
+		type: 'server',
+		entries: [['title', 'Example']],
+		error: null,
+	});
+
+	const asyncPassState = updateCustomState(pendingState, asyncPassAction, {
+		handlers,
+	});
+
+	expect(asyncPassState).toEqual({
+		submitCount: 1,
+		failedSubmitCount: 0,
+		summary: { dismissed: false },
+		status: 'success',
+		step: 0,
+	});
+
+	const serverPassState = updateCustomState(
+		asyncPassState,
+		createAction({
+			type: 'server',
+			entries: [['title', 'Example']],
+			error: null,
+		}),
+		{
+			handlers,
+		},
+	);
+
+	expect(serverPassState).toEqual({
+		submitCount: 1,
+		failedSubmitCount: 0,
+		summary: { dismissed: false },
+		status: 'success',
+		step: 0,
+	});
+
+	const failureState = updateCustomState(
+		initialState,
+		createAction({
+			type: 'client',
+			entries: [['title', '']],
+			error: {
+				fieldErrors: {
+					title: ['Required'],
+				},
+			},
+		}),
+		{
+			handlers,
+		},
+	);
+
+	expect(failureState).toEqual({
+		submitCount: 1,
+		failedSubmitCount: 1,
+		summary: { dismissed: false },
+		status: 'error',
+		step: 0,
+	});
+
+	const ssrState = updateCustomState(
+		initialState,
+		createAction({
+			type: 'initialize',
+			entries: [['title', 'Example']],
+			error: null,
+		}),
+		{
+			handlers,
+		},
+	);
+
+	expect(ssrState).toEqual({
+		submitCount: 1,
+		failedSubmitCount: 0,
+		summary: { dismissed: false },
+		status: 'success',
+		step: 0,
+	});
+
+	const nextState2 = updateCustomState(
+		serverPassState,
+		createAction({
+			type: 'client',
+			entries: [
+				[DEFAULT_INTENT_NAME, serializeIntent({ type: 'reset', args: [] })],
+			],
+			reset: true,
+		}),
+		{
+			handlers,
+		},
+	);
+
+	expect(nextState2).toEqual({
+		submitCount: 0,
+		failedSubmitCount: 0,
+		summary: { dismissed: false },
+		status: 'success',
+		step: 0,
+	});
 });

--- a/packages/conform-react/tests/state.test.ts
+++ b/packages/conform-react/tests/state.test.ts
@@ -25,6 +25,7 @@ import {
 	getFieldList,
 	defineCustomState,
 	initializeCustomState,
+	mergeCustomStateHandlers,
 	updateCustomState,
 } from '../future/state';
 import { defineIntent, serializeIntent } from '../future/intent';
@@ -2014,7 +2015,8 @@ test('getFieldList', () => {
 	expect(firstUserFieldset?.age?.defaultValue).toBe('25');
 });
 
-test('initializeCustomState', () => {
+test('custom state', () => {
+	// Test initialization
 	const customState = initializeCustomState({
 		handlers: {
 			wizard: defineCustomState({
@@ -2034,16 +2036,83 @@ test('initializeCustomState', () => {
 				},
 			}),
 		},
-		reset: false,
 	});
 
 	expect(customState).toEqual({
 		wizard: { step: 0 },
 		summary: { dismissed: false },
 	});
-});
 
-test('updateCustomState', () => {
+	// Test reset handling
+	const initializePreserved = vi.fn(() => 0);
+	const initializeReinitialized = vi.fn(() => 0);
+	const resetHandlers = {
+		preserved: defineCustomState({
+			initialize: initializePreserved,
+			reset: false,
+		}),
+		reinitialized: defineCustomState({
+			initialize: initializeReinitialized,
+			reset: true,
+		}),
+	};
+	const initialResetState = initializeCustomState({ handlers: resetHandlers });
+
+	expect(
+		initializeCustomState({
+			handlers: resetHandlers,
+			currentState: initialResetState,
+		}),
+	).toEqual({ preserved: 0, reinitialized: 0 });
+	expect(initializePreserved).toHaveBeenCalledOnce();
+	expect(initializeReinitialized).toHaveBeenCalledTimes(2);
+
+	// Test custom state handler collisions
+	const slice = defineCustomState({
+		initialize() {
+			return 0;
+		},
+	});
+
+	expect(
+		mergeCustomStateHandlers({ global: slice }, { toString: slice }).toString,
+	).toBe(slice);
+	expect(() =>
+		mergeCustomStateHandlers({ duplicate: slice }, { duplicate: slice }),
+	).toThrow('Duplicate custom state key "duplicate"');
+
+	// Test pending and explicit results
+	const handleResult = vi.fn((state: number) => state + 1);
+	const resultHandlers = {
+		resultCount: defineCustomState({
+			initialize() {
+				return 0;
+			},
+			handleResult,
+		}),
+	};
+	const initialResultState = initializeCustomState({
+		handlers: resultHandlers,
+	});
+	const pendingResultState = updateCustomState(
+		initialResultState,
+		createAction({ type: 'client', entries: [] }),
+		{ handlers: resultHandlers },
+	);
+
+	expect(pendingResultState).toEqual({ resultCount: 0 });
+	expect(handleResult).not.toHaveBeenCalled();
+
+	const resultState = updateCustomState(
+		initialResultState,
+		createAction({ type: 'client:async', entries: [], error: null }),
+		{ handlers: resultHandlers },
+	);
+
+	expect(resultState).toEqual({ resultCount: 1 });
+	expect(handleResult).toHaveBeenCalledOnce();
+
+	// Test action phases
 	const handlers = {
 		submitCount: defineCustomState({
 			initialize() {
@@ -2078,11 +2147,7 @@ test('updateCustomState', () => {
 			},
 		}),
 		status: defineCustomState<'idle' | 'submitted' | 'success' | 'error'>({
-			initialize(ctx) {
-				if (ctx.reset && ctx.lastState) {
-					return ctx.lastState;
-				}
-
+			initialize() {
 				return 'idle';
 			},
 			handleIntent(state, ctx) {
@@ -2236,25 +2301,16 @@ test('updateCustomState', () => {
 		step: 0,
 	});
 
-	const nextState2 = updateCustomState(
-		serverPassState,
-		createAction({
-			type: 'client',
-			entries: [
-				[DEFAULT_INTENT_NAME, serializeIntent({ type: 'reset', args: [] })],
-			],
-			reset: true,
-		}),
-		{
-			handlers,
-		},
-	);
+	const nextState2 = initializeCustomState({
+		handlers,
+		currentState: serverPassState,
+	});
 
 	expect(nextState2).toEqual({
 		submitCount: 0,
 		failedSubmitCount: 0,
 		summary: { dismissed: false },
-		status: 'success',
+		status: 'idle',
 		step: 0,
 	});
 });

--- a/packages/conform-react/tests/state.test.ts
+++ b/packages/conform-react/tests/state.test.ts
@@ -2046,6 +2046,9 @@ test('custom state', () => {
 	// Test reset handling
 	const initializePreserved = vi.fn(() => 0);
 	const initializeReinitialized = vi.fn(() => 0);
+	const resetCustomized = vi.fn();
+	const handleCustomizedIntent = vi.fn((state: number) => state + 10);
+	const handleCustomizedResult = vi.fn((state: number) => state + 100);
 	const resetHandlers = {
 		preserved: defineCustomState({
 			initialize: initializePreserved,
@@ -2055,17 +2058,65 @@ test('custom state', () => {
 			initialize: initializeReinitialized,
 			reset: true,
 		}),
+		customized: defineCustomState({
+			initialize() {
+				return 0;
+			},
+			reset(state, { result }) {
+				resetCustomized(state, result);
+				return result?.error === null ? state + 1 : state;
+			},
+			handleIntent: handleCustomizedIntent,
+			handleResult: handleCustomizedResult,
+		}),
 	};
 	const initialResetState = initializeCustomState({ handlers: resetHandlers });
 
+	const lifecycleResetState = initializeCustomState({
+		handlers: resetHandlers,
+		currentState: initialResetState,
+	});
+
+	expect(lifecycleResetState).toEqual({
+		preserved: 0,
+		reinitialized: 0,
+		customized: 0,
+	});
+	expect(initializePreserved).toHaveBeenCalledOnce();
+	expect(initializeReinitialized).toHaveBeenCalledTimes(2);
+	expect(resetCustomized).toHaveBeenCalledWith(0, undefined);
+
+	const formState = initializeState({
+		customStateHandlers: resetHandlers,
+	});
+	const resetAction = createAction({
+		type: 'client',
+		entries: [['title', 'Example']],
+		reset: true,
+		targetValue: { title: 'Reset title' },
+		error: null,
+		customStateHandlers: resetHandlers,
+		lastCustomState: formState.customState,
+	});
 	expect(
 		initializeCustomState({
 			handlers: resetHandlers,
-			currentState: initialResetState,
+			currentState: lifecycleResetState,
+			result: resetAction.result,
 		}),
-	).toEqual({ preserved: 0, reinitialized: 0 });
-	expect(initializePreserved).toHaveBeenCalledOnce();
-	expect(initializeReinitialized).toHaveBeenCalledTimes(2);
+	).toEqual({ preserved: 0, reinitialized: 0, customized: 1 });
+	expect(resetCustomized).toHaveBeenLastCalledWith(0, resetAction.result);
+
+	const resetState = updateState(formState, resetAction);
+
+	expect(resetState.defaultValue).toEqual({ title: 'Reset title' });
+	expect(resetState.customState).toEqual({
+		preserved: 0,
+		reinitialized: 0,
+		customized: 1,
+	});
+	expect(handleCustomizedIntent).not.toHaveBeenCalled();
+	expect(handleCustomizedResult).not.toHaveBeenCalled();
 
 	// Test custom state handler collisions
 	const slice = defineCustomState({
@@ -2131,7 +2182,7 @@ test('custom state', () => {
 				return 0;
 			},
 			handleResult(state, ctx) {
-				if (ctx.intent.type === 'submit' && ctx.error) {
+				if (ctx.intent.type === 'submit' && ctx.result.error) {
 					return state + 1;
 				}
 
@@ -2162,11 +2213,11 @@ test('custom state', () => {
 					return state;
 				}
 
-				if (ctx.error) {
+				if (ctx.result.error) {
 					return 'error';
 				}
 
-				if (ctx.phase === 'server' && ctx.error === null) {
+				if (ctx.phase === 'server' && ctx.result.error === null) {
 					return 'success';
 				}
 
@@ -2181,7 +2232,7 @@ test('custom state', () => {
 				if (
 					ctx.intent.type === 'submit' &&
 					ctx.phase === 'client' &&
-					ctx.error === null
+					ctx.result.error === null
 				) {
 					return state + 1;
 				}

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -12,6 +12,7 @@ import type {
 	InferBaseErrorShape,
 	InferCustomFieldMetadata,
 	InferCustomFormMetadata,
+	InferCustomState,
 	IntentDispatcher,
 	IntentHandler,
 } from '@conform-to/react/future';
@@ -22,6 +23,7 @@ import {
 	configureForms,
 	shape,
 	defineIntent,
+	defineCustomState,
 } from '@conform-to/react/future';
 import { useRef } from 'react';
 
@@ -666,6 +668,181 @@ describe('configureForms', () => {
 		expectTypeOf(custom.useIntent('form-id').goToStep).toEqualTypeOf<
 			(payload: { step: number }) => void
 		>();
+	});
+
+	test('custom state', () => {
+		const goToStep = defineIntent<{ step: number }>({
+			parse(payload) {
+				if (
+					typeof payload !== 'object' ||
+					payload === null ||
+					!('step' in payload) ||
+					typeof payload.step !== 'number'
+				) {
+					throw new Error('Invalid goToStep payload');
+				}
+
+				return payload;
+			},
+		});
+		const step = defineCustomState<number, { goToStep: typeof goToStep }>({
+			initialize() {
+				return 0;
+			},
+			handleIntent(state, ctx) {
+				assertType<
+					| 'submit'
+					| 'reset'
+					| 'validate'
+					| 'update'
+					| 'insert'
+					| 'remove'
+					| 'reorder'
+					| 'goToStep'
+				>(ctx.intent.type);
+				if (ctx.intent.type === 'goToStep') {
+					assertType<number>(ctx.intent.payload.step);
+					return ctx.intent.payload.step;
+				}
+
+				return state;
+			},
+		});
+		const dismiss = defineIntent();
+		const summary = defineCustomState<
+			{ dismissed: boolean },
+			{ goToStep: typeof goToStep; dismiss: typeof dismiss }
+		>({
+			initialize() {
+				return { dismissed: false };
+			},
+			handleIntent(state, ctx) {
+				if (ctx.intent.type === 'dismiss') {
+					return {
+						dismissed: true,
+					};
+				}
+
+				if (ctx.intent.type === 'goToStep') {
+					return {
+						dismissed: false,
+					};
+				}
+
+				return state;
+			},
+		});
+		const status = defineCustomState<'idle' | 'success' | 'error'>({
+			initialize() {
+				return 'idle';
+			},
+			handleResult(state, ctx) {
+				assertType<'client' | 'server'>(ctx.phase);
+				assertType<string[] | null | undefined>(ctx.error?.formErrors);
+
+				if (ctx.intent.type === 'submit') {
+					return ctx.error ? 'error' : 'success';
+				}
+
+				return state;
+			},
+		});
+
+		const custom = configureForms({
+			customState: {
+				step,
+				status,
+			},
+			intents: {
+				goToStep,
+			},
+			extendFormMetadata(form) {
+				return {
+					currentStep: form.customState.step,
+				};
+			},
+		});
+
+		expectTypeOf<InferCustomState<typeof custom.config>>().toEqualTypeOf<{
+			step: number;
+			status: 'idle' | 'success' | 'error';
+		}>();
+
+		const setup = custom.useForm({
+			intents: {
+				dismiss,
+			},
+			customState: {
+				summary,
+			},
+			onValidate({ error }) {
+				return error;
+			},
+		});
+
+		expectTypeOf(setup.form.customState).toEqualTypeOf<{
+			step: number;
+			status: 'idle' | 'success' | 'error';
+			summary: { dismissed: boolean };
+		}>();
+		expectTypeOf(setup.form.currentStep).toEqualTypeOf<number>();
+
+		configureForms({
+			customState: {
+				// @ts-expect-error custom intents used in custom state handlers must be defined
+				step,
+			},
+		});
+
+		custom.useForm({
+			customState: {
+				// @ts-expect-error custom intents used in custom state handlers must be defined
+				summary,
+			},
+			onValidate({ error }) {
+				return error;
+			},
+		});
+
+		configureForms({
+			intents: {
+				goToStep: defineIntent<(step: number) => void>(),
+			},
+			customState: {
+				// @ts-expect-error custom intent signature should match (`step: number` vs `{ step: number }`)
+				wizard: defineCustomState<
+					{ step: number },
+					{ goToStep: typeof goToStep }
+				>({
+					initialize() {
+						return { step: 0 };
+					},
+					handleIntent(state) {
+						return state;
+					},
+				}),
+			},
+		});
+
+		const inlineSetup = useForm({
+			customState: {
+				summary: defineCustomState({
+					initialize() {
+						return { dismissed: false };
+					},
+					handleIntent(state) {
+						return state;
+					},
+				}),
+			},
+			onValidate({ error }) {
+				return error;
+			},
+		});
+
+		expectTypeOf(inlineSetup.form.customState).toEqualTypeOf<{
+			summary: { dismissed: boolean };
+		}>();
 	});
 });
 

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -9,6 +9,7 @@ import type {
 	FormValue,
 	FormMetadata,
 	FormOptions,
+	SubmissionResult,
 	InferBaseErrorShape,
 	InferCustomFieldMetadata,
 	InferCustomFormMetadata,
@@ -717,6 +718,11 @@ describe('configureForms', () => {
 			initialize() {
 				return { dismissed: false };
 			},
+			reset(state, ctx) {
+				assertType<SubmissionResult | undefined>(ctx.result);
+
+				return state;
+			},
 			handleIntent(state, ctx) {
 				if (ctx.intent.type === 'dismiss') {
 					return {
@@ -733,16 +739,28 @@ describe('configureForms', () => {
 				return state;
 			},
 		});
-		const status = defineCustomState<'idle' | 'success' | 'error'>({
+		const status = defineCustomState<
+			'idle' | 'success' | 'error',
+			{},
+			string[]
+		>({
 			initialize() {
 				return 'idle';
 			},
+			reset(state, ctx) {
+				assertType<'idle' | 'success' | 'error'>(state);
+				assertType<SubmissionResult<string[]> | undefined>(ctx.result);
+				assertType<string[] | null | undefined>(ctx.result?.error?.formErrors);
+
+				return state;
+			},
 			handleResult(state, ctx) {
 				assertType<'client' | 'server'>(ctx.phase);
-				assertType<string[] | undefined>(ctx.error?.formErrors);
+				assertType<SubmissionResult<string[]>>(ctx.result);
+				assertType<string[] | null | undefined>(ctx.result.error?.formErrors);
 
 				if (ctx.intent.type === 'submit') {
-					return ctx.error ? 'error' : 'success';
+					return ctx.result.error ? 'error' : 'success';
 				}
 
 				return state;

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -689,6 +689,7 @@ describe('configureForms', () => {
 			initialize() {
 				return 0;
 			},
+			reset: false,
 			handleIntent(state, ctx) {
 				assertType<
 					| 'submit'
@@ -738,7 +739,7 @@ describe('configureForms', () => {
 			},
 			handleResult(state, ctx) {
 				assertType<'client' | 'server'>(ctx.phase);
-				assertType<string[] | null | undefined>(ctx.error?.formErrors);
+				assertType<string[] | undefined>(ctx.error?.formErrors);
 
 				if (ctx.intent.type === 'submit') {
 					return ctx.error ? 'error' : 'success';

--- a/packages/conform-react/tests/useForm.browser.test.tsx
+++ b/packages/conform-react/tests/useForm.browser.test.tsx
@@ -6,6 +6,7 @@ import {
 	type FormValue,
 	type FormError,
 	type FormOptions,
+	type SubmissionResult,
 	defineIntent,
 	defineCustomState,
 	useForm as useFormDefault,
@@ -1107,6 +1108,14 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 				return ctx.intent.type === 'submit' ? state + 1 : state;
 			},
 		});
+		const resetHistory = defineCustomState({
+			initialize(): string[] {
+				return [];
+			},
+			reset(history, { result }) {
+				return history.concat(result ? 'result' : 'lifecycle');
+			},
+		});
 
 		function CustomStateForm({ formKey }: { formKey: string }) {
 			const { form, fields, intent } = useForm({
@@ -1117,6 +1126,7 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 				customState: {
 					submitCount,
 					preservedCount,
+					resetHistory,
 				},
 				onValidate({ error }) {
 					return error;
@@ -1136,6 +1146,9 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 					<div data-testid="submit-count">{form.customState.submitCount}</div>
 					<div data-testid="preserved-count">
 						{form.customState.preservedCount}
+					</div>
+					<div data-testid="reset-history">
+						{form.customState.resetHistory.join(',')}
 					</div>
 					<button>Submit</button>
 					<button type="button" onClick={() => intent.reset()}>
@@ -1168,6 +1181,9 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 		await expect
 			.element(screen.getByTestId('preserved-count'))
 			.toHaveTextContent('2');
+		await expect
+			.element(screen.getByTestId('reset-history'))
+			.toHaveTextContent('result');
 
 		screen.rerender(<CustomStateForm formKey="second" />);
 		await expect
@@ -1176,6 +1192,61 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 		await expect
 			.element(screen.getByTestId('preserved-count'))
 			.toHaveTextContent('2');
+		await expect
+			.element(screen.getByTestId('reset-history'))
+			.toHaveTextContent('result,lifecycle');
+	});
+
+	test('custom state reset callback receives server result', async () => {
+		const handleResult = vi.fn((state: string) => state);
+		const submissionStatus = defineCustomState({
+			initialize() {
+				return 'idle';
+			},
+			reset(_state, { result }) {
+				return result?.error === null ? 'success' : 'idle';
+			},
+			handleResult,
+		});
+
+		function CustomStateForm({
+			lastResult,
+		}: {
+			lastResult?: SubmissionResult<string[]>;
+		}) {
+			const { form } = useForm({
+				lastResult,
+				customState: {
+					submissionStatus,
+				},
+				onValidate({ error }) {
+					return error;
+				},
+				onSubmit(event) {
+					event.preventDefault();
+				},
+			});
+
+			return (
+				<form {...form.props}>
+					<output>{form.customState.submissionStatus}</output>
+				</form>
+			);
+		}
+
+		const screen = render(<CustomStateForm />);
+		await expect.element(screen.getByText('idle')).toBeInTheDocument();
+
+		const formData = new FormData();
+		formData.set('title', 'Example');
+		const result = report<string[]>(parseSubmission(formData), {
+			reset: true,
+			error: null,
+		});
+
+		screen.rerender(<CustomStateForm lastResult={result} />);
+		await expect.element(screen.getByText('success')).toBeInTheDocument();
+		expect(handleResult).not.toHaveBeenCalled();
 	});
 
 	test('server report', async () => {

--- a/packages/conform-react/tests/useForm.browser.test.tsx
+++ b/packages/conform-react/tests/useForm.browser.test.tsx
@@ -7,6 +7,7 @@ import {
 	type FormError,
 	type FormOptions,
 	defineIntent,
+	defineCustomState,
 	useForm as useFormDefault,
 	report,
 	parseSubmission,
@@ -1082,6 +1083,71 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 		await expect
 			.element(screen.getByLabelText('Task #3 Local'))
 			.toHaveValue('Local 2 preserved');
+	});
+
+	test('custom state', async () => {
+		const submitCount = defineCustomState({
+			initialize() {
+				return 0;
+			},
+			handleIntent(count, ctx) {
+				if (ctx.intent.type === 'submit') {
+					return count + 1;
+				}
+
+				return count;
+			},
+		});
+
+		function CustomStateForm() {
+			const { form, fields, intent } = useForm({
+				defaultValue: {
+					title: 'Example',
+				},
+				customState: {
+					submitCount,
+				},
+				onValidate({ error }) {
+					return error;
+				},
+				onSubmit(event) {
+					event.preventDefault();
+				},
+			});
+
+			return (
+				<form {...form.props}>
+					<input
+						name={fields.title.name}
+						defaultValue={fields.title.defaultValue}
+						aria-label="Title"
+					/>
+					<div data-testid="submit-count">{form.customState.submitCount}</div>
+					<button>Submit</button>
+					<button type="button" onClick={() => intent.reset()}>
+						Reset
+					</button>
+				</form>
+			);
+		}
+
+		const screen = render(<CustomStateForm />);
+
+		await expect
+			.element(screen.getByTestId('submit-count'))
+			.toHaveTextContent('0');
+		await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+		await expect
+			.element(screen.getByTestId('submit-count'))
+			.toHaveTextContent('1');
+		await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+		await expect
+			.element(screen.getByTestId('submit-count'))
+			.toHaveTextContent('2');
+		await userEvent.click(screen.getByRole('button', { name: 'Reset' }));
+		await expect
+			.element(screen.getByTestId('submit-count'))
+			.toHaveTextContent('0');
 	});
 
 	test('server report', async () => {

--- a/packages/conform-react/tests/useForm.browser.test.tsx
+++ b/packages/conform-react/tests/useForm.browser.test.tsx
@@ -1098,14 +1098,25 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 				return count;
 			},
 		});
+		const preservedCount = defineCustomState({
+			initialize() {
+				return 0;
+			},
+			reset: false,
+			handleIntent(state, ctx) {
+				return ctx.intent.type === 'submit' ? state + 1 : state;
+			},
+		});
 
-		function CustomStateForm() {
+		function CustomStateForm({ formKey }: { formKey: string }) {
 			const { form, fields, intent } = useForm({
+				key: formKey,
 				defaultValue: {
 					title: 'Example',
 				},
 				customState: {
 					submitCount,
+					preservedCount,
 				},
 				onValidate({ error }) {
 					return error;
@@ -1123,6 +1134,9 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 						aria-label="Title"
 					/>
 					<div data-testid="submit-count">{form.customState.submitCount}</div>
+					<div data-testid="preserved-count">
+						{form.customState.preservedCount}
+					</div>
 					<button>Submit</button>
 					<button type="button" onClick={() => intent.reset()}>
 						Reset
@@ -1131,7 +1145,7 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 			);
 		}
 
-		const screen = render(<CustomStateForm />);
+		const screen = render(<CustomStateForm formKey="first" />);
 
 		await expect
 			.element(screen.getByTestId('submit-count'))
@@ -1144,10 +1158,24 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 		await expect
 			.element(screen.getByTestId('submit-count'))
 			.toHaveTextContent('2');
+		await expect
+			.element(screen.getByTestId('preserved-count'))
+			.toHaveTextContent('2');
 		await userEvent.click(screen.getByRole('button', { name: 'Reset' }));
 		await expect
 			.element(screen.getByTestId('submit-count'))
 			.toHaveTextContent('0');
+		await expect
+			.element(screen.getByTestId('preserved-count'))
+			.toHaveTextContent('2');
+
+		screen.rerender(<CustomStateForm formKey="second" />);
+		await expect
+			.element(screen.getByTestId('submit-count'))
+			.toHaveTextContent('0');
+		await expect
+			.element(screen.getByTestId('preserved-count'))
+			.toHaveTextContent('2');
 	});
 
 	test('server report', async () => {


### PR DESCRIPTION
Draft only. Still deciding the API surface. Hopefully have something up in the next couple days.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

- Added an experimental **custom form state** mechanism to `@conform-to/react` “future” APIs via `defineCustomState`, with `customState` registration supported in both `configureForms` and `useForm`, and exposed on `form.customState` / `useFormMetadata().customState`.
- Implemented custom-state lifecycle across initialization, reset/preservation, and intent/result-driven updates (including client/server and async phases), including full TypeScript support (`CustomStateHandler`, `FormCustomState`, `InferCustomState`).
- Updated intent serialization/deserialization to properly round-trip **`undefined`** arguments and adjusted intent parsing behavior; propagated the new `client:async` handling through the intent pipeline.
- Updated/added runtime, browser, and type tests covering initialization/reset behavior, handler merge collisions, multi-phase intent/result behavior, and `undefined` argument encoding; documented the API across `docs/api/react/future/*`, added a changeset, and updated `.gitignore` to ignore `.vitest-attachments`.

```ts
import { configureForms, defineCustomState } from "`@conform-to/react/future`";

const submitCount = defineCustomState({
  initialize: () => ({ value: 0 }),
  handleIntent: (state) => ({ ...state, value: state.value + 1 }),
});

const forms = configureForms({
  customState: { submitCount },
});

// later: form.customState.submitCount.value
```
</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->