### PR TITLE
fix(conform-react): fix faulty case when inferring schema output type

### DIFF
--- a/.changeset/fuzzy-schemas-report.md
+++ b/.changeset/fuzzy-schemas-report.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/react': patch
+---
+
+Fix output inference for unrecognized schemas to fall back to `unknown` while preserving `undefined` when no schema is provided.

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -478,17 +478,19 @@ export type InferFormShape<Schema> =
  * For StandardSchemaV1 schemas (zod, valibot, etc.), uses StandardSchemaV1.InferOutput.
  * For other schemas, uses CustomSchemaTypes if augmented.
  */
-export type InferOutput<Schema> = Schema extends StandardSchemaV1
-	? StandardSchemaV1.InferOutput<Schema>
-	: CustomSchemaTypes<Schema> extends { output: infer T }
-		? T
-		: unknown;
+export type InferOutput<Schema> = Schema extends undefined
+	? undefined
+	: Schema extends StandardSchemaV1
+		? StandardSchemaV1.InferOutput<Schema>
+		: CustomSchemaTypes<Schema> extends { output: infer T }
+			? T
+			: unknown;
 
 export type FormOptions<
 	FormShape extends Record<string, any> = Record<string, any>,
 	ErrorShape = any,
 	Value = undefined,
-	Schema = unknown,
+	Schema = undefined,
 	SchemaErrorShape = ErrorShape,
 	CustomIntentHandlers extends Record<string, IntentHandler<any, any>> = {},
 	GlobalIntentHandlers extends Record<string, IntentHandler<any, any>> = {},

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -482,7 +482,7 @@ export type InferOutput<Schema> = Schema extends StandardSchemaV1
 	? StandardSchemaV1.InferOutput<Schema>
 	: CustomSchemaTypes<Schema> extends { output: infer T }
 		? T
-		: undefined;
+		: unknown;
 
 export type FormOptions<
 	FormShape extends Record<string, any> = Record<string, any>,

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -141,11 +141,21 @@ test('FormOptions', () => {
 	});
 
 	assertType<FormOptions<TestSchema>>({
-		onValidate({ error }) {
+		onValidate({ error, schemaValue }) {
+			expectTypeOf(schemaValue).toEqualTypeOf<undefined>();
+
 			return {
 				result: error,
 				pending: Promise.resolve(null),
 			};
+		},
+	});
+
+	assertType<FormOptions<TestSchema, any, undefined, object>>({
+		onValidate({ schemaValue }) {
+			expectTypeOf(schemaValue).toEqualTypeOf<unknown>();
+
+			return undefined;
 		},
 	});
 


### PR DESCRIPTION
An unexpected schema still produces an output, it's just that we don't know its type. `undefined` is the wrong fallback type. It makes more sense for `InferOutput` to fallback to `unknown`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

- Updated `packages/conform-react/future/types.ts` to make `InferOutput<Schema>` return `undefined` when the schema type is actually `undefined`, while changing the unsupported/custom-schema fallback from `undefined` to `unknown`.
- Adjusted the `FormOptions` default for the `Schema` generic from `unknown` to `undefined` to align the “schema not provided” case with the new `InferOutput` behavior.
- Updated `packages/conform-react/tests/types.test-d.ts` type tests to validate `onValidate`’s `schemaValue` inference (`undefined` for the defaulted `FormOptions`, `unknown` for the configured variant).
- Added a patch Changeset for `@conform-to/react` documenting the type inference fix for unexpected/unsupported custom schemas.

```ts
// Illustration of the intended behavior
type A = InferOutput<undefined>; // undefined
type B = InferOutput<SomeUnsupportedSchema>; // unknown
```

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->