### PR TITLE
feat(conform-react): preserve string literal types in DefaultValue

### DIFF
--- a/.changeset/olive-trees-narrow.md
+++ b/.changeset/olive-trees-narrow.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/react': minor
+---
+
+Fix `DefaultValue` to preserve string literal types so `z.literal(...)` schemas infer their literal value instead of widening to `string`.

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -195,7 +195,9 @@ export type DefaultValue<Shape> =
 			? Array<DefaultValue<Item>> | null | undefined
 			: Shape extends File | File[]
 				? null | undefined // We don't support setting default value for file inputs yet
-				: Shape | string | null | undefined;
+				: Shape extends string | null | undefined
+					? Shape | null | undefined
+					: Shape | string | null | undefined;
 
 export type FormState<
 	ErrorShape = any,

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -120,6 +120,52 @@ test('DefaultValue', () => {
 	assertType<DefaultValue<number>>(numberWithUndefined);
 	assertType<DefaultValue<UserObject>>(objectWithUndefined);
 	assertType<DefaultValue<string[]>>(arrayWithUndefined);
+
+	// String literal types should not be widened to string
+	expectTypeOf<DefaultValue<'abc'>>().toEqualTypeOf<'abc' | null | undefined>();
+	// @ts-expect-error default value should not accept any string
+	assertType<DefaultValue<'abc'>>('def');
+
+	// Unions of string literals stay narrow
+	expectTypeOf<DefaultValue<'active' | 'inactive'>>().toEqualTypeOf<
+		'active' | 'inactive' | null | undefined
+	>();
+
+	// Template literal types stay narrow
+	expectTypeOf<DefaultValue<`#${string}`>>().toEqualTypeOf<
+		`#${string}` | null | undefined
+	>();
+
+	// Literal-typed object properties narrow
+	type StatusObject = { status: 'abc'; name: string };
+	expectTypeOf<DefaultValue<StatusObject>>().toEqualTypeOf<
+		| { status?: 'abc' | null | undefined; name?: string | null | undefined }
+		| null
+		| undefined
+	>();
+	// @ts-expect-error wrong literal on a field should be rejected
+	assertType<DefaultValue<StatusObject>>({ status: 'def', name: 'John' });
+
+	// Arrays of literals narrow their items
+	expectTypeOf<DefaultValue<'abc'[]>>().toEqualTypeOf<
+		('abc' | null | undefined)[] | null | undefined
+	>();
+
+	// Nullable and optional constituents of string unions keep their literals
+	expectTypeOf<DefaultValue<'save' | 'publish' | undefined>>().toEqualTypeOf<
+		'save' | 'publish' | null | undefined
+	>();
+	expectTypeOf<DefaultValue<'save' | null>>().toEqualTypeOf<
+		'save' | null | undefined
+	>();
+
+	// Optional literal-typed fields (e.g. z.enum([...]).optional()) stay narrow
+	type IntentObject = { intent?: 'save' | 'publish' };
+	expectTypeOf<DefaultValue<IntentObject>>().toEqualTypeOf<
+		{ intent?: 'save' | 'publish' | null | undefined } | null | undefined
+	>();
+	// @ts-expect-error unsupported literal should be rejected
+	assertType<DefaultValue<IntentObject>>({ intent: 'delete' });
 });
 
 test('FormOptions', () => {


### PR DESCRIPTION
This was previously proposed via #1281, which I had closed prematurely. GitHub doesn't seem to let me reopen it.

Since @edmundhung has kindly migrated the examples to use `URLSearchParams` in the meantime, they shouldn't clash with the narrower `DefaultValue` type like they did in the prior PR.

Description copied over:

This adds a case to `DefaultValue` so that string literal types are preserved instead of being widened to `string`, making fields like submit intents type-safe.

```ts
const schema = z.object({
	status: z.literal('active'),
	role: z.enum(['admin', 'user']),
	name: z.string(),
});

const form = useForm({
	schema,
	defaultValue: {
		// ❌ before: string | null | undefined
		// ✅  after: 'active' | null | undefined
		status: 'active',

		// ❌ before: string | null | undefined
		// ✅  after: 'admin' | 'user' | null | undefined
		role: 'admin',

		// ✅ string | null | undefined (unchanged)
		name: 'John',
	},
});
```

The PR doesn't touch v1 in anticipation of its soon removal. If this is too soon, please don't hesitate to let me know, and I will retrofit it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

- Preserves string literal and template literal types in `DefaultValue<Shape>`.
- Adds type-level coverage for unions, nullable and optional fields, object properties, and array items.
- Rejects invalid literal defaults at compile time.

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->