### PR TITLE
fix(conform-zod): correct v4 schema guard type

### DIFF
--- a/.changeset/fix-zod-v4-schema-guard.md
+++ b/.changeset/fix-zod-v4-schema-guard.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/zod': patch
+---
+
+Fix the Zod v4 `isSchema` type guard to accept all Zod v4 schemas.

--- a/packages/conform-zod/v4/schema.ts
+++ b/packages/conform-zod/v4/schema.ts
@@ -1,11 +1,12 @@
-import type { ZodAny } from 'zod/v4';
+import type { ZodType } from 'zod/v4';
+import type { ZodMiniType } from 'zod/v4/mini';
 import type { ValidationAttributes } from '@conform-to/dom/future';
 import { getZodConstraint } from './constraint';
 
 /**
  * Type guard to check if a value is a Zod v4 schema.
  */
-export function isSchema(schema: unknown): schema is ZodAny {
+export function isSchema(schema: unknown): schema is ZodType | ZodMiniType {
 	return (
 		typeof schema === 'object' &&
 		schema !== null &&

--- a/packages/conform-zod/v4/tests/types.test-d.ts
+++ b/packages/conform-zod/v4/tests/types.test-d.ts
@@ -1,7 +1,8 @@
 import type { Constraint, Submission } from '@conform-to/dom';
 import type { FormError, ValidationAttributes } from '@conform-to/dom/future';
 import { expectTypeOf, test } from 'vitest';
-import { z, type ZodAny } from 'zod';
+import { z } from 'zod';
+import { object as miniObject, string as miniString } from 'zod/v4/mini';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod/v4';
 import {
 	coerceFormValue,
@@ -133,5 +134,16 @@ test('getConstraints', () => {
 });
 
 test('isSchema', () => {
-	expectTypeOf(isSchema).toEqualTypeOf<(schema: unknown) => schema is ZodAny>();
+	function configure<Schema>(
+		guard: (schema: unknown) => schema is Schema,
+	): (schema: Schema) => boolean {
+		return (schema) => guard(schema);
+	}
+
+	const configured = configure(isSchema);
+
+	expectTypeOf(configured(z.string())).toEqualTypeOf<boolean>();
+	expectTypeOf(configured(miniString())).toEqualTypeOf<boolean>();
+	expectTypeOf(configured(z.object({}))).toEqualTypeOf<boolean>();
+	expectTypeOf(configured(miniObject({}))).toEqualTypeOf<boolean>();
 });


### PR DESCRIPTION
## Summary

- widen the Zod v4 `isSchema` predicate to accept both Classic and Mini schemas
- add type regression coverage for common string and object schemas
- add a patch changeset

## Testing

- `tsc --project packages/conform-zod/tsconfig.json`
- `vitest --run --project "conform-zod (node, zod v4)"`

Closes #1225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

- Widened Zod v4 `isSchema` to recognize both Classic and Mini schemas via `ZodType | ZodMiniType`.
- Added type regression coverage for string and object schemas.
- Included a patch changeset and validated with TypeScript and Vitest.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->