### PR TITLE
feat: deprecate formatResult includeValue option

### DIFF
--- a/.changeset/quiet-results-value.md
+++ b/.changeset/quiet-results-value.md
@@ -1,0 +1,8 @@
+---
+'@conform-to/zod': minor
+'@conform-to/valibot': minor
+---
+
+Deprecated the `includeValue` option on the future `formatResult()` API.
+
+The option will be removed in the next minor release. `formatResult()` will then always return both `error` and `value`, equivalent to the current `includeValue: true` behavior.

--- a/docs/api/valibot/future/formatResult.md
+++ b/docs/api/valibot/future/formatResult.md
@@ -20,6 +20,8 @@ The Valibot validation result to be formatted. This should be the result from `v
 
 Optional. Set to `true` if you want both the error and the parsed value returned in an object. This is useful when you are parsing the form value manually and still want to access the parsed value in the `onSubmit` handler on the `useForm` hook.
 
+> **Deprecated:** This option will be removed in the next minor release. `formatResult()` will then always return both `error` and `value`, equivalent to the current `includeValue: true` behavior.
+
 ### `options.formatIssues?: (issue: BaseIssue<unknown>[], name: string) => ErrorShape`
 
 Optional. A function to customize how valibot issues are formatted for each field. This is particularly useful if you want to include additional information from the `BaseIssue` object in the error messages, or if you need to support internationalization.

--- a/docs/api/zod/future/formatResult.md
+++ b/docs/api/zod/future/formatResult.md
@@ -20,6 +20,8 @@ The Zod validation result to be formatted. This should be the result from `schem
 
 Optional. Set to `true` if you want both the error and the parsed value returned in an object. This is useful when you are parsing the form value manually and still want to access the parsed value in the `onSubmit` handler on the `useForm` hook.
 
+> **Deprecated:** This option will be removed in the next minor release. `formatResult()` will then always return both `error` and `value`, equivalent to the current `includeValue: true` behavior.
+
 ### `options.formatIssues?: (issues: ZodIssue[], name: string) => ErrorShape`
 
 Optional. A function to customize how zod issues are formatted for each field. This is particularly useful if you want to include additional information from the `ZodIssue` object in the error messages, or if you need to support internationalization.

