### PR TITLE
feat: align future APIs on targetValue

### DIFF
--- a/.changeset/clean-dodos-target.md
+++ b/.changeset/clean-dodos-target.md
@@ -3,4 +3,22 @@
 '@conform-to/react': minor
 ---
 
-Rename the future `report()` option and `resolveSubmission()` result from `value` to `targetValue` for consistency with `SubmissionResult.targetValue`.
+Align the experimental future APIs on `targetValue` for the form value produced by resolving an intent and applied by a submission result.
+
+The `resolveSubmission()` result has a breaking change:
+
+```diff
+-const { intent, value } = resolveSubmission(submission);
++const { intent, targetValue } = resolveSubmission(submission);
+```
+
+The `report()` option is renamed too, but `value` remains available as a deprecated alias for one minor release:
+
+```diff
+ report(submission, {
+-  value,
++  targetValue,
+ });
+```
+
+`value` will be removed from `report()` in the next minor release. If both `value` and `targetValue` are provided during migration, `targetValue` takes precedence.

--- a/.changeset/clean-dodos-target.md
+++ b/.changeset/clean-dodos-target.md
@@ -1,0 +1,6 @@
+---
+'@conform-to/dom': minor
+'@conform-to/react': minor
+---
+
+Rename the future `report()` option and `resolveSubmission()` result from `value` to `targetValue` for consistency with `SubmissionResult.targetValue`.

--- a/.changeset/clean-dodos-target.md
+++ b/.changeset/clean-dodos-target.md
@@ -1,24 +1,10 @@
 ---
-'@conform-to/dom': minor
 '@conform-to/react': minor
 ---
 
-Align the experimental future APIs on `targetValue` for the form value produced by resolving an intent and applied by a submission result.
-
-The `resolveSubmission()` result has a breaking change:
+Breaking Change: Renamed the result `value` to `targetValue` in the future `resolveSubmission()` API.
 
 ```diff
 -const { intent, value } = resolveSubmission(submission);
 +const { intent, targetValue } = resolveSubmission(submission);
 ```
-
-The `report()` option is renamed too, but `value` remains available as a deprecated alias for one minor release:
-
-```diff
- report(submission, {
--  value,
-+  targetValue,
- });
-```
-
-`value` will be removed from `report()` in the next minor release. If both `value` and `targetValue` are provided during migration, `targetValue` takes precedence.

--- a/.changeset/warm-moles-report.md
+++ b/.changeset/warm-moles-report.md
@@ -1,0 +1,15 @@
+---
+'@conform-to/dom': minor
+'@conform-to/react': minor
+---
+
+Deprecated the `value` option in the future `report()` API. Use `targetValue` instead:
+
+```diff
+ report(submission, {
+-  value,
++  targetValue,
+ });
+```
+
+`value` remains available as an alias and will be removed in the next minor version. If both options are provided, `targetValue` takes precedence.

--- a/docs/api/react/future/report.md
+++ b/docs/api/react/future/report.md
@@ -29,6 +29,10 @@ Set to `null` to indicate validation passed with no errors. If you need schema i
 
 The target form value to apply. Use this to update the form or reset it to a specific value when combined with `reset: true`. Pass `null` to apply an empty value.
 
+### `options.value?: Record<string, unknown> | null` (deprecated)
+
+Deprecated alias for `targetValue`. It will be removed in the next minor release. When both options are provided, `targetValue` takes precedence.
+
 ### `options.keepFiles?: boolean`
 
 Controls whether file objects are preserved in the submission payload:

--- a/docs/api/react/future/report.md
+++ b/docs/api/react/future/report.md
@@ -25,9 +25,9 @@ Error information to include in the result. Choose one of these shapes:
 
 Set to `null` to indicate validation passed with no errors. If you need schema issues and additional errors together, append additional issue before calling `report()`, or construct an explicit error payload yourself.
 
-### `options.value?: Record<string, unknown> | null`
+### `options.targetValue?: Record<string, unknown> | null`
 
-The form value to set. Use this to update the form or reset it to a specific value when combined with reset: true.
+The target form value to apply. Use this to update the form or reset it to a specific value when combined with `reset: true`. Pass `null` to apply an empty value.
 
 ### `options.keepFiles?: boolean`
 
