### PR TITLE
feat(conform-react): serialize intent dispatcher values

### DIFF
--- a/.changeset/soft-tools-serialize.md
+++ b/.changeset/soft-tools-serialize.md
@@ -1,0 +1,7 @@
+---
+'@conform-to/react': minor
+---
+
+feat: add intent serialization to intent dispatchers
+
+Intent dispatcher methods now expose a `serialize()` method with the same arguments. Use the returned value with `form.intentName` on a native submit button to trigger form intents for progressive enhancement.

--- a/docs/api/react/future/useFormMetadata.md
+++ b/docs/api/react/future/useFormMetadata.md
@@ -24,6 +24,10 @@ A `FormMetadata` object containing:
 
 The form's unique identifier.
 
+### `intentName: string`
+
+The name of the submit button field that indicates the submission intent. Use it with [`intent.*.serialize()`](./useIntent.md) when rendering native submit buttons for form intents.
+
 ### `key: string`
 
 Unique identifier that changes on form reset.

--- a/docs/api/react/future/useIntent.md
+++ b/docs/api/react/future/useIntent.md
@@ -25,6 +25,27 @@ A reference to the form element. Can be either:
 
 An `IntentDispatcher` object with the built-in methods below. A customized `useIntent` returned from [`configureForms`](./configureForms.md) also includes that factory's custom intents:
 
+Each intent method also exposes a `serialize()` method with the same arguments. It returns the intent value without dispatching it, which lets a native submit button trigger the same form intent when JavaScript is unavailable:
+
+```tsx
+import { useForm } from '@conform-to/react/future';
+
+function Example() {
+  const { form, intent } = useForm({
+    // ...
+  });
+
+  return (
+    <form {...form.props}>
+      <input name="title" />
+      <button name={form.intentName} value={intent.validate.serialize('title')}>
+        Validate title
+      </button>
+    </form>
+  );
+}
+```
+
 ### `validate(name?: string): void`
 
 Triggers validation for the entire form or a specific field. If you provide a name that includes nested fields (e.g. `user.email`), it will validate all fields within that fieldset.

