### PR TITLE
feat(conform-react): allow submit and form intents to share a field

### DIFF
--- a/.changeset/bright-forms-submit.md
+++ b/.changeset/bright-forms-submit.md
@@ -1,0 +1,15 @@
+---
+'@conform-to/react': minor
+---
+
+feat: allow submit and form intents to share a field name
+
+`resolveSubmission()` now lets submit intents and form intents share the same `intentName`. Plain intent values are preserved as submit intent payloads:
+
+```ts
+// submission.intent === 'delete'
+resolveSubmission(submission).intent;
+// { type: 'submit', payload: 'delete' }
+```
+
+Registered form intents continue to resolve through their handlers, while invalid form intents resolve to `undefined`.

--- a/docs/api/react/future/resolveSubmission.md
+++ b/docs/api/react/future/resolveSubmission.md
@@ -2,7 +2,7 @@
 
 > The `resolveSubmission` function is part of Conform's future export. These APIs are experimental and may change in minor versions. [Learn more](https://github.com/edmundhung/conform/discussions/954)
 
-`resolveSubmission` gives you the value to validate or save for a submission. Use it for progressive enhancement in server actions.
+`resolveSubmission` interprets the intent in a parsed submission and returns the form value produced by it. This lets a server action distinguish a submit intent from a form intent, such as inserting or removing a list item, and validate the updated form value before reporting it back. Use it to support form intent controls through native form submissions as part of progressive enhancement.
 
 If you already created a customized forms factory with [`configureForms`](./configureForms.md), use `forms.resolveSubmission(...)` so the factory's custom intent handlers are included too.
 
