### PR TITLE
fix(conform-react): preserve string literal types in DefaultValue

### DIFF
--- a/.changeset/olive-trees-narrow.md
+++ b/.changeset/olive-trees-narrow.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/react': patch
+---
+
+Fix `DefaultValue` to preserve string literal types so `z.literal(...)` schemas infer their literal value instead of widening to `string`.

--- a/.changeset/olive-trees-narrow.md
+++ b/.changeset/olive-trees-narrow.md
@@ -1,5 +1,5 @@
 ---
-'@conform-to/react': patch
+'@conform-to/react': minor
 ---
 
 Fix `DefaultValue` to preserve string literal types so `z.literal(...)` schemas infer their literal value instead of widening to `string`.

--- a/examples/headless-ui/src/App.tsx
+++ b/examples/headless-ui/src/App.tsx
@@ -33,6 +33,8 @@ const schema = coerceFormValue(
 	}),
 );
 
+type FormShape = z.input<typeof schema>;
+
 const options = [
 	{ label: 'Durward Reynolds', value: '1' },
 	{ label: 'Kenton Towne', value: '2' },
@@ -56,7 +58,8 @@ export default function App() {
 			color: searchParams.get('color'),
 			project: searchParams.get('project'),
 			notes: searchParams.get('notes'),
-			priority: searchParams.get('priority') ?? 'normal',
+			priority: (searchParams.get('priority') ??
+				'normal') as FormShape['priority'],
 			notifications: searchParams.get('notifications'),
 		},
 		onSubmit(event, { formData, value }) {

--- a/examples/headless-ui/src/App.tsx
+++ b/examples/headless-ui/src/App.tsx
@@ -1,3 +1,4 @@
+import { parseWithZod } from '@conform-to/zod/v4';
 import { coerceFormValue } from '@conform-to/zod/v4/future';
 import {
 	Description,
@@ -33,8 +34,6 @@ const schema = coerceFormValue(
 	}),
 );
 
-type FormShape = z.input<typeof schema>;
-
 const options = [
 	{ label: 'Durward Reynolds', value: '1' },
 	{ label: 'Kenton Towne', value: '2' },
@@ -50,18 +49,13 @@ export default function App() {
 	const [searchParams, setSearchParams] = useState(
 		() => new URLSearchParams(window.location.search),
 	);
+	const submission = parseWithZod(searchParams, { schema });
+	const defaultValue =
+		submission.status === 'success' ? submission.value : undefined;
 	const { form, fields, intent } = useForm(schema, {
-		defaultValue: {
-			owner: searchParams.getAll('owner'),
-			assignee: searchParams.get('assignee'),
-			enabled: searchParams.get('enabled'),
-			color: searchParams.get('color'),
-			project: searchParams.get('project'),
-			notes: searchParams.get('notes'),
-			priority: (searchParams.get('priority') ??
-				'normal') as FormShape['priority'],
-			notifications: searchParams.get('notifications'),
-		},
+		// Fall back to 'normal' when the URL has no priority (the browser would
+		// otherwise submit the first option of the native select)
+		defaultValue: { priority: 'normal', ...defaultValue },
 		onSubmit(event, { formData, value }) {
 			event.preventDefault();
 

--- a/examples/radix-ui/src/App.tsx
+++ b/examples/radix-ui/src/App.tsx
@@ -22,6 +22,8 @@ const schema = coerceFormValue(
 	}),
 );
 
+type FormShape = z.input<typeof schema>;
+
 export default function App() {
 	const [submittedValue, setSubmittedValue] = useState<z.output<
 		typeof schema
@@ -32,13 +34,15 @@ export default function App() {
 	const { form, fields, intent } = useForm(schema, {
 		defaultValue: {
 			isTermsAgreed: searchParams.get('isTermsAgreed'),
-			carType: searchParams.get('carType'),
-			userCountry: searchParams.get('userCountry'),
+			carType: searchParams.get('carType') as FormShape['carType'],
+			userCountry: searchParams.get('userCountry') as FormShape['userCountry'],
 			estimatedKilometersPerYear: searchParams.get(
 				'estimatedKilometersPerYear',
 			),
 			insurance: searchParams.get('insurance'),
-			desiredContractType: searchParams.get('desiredContractType'),
+			desiredContractType: searchParams.get(
+				'desiredContractType',
+			) as FormShape['desiredContractType'],
 		},
 		onSubmit(event, { formData, value }) {
 			event.preventDefault();

--- a/examples/radix-ui/src/App.tsx
+++ b/examples/radix-ui/src/App.tsx
@@ -1,3 +1,4 @@
+import { parseWithZod } from '@conform-to/zod/v4';
 import { coerceFormValue } from '@conform-to/zod/v4/future';
 import { useState } from 'react';
 import { z } from 'zod';
@@ -22,8 +23,6 @@ const schema = coerceFormValue(
 	}),
 );
 
-type FormShape = z.input<typeof schema>;
-
 export default function App() {
 	const [submittedValue, setSubmittedValue] = useState<z.output<
 		typeof schema
@@ -31,19 +30,11 @@ export default function App() {
 	const [searchParams, setSearchParams] = useState(
 		() => new URLSearchParams(window.location.search),
 	);
+	const submission = parseWithZod(searchParams, { schema });
+	const defaultValue =
+		submission.status === 'success' ? submission.value : undefined;
 	const { form, fields, intent } = useForm(schema, {
-		defaultValue: {
-			isTermsAgreed: searchParams.get('isTermsAgreed'),
-			carType: searchParams.get('carType') as FormShape['carType'],
-			userCountry: searchParams.get('userCountry') as FormShape['userCountry'],
-			estimatedKilometersPerYear: searchParams.get(
-				'estimatedKilometersPerYear',
-			),
-			insurance: searchParams.get('insurance'),
-			desiredContractType: searchParams.get(
-				'desiredContractType',
-			) as FormShape['desiredContractType'],
-		},
+		defaultValue,
 		onSubmit(event, { formData, value }) {
 			event.preventDefault();
 

--- a/examples/react-aria/src/App.tsx
+++ b/examples/react-aria/src/App.tsx
@@ -1,3 +1,4 @@
+import { parseWithZod } from '@conform-to/zod/v3';
 import { coerceFormValue } from '@conform-to/zod/v3/future';
 import { useState } from 'react';
 import { z } from 'zod';
@@ -14,25 +15,24 @@ import { ComboBox, ComboBoxItem } from './components/ComboBox';
 import { FileTrigger } from './components/FileTrigger';
 import { useForm } from './forms';
 
-const schema = coerceFormValue(
-	z.object({
-		email: z.string(),
-		price: z.number(),
-		language: z.enum(['en', 'de', 'ja']),
-		colors: z.enum(['red', 'green', 'blue']).array().min(1),
-		date: z.date(),
-		range: z.object({
-			start: z.string(),
-			end: z.string(),
-		}),
-		category: z.string(),
-		author: z.string(),
-		profile: z.instanceof(File, { message: 'Required' }),
-		acceptTerms: z.boolean(),
+const formSchema = z.object({
+	email: z.string(),
+	price: z.number(),
+	language: z.enum(['en', 'de', 'ja']),
+	colors: z.enum(['red', 'green', 'blue']).array().min(1),
+	date: z.date(),
+	range: z.object({
+		start: z.string(),
+		end: z.string(),
 	}),
-);
+	category: z.string(),
+	author: z.string(),
+	profile: z.instanceof(File, { message: 'Required' }),
+	acceptTerms: z.boolean(),
+});
 
-type FormShape = z.input<typeof schema>;
+const schema = coerceFormValue(formSchema);
+const defaultSchema = formSchema.omit({ profile: true });
 
 export default function App() {
 	const [submittedValue, setSubmittedValue] = useState<z.output<
@@ -41,21 +41,11 @@ export default function App() {
 	const [searchParams, setSearchParams] = useState(
 		() => new URLSearchParams(window.location.search),
 	);
+	const submission = parseWithZod(searchParams, { schema: defaultSchema });
+	const defaultValue =
+		submission.status === 'success' ? submission.value : undefined;
 	const { form, fields, intent } = useForm(schema, {
-		defaultValue: {
-			email: searchParams.get('email'),
-			price: searchParams.get('price'),
-			language: searchParams.get('language') as FormShape['language'],
-			colors: searchParams.getAll('colors') as FormShape['colors'],
-			date: searchParams.get('date'),
-			range: {
-				start: searchParams.get('range.start'),
-				end: searchParams.get('range.end'),
-			},
-			category: searchParams.get('category'),
-			author: searchParams.get('author'),
-			acceptTerms: searchParams.get('acceptTerms'),
-		},
+		defaultValue,
 		onSubmit(event, { formData, value }) {
 			event.preventDefault();
 

--- a/examples/react-aria/src/App.tsx
+++ b/examples/react-aria/src/App.tsx
@@ -32,6 +32,8 @@ const schema = coerceFormValue(
 	}),
 );
 
+type FormShape = z.input<typeof schema>;
+
 export default function App() {
 	const [submittedValue, setSubmittedValue] = useState<z.output<
 		typeof schema
@@ -43,8 +45,8 @@ export default function App() {
 		defaultValue: {
 			email: searchParams.get('email'),
 			price: searchParams.get('price'),
-			language: searchParams.get('language'),
-			colors: searchParams.getAll('colors'),
+			language: searchParams.get('language') as FormShape['language'],
+			colors: searchParams.getAll('colors') as FormShape['colors'],
 			date: searchParams.get('date'),
 			range: {
 				start: searchParams.get('range.start'),

--- a/examples/react-aria/src/components/DatePicker.tsx
+++ b/examples/react-aria/src/components/DatePicker.tsx
@@ -32,6 +32,13 @@ export interface DatePickerProps<T extends DateValue> extends Omit<
 	errors?: string[];
 }
 
+// Conform serializes a `Date` default via `toISOString()`, which produces a
+// Z-suffixed string (e.g. `2025-04-01T00:00:00.000Z`) that `parseDateTime`
+// rejects. Drop the suffix so the value conform produced can be parsed back.
+function parseDate(value: string): CalendarDateTime {
+	return parseDateTime(value.replace(/Z$/, ''));
+}
+
 export function DatePicker({
 	label,
 	name,
@@ -52,7 +59,7 @@ export function DatePicker({
 	return (
 		<AriaDatePicker
 			{...props}
-			value={control.value ? parseDateTime(control.value) : null}
+			value={control.value ? parseDate(control.value) : null}
 			onChange={(value) => control.change(value?.toString() ?? '')}
 			onBlur={() => control.blur()}
 		>

--- a/examples/shadcn-ui/src/App.tsx
+++ b/examples/shadcn-ui/src/App.tsx
@@ -42,6 +42,8 @@ const schema = coerceFormValue(
 	}),
 );
 
+type FormShape = z.input<typeof schema>;
+
 function getDefaultMembers(searchParams: URLSearchParams) {
 	const defaultMembers: Array<Record<string, string>> = [];
 
@@ -71,17 +73,17 @@ export default function App() {
 			name: searchParams.get('name'),
 			dateOfBirth: searchParams.get('dateOfBirth'),
 			country: searchParams.get('country'),
-			gender: searchParams.get('gender'),
+			gender: searchParams.get('gender') as FormShape['gender'],
 			agreeToTerms: searchParams.get('agreeToTerms'),
-			job: searchParams.get('job'),
+			job: searchParams.get('job') as FormShape['job'],
 			age: searchParams.get('age'),
 			isAdult: searchParams.get('isAdult'),
 			description: searchParams.get('description'),
-			accountType: searchParams.get('accountType'),
-			categories: searchParams.getAll('categories'),
+			accountType: searchParams.get('accountType') as FormShape['accountType'],
+			categories: searchParams.getAll('categories') as FormShape['categories'],
 			interests: searchParams.getAll('interests'),
 			code: searchParams.get('code'),
-			members: getDefaultMembers(searchParams),
+			members: getDefaultMembers(searchParams) as FormShape['members'],
 		},
 		onSubmit(event, { formData, value }) {
 			event.preventDefault();

--- a/examples/shadcn-ui/src/App.tsx
+++ b/examples/shadcn-ui/src/App.tsx
@@ -1,3 +1,4 @@
+import { parseWithZod } from '@conform-to/zod/v3';
 import { coerceFormValue } from '@conform-to/zod/v3/future';
 import { useState } from 'react';
 import { z } from 'zod';
@@ -42,25 +43,6 @@ const schema = coerceFormValue(
 	}),
 );
 
-type FormShape = z.input<typeof schema>;
-
-function getDefaultMembers(searchParams: URLSearchParams) {
-	const defaultMembers: Array<Record<string, string>> = [];
-
-	for (let i = 0; searchParams.has(`members[${i}].id`); i++) {
-		const id = searchParams.get(`members[${i}].id`);
-		const name = searchParams.get(`members[${i}].name`);
-		const email = searchParams.get(`members[${i}].email`);
-		const role = searchParams.get(`members[${i}].role`);
-
-		if (id && name && email && role) {
-			defaultMembers.push({ id, name, email, role });
-		}
-	}
-
-	return defaultMembers;
-}
-
 export default function App() {
 	const [submittedValue, setSubmittedValue] = useState<z.output<
 		typeof schema
@@ -68,23 +50,11 @@ export default function App() {
 	const [searchParams, setSearchParams] = useState(
 		() => new URLSearchParams(window.location.search),
 	);
+	const submission = parseWithZod(searchParams, { schema });
+	const defaultValue =
+		submission.status === 'success' ? submission.value : undefined;
 	const { form, fields, intent } = useForm(schema, {
-		defaultValue: {
-			name: searchParams.get('name'),
-			dateOfBirth: searchParams.get('dateOfBirth'),
-			country: searchParams.get('country'),
-			gender: searchParams.get('gender') as FormShape['gender'],
-			agreeToTerms: searchParams.get('agreeToTerms'),
-			job: searchParams.get('job') as FormShape['job'],
-			age: searchParams.get('age'),
-			isAdult: searchParams.get('isAdult'),
-			description: searchParams.get('description'),
-			accountType: searchParams.get('accountType') as FormShape['accountType'],
-			categories: searchParams.getAll('categories') as FormShape['categories'],
-			interests: searchParams.getAll('interests'),
-			code: searchParams.get('code'),
-			members: getDefaultMembers(searchParams) as FormShape['members'],
-		},
+		defaultValue,
 		onSubmit(event, { formData, value }) {
 			event.preventDefault();
 

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -195,7 +195,7 @@ export type DefaultValue<Shape> =
 			? Array<DefaultValue<Item>> | null | undefined
 			: Shape extends File | File[]
 				? null | undefined // We don't support setting default value for file inputs yet
-				: Shape extends string
+				: Shape extends string | null | undefined
 					? Shape | null | undefined
 					: Shape | string | null | undefined;
 

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -195,7 +195,9 @@ export type DefaultValue<Shape> =
 			? Array<DefaultValue<Item>> | null | undefined
 			: Shape extends File | File[]
 				? null | undefined // We don't support setting default value for file inputs yet
-				: Shape | string | null | undefined;
+				: Shape extends string
+					? Shape | null | undefined
+					: Shape | string | null | undefined;
 
 export type FormState<
 	ErrorShape = any,

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -150,6 +150,22 @@ test('DefaultValue', () => {
 	expectTypeOf<DefaultValue<'abc'[]>>().toEqualTypeOf<
 		('abc' | null | undefined)[] | null | undefined
 	>();
+
+	// Nullable and optional constituents of string unions keep their literals
+	expectTypeOf<DefaultValue<'save' | 'publish' | undefined>>().toEqualTypeOf<
+		'save' | 'publish' | null | undefined
+	>();
+	expectTypeOf<DefaultValue<'save' | null>>().toEqualTypeOf<
+		'save' | null | undefined
+	>();
+
+	// Optional literal-typed fields (e.g. z.enum([...]).optional()) stay narrow
+	type IntentObject = { intent?: 'save' | 'publish' };
+	expectTypeOf<DefaultValue<IntentObject>>().toEqualTypeOf<
+		{ intent?: 'save' | 'publish' | null | undefined } | null | undefined
+	>();
+	// @ts-expect-error unsupported literal should be rejected
+	assertType<DefaultValue<IntentObject>>({ intent: 'delete' });
 });
 
 test('FormOptions', () => {

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -120,6 +120,36 @@ test('DefaultValue', () => {
 	assertType<DefaultValue<number>>(numberWithUndefined);
 	assertType<DefaultValue<UserObject>>(objectWithUndefined);
 	assertType<DefaultValue<string[]>>(arrayWithUndefined);
+
+	// String literal types should not be widened to string
+	expectTypeOf<DefaultValue<'abc'>>().toEqualTypeOf<'abc' | null | undefined>();
+	// @ts-expect-error default value should not accept any string
+	assertType<DefaultValue<'abc'>>('def');
+
+	// Unions of string literals stay narrow
+	expectTypeOf<DefaultValue<'active' | 'inactive'>>().toEqualTypeOf<
+		'active' | 'inactive' | null | undefined
+	>();
+
+	// Template literal types stay narrow
+	expectTypeOf<DefaultValue<`#${string}`>>().toEqualTypeOf<
+		`#${string}` | null | undefined
+	>();
+
+	// Literal-typed object properties narrow
+	type StatusObject = { status: 'abc'; name: string };
+	expectTypeOf<DefaultValue<StatusObject>>().toEqualTypeOf<
+		| { status?: 'abc' | null | undefined; name?: string | null | undefined }
+		| null
+		| undefined
+	>();
+	// @ts-expect-error wrong literal on a field should be rejected
+	assertType<DefaultValue<StatusObject>>({ status: 'def', name: 'John' });
+
+	// Arrays of literals narrow their items
+	expectTypeOf<DefaultValue<'abc'[]>>().toEqualTypeOf<
+		('abc' | null | undefined)[] | null | undefined
+	>();
 });
 
 test('FormOptions', () => {


### PR DESCRIPTION
This adds a case to `DefaultValue` so that string literal types are preserved instead of being widened to `string`, making fields like submit intents type-safe.

```ts
const schema = z.object({
	status: z.literal('active'),
	role: z.enum(['admin', 'user']),
	name: z.string(),
});

const form = useForm({
	schema,
	defaultValue: {
		// ❌ before: string | null | undefined
		// ✅  after: 'active' | null | undefined
		status: 'active',

		// ❌ before: string | null | undefined
		// ✅  after: 'admin' | 'user' | null | undefined
		role: 'admin',

		// ✅ string | null | undefined (unchanged)
		name: 'John',
	},
});
```

The PR doesn't touch v1 in anticipation of its soon removal. If this is too soon, please don't hesitate to let me know, and I will retrofit it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

`DefaultValue` now preserves string literal types in `conform-react/future`, including optional, nullable, template-literal, and nested values. Other types retain existing behavior. Type tests cover these cases and reject incompatible literals. Examples cast URL-derived defaults to schema-specific types. A patch changeset was added.

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->