--- a/packages/conform-react/future/dom.ts
+++ b/packages/conform-react/future/dom.ts
@@ -291,26 +291,28 @@ export function createIntentDispatcher<
 	return new Proxy({} as IntentDispatcher<FormShape, IntentHandlers>, {
 		get(target, type, receiver) {
 			if (typeof type === 'string') {
+				const serialize = (...args: unknown[]) =>
+					serializeIntent({
+						type,
+						args,
+					});
+
 				// @ts-expect-error
-				target[type] ??= (...args: unknown[]) => {
-					const form =
-						typeof formElement === 'function' ? formElement() : formElement;
+				target[type] ??= Object.assign(
+					(...args: unknown[]) => {
+						const form =
+							typeof formElement === 'function' ? formElement() : formElement;
 
-					if (!form) {
-						throw new Error(
-							`Dispatching "${type}" intent failed; No form element found.`,
-						);
-					}
+						if (!form) {
+							throw new Error(
+								`Dispatching "${type}" intent failed; No form element found.`,
+							);
+						}
 
-					requestIntent(
-						form,
-						intentName,
-						serializeIntent({
-							type,
-							args,
-						}),
-					);
-				};
+						requestIntent(form, intentName, serialize(...args));
+					},
+					{ serialize },
+				);
 			}
 
 			return Reflect.get(target, type, receiver);

--- a/packages/conform-react/future/forms.tsx
+++ b/packages/conform-react/future/forms.tsx
@@ -490,6 +490,7 @@ export function configureForms<
 		>(
 			() => ({
 				formId,
+				intentName: globalConfig.intentName,
 				state,
 				serialize,
 				constraint: constraint ?? null,

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -796,6 +796,7 @@ export function getFormMetadata<
 	const metadata: BaseFormMetadata<ErrorShape, CustomState> = {
 		key: context.state.resetKey,
 		id: context.formId,
+		intentName: context.intentName,
 		errorId: `${context.formId}-form-error`,
 		descriptionId: `${context.formId}-form-description`,
 		defaultValue: context.state.defaultValue,

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -603,6 +603,8 @@ export interface FormContext<
 > {
 	/** The form's unique identifier */
 	formId: string;
+	/** The name of the submit button field that indicates the submission intent. */
+	intentName: string;
 	/** Internal form state with validation results and field data */
 	state: FormState<ErrorShape, CustomState>;
 	/** Serializer used to derive field defaults and sync values for this form. */
@@ -666,7 +668,13 @@ export type ApplyStatus = 'applied' | 'reverted' | 'modified';
 export type IntentDispatch<
 	Intent extends IntentDefinition,
 	FormShape extends Record<string, any> = Record<string, any>,
-> = ExtractDispatchSignature<NormalizeIntentType<Intent>, FormShape>;
+> = ExtractDispatchSignature<NormalizeIntentType<Intent>, FormShape> & {
+	serialize(
+		...args: Parameters<
+			ExtractDispatchSignature<NormalizeIntentType<Intent>, FormShape>
+		>
+	): string;
+};
 
 export type IntentHandlerPayload<
 	Dispatch extends IntentDefinition,
@@ -1017,6 +1025,8 @@ export type FormMetadata<
 		key: string;
 		/** The form's unique identifier. */
 		id: string;
+		/** The name of the submit button field that indicates the submission intent. */
+		intentName: string;
 		/** Auto-generated ID for associating form descriptions via aria-describedby. */
 		descriptionId: string;
 		/** Auto-generated ID for associating form errors via aria-describedby. */

--- a/packages/conform-react/tests/dom.browser.test.ts
+++ b/packages/conform-react/tests/dom.browser.test.ts
@@ -379,6 +379,8 @@ test('createIntentDispatcher', () => {
 	// Test property access creates function
 	expect(typeof dispatcher.reset).toBe('function');
 	expect(typeof dispatcher.validate).toBe('function');
+	expect(dispatcher.reset.serialize()).toBe('reset()');
+	expect(dispatcher.validate.serialize('email')).toBe('validate("email")');
 
 	// Test with form getter function
 	const getForm = vi.fn(() => mockForm);
@@ -388,6 +390,7 @@ test('createIntentDispatcher', () => {
 	// Test error when form is not found
 	const getNullForm = vi.fn(() => null);
 	const dispatcher3 = createIntentDispatcher(getNullForm, 'intent');
+	expect(dispatcher3.reset.serialize()).toBe('reset()');
 	expect(() => dispatcher3.reset()).toThrow(
 		'Dispatching "reset" intent failed; No form element found.',
 	);

--- a/packages/conform-react/tests/state.test.ts
+++ b/packages/conform-react/tests/state.test.ts
@@ -38,6 +38,7 @@ function createContext(
 ): FormContext<any> {
 	return {
 		formId: 'test-id',
+		intentName: DEFAULT_INTENT_NAME,
 		serialize: defaultSerialize,
 		constraint: null,
 		state: initializeState(),
@@ -1730,6 +1731,7 @@ test('getFormMetadata', () => {
 
 	// Test basic properties
 	expect(metadata.id).toBe('test-id');
+	expect(metadata.intentName).toBe(DEFAULT_INTENT_NAME);
 	expect(metadata.key).toBe(context.state.resetKey);
 	expect(metadata.errorId).toBe('test-id-form-error');
 	expect(metadata.descriptionId).toBe('test-id-form-description');

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -286,9 +286,8 @@ test('useForm', () => {
 	expectTypeOf(intentInferred.intent).toEqualTypeOf<
 		IntentDispatcher<Record<string, any>, { goToStep: typeof goToStep }>
 	>();
-	expectTypeOf(intentInferred.intent.goToStep).toEqualTypeOf<
-		(payload: { step: number }) => void
-	>();
+	assertType<void>(intentInferred.intent.goToStep({ step: 1 }));
+	assertType<string>(intentInferred.intent.goToStep.serialize({ step: 1 }));
 });
 
 describe('configureForms', () => {
@@ -622,12 +621,14 @@ describe('configureForms', () => {
 		expectTypeOf(globalIntentSetup.intent).toEqualTypeOf<
 			IntentDispatcher<Record<string, any>, { goToStep: typeof goToStep }>
 		>();
-		expectTypeOf(globalIntentSetup.intent.goToStep).toEqualTypeOf<
-			(payload: { step: number }) => void
-		>();
-		expectTypeOf(custom.useIntent('form-id').goToStep).toEqualTypeOf<
-			(payload: { step: number }) => void
-		>();
+		assertType<void>(globalIntentSetup.intent.goToStep({ step: 1 }));
+		assertType<string>(
+			globalIntentSetup.intent.goToStep.serialize({ step: 1 }),
+		);
+		assertType<void>(custom.useIntent('form-id').goToStep({ step: 1 }));
+		assertType<string>(
+			custom.useIntent('form-id').goToStep.serialize({ step: 1 }),
+		);
 
 		// @ts-expect-error unknown custom intents should not be exposed without typing
 		custom.useIntent('form-id').unknownIntent();
@@ -693,12 +694,12 @@ describe('configureForms', () => {
 				{ goToStep: typeof goToStep; confirm: typeof confirm }
 			>
 		>();
-		expectTypeOf(inlineIntentSetup.intent.confirm).toEqualTypeOf<
-			(payload: string) => void
-		>();
-		expectTypeOf(custom.useIntent('form-id').goToStep).toEqualTypeOf<
-			(payload: { step: number }) => void
-		>();
+		assertType<void>(inlineIntentSetup.intent.confirm('confirm'));
+		assertType<string>(inlineIntentSetup.intent.confirm.serialize('confirm'));
+		assertType<void>(custom.useIntent('form-id').goToStep({ step: 1 }));
+		assertType<string>(
+			custom.useIntent('form-id').goToStep.serialize({ step: 1 }),
+		);
 	});
 
 	test('custom state', () => {
@@ -957,20 +958,39 @@ test('defineIntent', () => {
 		},
 	});
 
-	expectTypeOf(configured.useIntent('form-id').updateField).toEqualTypeOf<
-		(name: string, value: string) => void
-	>();
+	assertType<void>(
+		configured.useIntent('form-id').updateField('title', 'value'),
+	);
+	assertType<string>(
+		configured.useIntent('form-id').updateField.serialize('title', 'value'),
+	);
+	// @ts-expect-error value must be a string
+	configured.useIntent('form-id').updateField.serialize('title', 1);
 	// @ts-expect-error unknown custom intents should not be exposed without typing
 	configured.useIntent('form-id').unknownIntent();
 
-	expectTypeOf(
-		useIntent<{ updateField: typeof updateField }>('form-id').updateField,
-	).toEqualTypeOf<(name: string, value: string) => void>();
+	assertType<void>(
+		useIntent<{ updateField: typeof updateField }>('form-id').updateField(
+			'title',
+			'value',
+		),
+	);
+	assertType<string>(
+		useIntent<{ updateField: typeof updateField }>(
+			'form-id',
+		).updateField.serialize('title', 'value'),
+	);
 
-	expectTypeOf(
-		useIntent<{ title: string }, { updateField: typeof updateField }>('form-id')
-			.updateField,
-	).toEqualTypeOf<(name: string, value: string) => void>();
+	assertType<void>(
+		useIntent<{ title: string }, { updateField: typeof updateField }>(
+			'form-id',
+		).updateField('title', 'value'),
+	);
+	assertType<string>(
+		useIntent<{ title: string }, { updateField: typeof updateField }>(
+			'form-id',
+		).updateField.serialize('title', 'value'),
+	);
 });
 
 test('IntentDispatcher', () => {
@@ -1003,19 +1023,27 @@ test('IntentDispatcher', () => {
 	// Test validate
 	assertType<void>(intent.validate());
 	assertType<void>(intent.validate('name'));
+	assertType<string>(intent.validate.serialize());
+	assertType<string>(intent.validate.serialize('name'));
 
 	// Test submit
 	assertType<void>(intent.submit());
 	assertType<void>(intent.submit('delete'));
+	assertType<string>(intent.submit.serialize());
+	assertType<string>(intent.submit.serialize('delete'));
 
 	// Test remove
 	assertType<void>(intent.remove({ name: 'tasks', index: 0 }));
+	assertType<string>(intent.remove.serialize({ name: 'tasks', index: 0 }));
+	// @ts-expect-error index must be a number
+	intent.remove.serialize({ name: 'tasks', index: '0' });
 
 	// Test reorder
 	assertType<void>(intent.reorder({ name: 'tasks', from: 0, to: 1 }));
 
 	// Test insert
 	assertType<void>(intent.insert({ name: 'tags' }));
+	assertType<string>(intent.insert.serialize({ name: 'tags' }));
 	assertType<void>(intent.insert({ name: 'tags', defaultValue: 'new-tag' }));
 	assertType<void>(intent.insert({ name: 'tags', defaultValue: undefined }));
 	assertType<void>(
@@ -1029,6 +1057,7 @@ test('IntentDispatcher', () => {
 
 	// Test update
 	assertType<void>(intent.update({ name: 'name', value: 'text' }));
+	assertType<string>(intent.update.serialize({ name: 'name', value: 'text' }));
 	assertType<void>(intent.update({ name: 'name', value: null }));
 	assertType<void>(intent.update({ name: 'name', value: undefined }));
 	assertType<void>(


### PR DESCRIPTION
## Summary

- add serialize() to every intent dispatcher method while preserving its arguments and custom intent types
- expose the resolved intentName through form metadata for native submit buttons
- document the progressive-enhancement pattern and add a changeset

## Testing

- TypeScript build and typecheck
- 33 node and type tests
- 7 Firefox browser tests
- oxlint and oxfmt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

- Added `serialize()` to all intent dispatchers with preserved argument and type support.
- Exposed `intentName` through `FormMetadata` for native submit buttons.
- Documented progressive enhancement and added type, browser, lint, format, and build coverage.
- Added a minor-release changeset for `@conform-to/react`.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->