### PR TITLE
chore: auto merge dependabot prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  # pnpm manages the root, packages, guide, playground, and every example as
+  # one workspace with a shared lockfile, so Dependabot must run from the root.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+      time: '06:00'
+      timezone: Europe/London
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 3
+    rebase-strategy: auto
+    commit-message:
+      prefix: 'chore(deps)'

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -52,6 +52,20 @@ jobs:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if ! pull_requests="$(
+            gh pr list \
+              --state open \
+              --limit 100 \
+              --json author,headRefOid,number \
+              --jq '.[] | select(.author.login == "app/dependabot") | [.number, .headRefOid] | @tsv'
+          )"; then
+            echo "Unable to list open Dependabot PRs" >&2
+            exit 1
+          fi
+          if [[ -z "$pull_requests" ]]; then
+            exit 0
+          fi
+
           while IFS=$'\t' read -r number head_sha; do
             run_id="$(
               gh run list \
@@ -77,10 +91,4 @@ jobs:
 
             gh run rerun "$run_id" --failed
             echo "Rerunning Preview for Dependabot PR #$number"
-          done < <(
-            gh pr list \
-              --state open \
-              --limit 100 \
-              --json author,headRefOid,number \
-              --jq '.[] | select(.author.login == "app/dependabot") | [.number, .headRefOid] | @tsv'
-          )
+          done <<< "$pull_requests"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -49,6 +49,7 @@ jobs:
     steps:
       - name: Rerun blocked Dependabot previews
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           while IFS=$'\t' read -r number head_sha; do

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Approve patch and minor updates

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -54,10 +54,11 @@ jobs:
         run: |
           if ! pull_requests="$(
             gh pr list \
+              --app dependabot \
               --state open \
               --limit 100 \
-              --json author,headRefOid,number \
-              --jq '.[] | select(.author.login == "app/dependabot") | [.number, .headRefOid] | @tsv'
+              --json headRefOid,number \
+              --jq '.[] | [.number, .headRefOid] | @tsv'
           )"; then
             echo "Unable to list open Dependabot PRs" >&2
             exit 1

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,85 @@
+name: Dependabot
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+jobs:
+  auto-merge:
+    name: Approve and enable auto-merge
+    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve patch and minor updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr review --approve "$PR_URL"
+      - name: Enable auto-merge for patch and minor updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"
+
+  retry-package-age:
+    name: Retry package age failures
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Rerun blocked Dependabot previews
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          while IFS=$'\t' read -r number head_sha; do
+            run_id="$(
+              gh run list \
+                --workflow preview.yml \
+                --commit "$head_sha" \
+                --event pull_request \
+                --status failure \
+                --limit 1 \
+                --json databaseId \
+                --jq '.[0].databaseId // empty'
+            )"
+            if [[ -z "$run_id" ]]; then
+              continue
+            fi
+
+            if ! failed_log="$(gh run view "$run_id" --log-failed)"; then
+              echo "Unable to read failed logs for PR #$number"
+              continue
+            fi
+            if [[ "$failed_log" != *ERR_PNPM_NO_MATURE_MATCHING_VERSION* ]]; then
+              continue
+            fi
+
+            gh run rerun "$run_id" --failed
+            echo "Rerunning Preview for Dependabot PR #$number"
+          done < <(
+            gh pr list \
+              --state open \
+              --limit 100 \
+              --json author,headRefOid,number \
+              --jq '.[] | select(.author.login == "app/dependabot") | [.number, .headRefOid] | @tsv'
+          )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

- Adds Dependabot v2 config at `.github/dependabot.yml` to run daily for `npm` updates from the repo root, with a 3-day cooldown, max 3 open PRs, auto-rebase, and `chore(deps)` commit prefixes.
- Adds a `.github/workflows/dependabot.yml` workflow to:
  - Auto-approve and enable squash auto-merge for `dependabot[bot]` PRs only when the update type is semver patch/minor:
    ```yaml
    if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
            steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
    ```
  - On schedule/manual runs, re-run the latest failed `preview.yml` for open Dependabot PRs only when the failure logs include `ERR_PNPM_NO_MATURE_MATCHING_VERSION`.
</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->