@@ -24,7 +24,7 @@ export async function action({ request }) {
   const result = schema.safeParse(targetValue);
 
   if (!intent) {
-    return new Response('Unknown intent', { status: 400 });
+    return new Response('Invalid form intent', { status: 400 });
   }
 
   if (intent.type !== 'submit' || !result.success) {
@@ -56,7 +56,32 @@ Optional intent handlers used to extend or override the configured intent handle
 
 An object with the following properties:
 
-- `intent`, the parsed intent, or `undefined` when the intent type is unknown or invalid
+- `intent`, the resolved submit intent or form intent, or `undefined` for an invalid form intent
 - `targetValue`, the value to validate or save
 
-If Conform cannot resolve the intent, `targetValue` falls back to the original submission payload.
+### Intent resolution
+
+`submission.intent` is the raw intent value. It resolves as follows:
+
+- A missing intent value becomes `{ type: 'submit', payload: undefined }`.
+- Values matching the complete `type(...)` pattern are treated as form intents. They resolve through their registered handlers, or to `undefined` when the type is unregistered, the arguments are malformed, or the handler rejects the arguments.
+- Every other value becomes a submit intent carrying the original value. For example, `delete` becomes `{ type: 'submit', payload: 'delete' }`.
+
+This allows submit intents to share a field name with form intents:
+
+```ts
+const submission = parseSubmission(formData, { intentName: 'intent' });
+const { intent, targetValue } = resolveSubmission(submission);
+
+if (intent?.type === 'submit') {
+  switch (intent.payload) {
+    case 'delete':
+      // Delete the validated target value
+      break;
+    case 'save':
+    case undefined:
+      // Save the validated target value
+      break;
+  }
+}
+```

--- a/packages/conform-react/future/forms.tsx
+++ b/packages/conform-react/future/forms.tsx
@@ -762,7 +762,7 @@ export function configureForms<
 					Record<string, any>,
 					DefaultIntentHandlers & GlobalIntentHandlers & IntentHandlers
 			  >
-			| { type: 'submit'; payload: undefined }
+			| { type: 'submit'; payload: string | undefined }
 			| undefined;
 		targetValue: Record<string, FormValue> | undefined;
 	} {

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -268,7 +268,7 @@ export function useConform<
 
 			if (!intent) {
 				throw new Error(
-					`Unknown intent found in the submission result; Received intent: ${result.submission.intent}`,
+					`Invalid form intent found in the submission result; Received intent: ${result.submission.intent}`,
 				);
 			}
 

--- a/packages/conform-react/future/intent.ts
+++ b/packages/conform-react/future/intent.ts
@@ -69,12 +69,6 @@ export function mergeIntentHandlers<
 
 const undefinedArg = '$$__undefined__$$';
 
-function deserializeIntentArgs(value: string): unknown[] {
-	return JSON.parse(`[${value}]`, (_, value) =>
-		value === undefinedArg ? undefined : value,
-	);
-}
-
 /**
  * Serializes a transport intent to string format.
  */
@@ -86,7 +80,7 @@ export function serializeIntent(intent: TransportIntent): string {
 	}
 
 	if (args.length === 0) {
-		return intent.type;
+		return `${intent.type}()`;
 	}
 
 	const serializedArgs = JSON.stringify(args, function (this, _, value) {
@@ -102,34 +96,28 @@ export function serializeIntent(intent: TransportIntent): string {
 
 /**
  * Parses the serialized intent string into a transport intent.
+ * Throws if the serialized arguments are malformed.
  */
 export function deserializeIntent(
 	serializedIntent: string,
 ): TransportIntent | undefined {
-	if (serializedIntent === '') {
-		return undefined;
-	}
-
-	let type = serializedIntent;
-	let args: Array<unknown> = [];
-
 	const openParenIndex = serializedIntent.indexOf('(');
 
 	if (
-		openParenIndex > 0 &&
-		serializedIntent[serializedIntent.length - 1] === ')'
+		openParenIndex <= 0 ||
+		serializedIntent[serializedIntent.length - 1] !== ')'
 	) {
-		type = serializedIntent.slice(0, openParenIndex);
+		return undefined;
+	}
 
-		const serializedArgs = serializedIntent.slice(openParenIndex + 1, -1);
+	const type = serializedIntent.slice(0, openParenIndex);
+	let args: Array<unknown> = [];
+	const serializedArgs = serializedIntent.slice(openParenIndex + 1, -1);
 
-		if (serializedArgs !== '') {
-			try {
-				args = deserializeIntentArgs(serializedArgs);
-			} catch {
-				return undefined;
-			}
-		}
+	if (serializedArgs !== '') {
+		args = JSON.parse(`[${serializedArgs}]`, (_, value) =>
+			value === undefinedArg ? undefined : value,
+		);
 	}
 
 	return {
@@ -147,16 +135,22 @@ export function parseIntent<
 	},
 ):
 	| FormIntent<Record<string, any>, Handlers>
-	| { type: 'submit'; payload: undefined }
+	| { type: 'submit'; payload: string | undefined }
 	| undefined {
 	if (intentValue === null) {
 		return { type: 'submit', payload: undefined };
 	}
 
-	const transportIntent = deserializeIntent(intentValue);
+	let transportIntent: TransportIntent | undefined;
+
+	try {
+		transportIntent = deserializeIntent(intentValue);
+	} catch {
+		return undefined;
+	}
 
 	if (!transportIntent) {
-		return undefined;
+		return { type: 'submit', payload: intentValue };
 	}
 
 	const handler = options.handlers[transportIntent.type];
@@ -166,9 +160,11 @@ export function parseIntent<
 	}
 
 	try {
+		const payload = handler.parse(...transportIntent.args);
+
 		return {
 			type: transportIntent.type,
-			payload: handler.parse(...transportIntent.args),
+			payload,
 		} as any;
 	} catch {
 		return undefined;

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -676,7 +676,7 @@ export type IntentHandlerPayload<
 	? IntentPayload<NormalizeIntentType<Dispatch>, FormShape>
 	: Payload;
 
-export type SubmitIntent = () => void;
+export type SubmitIntent = (value?: string) => void;
 
 export interface ResetIntent extends TypedIntentDefinition {
 	dispatch<

--- a/packages/conform-react/tests/intent.test.ts
+++ b/packages/conform-react/tests/intent.test.ts
@@ -17,7 +17,7 @@ import { IntentHandler } from '../future/types';
 
 test('serializeIntent', () => {
 	// Test intent without payload
-	expect(serializeIntent({ type: 'reset', args: [] })).toBe('reset');
+	expect(serializeIntent({ type: 'reset', args: [] })).toBe('reset()');
 
 	// Test intent with payload
 	expect(serializeIntent({ type: 'validate', args: ['email'] })).toBe(
@@ -51,7 +51,9 @@ test('serializeIntent', () => {
 			args: [undefined, 1, undefined, 2, undefined],
 		}),
 	).toBe('custom("$$__undefined__$$",1,"$$__undefined__$$",2)');
-	expect(serializeIntent({ type: 'custom', args: [undefined] })).toBe('custom');
+	expect(serializeIntent({ type: 'custom', args: [undefined] })).toBe(
+		'custom()',
+	);
 	expect(
 		serializeIntent({
 			type: 'custom',
@@ -79,15 +81,12 @@ test('serializeIntent', () => {
 	).toBe('custom([1,"$$__undefined__$$"])');
 
 	// Test intent with undefined payload
-	expect(serializeIntent({ type: 'reset', args: [] })).toBe('reset');
+	expect(serializeIntent({ type: 'reset', args: [] })).toBe('reset()');
 });
 
 test('deserializeIntent', () => {
 	// Test simple intent
-	expect(deserializeIntent('reset')).toEqual({
-		type: 'reset',
-		args: [],
-	});
+	expect(deserializeIntent('reset')).toBeUndefined();
 
 	// Test intent with string payload
 	expect(deserializeIntent('validate("email")')).toEqual({
@@ -102,13 +101,10 @@ test('deserializeIntent', () => {
 	});
 
 	// Test malformed JSON
-	expect(deserializeIntent('update({invalid)')).toBeUndefined();
+	expect(() => deserializeIntent('update({invalid)')).toThrow();
 
 	// Test without closing parenthesis
-	expect(deserializeIntent('validate("email"')).toEqual({
-		type: 'validate("email"',
-		args: [],
-	});
+	expect(deserializeIntent('validate("email"')).toBeUndefined();
 
 	// Test empty parentheses
 	expect(deserializeIntent('reset()')).toEqual({
@@ -201,13 +197,13 @@ test('deserializeIntent', () => {
 		type: 'custom',
 		args: [0],
 	});
-	expect(deserializeIntent('custom(1,)')).toBeUndefined();
-	expect(deserializeIntent('custom({])')).toBeUndefined();
-	expect(deserializeIntent('custom([})')).toBeUndefined();
-	expect(deserializeIntent('custom("unterminated,,,,)')).toBeUndefined();
-	expect(
+	expect(() => deserializeIntent('custom(1,)')).toThrow();
+	expect(() => deserializeIntent('custom({])')).toThrow();
+	expect(() => deserializeIntent('custom([})')).toThrow();
+	expect(() => deserializeIntent('custom("unterminated,,,,)')).toThrow();
+	expect(() =>
 		deserializeIntent(`custom("${'\\"?'.repeat(50_000)})`),
-	).toBeUndefined();
+	).toThrow();
 
 	// Test empty string
 	expect(deserializeIntent('')).toBeUndefined();
@@ -221,16 +217,39 @@ test('parseIntent', () => {
 
 	expect(parseIntent('submit', { handlers: defaultIntentHandlers })).toEqual({
 		type: 'submit',
-		payload: undefined,
+		payload: 'submit',
 	});
-	expect(parseIntent('custom', { handlers: defaultIntentHandlers })).toBe(
-		undefined,
-	);
+	expect(
+		parseIntent('submit("delete")', { handlers: defaultIntentHandlers }),
+	).toEqual({
+		type: 'submit',
+		payload: 'delete',
+	});
+	expect(parseIntent('custom', { handlers: defaultIntentHandlers })).toEqual({
+		type: 'submit',
+		payload: 'custom',
+	});
 	expect(
 		parseIntent('validate(null)', { handlers: defaultIntentHandlers }),
-	).toBe(undefined);
+	).toBeUndefined();
 	expect(parseIntent('validate', { handlers: defaultIntentHandlers })).toEqual({
-		type: 'validate',
+		type: 'submit',
+		payload: 'validate',
+	});
+	expect(parseIntent('reset', { handlers: defaultIntentHandlers })).toEqual({
+		type: 'submit',
+		payload: 'reset',
+	});
+	expect(parseIntent('update', { handlers: defaultIntentHandlers })).toEqual({
+		type: 'submit',
+		payload: 'update',
+	});
+	expect(parseIntent('insert', { handlers: defaultIntentHandlers })).toEqual({
+		type: 'submit',
+		payload: 'insert',
+	});
+	expect(parseIntent('reset()', { handlers: defaultIntentHandlers })).toEqual({
+		type: 'reset',
 		payload: undefined,
 	});
 
@@ -258,13 +277,13 @@ test('parseIntent', () => {
 		type: 'singleArg',
 		payload: 'field',
 	});
-	expect(parseIntent('zeroArg', { handlers: fallbackHandlers })).toEqual({
+	expect(parseIntent('zeroArg()', { handlers: fallbackHandlers })).toEqual({
 		type: 'zeroArg',
 		payload: undefined,
 	});
 	expect(
 		parseIntent('singleArg("field",1)', { handlers: fallbackHandlers }),
-	).toBe(undefined);
+	).toBeUndefined();
 
 	expect(
 		parseIntent('reset({invalid)', { handlers: defaultIntentHandlers }),
@@ -289,11 +308,25 @@ test('parseIntent', () => {
 			{ handlers: defaultIntentHandlers },
 		),
 	).toBeUndefined();
+
+	// Incomplete call syntax remains a submit intent
+	expect(
+		parseIntent('custom("field"', { handlers: defaultIntentHandlers }),
+	).toEqual({
+		type: 'submit',
+		payload: 'custom("field"',
+	});
+	expect(
+		parseIntent('custom()extra', { handlers: defaultIntentHandlers }),
+	).toEqual({
+		type: 'submit',
+		payload: 'custom()extra',
+	});
 });
 
 test('resolveIntent', () => {
 	const submission: Submission = {
-		intent: 'reset',
+		intent: 'reset()',
 		payload: { email: 'test@example.com', name: 'John' },
 		fields: ['email', 'name'],
 	};
@@ -335,7 +368,7 @@ test('resolveIntent', () => {
 	} satisfies Record<string, IntentHandler>;
 
 	const customSubmission: Submission = {
-		intent: 'custom',
+		intent: 'custom()',
 		payload: { email: 'test' },
 		fields: ['email'],
 	};
@@ -361,7 +394,7 @@ test('resolveIntent', () => {
 	} satisfies Record<string, IntentHandler>;
 
 	const failingSubmission: Submission = {
-		intent: 'failing',
+		intent: 'failing()',
 		payload: { test: true },
 		fields: ['test'],
 	};
@@ -385,13 +418,13 @@ test('resolveIntent', () => {
 
 	const targetedResult = resolveIntent(
 		{
-			intent: 'targeted',
+			intent: 'targeted()',
 			payload: { email: 'test@example.com', name: 'John' },
 			fields: ['email', 'name'],
 		},
 		{
 			handlers: targetedHandlers,
-			intent: parseIntent('targeted', { handlers: targetedHandlers }),
+			intent: parseIntent('targeted()', { handlers: targetedHandlers }),
 		},
 	);
 	expect(targetedResult).toEqual({
@@ -408,13 +441,13 @@ test('resolveIntent', () => {
 
 	const wrappedResult = resolveIntent(
 		{
-			intent: 'wrapped',
+			intent: 'wrapped()',
 			payload: { email: 'test@example.com' },
 			fields: ['email'],
 		},
 		{
 			handlers: wrappedHandlers,
-			intent: parseIntent('wrapped', { handlers: wrappedHandlers }),
+			intent: parseIntent('wrapped()', { handlers: wrappedHandlers }),
 		},
 	);
 	expect(wrappedResult).toEqual({ email: 'wrapped@example.com' });
@@ -423,7 +456,7 @@ test('resolveIntent', () => {
 test('applyIntent', () => {
 	const resetResult: SubmissionResult = {
 		submission: {
-			intent: 'reset',
+			intent: 'reset()',
 			payload: { email: 'test@example.com' },
 			fields: ['email'],
 		},
@@ -456,7 +489,7 @@ test('applyIntent', () => {
 	} satisfies Record<string, IntentHandler>;
 	const customResult: SubmissionResult = {
 		submission: {
-			intent: 'custom',
+			intent: 'custom()',
 			payload: { email: 'test@example.com' },
 			fields: ['email'],
 		},

--- a/packages/conform-react/tests/resolveSubmission.browser.test.tsx
+++ b/packages/conform-react/tests/resolveSubmission.browser.test.tsx
@@ -26,7 +26,7 @@ test('resolveSubmission', () => {
 
 	expect(
 		resolveSubmission({
-			intent: 'reset',
+			intent: 'reset()',
 			payload: { email: 'test@example.com' },
 			fields: ['email'],
 		}),
@@ -61,6 +61,27 @@ test('resolveSubmission', () => {
 		resolveSubmission(
 			{
 				intent: 'unknown',
+				payload: { email: 'test@example.com' },
+				fields: ['email'],
+			},
+			{
+				handlers: customHandlers,
+			},
+		),
+	).toEqual({
+		intent: {
+			type: 'submit',
+			payload: 'unknown',
+		},
+		targetValue: {
+			email: 'test@example.com',
+		},
+	});
+
+	expect(
+		resolveSubmission(
+			{
+				intent: 'unknown()',
 				payload: { email: 'test@example.com' },
 				fields: ['email'],
 			},

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -647,7 +647,9 @@ describe('configureForms', () => {
 		if (resolvedConfiguredSubmission.intent?.type === 'goToStep') {
 			assertType<number>(resolvedConfiguredSubmission.intent.payload.step);
 		} else if (resolvedConfiguredSubmission.intent?.type === 'submit') {
-			assertType<undefined>(resolvedConfiguredSubmission.intent.payload);
+			assertType<string | undefined>(
+				resolvedConfiguredSubmission.intent.payload,
+			);
 		}
 
 		const unresolvedConfiguredSubmission = custom.resolveSubmission({
@@ -991,6 +993,7 @@ test('IntentDispatcher', () => {
 	const intent = {} as IntentDispatcher<TestSchema>;
 
 	// Verify all intent methods exist
+	expectTypeOf(intent.submit).toBeFunction();
 	expectTypeOf(intent.validate).toBeFunction();
 	expectTypeOf(intent.update).toBeFunction();
 	expectTypeOf(intent.insert).toBeFunction();
@@ -1000,6 +1003,10 @@ test('IntentDispatcher', () => {
 	// Test validate
 	assertType<void>(intent.validate());
 	assertType<void>(intent.validate('name'));
+
+	// Test submit
+	assertType<void>(intent.submit());
+	assertType<void>(intent.submit('delete'));
 
 	// Test remove
 	assertType<void>(intent.remove({ name: 'tasks', index: 0 }));

--- a/packages/conform-react/tests/useForm.node.test.tsx
+++ b/packages/conform-react/tests/useForm.node.test.tsx
@@ -82,6 +82,28 @@ describe.each(testCases)('future export: useForm - $name', ({ useForm }) => {
 		expect(fields.description.errors).toEqual(['Description error']);
 	});
 
+	test('initialize with submit intent', () => {
+		const { form, fields } = serverRenderHook(() =>
+			useForm<{ title: string }, string[]>({
+				lastResult: createResult(
+					[
+						['title', 'Example'],
+						[DEFAULT_INTENT_NAME, 'delete'],
+					],
+					{
+						error: {
+							formErrors: ['Confirm deletion'],
+						},
+					},
+				),
+				onValidate: () => undefined,
+			}),
+		);
+
+		expect(form.errors).toEqual(['Confirm deletion']);
+		expect(fields.title.defaultValue).toBe('Example');
+	});
+
 	test('initialize with validate intent', () => {
 		const { form, fields } = serverRenderHook(() =>
 			useForm<{ title: string; description: string }, string[]>({


### PR DESCRIPTION
## Summary

- serialize form intents using `type(...)`, including empty parentheses for zero-argument intents
- resolve any value that is not successfully handled as a form intent to a submit intent carrying the original value
- preserve server results for manual submit intents and document the progressive-enhancement pattern
- update intent resolution, SSR initialization, and type-level regression coverage

Related to #1279.

## Verification

- 109 conform-react node tests passed
- TypeScript build and type checks passed
- Oxlint and formatting checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

- Serializes form intents with callable syntax, including zero-argument forms such as `reset()`.
- Treats unrecognized bare values as submit intents with the original payload.
- Keeps malformed or unresolved form intents invalid.
- Supports optional submit payloads and preserves server results during initialization.
- Updates intent parsing, types, documentation, and regression tests.

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->