### PR TITLE
fix(conform-react): export FormHandle type

### DIFF
--- a/.changeset/export-form-handle-type.md
+++ b/.changeset/export-form-handle-type.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/react': patch
+---
+
+Export the `FormHandle` type from the public interface so consumers can wrap the `useForm` API with properly typed handles.

--- a/packages/conform-react/future/index.ts
+++ b/packages/conform-react/future/index.ts
@@ -21,6 +21,7 @@ export type {
 	CustomStateHandler,
 	FormsConfig,
 	FormContext,
+	FormHandle,
 	FormMetadata,
 	FormOptions,
 	FormRef,


### PR DESCRIPTION
`FormHandle` can be a useful type for library consumers, as it allows wrapping `useForm` without risking type drift, thereby making it easier to build on top of Conform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

Re-exported the `FormHandle` type from `@conform-to/dom/future` via `packages/conform-react/future/index.ts`, and added a patch changeset to publish the updated public API for `@conform-to/react`.

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->