### PR TITLE
fix(conform-react): restore server control updates

### DIFF
--- a/.changeset/calm-controls-sync.md
+++ b/.changeset/calm-controls-sync.md
@@ -2,4 +2,4 @@
 '@conform-to/react': patch
 ---
 
-fix: synchronize `useControl().defaultValue` when form defaults change
+fix: restore `useControl().defaultValue` updates after client and server form updates

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -279,12 +279,13 @@ export function useConform<
 							handlers: options.intentHandlers,
 						})
 					: normalizedResult;
+			const shouldNotifyFormUpdate =
+				// Server results can replace values too. The async client phase only
+				// resolves validation for the target applied by the initial client phase.
+				type !== 'client:async' &&
+				(finalResult.reset || typeof finalResult.targetValue !== 'undefined');
 
-			if (
-				formElement &&
-				type === 'client' &&
-				(finalResult.reset || typeof finalResult.targetValue !== 'undefined')
-			) {
+			if (formElement && shouldNotifyFormUpdate) {
 				dispatchInternalUpdateEvent(formElement);
 			}
 
@@ -601,7 +602,6 @@ export function useControl(options: ControlOptions = {}): Control<any> {
 	const optionDefaultValue = deriveDefaultPayload(options);
 	const [structuralOverride, setStructuralOverride] = useState<{
 		value: unknown;
-		defaultValue: unknown;
 	} | null>(null);
 	const hasInternalUpdateSinceChangeRef = useRef(false);
 	const isStructuralControl = isGlobalInstance(
@@ -615,32 +615,16 @@ export function useControl(options: ControlOptions = {}): Control<any> {
 	 * stores an override in React state. Until then, the fieldset follows the
 	 * latest option directly, just like a standard control.
 	 *
-	 * The override becomes stale when either an internal update has happened or
-	 * the default value captured by control.change() no longer matches. The boolean
-	 * handles client resets, updates and form-key replacements even when the next
-	 * option is deeply equal to the previous one. It remains set while stale state
-	 * is cleared and is reset only by a later control.change(), so an interrupted
-	 * render cannot consume the signal. The option comparison handles updates
-	 * without an internal event, such as a server lastResult with a targetValue.
-	 *
-	 * Clearing stale state during render is intentional. React retries this
-	 * component before committing, so BaseControl never commits outdated hidden
-	 * descendants. Standard controls never create this override.
+	 * Conform dispatches an internal event before replacing form values through a
+	 * reset, target value or new form key. Once that happens, the option becomes
+	 * the source of truth until the next control.change(), which replaces the
+	 * override and clears the marker. Keeping the inactive override avoids another
+	 * render just to clear stale state.
 	 */
-	const hasStaleStructuralOverride =
-		isStructuralControl &&
-		structuralOverride !== null &&
-		(hasInternalUpdateSinceChangeRef.current ||
-			!deepEqual(structuralOverride.defaultValue, optionDefaultValue));
-
-	if (hasStaleStructuralOverride) {
-		setStructuralOverride(null);
-	}
-
 	const defaultValue =
 		isStructuralControl &&
 		structuralOverride !== null &&
-		!hasStaleStructuralOverride
+		!hasInternalUpdateSinceChangeRef.current
 			? structuralOverride.value
 			: optionDefaultValue;
 
@@ -892,23 +876,14 @@ export function useControl(options: ControlOptions = {}): Control<any> {
 					// Fieldset mode renders hidden descendant inputs from defaultValue.
 					// Flush this update before dispatching events so listeners see the
 					// latest form structure in the same input/change cycle.
-					// Any pending internal update happened before this change. Clear the
-					// marker before flushSync so its synchronous render keeps the new override.
+					// This change supersedes any previous form update, so reactivate the
+					// override before rendering its new value.
 					hasInternalUpdateSinceChangeRef.current = false;
 
 					flushSync(() => {
-						const currentDefaultValue = deriveDefaultPayload(
-							optionsRef.current,
-						);
-
-						setStructuralOverride(
-							deepEqual(serializedValue, currentDefaultValue)
-								? null
-								: {
-										value: serializedValue,
-										defaultValue: currentDefaultValue,
-									},
-						);
+						// The wrapper distinguishes no override from null / undefined, and
+						// its fresh identity reactivates an identical previous value.
+						setStructuralOverride({ value: serializedValue });
 					});
 				}
 

--- a/packages/conform-react/tests/useControl.browser.test.tsx
+++ b/packages/conform-react/tests/useControl.browser.test.tsx
@@ -1375,11 +1375,33 @@ describe('future export: useControl', () => {
 			}),
 		);
 
-		const formData = new FormData();
-		formData.append('address.street', '456 Elm St');
-		formData.append('address.city', 'Othertown');
-		formData.append('address.contacts[0]', 'Jane');
-		const lastResult = report(parseSubmission(formData), {
+		const lastResult = report(
+			parseSubmission(new FormData(formElement ?? undefined)),
+			{
+				targetValue: {
+					address: { street: '123 Main St' },
+				},
+			},
+		);
+
+		// The target intentionally matches the value from before change(). Value
+		// comparison cannot distinguish this update from the original default.
+		screen.rerender(<TestForm lastResult={lastResult} />);
+
+		await expect.element(state).toHaveTextContent(
+			JSON.stringify({
+				payload: { street: '123 Main St' },
+				defaultValue: { street: '123 Main St' },
+			}),
+		);
+		await expect.element(formElement).toHaveFormValues({
+			'address.street': '123 Main St',
+		});
+
+		await userEvent.click(screen.getByText('Change address'));
+
+		const formData = new FormData(formElement ?? undefined);
+		const nextResult = report(parseSubmission(formData), {
 			targetValue: {
 				address: {
 					street: '456 Elm St',
@@ -1389,9 +1411,7 @@ describe('future export: useControl', () => {
 			},
 		});
 
-		// Server results do not dispatch the internal update event. The new option
-		// must still replace the structural override and add the contacts input.
-		screen.rerender(<TestForm lastResult={lastResult} />);
+		screen.rerender(<TestForm lastResult={nextResult} />);
 
 		await expect.element(state).toHaveTextContent(
 			JSON.stringify({


### PR DESCRIPTION
## Summary

Follow-up to #1268.

- restore structural-control invalidation for server reset and target-value results
- remove the structural deep comparison, captured default, and render-phase cleanup
- keep an override inactive after a form update until the next control.change()
- cover a server target equal to the value from before control.change(), plus structural FormData serialization
- clarify the existing unreleased changeset

## Testing

- Conform React JavaScript and declaration builds
- Conform React typecheck
- repository Oxlint
- formatting and diff checks
- full Conform React Vitest browser matrix: 638 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

- Restored server-driven structural control updates for reset and target-value results.
- Simplified structural override state and reactivation behavior after `control.change()`.
- Updated coverage for unchanged server targets and structural `FormData` serialization.
- Clarified the unreleased changeset description.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->