### PR TITLE
feat(conform-react): preserve intent value types

### DIFF
--- a/.changeset/fair-intents-infer.md
+++ b/.changeset/fair-intents-infer.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/react': minor
+---
+
+Preserve inferred form and field shapes when passing values to the reset, update, insert, and remove intents.

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -691,52 +691,44 @@ export type IntentHandlerPayload<
 
 export type SubmitIntent = (value?: string) => void;
 
+type ResetIntentOptions<FormShape> = {
+	defaultValue?: DefaultValue<
+		FormShape extends Record<string, any> ? FormShape : never
+	>;
+};
+
 export interface ResetIntent extends TypedIntentDefinition {
-	dispatch<
-		FormShape extends Record<string, any> = this['FormShape'] extends Record<
-			string,
-			any
-		>
-			? this['FormShape']
-			: never,
-	>(options?: {
-		defaultValue?: DefaultValue<FormShape>;
-	}): void;
+	dispatch(options?: ResetIntentOptions<this['FormShape']>): void;
 }
 
 export type ValidateIntent = (name?: string) => void;
 
-export type IsUntypedFormShape<FormShape> = unknown extends FormShape
-	? true
-	: string extends keyof FormShape
-		? true
-		: false;
+type UpdateIntentOptions<FormShape, FieldShape> =
+	| {
+			name?: undefined;
+			index?: undefined;
+			value: DefaultValue<NoInfer<FormShape>>;
+	  }
+	| {
+			name: FieldName<FieldShape>;
+			index?: undefined;
+			value: DefaultValue<NoInfer<FieldShape>>;
+	  }
+	| {
+			name: FieldName<
+				FieldShape extends Array<any> | null | undefined ? FieldShape : never
+			>;
+			index: number;
+			value: unknown extends FieldShape
+				? unknown
+				: NonNullable<NoInfer<FieldShape>> extends Array<infer ItemShape>
+					? DefaultValue<ItemShape>
+					: never;
+	  };
 
 export interface UpdateIntent extends TypedIntentDefinition {
-	dispatch<FieldShape = this['FormShape']>(
-		options: IsUntypedFormShape<this['FormShape']> extends true
-			? {
-					name?: string | undefined;
-					index?: number | undefined;
-					value: unknown;
-				}
-			:
-					| {
-							name?: FieldName<FieldShape>;
-							index?: undefined;
-							value: DefaultValue<FieldShape>;
-					  }
-					| {
-							name: FieldName<
-								FieldShape extends Array<any> | null | undefined
-									? FieldShape
-									: never
-							>;
-							index: number;
-							value: NonNullable<FieldShape> extends Array<infer ItemShape>
-								? DefaultValue<ItemShape>
-								: never;
-					  },
+	dispatch<FieldShape = unknown>(
+		options: UpdateIntentOptions<this['FormShape'], FieldShape>,
 	): void;
 }
 
@@ -744,7 +736,9 @@ export interface InsertIntent extends TypedIntentDefinition {
 	dispatch<FieldShape extends Array<any> | null | undefined>(options: {
 		name: FieldName<FieldShape>;
 		index?: number;
-		defaultValue?: NonNullable<FieldShape> extends Array<infer ItemShape>
+		defaultValue?: NonNullable<NoInfer<FieldShape>> extends Array<
+			infer ItemShape
+		>
 			? DefaultValue<ItemShape>
 			: never;
 		from?: string;
@@ -757,7 +751,9 @@ export interface RemoveIntent extends TypedIntentDefinition {
 		name: FieldName<FieldShape>;
 		index: number;
 		onInvalid?: 'revert' | 'insert';
-		defaultValue?: NonNullable<FieldShape> extends Array<infer ItemShape>
+		defaultValue?: NonNullable<NoInfer<FieldShape>> extends Array<
+			infer ItemShape
+		>
 			? DefaultValue<ItemShape>
 			: never;
 	}): void;

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -719,11 +719,16 @@ type UpdateIntentOptions<FormShape, FieldShape> =
 				FieldShape extends Array<any> | null | undefined ? FieldShape : never
 			>;
 			index: number;
-			value: unknown extends FieldShape
+			value: unknown extends NoInfer<FieldShape>
 				? unknown
 				: NonNullable<NoInfer<FieldShape>> extends Array<infer ItemShape>
 					? DefaultValue<ItemShape>
 					: never;
+	  }
+	| {
+			name: FieldName<FieldShape> | undefined;
+			index?: undefined;
+			value: unknown extends NoInfer<FieldShape> ? unknown : never;
 	  };
 
 export interface UpdateIntent extends TypedIntentDefinition {

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -640,7 +640,8 @@ export type UnknownArgs<Args extends any[]> = {
 
 export interface TypedIntentDefinition {
 	readonly FormShape: unknown;
-	dispatch(...args: any[]): void;
+	readonly Result: unknown;
+	dispatch(...args: any[]): this['Result'];
 }
 
 export type IntentDefinition =
@@ -650,19 +651,25 @@ export type IntentDefinition =
 export type ExtractDispatchSignature<
 	Intent extends IntentDefinition,
 	FormShape extends Record<string, any>,
+	Result,
 > = Intent extends (...args: any[]) => void
-	? Intent
+	? Result extends void
+		? Intent
+		: (...args: Parameters<Intent>) => Result
 	: Intent extends TypedIntentDefinition
-		? (Intent & { readonly FormShape: FormShape })['dispatch']
+		? ({
+				readonly FormShape: FormShape;
+				readonly Result: Result;
+			} & Intent)['dispatch']
 		: never;
 
 export type IntentPayload<
 	Intent extends IntentDefinition,
 	FormShape extends Record<string, any> = Record<string, any>,
 > =
-	Parameters<ExtractDispatchSignature<Intent, FormShape>> extends []
+	Parameters<ExtractDispatchSignature<Intent, FormShape, void>> extends []
 		? undefined
-		: Parameters<ExtractDispatchSignature<Intent, FormShape>>[0];
+		: Parameters<ExtractDispatchSignature<Intent, FormShape, void>>[0];
 
 export type NormalizeIntentType<T> = T extends IntentDefinition
 	? T
@@ -673,12 +680,12 @@ export type ApplyStatus = 'applied' | 'reverted' | 'modified';
 export type IntentDispatch<
 	Intent extends IntentDefinition,
 	FormShape extends Record<string, any> = Record<string, any>,
-> = ExtractDispatchSignature<NormalizeIntentType<Intent>, FormShape> & {
-	serialize(
-		...args: Parameters<
-			ExtractDispatchSignature<NormalizeIntentType<Intent>, FormShape>
-		>
-	): string;
+> = ExtractDispatchSignature<NormalizeIntentType<Intent>, FormShape, void> & {
+	serialize: ExtractDispatchSignature<
+		NormalizeIntentType<Intent>,
+		FormShape,
+		string
+	>;
 };
 
 export type IntentHandlerPayload<
@@ -698,7 +705,7 @@ type ResetIntentOptions<FormShape> = {
 };
 
 export interface ResetIntent extends TypedIntentDefinition {
-	dispatch(options?: ResetIntentOptions<this['FormShape']>): void;
+	dispatch(options?: ResetIntentOptions<this['FormShape']>): this['Result'];
 }
 
 export type ValidateIntent = (name?: string) => void;
@@ -734,7 +741,7 @@ type UpdateIntentOptions<FormShape, FieldShape> =
 export interface UpdateIntent extends TypedIntentDefinition {
 	dispatch<FieldShape = unknown>(
 		options: UpdateIntentOptions<this['FormShape'], FieldShape>,
-	): void;
+	): this['Result'];
 }
 
 export interface InsertIntent extends TypedIntentDefinition {
@@ -748,7 +755,7 @@ export interface InsertIntent extends TypedIntentDefinition {
 			: never;
 		from?: string;
 		onInvalid?: 'revert';
-	}): void;
+	}): this['Result'];
 }
 
 export interface RemoveIntent extends TypedIntentDefinition {
@@ -761,7 +768,7 @@ export interface RemoveIntent extends TypedIntentDefinition {
 		>
 			? DefaultValue<ItemShape>
 			: never;
-	}): void;
+	}): this['Result'];
 }
 
 export type ReorderIntent = (options: {

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -178,6 +178,7 @@ test('literal default values in intents', () => {
 	const untypedIntent = {} as IntentDispatcher<Record<string, any>>;
 	const statusName = 'status' as FieldName<FormShape['status']>;
 	const itemsName = 'items' as FieldName<FormShape['items']>;
+	const dynamicName = 'status' as string | undefined;
 
 	assertType<void>(intent.reset({ defaultValue: { status: 'published' } }));
 	// @ts-expect-error programmatic reset should reject unsupported literals
@@ -212,6 +213,10 @@ test('literal default values in intents', () => {
 	);
 	// @ts-expect-error indexed branded names should remain typed on an untyped form
 	untypedIntent.update({ name: itemsName, index: 0, value: { role: 'owner' } });
+
+	assertType<void>(
+		intent.update({ name: dynamicName, value: { arbitrary: true } }),
+	);
 
 	assertType<void>(
 		intent.insert({ name: itemsName, defaultValue: { role: 'admin' } }),

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -168,6 +168,80 @@ test('DefaultValue', () => {
 	assertType<DefaultValue<IntentObject>>({ intent: 'delete' });
 });
 
+test('literal default values in intents', () => {
+	type FormShape = {
+		status: 'draft' | 'published';
+		items: Array<{ role: 'admin' | 'member' }>;
+	};
+
+	const intent = {} as IntentDispatcher<FormShape>;
+	const untypedIntent = {} as IntentDispatcher<Record<string, any>>;
+	const statusName = 'status' as FieldName<FormShape['status']>;
+	const itemsName = 'items' as FieldName<FormShape['items']>;
+
+	assertType<void>(intent.reset({ defaultValue: { status: 'published' } }));
+	// @ts-expect-error programmatic reset should reject unsupported literals
+	intent.reset({ defaultValue: { status: 'archived' } });
+
+	assertType<void>(intent.update({ value: { status: 'published' } }));
+	// @ts-expect-error whole-form updates should reject unsupported literals
+	intent.update({ value: { status: 'archived' } });
+
+	assertType<void>(intent.update({ name: statusName, value: 'draft' }));
+	// @ts-expect-error branded field updates should reject unsupported literals
+	intent.update({ name: statusName, value: 'archived' });
+
+	assertType<void>(
+		intent.update({ name: itemsName, index: 0, value: { role: 'member' } }),
+	);
+	// @ts-expect-error indexed field updates should reject unsupported literals
+	intent.update({ name: itemsName, index: 0, value: { role: 'owner' } });
+
+	assertType<void>(
+		untypedIntent.update({ name: statusName, value: 'published' }),
+	);
+	// @ts-expect-error branded names should remain typed on an untyped form
+	untypedIntent.update({ name: statusName, value: 'archived' });
+
+	assertType<void>(
+		untypedIntent.update({
+			name: itemsName,
+			index: 0,
+			value: { role: 'admin' },
+		}),
+	);
+	// @ts-expect-error indexed branded names should remain typed on an untyped form
+	untypedIntent.update({ name: itemsName, index: 0, value: { role: 'owner' } });
+
+	assertType<void>(
+		intent.insert({ name: itemsName, defaultValue: { role: 'admin' } }),
+	);
+	// @ts-expect-error programmatic inserts should reject unsupported literals
+	intent.insert({ name: itemsName, defaultValue: { role: 'owner' } });
+
+	assertType<void>(
+		intent.remove({
+			name: itemsName,
+			index: 0,
+			onInvalid: 'insert',
+			defaultValue: { role: 'member' },
+		}),
+	);
+	intent.remove({
+		name: itemsName,
+		index: 0,
+		onInvalid: 'insert',
+		// @ts-expect-error programmatic fallback inserts should reject unsupported literals
+		defaultValue: { role: 'owner' },
+	});
+
+	// DOM-derived metadata remains intentionally broad
+	const metadata = {} as FieldMetadata<FormShape['status']>;
+
+	assertType<string>(metadata.defaultValue);
+	assertType<unknown>(metadata.defaultPayload);
+});
+
 test('FormOptions', () => {
 	type TestSchema = { name: string; email: string };
 

--- a/packages/conform-react/tests/types.test-d.ts
+++ b/packages/conform-react/tests/types.test-d.ts
@@ -183,26 +183,59 @@ test('literal default values in intents', () => {
 	assertType<void>(intent.reset({ defaultValue: { status: 'published' } }));
 	// @ts-expect-error programmatic reset should reject unsupported literals
 	intent.reset({ defaultValue: { status: 'archived' } });
+	assertType<string>(
+		intent.reset.serialize({ defaultValue: { status: 'published' } }),
+	);
+	// @ts-expect-error serialized reset should reject unsupported literals
+	intent.reset.serialize({ defaultValue: { status: 'archived' } });
 
 	assertType<void>(intent.update({ value: { status: 'published' } }));
 	// @ts-expect-error whole-form updates should reject unsupported literals
 	intent.update({ value: { status: 'archived' } });
+	assertType<string>(
+		intent.update.serialize({ value: { status: 'published' } }),
+	);
+	// @ts-expect-error serialized whole-form updates should reject unsupported literals
+	intent.update.serialize({ value: { status: 'archived' } });
 
 	assertType<void>(intent.update({ name: statusName, value: 'draft' }));
 	// @ts-expect-error branded field updates should reject unsupported literals
 	intent.update({ name: statusName, value: 'archived' });
+	assertType<string>(
+		intent.update.serialize({ name: statusName, value: 'draft' }),
+	);
+	// @ts-expect-error serialized branded field updates should reject unsupported literals
+	intent.update.serialize({ name: statusName, value: 'archived' });
 
 	assertType<void>(
 		intent.update({ name: itemsName, index: 0, value: { role: 'member' } }),
 	);
 	// @ts-expect-error indexed field updates should reject unsupported literals
 	intent.update({ name: itemsName, index: 0, value: { role: 'owner' } });
+	assertType<string>(
+		intent.update.serialize({
+			name: itemsName,
+			index: 0,
+			value: { role: 'member' },
+		}),
+	);
+	intent.update.serialize({
+		name: itemsName,
+		index: 0,
+		// @ts-expect-error serialized indexed updates should reject unsupported literals
+		value: { role: 'owner' },
+	});
 
 	assertType<void>(
 		untypedIntent.update({ name: statusName, value: 'published' }),
 	);
 	// @ts-expect-error branded names should remain typed on an untyped form
 	untypedIntent.update({ name: statusName, value: 'archived' });
+	assertType<string>(
+		untypedIntent.update.serialize({ name: statusName, value: 'published' }),
+	);
+	// @ts-expect-error serialized branded names should remain typed on an untyped form
+	untypedIntent.update.serialize({ name: statusName, value: 'archived' });
 
 	assertType<void>(
 		untypedIntent.update({
@@ -217,12 +250,29 @@ test('literal default values in intents', () => {
 	assertType<void>(
 		intent.update({ name: dynamicName, value: { arbitrary: true } }),
 	);
+	assertType<string>(
+		intent.update.serialize({
+			name: dynamicName,
+			value: { arbitrary: true },
+		}),
+	);
 
 	assertType<void>(
 		intent.insert({ name: itemsName, defaultValue: { role: 'admin' } }),
 	);
 	// @ts-expect-error programmatic inserts should reject unsupported literals
 	intent.insert({ name: itemsName, defaultValue: { role: 'owner' } });
+	assertType<string>(
+		intent.insert.serialize({
+			name: itemsName,
+			defaultValue: { role: 'admin' },
+		}),
+	);
+	intent.insert.serialize({
+		name: itemsName,
+		// @ts-expect-error serialized inserts should reject unsupported literals
+		defaultValue: { role: 'owner' },
+	});
 
 	assertType<void>(
 		intent.remove({
@@ -237,6 +287,21 @@ test('literal default values in intents', () => {
 		index: 0,
 		onInvalid: 'insert',
 		// @ts-expect-error programmatic fallback inserts should reject unsupported literals
+		defaultValue: { role: 'owner' },
+	});
+	assertType<string>(
+		intent.remove.serialize({
+			name: itemsName,
+			index: 0,
+			onInvalid: 'insert',
+			defaultValue: { role: 'member' },
+		}),
+	);
+	intent.remove.serialize({
+		name: itemsName,
+		index: 0,
+		onInvalid: 'insert',
+		// @ts-expect-error serialized fallback inserts should reject unsupported literals
 		defaultValue: { role: 'owner' },
 	});
 


### PR DESCRIPTION
## Summary

- bind reset default values to the dispatcher form shape
- prevent update, insert, and remove values from widening inferred shapes
- preserve branded field-name inference when the enclosing form shape is untyped

## Testing

- `tsc --project packages/conform-react/tsconfig.build.json`
- `vitest --config packages/conform-react/vitest.config.ts --project "conform-react (node)" --run tests/types.test-d.ts tests/intent.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

- Prevents reset, update, insert, and remove intents from widening inferred form and field value types.
- Preserves branded field-name inference for untyped dispatchers.
- Adds compile-time coverage for literal values, indexed updates, fallback defaults, and dynamic field names.

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->