### PR TITLE
feat(conform-react): accept URLSearchParams as default value

### DIFF
--- a/.changeset/fuzzy-pans-smile.md
+++ b/.changeset/fuzzy-pans-smile.md
@@ -1,0 +1,13 @@
+---
+'@conform-to/react': minor
+---
+
+feat: accept URLSearchParams as the form default value
+
+`useForm` can now parse URL search parameters directly. The parameters are parsed only when the form is initialized or reset:
+
+```ts
+const { form, fields } = useForm({
+  defaultValue: new URLSearchParams(window.location.search),
+});
+```

--- a/docs/api/react/future/useForm.md
+++ b/docs/api/react/future/useForm.md
@@ -38,9 +38,12 @@ Optional form identifier. If not provided, a unique ID is automatically generate
 
 Optional key for form state reset. When the key changes, the form resets to its initial state.
 
-### `defaultValue?: DefaultValue<FormShape>`
+### `defaultValue?: DefaultValue<FormShape> | URLSearchParams`
 
-Initial form values. Can be a partial object matching your form structure.
+Initial form values. This can be either:
+
+- A partial object matching your form structure
+- A `URLSearchParams` object
 
 ### `serialize?: (value, ctx) => FormValue | null | undefined`
 

--- a/examples/chakra-ui/src/App.tsx
+++ b/examples/chakra-ui/src/App.tsx
@@ -49,18 +49,7 @@ export default function App() {
 		() => new URLSearchParams(window.location.search),
 	);
 	const { form, fields, intent } = useForm(schema, {
-		defaultValue: {
-			email: searchParams.get('email'),
-			language: searchParams.get('language'),
-			description: searchParams.get('description'),
-			quantity: searchParams.get('quantity'),
-			pin: searchParams.get('pin'),
-			title: searchParams.get('title'),
-			subscribe: searchParams.get('subscribe'),
-			enabled: searchParams.get('enabled'),
-			progress: searchParams.get('progress'),
-			active: searchParams.get('active'),
-		},
+		defaultValue: searchParams,
 		onSubmit(event, { formData, value }) {
 			event.preventDefault();
 

--- a/examples/headless-ui/src/App.tsx
+++ b/examples/headless-ui/src/App.tsx
@@ -45,20 +45,17 @@ export default function App() {
 	const [submittedValue, setSubmittedValue] = useState<z.output<
 		typeof schema
 	> | null>(null);
-	const [searchParams, setSearchParams] = useState(
-		() => new URLSearchParams(window.location.search),
-	);
+	const [searchParams, setSearchParams] = useState(() => {
+		const searchParams = new URLSearchParams(window.location.search);
+
+		if (!searchParams.has('priority')) {
+			searchParams.set('priority', 'normal');
+		}
+
+		return searchParams;
+	});
 	const { form, fields, intent } = useForm(schema, {
-		defaultValue: {
-			owner: searchParams.getAll('owner'),
-			assignee: searchParams.get('assignee'),
-			enabled: searchParams.get('enabled'),
-			color: searchParams.get('color'),
-			project: searchParams.get('project'),
-			notes: searchParams.get('notes'),
-			priority: searchParams.get('priority') ?? 'normal',
-			notifications: searchParams.get('notifications'),
-		},
+		defaultValue: searchParams,
 		onSubmit(event, { formData, value }) {
 			event.preventDefault();
 

--- a/examples/material-ui/src/App.tsx
+++ b/examples/material-ui/src/App.tsx
@@ -47,17 +47,7 @@ export default function App() {
 		() => new URLSearchParams(window.location.search),
 	);
 	const { form, fields, intent } = useForm(schema, {
-		defaultValue: {
-			email: searchParams.get('email'),
-			description: searchParams.get('description'),
-			language: searchParams.get('language'),
-			movie: searchParams.get('movie'),
-			subscribe: searchParams.get('subscribe'),
-			active: searchParams.get('active'),
-			enabled: searchParams.get('enabled'),
-			score: searchParams.get('score'),
-			progress: searchParams.get('progress'),
-		},
+		defaultValue: searchParams,
 		onSubmit(event, { formData, value }) {
 			event.preventDefault();
 

--- a/examples/radix-ui/src/App.tsx
+++ b/examples/radix-ui/src/App.tsx
@@ -30,16 +30,7 @@ export default function App() {
 		() => new URLSearchParams(window.location.search),
 	);
 	const { form, fields, intent } = useForm(schema, {
-		defaultValue: {
-			isTermsAgreed: searchParams.get('isTermsAgreed'),
-			carType: searchParams.get('carType'),
-			userCountry: searchParams.get('userCountry'),
-			estimatedKilometersPerYear: searchParams.get(
-				'estimatedKilometersPerYear',
-			),
-			insurance: searchParams.get('insurance'),
-			desiredContractType: searchParams.get('desiredContractType'),
-		},
+		defaultValue: searchParams,
 		onSubmit(event, { formData, value }) {
 			event.preventDefault();
 

--- a/examples/react-aria/src/App.tsx
+++ b/examples/react-aria/src/App.tsx
@@ -40,20 +40,7 @@ export default function App() {
 		() => new URLSearchParams(window.location.search),
 	);
 	const { form, fields, intent } = useForm(schema, {
-		defaultValue: {
-			email: searchParams.get('email'),
-			price: searchParams.get('price'),
-			language: searchParams.get('language'),
-			colors: searchParams.getAll('colors'),
-			date: searchParams.get('date'),
-			range: {
-				start: searchParams.get('range.start'),
-				end: searchParams.get('range.end'),
-			},
-			category: searchParams.get('category'),
-			author: searchParams.get('author'),
-			acceptTerms: searchParams.get('acceptTerms'),
-		},
+		defaultValue: searchParams,
 		onSubmit(event, { formData, value }) {
 			event.preventDefault();
 

--- a/examples/shadcn-ui/src/App.tsx
+++ b/examples/shadcn-ui/src/App.tsx
@@ -42,23 +42,6 @@ const schema = coerceFormValue(
 	}),
 );
 
-function getDefaultMembers(searchParams: URLSearchParams) {
-	const defaultMembers: Array<Record<string, string>> = [];
-
-	for (let i = 0; searchParams.has(`members[${i}].id`); i++) {
-		const id = searchParams.get(`members[${i}].id`);
-		const name = searchParams.get(`members[${i}].name`);
-		const email = searchParams.get(`members[${i}].email`);
-		const role = searchParams.get(`members[${i}].role`);
-
-		if (id && name && email && role) {
-			defaultMembers.push({ id, name, email, role });
-		}
-	}
-
-	return defaultMembers;
-}
-
 export default function App() {
 	const [submittedValue, setSubmittedValue] = useState<z.output<
 		typeof schema
@@ -67,22 +50,7 @@ export default function App() {
 		() => new URLSearchParams(window.location.search),
 	);
 	const { form, fields, intent } = useForm(schema, {
-		defaultValue: {
-			name: searchParams.get('name'),
-			dateOfBirth: searchParams.get('dateOfBirth'),
-			country: searchParams.get('country'),
-			gender: searchParams.get('gender'),
-			agreeToTerms: searchParams.get('agreeToTerms'),
-			job: searchParams.get('job'),
-			age: searchParams.get('age'),
-			isAdult: searchParams.get('isAdult'),
-			description: searchParams.get('description'),
-			accountType: searchParams.get('accountType'),
-			categories: searchParams.getAll('categories'),
-			interests: searchParams.getAll('interests'),
-			code: searchParams.get('code'),
-			members: getDefaultMembers(searchParams),
-		},
+		defaultValue: searchParams,
 		onSubmit(event, { formData, value }) {
 			event.preventDefault();
 

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -30,7 +30,11 @@ import {
 	useLayoutEffect,
 	forwardRef,
 } from 'react';
-import { appendUniqueItem, resolveValidateResult } from './util';
+import {
+	appendUniqueItem,
+	resolveDefaultValue,
+	resolveValidateResult,
+} from './util';
 import { getApplyStatus, initializeState, updateState } from './state';
 import type {
 	FormContext,
@@ -75,15 +79,6 @@ export const GlobalFormsObserverContext = createContext(
 );
 
 export const FormContextContext = createContext<FormContext[]>([]);
-
-function resolveDefaultValue<Value>(
-	defaultValue: Record<string, Value> | URLSearchParams | null | undefined,
-	intentName: string,
-): Record<string, Value | FormValue> {
-	return isGlobalInstance(defaultValue, 'URLSearchParams')
-		? parseSubmission(defaultValue, { intentName }).payload
-		: (defaultValue ?? {});
-}
 
 /**
  * Preserves form field values when its contents are unmounted.

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -76,6 +76,15 @@ export const GlobalFormsObserverContext = createContext(
 
 export const FormContextContext = createContext<FormContext[]>([]);
 
+function resolveDefaultValue<Value>(
+	defaultValue: Record<string, Value> | URLSearchParams | null | undefined,
+	intentName: string,
+): Record<string, Value | FormValue> {
+	return isGlobalInstance(defaultValue, 'URLSearchParams')
+		? parseSubmission(defaultValue, { intentName }).payload
+		: (defaultValue ?? {});
+}
+
 /**
  * Preserves form field values when its contents are unmounted.
  * Useful for multi-step forms and virtualized lists.
@@ -178,7 +187,11 @@ export function useConform<
 	formRef: FormRef,
 	options: {
 		key?: string | undefined;
-		defaultValue?: Record<string, FormValue> | null | undefined;
+		defaultValue?:
+			| Record<string, FormValue>
+			| URLSearchParams
+			| null
+			| undefined;
 		serialize: Serialize;
 		intentName: string;
 		intentHandlers: Record<string, IntentHandler<any, any>>;
@@ -201,7 +214,10 @@ export function useConform<
 		FormState<ErrorShape, FormCustomState<CustomStateHandlers>>
 	>(() => {
 		let state = initializeState<ErrorShape, CustomStateHandlers>({
-			defaultValue: options.defaultValue,
+			defaultValue: resolveDefaultValue(
+				options.defaultValue,
+				options.intentName,
+			),
 			customStateHandlers: options.customStateHandlers,
 			resetKey: INITIAL_KEY,
 		});
@@ -226,7 +242,10 @@ export function useConform<
 						status: getApplyStatus(lastResult.targetValue, result.targetValue),
 						reset() {
 							return initializeState<ErrorShape, CustomStateHandlers>({
-								defaultValue: result.targetValue ?? options.defaultValue,
+								defaultValue: resolveDefaultValue(
+									result.targetValue ?? options.defaultValue,
+									options.intentName,
+								),
 								resetKey: INITIAL_KEY,
 								customStateHandlers: options.customStateHandlers,
 								lastCustomState: state.customState,
@@ -303,7 +322,10 @@ export function useConform<
 						),
 						reset() {
 							return initializeState<ErrorShape, CustomStateHandlers>({
-								defaultValue: finalResult.targetValue ?? options.defaultValue,
+								defaultValue: resolveDefaultValue(
+									finalResult.targetValue ?? options.defaultValue,
+									options.intentName,
+								),
 								customStateHandlers: options.customStateHandlers,
 								lastCustomState: current.customState,
 								result: finalResult,
@@ -337,7 +359,10 @@ export function useConform<
 
 		setState((current) =>
 			initializeState<ErrorShape, CustomStateHandlers>({
-				defaultValue: options.defaultValue,
+				defaultValue: resolveDefaultValue(
+					options.defaultValue,
+					options.intentName,
+				),
 				customStateHandlers: options.customStateHandlers,
 				lastCustomState: current.customState,
 			}),
@@ -510,7 +535,11 @@ export function useConform<
 
 				if (clientResult.reset || clientResult.targetValue !== undefined) {
 					pendingValueRef.current =
-						clientResult.targetValue ?? optionsRef.current.defaultValue ?? {};
+						clientResult.targetValue ??
+						resolveDefaultValue(
+							optionsRef.current.defaultValue,
+							optionsRef.current.intentName,
+						);
 				}
 
 				if (

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -509,8 +509,11 @@ export type FormOptions<
 	onSubmit?:
 		| SubmitHandler<FormShape, NoInfer<ErrorShape>, NoInfer<Value>>
 		| undefined;
-	/** Initial form values. Can be a partial object matching your form structure. */
-	defaultValue?: DefaultValue<FormShape> | undefined;
+	/**
+	 * Initial form values. Can be a partial object matching your form structure or
+	 * URL search parameters.
+	 */
+	defaultValue?: DefaultValue<FormShape> | URLSearchParams | undefined;
 	/**
 	 * Override serialization for specific fields on this form and delegate the rest
 	 * to the configured global serializer.

--- a/packages/conform-react/future/util.ts
+++ b/packages/conform-react/future/util.ts
@@ -1,6 +1,7 @@
 import type {
 	CustomSerialize,
 	FormError,
+	FormValue,
 	Serialize,
 } from '@conform-to/dom/future';
 import {
@@ -9,6 +10,8 @@ import {
 	parsePath,
 	getPathValue,
 	isPlainObject,
+	isGlobalInstance,
+	parseSubmission,
 	setPathValue,
 	normalizeFormError,
 } from '@conform-to/dom/future';
@@ -57,6 +60,15 @@ export function getPathArray<Type>(
 	}
 
 	return value;
+}
+
+export function resolveDefaultValue<Value>(
+	defaultValue: Record<string, Value> | URLSearchParams | null | undefined,
+	intentName: string,
+): Record<string, Value | FormValue> {
+	return isGlobalInstance(defaultValue, 'URLSearchParams')
+		? parseSubmission(defaultValue, { intentName }).payload
+		: (defaultValue ?? {});
 }
 
 /**

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -141,6 +141,10 @@ test('FormOptions', () => {
 	});
 
 	assertType<FormOptions<TestSchema>>({
+		defaultValue: new URLSearchParams('name=John&email=john%40example.com'),
+	});
+
+	assertType<FormOptions<TestSchema>>({
 		onValidate({ error, schemaValue }) {
 			expectTypeOf(schemaValue).toEqualTypeOf<undefined>();
 

--- a/packages/conform-react/tests/useForm.node.test.tsx
+++ b/packages/conform-react/tests/useForm.node.test.tsx
@@ -53,6 +53,33 @@ describe.each(testCases)('future export: useForm - $name', ({ useForm }) => {
 		expect(fields.description.errors).toBe(undefined);
 	});
 
+	test('default value from URLSearchParams', () => {
+		const searchParams = new URLSearchParams([
+			['owner', '1'],
+			['owner', '2'],
+			['tasks[0].content', 'First task'],
+			['tasks[1].content', 'Second task'],
+		]);
+		const { form } = serverRenderHook(() =>
+			useForm<
+				{
+					owner: string[];
+					tasks: Array<{ content: string }>;
+				},
+				string[]
+			>({
+				lastResult: null,
+				defaultValue: searchParams,
+				onValidate: () => undefined,
+			}),
+		);
+
+		expect(form.defaultValue).toEqual({
+			owner: ['1', '2'],
+			tasks: [{ content: 'First task' }, { content: 'Second task' }],
+		});
+	});
+
 	test('initialize with last submission result', () => {
 		const { form, fields } = serverRenderHook(() =>
 			useForm<{ title: string; description: string }, string[]>({

--- a/packages/conform-react/tests/util.test.ts
+++ b/packages/conform-react/tests/util.test.ts
@@ -5,6 +5,7 @@ import {
 	isNumber,
 	isOptional,
 	getPathArray,
+	resolveDefaultValue,
 	updatePathValue,
 	updatePathIndex,
 	normalizeValidateResult,
@@ -74,6 +75,26 @@ test('getPathArray', () => {
 	expect(() => getPathArray(invalidValue, 'notArray')).toThrow(
 		'The value of "notArray" is not an array',
 	);
+});
+
+test('resolveDefaultValue', () => {
+	const object = { title: 'Example' };
+
+	expect(resolveDefaultValue(object, 'intent')).toBe(object);
+	expect(
+		resolveDefaultValue(
+			new URLSearchParams([
+				['owner', '1'],
+				['owner', '2'],
+				['tasks[0].content', 'First task'],
+				['intent', 'save'],
+			]),
+			'intent',
+		),
+	).toEqual({
+		owner: ['1', '2'],
+		tasks: [{ content: 'First task' }],
+	});
 });
 
 test('updatePathValue', () => {


### PR DESCRIPTION
## Summary

- accept URLSearchParams in useForm defaultValue
- parse search parameters only during initialization and reset using the configured intentName
- simplify GET-form examples and document the new input

## Testing

- 97 conform-react node tests
- conform-react source typecheck
- formatting and diff checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

- `useForm` now accepts `URLSearchParams` for `defaultValue`.
- `URLSearchParams` values are parsed with the configured `intentName` during initialization and reset.
- GET-form examples pass `URLSearchParams` directly.
- Added type coverage and runtime tests for repeated and nested values.

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->