### PR TITLE
fix(conform-react): reject extra properties when updating form value with an index

### DIFF
--- a/.changeset/fix-indexed-update-types.md
+++ b/.changeset/fix-indexed-update-types.md
@@ -1,0 +1,17 @@
+---
+'@conform-to/react': patch
+---
+
+Reject extra properties in `intent.update()` values when updating an array item with `index`.
+
+```ts
+intent.update({
+  name: tasks.name,
+  index: 0,
+  value: {
+    content: 'Write changelog',
+    // @ts-expect-error extra properties are rejected
+    extra: true,
+  },
+});
+```

--- a/packages/conform-react/future/intent.ts
+++ b/packages/conform-react/future/intent.ts
@@ -288,11 +288,10 @@ export const update = defineIntent<UpdateIntent>({
 	},
 	resolve({ value, payload }) {
 		const fieldName = appendPath(payload.name, payload.index);
-		return updatePathValue(
-			value,
-			fieldName,
-			payload.value ?? (fieldName === '' ? {} : null),
-		);
+		const nextValue = (payload.value ??
+			(fieldName === '' ? {} : null)) as FormValue | null;
+
+		return updatePathValue(value, fieldName, nextValue);
 	},
 	touch({ name, payload }) {
 		const fieldName = appendPath(payload.name, payload.index);

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -648,23 +648,37 @@ export interface ResetIntent extends TypedIntentDefinition {
 
 export type ValidateIntent = (name?: string) => void;
 
+export type IsUntypedFormShape<FormShape> = unknown extends FormShape
+	? true
+	: string extends keyof FormShape
+		? true
+		: false;
+
 export interface UpdateIntent extends TypedIntentDefinition {
 	dispatch<FieldShape = this['FormShape']>(
-		options:
-			| {
-					name?: FieldName<FieldShape>;
-					index?: undefined;
-					value: DefaultValue<FieldShape>;
-			  }
-			| {
-					name: FieldName<FieldShape>;
-					index: number;
-					value: unknown extends FieldShape
-						? any
-						: FieldShape extends Array<infer ItemShape>
-							? ItemShape
-							: any;
-			  },
+		options: IsUntypedFormShape<this['FormShape']> extends true
+			? {
+					name?: string | undefined;
+					index?: number | undefined;
+					value: unknown;
+				}
+			:
+					| {
+							name?: FieldName<FieldShape>;
+							index?: undefined;
+							value: DefaultValue<FieldShape>;
+					  }
+					| {
+							name: FieldName<
+								FieldShape extends Array<any> | null | undefined
+									? FieldShape
+									: never
+							>;
+							index: number;
+							value: NonNullable<FieldShape> extends Array<infer ItemShape>
+								? DefaultValue<ItemShape>
+								: never;
+					  },
 	): void;
 }
 

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -749,10 +749,19 @@ test('defineIntent', () => {
 
 test('IntentDispatcher', () => {
 	// IntentDispatcher is the return type of useIntent
+	type Trial = {
+		foo: string;
+		bar: number;
+		baz: boolean;
+	};
+
 	type TestSchema = {
 		name: string;
 		tags: string[];
 		tasks: Array<{ content: string; completed: boolean }>;
+		trial: Trial;
+		trials: Trial[];
+		nullableTrials: Trial[] | null | undefined;
 	};
 
 	const intent = {} as IntentDispatcher<TestSchema>;
@@ -792,8 +801,77 @@ test('IntentDispatcher', () => {
 	assertType<void>(intent.update({ name: 'name', value: null }));
 	assertType<void>(intent.update({ name: 'name', value: undefined }));
 	assertType<void>(
-		intent.update({ name: 'tasks', index: 0, value: { content: 'foo' } }),
+		intent.update({
+			name: 'tasks' as FieldName<
+				Array<{ content: string; completed: boolean }>
+			>,
+			index: 0,
+			value: { content: 'foo' },
+		}),
 	);
+	assertType<void>(
+		intent.update({
+			name: 'trials' as FieldName<Trial[]>,
+			index: 0,
+			value: { foo: 'foo' },
+		}),
+	);
+	assertType<void>(
+		intent.update({
+			name: 'trials' as FieldName<Trial[]>,
+			index: 0,
+			value: undefined,
+		}),
+	);
+	assertType<void>(
+		intent.update({
+			name: 'nullableTrials' as FieldName<Trial[] | null | undefined>,
+			index: 0,
+			value: { bar: 1 },
+		}),
+	);
+	assertType<void>(
+		intent.update({
+			name: 'trial' as FieldName<Trial>,
+			value: {
+				foo: 'foo',
+				bar: 1,
+				baz: true,
+			},
+		}),
+	);
+	intent.update({
+		name: 'trial' as FieldName<Trial>,
+		value: {
+			foo: 'foo',
+			bar: 1,
+			baz: true,
+			// @ts-expect-error extra properties should be rejected on non-indexed updates
+			extra: 123,
+		},
+	});
+	intent.update({
+		name: 'trials' as FieldName<Trial[]>,
+		index: 0,
+		value: {
+			foo: 'foo',
+			bar: 1,
+			baz: true,
+			// @ts-expect-error extra properties should be rejected on indexed updates
+			extra: 123,
+		},
+	});
+	intent.update({
+		name: 'nullableTrials' as FieldName<Trial[] | null | undefined>,
+		index: 0,
+		value: {
+			foo: 'foo',
+			bar: 1,
+			baz: true,
+			// @ts-expect-error extra properties should be rejected on nullable indexed updates
+			extra: 123,
+		},
+	});
 	assertType<void>(
 		intent.update({
 			value: {


### PR DESCRIPTION
Fix #1241

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

A detailed high-level summary could not be generated for this review. Here is an overview derived from the analyzed file changes:

- **.changeset/fix-indexed-update-types.md**: ## AI-generated summary of changes
- **packages/conform-react/future/intent.ts**: ## AI-generated summary of changes
- **packages/conform-react/future/types.ts**: ## AI-generated summary of changes
- **packages/conform-react/tests/types.test-d.ts**: ## AI-generated summary of changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->