--- a/packages/conform-valibot/format.ts
+++ b/packages/conform-valibot/format.ts
@@ -16,7 +16,7 @@ export function formatResult<
 >(
 	result: SafeParseResult<Schema>,
 	options: {
-		/** Whether to include the parsed value in the returned object */
+		/** @deprecated This option will be removed in the next minor release, when the parsed value will always be included. */
 		includeValue: true;
 		/** Custom function to format validation issues for each field */
 		formatIssues: (issues: InferIssue<Schema>[], name: string) => ErrorShape;
@@ -28,6 +28,7 @@ export function formatResult<
 export function formatResult<Schema extends GenericSchema | GenericSchemaAsync>(
 	result: SafeParseResult<Schema>,
 	options: {
+		/** @deprecated This option will be removed in the next minor release, when the parsed value will always be included. */
 		includeValue: true;
 		formatIssues?: undefined;
 	},
@@ -41,6 +42,7 @@ export function formatResult<
 >(
 	result: SafeParseResult<Schema>,
 	options: {
+		/** @deprecated This option will be removed in the next minor release, when the parsed value will always be included. */
 		includeValue?: false;
 		formatIssues: (issues: InferIssue<Schema>[], name: string) => ErrorShape;
 	},

--- a/packages/conform-zod/default/format.ts
+++ b/packages/conform-zod/default/format.ts
@@ -17,7 +17,7 @@ export function formatResult(
 export function formatResult<Output, ErrorShape>(
 	result: SafeParseReturnType<any, Output>,
 	options: {
-		/** Whether to include the parsed value in the returned object */
+		/** @deprecated This option will be removed in the next minor release, when the parsed value will always be included. */
 		includeValue: true;
 		/** Custom function to format validation issues for each field */
 		formatIssues: (issue: ZodIssue[], name: string) => ErrorShape;
@@ -29,6 +29,7 @@ export function formatResult<Output, ErrorShape>(
 export function formatResult<Output>(
 	result: SafeParseReturnType<any, Output>,
 	options: {
+		/** @deprecated This option will be removed in the next minor release, when the parsed value will always be included. */
 		includeValue: true;
 		formatIssues?: undefined;
 	},
@@ -39,6 +40,7 @@ export function formatResult<Output>(
 export function formatResult<Output, ErrorShape>(
 	result: SafeParseReturnType<any, Output>,
 	options: {
+		/** @deprecated This option will be removed in the next minor release, when the parsed value will always be included. */
 		includeValue?: false;
 		formatIssues: (issue: ZodIssue[], name: string) => ErrorShape;
 	},

--- a/packages/conform-zod/v3/format.ts
+++ b/packages/conform-zod/v3/format.ts
@@ -17,7 +17,7 @@ export function formatResult(
 export function formatResult<Output, ErrorShape>(
 	result: SafeParseReturnType<any, Output>,
 	options: {
-		/** Whether to include the parsed value in the returned object */
+		/** @deprecated This option will be removed in the next minor release, when the parsed value will always be included. */
 		includeValue: true;
 		/** Custom function to format validation issues for each field */
 		formatIssues: (issue: ZodIssue[], name: string) => ErrorShape;
@@ -29,6 +29,7 @@ export function formatResult<Output, ErrorShape>(
 export function formatResult<Output>(
 	result: SafeParseReturnType<any, Output>,
 	options: {
+		/** @deprecated This option will be removed in the next minor release, when the parsed value will always be included. */
 		includeValue: true;
 		formatIssues?: undefined;
 	},
@@ -39,6 +40,7 @@ export function formatResult<Output>(
 export function formatResult<Output, ErrorShape>(
 	result: SafeParseReturnType<any, Output>,
 	options: {
+		/** @deprecated This option will be removed in the next minor release, when the parsed value will always be included. */
 		includeValue?: false;
 		formatIssues: (issue: ZodIssue[], name: string) => ErrorShape;
 	},

--- a/packages/conform-zod/v4/format.ts
+++ b/packages/conform-zod/v4/format.ts
@@ -17,7 +17,7 @@ export function formatResult<Output>(
 export function formatResult<Output, ErrorShape = string[]>(
 	result: ZodSafeParseResult<Output>,
 	options: {
-		/** Whether to include the parsed value in the returned object */
+		/** @deprecated This option will be removed in the next minor release, when the parsed value will always be included. */
 		includeValue: true;
 		/** Custom function to format validation issues for each field */
 		formatIssues: (issue: core.$ZodIssue[], name: string) => ErrorShape;
@@ -29,6 +29,7 @@ export function formatResult<Output, ErrorShape = string[]>(
 export function formatResult<Output>(
 	result: ZodSafeParseResult<Output>,
 	options: {
+		/** @deprecated This option will be removed in the next minor release, when the parsed value will always be included. */
 		includeValue: true;
 		formatIssues?: undefined;
 	},
@@ -39,6 +40,7 @@ export function formatResult<Output>(
 export function formatResult<Output, ErrorShape = string[]>(
 	result: ZodSafeParseResult<Output>,
 	options: {
+		/** @deprecated This option will be removed in the next minor release, when the parsed value will always be included. */
 		includeValue?: false;
 		formatIssues: (issue: core.$ZodIssue[], name: string) => ErrorShape;
 	},


### PR DESCRIPTION
## Summary
- deprecate includeValue on the future Zod and Valibot formatResult APIs
- keep existing runtime and return-shape behavior unchanged
- announce that the option will be removed next minor and values will always be included
- update API docs and add a release changeset

## Validation
- conform-zod typecheck passes
- conform-valibot typecheck passes
- oxlint and oxfmt checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

- Deprecates `includeValue` in future Zod and Valibot `formatResult` APIs without changing runtime behavior.
- Updates TypeScript documentation and API references.
- Adds minor-release changesets for both packages.
- Validates the changes with package typechecks, oxlint, and oxfmt.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->