### PR TITLE
feat: refine staged validation results

### DIFF
--- a/.changeset/fresh-ravens-validate.md
+++ b/.changeset/fresh-ravens-validate.md
@@ -2,4 +2,21 @@
 '@conform-to/react': minor
 ---
 
-Replace the future staged validation tuple with a `{ result, pending }` object and preserve explicit synchronous `null` validation results.
+Refine the experimental future validation-result contract.
+
+Returning staged validation from `onValidate` has a breaking change. Replace the positional tuple with a descriptive object:
+
+```diff
+-return [
+-  error,
+-  validateRemotely(),
+-];
++return {
++  result: error,
++  pending: validateRemotely(),
++};
+```
+
+The `pending` promise must resolve to the complete later validation result that replaces `result`.
+
+This also fixes synchronous `null` handling. `null` now consistently means that validation completed successfully and clears any previous client error; only `undefined` means no synchronous validation result was provided.

--- a/.changeset/fresh-ravens-validate.md
+++ b/.changeset/fresh-ravens-validate.md
@@ -2,21 +2,39 @@
 '@conform-to/react': minor
 ---
 
-Refine the experimental future validation-result contract.
+Formalized staged validation for the future `useForm()` API.
 
-Returning staged validation from `onValidate` has a breaking change. Replace the positional tuple with a descriptive object:
+Staged validation lets `onValidate` flush the known validation result immediately while a slower asynchronous check continues:
 
-```diff
--return [
--  error,
--  validateRemotely(),
--];
-+return {
-+  result: error,
-+  pending: validateRemotely(),
-+};
+```tsx
+const schema = z.object({
+  email: z.string().email('Email is invalid'),
+});
+
+const { form } = useForm(schema, {
+  onValidate({ schemaValue, error }) {
+    if (error.fieldErrors.email) {
+      return error;
+    }
+
+    return {
+      result: error,
+      pending: isEmailAvailable(schemaValue.email).then((available) =>
+        available
+          ? error
+          : {
+              formErrors: error.formErrors,
+              fieldErrors: {
+                ...error.fieldErrors,
+                email: ['Email is already used'],
+              },
+            },
+      ),
+    };
+  },
+});
 ```
 
-The `pending` promise must resolve to the complete later validation result that replaces `result`.
+The `pending` promise replaces rather than merges with `result`, so it should resolve to a full validation result that includes any errors already present in `result`.
 
-This also fixes synchronous `null` handling. `null` now consistently means that validation completed successfully and clears any previous client error; only `undefined` means no synchronous validation result was provided.
+This also fixed schema-backed validation where returning `null` from `onValidate` could leave a previous client error displayed.

--- a/.changeset/fresh-ravens-validate.md
+++ b/.changeset/fresh-ravens-validate.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/react': minor
+---
+
+Replace the future staged validation tuple with a `{ result, pending }` object and preserve explicit synchronous `null` validation results.

--- a/docs/api/react/future/useForm.md
+++ b/docs/api/react/future/useForm.md
@@ -91,8 +91,6 @@ Server-side submission result for form state synchronization.
 
 Custom validation handler. Can be skipped when a schema is passed as the first argument, or combined with schema validation to customize validation errors.
 
-Return a validation result when it is available immediately, a promise when it is only available asynchronously, or `{ result, pending }` when an immediate result will be replaced by a complete asynchronous result. Returning `null` represents successful validation, while `undefined` means no validation result was provided.
-
 ### `onError?: ErrorHandler<ErrorShape>`
 
 Error handling callback triggered when validation errors occur. By default, it focuses the first invalid field.
@@ -252,6 +250,41 @@ function DynamicForm() {
 ```
 
 ## Tips
