### PR TITLE
feat(conform-react): add targetValue to submit update

### DIFF
--- a/.changeset/tidy-submit-target.md
+++ b/.changeset/tidy-submit-target.md
@@ -1,0 +1,18 @@
+---
+'@conform-to/react': minor
+---
+
+Deprecated the `value` option on the `update()` function provided to the future `onSubmit` handler. Use `targetValue` instead:
+
+```diff
+ onSubmit(event, { value, update }) {
+   event.preventDefault();
+   update({
+     reset: true,
+-    value,
++    targetValue: value,
+   });
+ }
+```
+
+`value` remains available as an alias and will be removed in the next minor version. If both options are provided, `targetValue` takes precedence.

--- a/docs/api/react/future/useForm.md
+++ b/docs/api/react/future/useForm.md
@@ -102,6 +102,20 @@ Error handling callback triggered when validation errors occur. By default, it f
 
 Form submission handler called when the form is submitted with no validation errors.
 
+The second argument includes the submitted `formData`, the validated `value`, and an `update()` function for applying the result. Pass `targetValue` to update or reset the form to a specific value:
+
+```tsx
+onSubmit(event, { value, update }) {
+  event.preventDefault();
+  update({
+    reset: true,
+    targetValue: value,
+  });
+}
+```
+
+The `value` option on `update()` is deprecated. It remains an alias for `targetValue`; when both options are provided, `targetValue` takes precedence.
+
 ### `onInput?: InputHandler`
 
 Input event handler for custom input event logic.

--- a/examples/react-spa/src/routes/todos.tsx
+++ b/examples/react-spa/src/routes/todos.tsx
@@ -44,7 +44,7 @@ export default function Todos() {
 			} else {
 				update({
 					reset: true,
-					value,
+					targetValue: value,
 				});
 			}
 		},

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -566,9 +566,11 @@ export function useConform<
 					},
 					update(options) {
 						if (!abortController.signal.aborted) {
+							const targetValue =
+								'targetValue' in options ? options.targetValue : options.value;
 							const submissionResult = report(result.submission, {
 								error: options.error,
-								targetValue: options.value,
+								targetValue,
 								reset: options.reset,
 								keepFiles: true,
 							});

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -1201,6 +1201,8 @@ export type SubmitContext<
 	value: Value;
 	update: (options: {
 		error?: Partial<FormError<ErrorShape>> | null | undefined;
+		targetValue?: FormShape | null | undefined;
+		/** @deprecated Use `targetValue` instead. This will be removed in the next minor release. */
 		value?: FormShape | null | undefined;
 		reset?: boolean | undefined;
 	}) => void;

--- a/packages/conform-react/tests/useForm.browser.test.tsx
+++ b/packages/conform-react/tests/useForm.browser.test.tsx
@@ -435,47 +435,61 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 		};
 	}
 
-	test('applies the value passed to submit update', async () => {
-		function SubmitUpdateForm() {
-			const { form, fields } = useForm<
-				{ title: string },
-				string[],
-				{ title: string }
-			>({
-				defaultValue: { title: 'Initial title' },
-				onValidate({ payload }) {
-					return {
-						error: null,
-						value: { title: String(payload.title ?? '') },
-					};
-				},
-				onSubmit(event, { value, update }) {
-					event.preventDefault();
-					update({ reset: true, value });
-				},
-			});
+	test.each(['value', 'targetValue', 'both'] as const)(
+		'applies the %s option passed to submit update',
+		async (option) => {
+			function SubmitUpdateForm() {
+				const { form, fields } = useForm<
+					{ title: string },
+					string[],
+					{ title: string }
+				>({
+					defaultValue: { title: 'Initial title' },
+					onValidate({ payload }) {
+						return {
+							error: null,
+							value: { title: String(payload.title ?? '') },
+						};
+					},
+					onSubmit(event, { value, update }) {
+						event.preventDefault();
 
-			return (
-				<form {...form.props}>
-					<label htmlFor={fields.title.id}>Submit update title</label>
-					<input
-						id={fields.title.id}
-						name={fields.title.name}
-						defaultValue={fields.title.defaultValue}
-					/>
-					<button>Save</button>
-				</form>
-			);
-		}
+						if (option === 'value') {
+							update({ reset: true, value });
+						} else if (option === 'targetValue') {
+							update({ reset: true, targetValue: value });
+						} else {
+							update({
+								reset: true,
+								value: { title: 'Legacy title' },
+								targetValue: value,
+							});
+						}
+					},
+				});
 
-		const screen = render(<SubmitUpdateForm />);
-		const title = screen.getByLabelText('Submit update title');
+				return (
+					<form {...form.props}>
+						<label htmlFor={fields.title.id}>Submit update title</label>
+						<input
+							id={fields.title.id}
+							name={fields.title.name}
+							defaultValue={fields.title.defaultValue}
+						/>
+						<button>Save</button>
+					</form>
+				);
+			}
 
-		await userEvent.clear(title);
-		await userEvent.type(title, 'Updated title');
-		await userEvent.click(screen.getByRole('button', { name: 'Save' }));
-		await expect.element(title).toHaveValue('Updated title');
-	});
+			const screen = render(<SubmitUpdateForm />);
+			const title = screen.getByLabelText('Submit update title');
+
+			await userEvent.clear(title);
+			await userEvent.type(title, 'Updated title');
+			await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+			await expect.element(title).toHaveValue('Updated title');
+		},
+	);
 
 	test('shouldValidate: onSubmit (default)', async () => {
 		const screen = render(<Form />);


### PR DESCRIPTION
## Summary
- add targetValue to the update function provided by the future onSubmit handler
- deprecate value while retaining it as an alias
- prefer targetValue when both options are provided, matching report behavior
- migrate the React SPA example and document the new option
- cover value, targetValue, and precedence behavior

## Validation
- 6 focused browser tests pass
- conform-react source build typecheck passes
- oxlint and oxfmt checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

- Adds `targetValue` support to future `onSubmit` updates.
- Keeps `value` as a deprecated alias and gives `targetValue` precedence.
- Updates the React SPA example and API documentation.
- Adds browser coverage for both options and precedence behavior.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->