@@ -38,7 +38,7 @@ Controls whether file objects are preserved in the submission payload:
 
 ### `options.hideFields?: string[]`
 
-Array of field names to hide from the result by setting them to `undefined` in both the submission payload and value. Primarily used for sensitive data like passwords that should not be sent back to the client.
+Array of field names to hide from the result by setting them to `undefined` in both the submission payload and target value. Primarily used for sensitive data like passwords that should not be sent back to the client.
 
 ```ts
 report(submission, {
@@ -58,7 +58,7 @@ A `SubmissionResult` object containing:
 
 The processed submission object. May have modified payload if some fields were hidden or files are stripped.
 
-### `targetValue?: Record<string, unknown> | null`
+### `targetValue?: Record<string, unknown>`
 
 The form value to apply, if different from the submission payload.
 

--- a/docs/api/react/future/resolveSubmission.md
+++ b/docs/api/react/future/resolveSubmission.md
@@ -20,8 +20,8 @@ const schema = z.object({
 export async function action({ request }) {
   const formData = await request.formData();
   const submission = parseSubmission(formData);
-  const { intent, value } = resolveSubmission(submission);
-  const result = schema.safeParse(value);
+  const { intent, targetValue } = resolveSubmission(submission);
+  const result = schema.safeParse(targetValue);
 
   if (!intent) {
     return new Response('Unknown intent', { status: 400 });
@@ -29,7 +29,7 @@ export async function action({ request }) {
 
   if (intent.type !== 'submit' || !result.success) {
     return report(submission, {
-      value,
+      targetValue,
       error: result.success ? null : result.error,
     });
   }
@@ -57,6 +57,6 @@ Optional intent handlers used to extend or override the configured intent handle
 An object with the following properties:
 
 - `intent`, the parsed intent, or `undefined` when the intent type is unknown or invalid
-- `value`, the value to validate or save
+- `targetValue`, the value to validate or save
 
-If Conform cannot resolve the intent, `value` falls back to the original submission payload.
+If Conform cannot resolve the intent, `targetValue` falls back to the original submission payload.

--- a/examples/astro/src/features/todos.tsx
+++ b/examples/astro/src/features/todos.tsx
@@ -79,7 +79,7 @@ export async function submitTodos(formData: FormData) {
 		success: true as const,
 		result: report(submission, {
 			reset: true,
-			value: result.data,
+			targetValue: result.data,
 		}),
 	};
 }

--- a/examples/react-router/app/routes/todos.tsx
+++ b/examples/react-router/app/routes/todos.tsx
@@ -55,7 +55,7 @@ export async function action({ request }: Route.ActionArgs) {
 	return {
 		result: report(submission, {
 			reset: true,
-			value: result.data,
+			targetValue: result.data,
 		}),
 	};
 }

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -566,6 +566,8 @@ export function report(
 		keepFiles?: false;
 		error?: null;
 		targetValue?: Record<string, FormValue> | null;
+		/** @deprecated Use `targetValue` instead. This will be removed in the next minor release. */
+		value?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
 	},
@@ -576,6 +578,8 @@ export function report(
 		keepFiles: true;
 		error?: null;
 		targetValue?: Record<string, FormValue> | null;
+		/** @deprecated Use `targetValue` instead. This will be removed in the next minor release. */
+		value?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
 	},
@@ -586,6 +590,8 @@ export function report<ErrorShape>(
 		keepFiles?: false;
 		error: CustomError<ErrorShape> | null;
 		targetValue?: Record<string, FormValue> | null;
+		/** @deprecated Use `targetValue` instead. This will be removed in the next minor release. */
+		value?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
 	},
@@ -599,6 +605,8 @@ export function report<ErrorShape>(
 		keepFiles: true;
 		error: CustomError<ErrorShape> | null;
 		targetValue?: Record<string, FormValue> | null;
+		/** @deprecated Use `targetValue` instead. This will be removed in the next minor release. */
+		value?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
 	},
@@ -609,6 +617,8 @@ export function report(
 		keepFiles?: false;
 		error: StandardSchemaError;
 		targetValue?: Record<string, FormValue> | null;
+		/** @deprecated Use `targetValue` instead. This will be removed in the next minor release. */
+		value?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
 	},
@@ -622,6 +632,8 @@ export function report(
 		keepFiles: true;
 		error: StandardSchemaError;
 		targetValue?: Record<string, FormValue> | null;
+		/** @deprecated Use `targetValue` instead. This will be removed in the next minor release. */
+		value?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
 	},
@@ -632,6 +644,8 @@ export function report<ErrorShape>(
 		keepFiles?: boolean;
 		error?: CustomError<ErrorShape> | null;
 		targetValue?: Record<string, FormValue> | null;
+		/** @deprecated Use `targetValue` instead. This will be removed in the next minor release. */
+		value?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
 	},
@@ -655,6 +669,10 @@ export function report<ErrorShape>(
 		 */
 		targetValue?: Record<string, FormValue> | null;
 		/**
+		 * @deprecated Use `targetValue` instead. This will be removed in the next minor release.
+		 */
+		value?: Record<string, FormValue> | null;
+		/**
 		 * Array of field names to hide from the result by setting them to `undefined`.
 		 * Primarily used for sensitive data like passwords that should not be sent back to the client.
 		 */
@@ -675,13 +693,15 @@ export function report<ErrorShape>(
 		error = normalizeFormError(options.error);
 	}
 
+	const targetValueOption =
+		'targetValue' in options ? options.targetValue : options.value;
 	const targetValue =
-		typeof options.targetValue === 'undefined' ||
-		(submission.payload === options.targetValue && !options.reset)
+		typeof targetValueOption === 'undefined' ||
+		(submission.payload === targetValueOption && !options.reset)
 			? undefined
-			: options.targetValue && !options.keepFiles
-				? stripFiles(options.targetValue)
-				: (options.targetValue ?? {});
+			: targetValueOption && !options.keepFiles
+				? stripFiles(targetValueOption)
+				: (targetValueOption ?? {});
 
 	if (options.hideFields) {
 		for (const name of options.hideFields) {

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -565,7 +565,7 @@ export function report(
 	options?: {
 		keepFiles?: false;
 		error?: null;
-		value?: Record<string, FormValue> | null;
+		targetValue?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
 	},
@@ -575,7 +575,7 @@ export function report(
 	options: {
 		keepFiles: true;
 		error?: null;
-		value?: Record<string, FormValue> | null;
+		targetValue?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
 	},
@@ -585,7 +585,7 @@ export function report<ErrorShape>(
 	options: {
 		keepFiles?: false;
 		error: CustomError<ErrorShape> | null;
-		value?: Record<string, FormValue> | null;
+		targetValue?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
 	},
@@ -598,7 +598,7 @@ export function report<ErrorShape>(
 	options: {
 		keepFiles: true;
 		error: CustomError<ErrorShape> | null;
-		value?: Record<string, FormValue> | null;
+		targetValue?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
 	},
@@ -608,7 +608,7 @@ export function report(
 	options: {
 		keepFiles?: false;
 		error: StandardSchemaError;
-		value?: Record<string, FormValue> | null;
+		targetValue?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
 	},
@@ -621,7 +621,7 @@ export function report(
 	options: {
 		keepFiles: true;
 		error: StandardSchemaError;
-		value?: Record<string, FormValue> | null;
+		targetValue?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
 	},
@@ -631,7 +631,7 @@ export function report<ErrorShape>(
 	options?: {
 		keepFiles?: boolean;
 		error?: CustomError<ErrorShape> | null;
-		value?: Record<string, FormValue> | null;
+		targetValue?: Record<string, FormValue> | null;
 		hideFields?: string[];
 		reset?: boolean;
 	},
@@ -650,10 +650,10 @@ export function report<ErrorShape>(
 		 */
 		error?: StandardSchemaError | CustomError<ErrorShape> | null;
 		/**
-		 * The form value to set. Use this to update the form or reset it
+		 * The target form value to apply. Use this to update the form or reset it
 		 * to a specific value when combined with `reset: true`.
 		 */
-		value?: Record<string, FormValue> | null;
+		targetValue?: Record<string, FormValue> | null;
 		/**
 		 * Array of field names to hide from the result by setting them to `undefined`.
 		 * Primarily used for sensitive data like passwords that should not be sent back to the client.
@@ -676,12 +676,12 @@ export function report<ErrorShape>(
 	}
 
 	const targetValue =
-		typeof options.value === 'undefined' ||
-		(submission.payload === options.value && !options.reset)
+		typeof options.targetValue === 'undefined' ||
+		(submission.payload === options.targetValue && !options.reset)
 			? undefined
-			: options.value && !options.keepFiles
-				? stripFiles(options.value)
-				: (options.value ?? {});
+			: options.targetValue && !options.keepFiles
+				? stripFiles(options.targetValue)
+				: (options.targetValue ?? {});
 
 	if (options.hideFields) {
 		for (const name of options.hideFields) {

--- a/packages/conform-dom/tests/formdata.test.ts
+++ b/packages/conform-dom/tests/formdata.test.ts
@@ -1306,6 +1306,25 @@ describe('report', () => {
 			error: undefined,
 		});
 
+		// Deprecated value option remains an alias for one minor release
+		const deprecatedValueResult = report(submission, {
+			value: { name: 'Jane', email: 'jane@example.com' },
+		});
+		expect(deprecatedValueResult.targetValue).toEqual({
+			name: 'Jane',
+			email: 'jane@example.com',
+		});
+
+		// targetValue takes precedence while callers migrate
+		const resultWithBothOptions = report(submission, {
+			value: { name: 'Legacy', email: 'legacy@example.com' },
+			targetValue: { name: 'Target', email: 'target@example.com' },
+		});
+		expect(resultWithBothOptions.targetValue).toEqual({
+			name: 'Target',
+			email: 'target@example.com',
+		});
+
 		// Edge case: when target value equals payload reference, should be undefined
 		const resultEqual = report(submission, {
 			targetValue: submission.payload,

--- a/packages/conform-dom/tests/formdata.test.ts
+++ b/packages/conform-dom/tests/formdata.test.ts
@@ -1194,7 +1194,7 @@ describe('report', () => {
 
 		const resultWithTargetValue = report(submission2, {
 			hideFields: ['password', 'email'],
-			value: {
+			targetValue: {
 				name: 'Jane',
 				email: 'jane@example.com',
 				password: 'newsecret',
@@ -1294,7 +1294,7 @@ describe('report', () => {
 
 		// Test with different target value
 		const result = report(submission, {
-			value: { name: 'Jane', email: 'jane@example.com' },
+			targetValue: { name: 'Jane', email: 'jane@example.com' },
 		});
 
 		expect(result).toEqual({
@@ -1308,7 +1308,7 @@ describe('report', () => {
 
 		// Edge case: when target value equals payload reference, should be undefined
 		const resultEqual = report(submission, {
-			value: submission.payload,
+			targetValue: submission.payload,
 		});
 
 		expect(resultEqual).toEqual({
@@ -1335,7 +1335,7 @@ describe('report', () => {
 
 		const resultWithFiles = report(submissionWithFile, {
 			keepFiles: false,
-			value: { name: 'Jane', file },
+			targetValue: { name: 'Jane', file },
 		});
 
 		expect(resultWithFiles).toEqual({

--- a/packages/conform-dom/tests/types.test-d.ts
+++ b/packages/conform-dom/tests/types.test-d.ts
@@ -185,7 +185,11 @@ test('report', () => {
 	/** Default behavior strips files from the submission payload and target value. */
 	const defaultResult = report(submission);
 	const explicitStripResult = report(submission, { keepFiles: false });
-	const defaultResultWithValue = report(submission, { value: updatedValue });
+	const defaultResultWithValue = report(submission, {
+		targetValue: updatedValue,
+	});
+	// @ts-expect-error report no longer accepts `value`
+	report(submission, { value: updatedValue });
 
 	expectTypeOf(defaultResult).toEqualTypeOf<
 		SubmissionResult<never, string | number | boolean | null>
@@ -203,7 +207,7 @@ test('report', () => {
 	/** `keepFiles: true` preserves file values in both payload and target value. */
 	const keepFilesResult = report(submission, {
 		keepFiles: true,
-		value: updatedValue,
+		targetValue: updatedValue,
 	});
 
 	expectTypeOf(keepFilesResult).toEqualTypeOf<

--- a/packages/conform-dom/tests/types.test-d.ts
+++ b/packages/conform-dom/tests/types.test-d.ts
@@ -188,8 +188,7 @@ test('report', () => {
 	const defaultResultWithValue = report(submission, {
 		targetValue: updatedValue,
 	});
-	// @ts-expect-error report no longer accepts `value`
-	report(submission, { value: updatedValue });
+	const deprecatedValueResult = report(submission, { value: updatedValue });
 
 	expectTypeOf(defaultResult).toEqualTypeOf<
 		SubmissionResult<never, string | number | boolean | null>
@@ -202,6 +201,9 @@ test('report', () => {
 	>();
 	expectTypeOf(defaultResultWithValue.targetValue).toEqualTypeOf<
 		Record<string, FormValue<string | number | boolean | null>> | undefined
+	>();
+	expectTypeOf(deprecatedValueResult).toEqualTypeOf<
+		SubmissionResult<never, string | number | boolean | null>
 	>();
 
 	/** `keepFiles: true` preserves file values in both payload and target value. */

--- a/packages/conform-react/future/forms.tsx
+++ b/packages/conform-react/future/forms.tsx
@@ -757,21 +757,21 @@ export function configureForms<
 			  >
 			| { type: 'submit'; payload: undefined }
 			| undefined;
-		value: Record<string, FormValue> | undefined;
+		targetValue: Record<string, FormValue> | undefined;
 	} {
 		const handlers = mergeIntentHandlers(
 			globalIntentHandlers,
 			options?.handlers,
 		);
 		const intent = parseIntent(submission.intent, { handlers });
-		const value = resolveIntent(submission, {
+		const targetValue = resolveIntent(submission, {
 			handlers,
 			intent,
 		});
 
 		return {
 			intent,
-			value,
+			targetValue,
 		};
 	}
 

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -442,7 +442,7 @@ export function useConform<
 				});
 				const submissionResult = report<ErrorShape>(submission, {
 					keepFiles: true,
-					value,
+					targetValue: value,
 				});
 
 				const validateResult =

--- a/packages/conform-react/tests/helpers.tsx
+++ b/packages/conform-react/tests/helpers.tsx
@@ -68,7 +68,7 @@ export function createResult(
 	const value = resolveIntent(submission, { handlers, intent });
 
 	return report(submission, {
-		value:
+		targetValue:
 			typeof options?.targetValue !== 'undefined' ? options.targetValue : value,
 		error: options?.error,
 	});
@@ -103,7 +103,7 @@ export function createAction(options: {
 	const intent = parseIntent(submission.intent, { handlers });
 	const value = resolveIntent(submission, { handlers, intent: intent });
 	const result = report(submission, {
-		value:
+		targetValue:
 			options.targetValue !== undefined
 				? options.targetValue
 				: options.reset

--- a/packages/conform-react/tests/resolveSubmission.browser.test.tsx
+++ b/packages/conform-react/tests/resolveSubmission.browser.test.tsx
@@ -14,6 +14,28 @@ test('resolveSubmission', () => {
 	} satisfies Record<string, IntentHandler>;
 
 	expect(
+		resolveSubmission({
+			intent: null,
+			payload: { email: 'test@example.com' },
+			fields: ['email'],
+		}),
+	).toEqual({
+		intent: { type: 'submit', payload: undefined },
+		targetValue: { email: 'test@example.com' },
+	});
+
+	expect(
+		resolveSubmission({
+			intent: 'reset',
+			payload: { email: 'test@example.com' },
+			fields: ['email'],
+		}),
+	).toEqual({
+		intent: { type: 'reset', payload: undefined },
+		targetValue: undefined,
+	});
+
+	expect(
 		resolveSubmission(
 			{
 				intent: 'copyField("email")',
@@ -29,7 +51,7 @@ test('resolveSubmission', () => {
 			type: 'copyField',
 			payload: 'email',
 		},
-		value: {
+		targetValue: {
 			email: 'test@example.com',
 			confirm: 'email',
 		},
@@ -48,7 +70,7 @@ test('resolveSubmission', () => {
 		),
 	).toEqual({
 		intent: undefined,
-		value: {
+		targetValue: {
 			email: 'test@example.com',
 		},
 	});

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -613,8 +613,10 @@ describe('configureForms', () => {
 		});
 
 		assertType<Record<string, FormValue> | undefined>(
-			resolvedConfiguredSubmission.value,
+			resolvedConfiguredSubmission.targetValue,
 		);
+		// @ts-expect-error resolveSubmission no longer returns `value`
+		void resolvedConfiguredSubmission.value;
 
 		if (resolvedConfiguredSubmission.intent?.type === 'goToStep') {
 			assertType<number>(resolvedConfiguredSubmission.intent.payload.step);
@@ -629,7 +631,7 @@ describe('configureForms', () => {
 		});
 
 		assertType<Record<string, FormValue> | undefined>(
-			unresolvedConfiguredSubmission.value,
+			unresolvedConfiguredSubmission.targetValue,
 		);
 
 		const confirm = defineIntent<string>({

--- a/packages/conform-react/tests/useForm.browser.test.tsx
+++ b/packages/conform-react/tests/useForm.browser.test.tsx
@@ -1318,7 +1318,7 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 			<Form
 				lastResult={report(parseSubmission(form.getFormData()), {
 					reset: true,
-					value: {
+					targetValue: {
 						title: 'Updated Title',
 						category: 'work',
 						description: 'Updated Description',
@@ -1365,7 +1365,7 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 		screen.rerender(
 			<Form
 				lastResult={report(parseSubmission(form.getFormData()), {
-					value: {
+					targetValue: {
 						title: 'Server Processed Title',
 						category: 'personal',
 						description: 'Server Updated Description',
@@ -1390,7 +1390,7 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 		screen.rerender(
 			<Form
 				lastResult={report(parseSubmission(form.getFormData()), {
-					value: null,
+					targetValue: null,
 				})}
 			/>,
 		);
@@ -1496,7 +1496,7 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 				defaultValue={defaultValue}
 				lastResult={report(parseSubmission(form.getFormData()), {
 					reset: true,
-					value: {
+					targetValue: {
 						title: 'Server Updated Title',
 						description: 'Server Updated Description',
 						confirmed: false,


### PR DESCRIPTION
## Summary
- rename the resolveSubmission result from value to targetValue
- add targetValue to report while retaining value as a deprecated alias for one minor release
- make targetValue take precedence when both report options are provided
- update runtime call sites, tests, examples, docs, and migration-focused changeset notes

resolveSubmission is an immediate breaking change in the experimental future API. report callers have a one-minor migration window before value is removed.

## Testing
- pnpm --filter @conform-to/dom build
- pnpm --filter @conform-to/dom test --run tests/formdata.test.ts
- pnpm --filter @conform-to/dom typecheck
- pnpm --filter @conform-to/react test --run tests/resolveSubmission.browser.test.tsx
- pnpm --filter @conform-to/react typecheck
- pnpm --filter react-router-example typecheck
- targeted oxlint and oxfmt checks

Astro check still reports two pre-existing nullability errors in examples/astro/src/features/login.tsx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

Renames the experimental future `report()` option from `value` to `targetValue` and updates `resolveSubmission()` to return `{ intent, targetValue }` instead of `{ intent, value }`. `value` remains as a deprecated alias for one minor release, and `targetValue` takes precedence when both are provided; `hideFields` behavior is documented in terms of the target payload. Updates include runtime plumbing, React/DOM call sites, docs, and tests (runtime + type tests asserting `value` is rejected via `@ts-expect-error`).

```ts
const { intent, targetValue } = await resolveSubmission(...);

return report(submission, {
  intent,
  targetValue,
});
```

Also adds changeset notes to publish the rename and temporary alias guidance (with example destructuring updates).
</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->