+
+### Staged validation for slow async checks
+
+Staged validation lets `onValidate` apply the known validation result immediately while a slower asynchronous check continues. Return `{ result, pending }` to provide both stages:
+
+```tsx
+const schema = z.object({
+  email: z.string().email('Email is invalid'),
+});
+
+const { form } = useForm(schema, {
+  onValidate({ schemaValue, error }) {
+    if (error.fieldErrors.email) {
+      return error;
+    }
+
+    return {
+      result: error,
+      pending: isEmailAvailable(schemaValue.email).then((available) =>
+        available
+          ? error
+          : {
+              formErrors: error.formErrors,
+              fieldErrors: {
+                ...error.fieldErrors,
+                email: ['Email is already used'],
+              },
+            },
+      ),
+    };
+  },
+});
+```
+
+`result` is applied immediately. The `pending` promise replaces rather than merges with `result`, so it should resolve to a full validation result that includes any errors already present in `result`.
 
 ### Field access patterns
 

--- a/docs/api/react/future/useForm.md
+++ b/docs/api/react/future/useForm.md
@@ -91,6 +91,8 @@ Server-side submission result for form state synchronization.
 
 Custom validation handler. Can be skipped when a schema is passed as the first argument, or combined with schema validation to customize validation errors.
 
+Return a validation result when it is available immediately, a promise when it is only available asynchronously, or `{ result, pending }` when an immediate result will be replaced by a complete asynchronous result. Returning `null` represents successful validation, while `undefined` means no validation result was provided.
+
 ### `onError?: ErrorHandler<ErrorShape>`
 
 Error handling callback triggered when validation errors occur. By default, it focuses the first invalid field.

--- a/docs/api/react/future/useIntent.md
+++ b/docs/api/react/future/useIntent.md
@@ -324,12 +324,12 @@ function Example() {
         },
       );
 
-      return [
+      return {
         // Synchronous validation result
-        error,
+        result: error,
         // Asynchronous validation result
-        errorPromise,
-      ];
+        pending: errorPromise,
+      };
     },
   });
 

--- a/packages/conform-react/future/forms.tsx
+++ b/packages/conform-react/future/forms.tsx
@@ -464,7 +464,14 @@ export function configureForms<
 						);
 					}
 
-					return [validateResult.syncResult, validateResult.asyncResult];
+					if (validateResult.syncResult && validateResult.asyncResult) {
+						return {
+							result: validateResult.syncResult,
+							pending: validateResult.asyncResult,
+						};
+					}
+
+					return validateResult.syncResult ?? validateResult.asyncResult;
 				}
 
 				return (

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -1087,6 +1087,13 @@ export type ValidateResult<ErrorShape, Value> =
 			value?: Value;
 	  };
 
+export type StagedValidateResult<ErrorShape, Value> = {
+	/** The validation result available immediately. */
+	result: ValidateResult<ErrorShape, Value>;
+	/** A complete validation result that replaces the immediate result when resolved. */
+	pending: Promise<ValidateResult<ErrorShape, Value>>;
+};
+
 export type ValidateContext<
 	SchemaValue,
 	SchemaErrorShape,
@@ -1136,10 +1143,7 @@ export type ValidateHandler<
 ) =>
 	| ValidateResult<ErrorShape, Value>
 	| Promise<ValidateResult<ErrorShape, Value>>
-	| [
-			ValidateResult<ErrorShape, Value> | undefined,
-			Promise<ValidateResult<ErrorShape, Value>> | undefined,
-	  ]
+	| StagedValidateResult<ErrorShape, Value>
 	| undefined;
 
 export interface FormInputEvent extends React.FormEvent<HTMLFormElement> {

--- a/packages/conform-react/future/util.ts
+++ b/packages/conform-react/future/util.ts
@@ -154,7 +154,7 @@ export function normalizeValidateResult<ErrorShape, Value>(
 /**
  * Handles different validation result formats:
  * - Promise: async validation only
- * - Array: [syncResult, asyncPromise]
+ * - Staged result: immediate result with a pending result
  * - Object: sync validation only
  */
 export function resolveValidateResult<ErrorShape, Value>(
@@ -165,15 +165,18 @@ export function resolveValidateResult<ErrorShape, Value>(
 
 	if (result instanceof Promise) {
 		asyncResult = result;
-	} else if (Array.isArray(result)) {
-		syncResult = result[0];
-		asyncResult = result[1];
+	} else if (result && 'result' in result && 'pending' in result) {
+		syncResult = result.result;
+		asyncResult = result.pending;
 	} else {
 		syncResult = result;
 	}
 
 	return {
-		syncResult: syncResult ? normalizeValidateResult(syncResult) : undefined,
+		syncResult:
+			typeof syncResult === 'undefined'
+				? undefined
+				: normalizeValidateResult(syncResult),
 		asyncResult: asyncResult
 			? asyncResult.then(normalizeValidateResult)
 			: undefined,

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -139,6 +139,22 @@ test('FormOptions', () => {
 	assertType<FormOptions<TestSchema>>({
 		lastResult: null,
 	});
+
+	assertType<FormOptions<TestSchema>>({
+		onValidate({ error }) {
+			return {
+				result: error,
+				pending: Promise.resolve(null),
+			};
+		},
+	});
+
+	assertType<FormOptions<TestSchema>>({
+		// @ts-expect-error staged validation no longer accepts a tuple
+		onValidate({ error }) {
+			return [error, Promise.resolve(null)];
+		},
+	});
 });
 
 test('useForm', () => {

--- a/packages/conform-react/tests/useForm.browser.test.tsx
+++ b/packages/conform-react/tests/useForm.browser.test.tsx
@@ -1669,6 +1669,67 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 		expect(isDirty(formData, { defaultValue: { date } })).toBe(false);
 	});
 
+	test('clears a previous schema-backed client error with null', async () => {
+		const schema = {
+			'~standard': {
+				version: 1,
+				vendor: 'test',
+				validate(value: unknown) {
+					return { value: value as { title: string } };
+				},
+				types: {} as {
+					input: { title: string };
+					output: { title: string };
+				},
+			},
+		} as const;
+
+		function SchemaForm() {
+			const { form, fields } = useForm(schema, {
+				defaultValue: { title: 'invalid' },
+				onValidate({ payload }) {
+					if (payload.title === 'invalid') {
+						return {
+							formErrors: null,
+							fieldErrors: { title: ['Title is invalid'] },
+						};
+					}
+
+					return null;
+				},
+				onSubmit(event) {
+					event.preventDefault();
+				},
+			});
+
+			return (
+				<form {...form.props}>
+					<input
+						aria-label="Title"
+						name={fields.title.name}
+						defaultValue={fields.title.defaultValue}
+					/>
+					<div data-testid="title-error">
+						{fields.title.errors?.join(', ') ?? 'n/a'}
+					</div>
+					<button>Submit</button>
+				</form>
+			);
+		}
+
+		const screen = render(<SchemaForm />);
+		const title = screen.getByRole('textbox', { name: 'Title' });
+		const error = screen.getByTestId('title-error');
+
+		await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+		await expect.element(error).toHaveTextContent('Title is invalid');
+
+		await userEvent.clear(title);
+		await userEvent.type(title, 'valid');
+		await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+		await expect.element(error).toHaveTextContent('n/a');
+	});
+
 	describe('async validation', () => {
 		beforeAll(() => {
 			vi.useFakeTimers();

--- a/packages/conform-react/tests/useIntent.browser.test.tsx
+++ b/packages/conform-react/tests/useIntent.browser.test.tsx
@@ -365,7 +365,7 @@ describe.each(testCases)(
 		});
 
 		test('array intents with sync validation and async onValidate', async () => {
-			// Test that onInvalid works when onValidate returns [syncResult, asyncPromise]
+			// Test that onInvalid works when onValidate returns a staged result
 			// The sync result provides array errors, async adds other checks
 			const screen = render(
 				<Form
@@ -400,7 +400,10 @@ describe.each(testCases)(
 							fieldErrors: syncError.fieldErrors,
 						});
 
-						return [syncError, asyncResult];
+						return {
+							result: syncError,
+							pending: asyncResult,
+						};
 					}}
 				/>,
 			);

--- a/packages/conform-react/tests/util.test.ts
+++ b/packages/conform-react/tests/util.test.ts
@@ -173,22 +173,45 @@ test('normalizeValidateResult', () => {
 	});
 });
 
-test('resolveValidateResult', () => {
+test('resolveValidateResult', async () => {
+	const unresolved = resolveValidateResult(undefined);
+	expect(unresolved.syncResult).toBeUndefined();
+	expect(unresolved.asyncResult).toBeUndefined();
+
 	// Test Promise result
 	const promiseResult = Promise.resolve(null);
 	const resolved1 = resolveValidateResult(promiseResult);
 	expect(resolved1.syncResult).toBeUndefined();
 	expect(resolved1.asyncResult).toBeInstanceOf(Promise);
 
-	// Test Array result [sync, async]
+	// Test staged result
 	const syncError: FormError<string[]> = {
 		formErrors: ['Sync error'],
 		fieldErrors: {},
 	};
 	const asyncPromise = Promise.resolve(null);
-	const resolved2 = resolveValidateResult([syncError, asyncPromise]);
+	const resolved2 = resolveValidateResult({
+		result: syncError,
+		pending: asyncPromise,
+	});
 	expect(resolved2.syncResult).toEqual({ error: syncError });
 	expect(resolved2.asyncResult).toBeInstanceOf(Promise);
+
+	// Test explicit synchronous success
+	const resolvedNull = resolveValidateResult(null);
+	expect(resolvedNull.syncResult).toEqual({ error: null });
+	expect(resolvedNull.asyncResult).toBeUndefined();
+
+	// Test explicit synchronous success in a staged result
+	const resolvedStagedNull = resolveValidateResult({
+		result: null,
+		pending: Promise.resolve(null),
+	});
+	expect(resolvedStagedNull.syncResult).toEqual({ error: null });
+	expect(resolvedStagedNull.asyncResult).toBeInstanceOf(Promise);
+	await expect(resolvedStagedNull.asyncResult).resolves.toEqual({
+		error: null,
+	});
 
 	// Test direct result
 	const directError: FormError<string[]> = {


### PR DESCRIPTION
## Summary
- replace the experimental future staged-validation tuple with a result and pending object
- preserve explicit synchronous null results instead of treating them as absent
- add type, utility, browser regression, documentation, and migration-focused changeset coverage

The pending promise resolves to a complete later result that replaces the immediate result. The changeset includes a before-and-after migration snippet for the breaking future API change.

## Testing
- pnpm --filter @conform-to/dom build
- pnpm --filter @conform-to/react build
- pnpm --filter @conform-to/react typecheck
- pnpm --filter @conform-to/react test --run
- pnpm exec changeset status
- targeted oxlint and oxfmt checks

Full conform-react result: 53 test files and 626 tests passed with no type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

- Replaced the experimental staged-validation tuple form with a `{ result, pending }` object contract, updating normalization to treat `undefined` as “no sync result provided” (while `null` represents successful validation that can clear prior client errors).
- Ensured `pending` represents the later complete validation outcome and replaces the immediate `result` (not merges), so async resolution yields the final error state.
- Added/updated typings (`StagedValidateResult`, `ValidateHandler` return types) and tightened tests to accept only the object shape (tuple form is now rejected).
- Updated `useForm`/`useIntent` implementations and docs (including a new “Staged validation for slow async checks” tip).
- Fixed schema-backed staged validation where returning `null` could leave an earlier client error displayed; added a browser regression test to confirm the error clears on subsequent validation.

```ts
onValidate: () => ({
  result: null,              // sync: validation complete + clears errors
  pending: fetchValidation() // async: later resolves to the final validation result
})
```

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->