### PR TITLE
fix: expose portable submission types

### DIFF
--- a/.changeset/portable-submission-types.md
+++ b/.changeset/portable-submission-types.md
@@ -1,0 +1,11 @@
+---
+'@conform-to/valibot': patch
+'@conform-to/yup': patch
+'@conform-to/zod': patch
+---
+
+fix: prevent non-portable inferred submission types in TypeScript 5.9+
+
+The stable schema adapters now re-export Submission and SubmissionResult. This
+prevents TS2742 and TS2883 when TypeScript emits declarations for inferred
+action return types with strict dependency layouts such as pnpm.

--- a/packages/conform-valibot/index.ts
+++ b/packages/conform-valibot/index.ts
@@ -1,3 +1,4 @@
+export type { Submission, SubmissionResult } from '@conform-to/dom';
 export { getValibotConstraint } from './constraint';
 export { conformValibotMessage, parseWithValibot } from './parse';
 export {

--- a/packages/conform-valibot/tests/tsconfig.json
+++ b/packages/conform-valibot/tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../tsconfig",
+	"compilerOptions": {
+		"composite": false,
+		"noEmit": true,
+		"types": ["vitest/globals"]
+	},
+	"include": ["types.test-d.ts"]
+}

--- a/packages/conform-valibot/tests/types.test-d.ts
+++ b/packages/conform-valibot/tests/types.test-d.ts
@@ -1,0 +1,13 @@
+import type {
+	Submission as DomSubmission,
+	SubmissionResult as DomSubmissionResult,
+} from '@conform-to/dom';
+import type { Submission, SubmissionResult } from '@conform-to/valibot';
+import { expectTypeOf, test } from 'vitest';
+
+test('submission types', () => {
+	type Schema = { name: string };
+
+	expectTypeOf<Submission<Schema>>().toEqualTypeOf<DomSubmission<Schema>>();
+	expectTypeOf<SubmissionResult>().toEqualTypeOf<DomSubmissionResult>();
+});

--- a/packages/conform-yup/index.ts
+++ b/packages/conform-yup/index.ts
@@ -1,6 +1,7 @@
 import { type Intent, type Submission, parse } from '@conform-to/dom';
 import * as yup from 'yup';
 
+export type { Submission, SubmissionResult } from '@conform-to/dom';
 export { getYupConstraint } from './constraint';
 
 export function parseWithYup<Schema extends yup.AnyObjectSchema>(

--- a/packages/conform-yup/package.json
+++ b/packages/conform-yup/package.json
@@ -27,6 +27,7 @@
 		"dev:js": "pnpm run build:js --watch",
 		"dev:ts": "pnpm run build:ts --watch",
 		"dev": "pnpm run \"/^dev:.*/\"",
+		"test": "vitest",
 		"typecheck": "tsc"
 	},
 	"repository": {
@@ -49,8 +50,12 @@
 		"@babel/preset-typescript": "^7.20.2",
 		"@rollup/plugin-babel": "^5.3.1",
 		"@rollup/plugin-node-resolve": "^16.0.3",
+		"@vitest/browser-playwright": "^4.1.5",
+		"playwright": "^1.49.1",
 		"rollup-plugin-copy": "^3.4.0",
 		"rollup": "^2.80.0",
+		"typescript": "^5.8.3",
+		"vitest": "^4.1.5",
 		"yup": "^0.32.11"
 	},
 	"keywords": [

--- a/packages/conform-yup/tests/tsconfig.json
+++ b/packages/conform-yup/tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../tsconfig",
+	"compilerOptions": {
+		"composite": false,
+		"noEmit": true,
+		"types": ["vitest/globals"]
+	},
+	"include": ["types.test-d.ts"]
+}

--- a/packages/conform-yup/tests/types.test-d.ts
+++ b/packages/conform-yup/tests/types.test-d.ts
@@ -1,0 +1,13 @@
+import type {
+	Submission as DomSubmission,
+	SubmissionResult as DomSubmissionResult,
+} from '@conform-to/dom';
+import type { Submission, SubmissionResult } from '@conform-to/yup';
+import { expectTypeOf, test } from 'vitest';
+
+test('submission types', () => {
+	type Schema = { name: string };
+
+	expectTypeOf<Submission<Schema>>().toEqualTypeOf<DomSubmission<Schema>>();
+	expectTypeOf<SubmissionResult>().toEqualTypeOf<DomSubmissionResult>();
+});

--- a/packages/conform-yup/vitest.config.ts
+++ b/packages/conform-yup/vitest.config.ts
@@ -1,0 +1,54 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+import { playwright } from '@vitest/browser-playwright';
+
+const root = fileURLToPath(new URL('.', import.meta.url));
+
+export default defineConfig({
+	root,
+	test: {
+		projects: [
+			{
+				test: {
+					name: 'conform-yup',
+					browser: {
+						enabled: true,
+						headless: true,
+						provider: playwright(),
+						fileParallelism: false,
+						instances: [
+							{ browser: 'chromium' },
+							{ browser: 'firefox' },
+							{ browser: 'webkit' },
+						],
+					},
+					include: ['**/tests/**/*.test.{ts,tsx}'],
+					exclude: ['**/node_modules/**', '**/tests/**/*.node.test.{ts,tsx}'],
+					testTimeout: process.env.CI ? 30_000 : 5_000,
+					expect: {
+						poll: {
+							timeout: process.env.CI ? 10_000 : 1_000,
+						},
+					},
+				},
+			},
+			{
+				test: {
+					name: 'conform-yup (node)',
+					environment: 'node',
+					typecheck: {
+						enabled: true,
+						tsconfig: './tests/tsconfig.json',
+						include: ['**/tests/**/*.test-d.ts'],
+					},
+					include: ['**/tests/**/*.test.{ts,tsx}'],
+					exclude: [
+						'**/node_modules/**',
+						'**/tests/**/*.browser.test.{ts,tsx}',
+					],
+					testTimeout: 1_000,
+				},
+			},
+		],
+	},
+});

--- a/packages/conform-zod/default/index.ts
+++ b/packages/conform-zod/default/index.ts
@@ -1,3 +1,4 @@
+export type { Submission, SubmissionResult } from '@conform-to/dom';
 export { getZodConstraint } from './constraint';
 export { parseWithZod, conformZodMessage } from './parse';
 export { coerceFormValue as unstable_coerceFormValue } from './coercion';

--- a/packages/conform-zod/v3/index.ts
+++ b/packages/conform-zod/v3/index.ts
@@ -2,6 +2,8 @@ import type { Constraint } from '@conform-to/dom';
 import type { ZodTypeAny } from 'zod/v3';
 import { getZodConstraint as baseGetZodConstraint } from './constraint';
 
+export type { Submission, SubmissionResult } from '@conform-to/dom';
+
 export function getZodConstraint(
 	schema: ZodTypeAny,
 ): Record<string, Constraint> {

--- a/packages/conform-zod/v3/tests/types.test-d.ts
+++ b/packages/conform-zod/v3/tests/types.test-d.ts
@@ -1,8 +1,21 @@
-import type { Constraint, Submission } from '@conform-to/dom';
+import type {
+	Constraint,
+	Submission as DomSubmission,
+	SubmissionResult as DomSubmissionResult,
+} from '@conform-to/dom';
 import type { FormError, ValidationAttributes } from '@conform-to/dom/future';
 import { expectTypeOf, test } from 'vitest';
 import { z, type ZodTypeAny } from 'zod';
-import { getZodConstraint, parseWithZod } from '@conform-to/zod/v3';
+import type {
+	Submission as DefaultSubmission,
+	SubmissionResult as DefaultSubmissionResult,
+} from '@conform-to/zod';
+import {
+	getZodConstraint,
+	parseWithZod,
+	type Submission,
+	type SubmissionResult,
+} from '@conform-to/zod/v3';
 import {
 	coerceFormValue,
 	coerceStructure,
@@ -53,6 +66,17 @@ test('parseWithZod', () => {
 			>
 		>
 	>();
+});
+
+test('submission types', () => {
+	type Schema = { name: string };
+
+	expectTypeOf<Submission<Schema>>().toEqualTypeOf<DomSubmission<Schema>>();
+	expectTypeOf<SubmissionResult>().toEqualTypeOf<DomSubmissionResult>();
+	expectTypeOf<DefaultSubmission<Schema>>().toEqualTypeOf<
+		DomSubmission<Schema>
+	>();
+	expectTypeOf<DefaultSubmissionResult>().toEqualTypeOf<DomSubmissionResult>();
 });
 
 test('configureCoercion', () => {

--- a/packages/conform-zod/v4/index.ts
+++ b/packages/conform-zod/v4/index.ts
@@ -2,6 +2,8 @@ import type { Constraint } from '@conform-to/dom';
 import type { $ZodType } from 'zod/v4/core';
 import { getZodConstraint as baseGetZodConstraint } from './constraint';
 
+export type { Submission, SubmissionResult } from '@conform-to/dom';
+
 export function getZodConstraint(schema: $ZodType): Record<string, Constraint> {
 	return baseGetZodConstraint(schema, {
 		preserveBranchSpecificRequired: false,

--- a/packages/conform-zod/v4/tests/types.test-d.ts
+++ b/packages/conform-zod/v4/tests/types.test-d.ts
@@ -1,9 +1,18 @@
-import type { Constraint, Submission } from '@conform-to/dom';
+import type {
+	Constraint,
+	Submission as DomSubmission,
+	SubmissionResult as DomSubmissionResult,
+} from '@conform-to/dom';
 import type { FormError, ValidationAttributes } from '@conform-to/dom/future';
 import { expectTypeOf, test } from 'vitest';
 import { z } from 'zod';
 import { object as miniObject, string as miniString } from 'zod/v4/mini';
-import { getZodConstraint, parseWithZod } from '@conform-to/zod/v4';
+import {
+	getZodConstraint,
+	parseWithZod,
+	type Submission,
+	type SubmissionResult,
+} from '@conform-to/zod/v4';
 import {
 	coerceFormValue,
 	coerceStructure,
@@ -54,6 +63,13 @@ test('parseWithZod', () => {
 			>
 		>
 	>();
+});
+
+test('submission types', () => {
+	type Schema = { name: string };
+
+	expectTypeOf<Submission<Schema>>().toEqualTypeOf<DomSubmission<Schema>>();
+	expectTypeOf<SubmissionResult>().toEqualTypeOf<DomSubmissionResult>();
 });
 
 test('configureCoercion', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1005,12 +1005,24 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: ^16.0.3
         version: 16.0.3(rollup@2.80.0)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.5
+        version: 4.1.5(playwright@1.49.1)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.3))(vitest@4.1.5)
+      playwright:
+        specifier: ^1.49.1
+        version: 1.49.1
       rollup:
         specifier: ^2.80.0
         version: 2.80.0
       rollup-plugin-copy:
         specifier: ^3.4.0
         version: 3.5.0
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.5.0)(@vitest/browser-playwright@4.1.5)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.3))
       yup:
         specifier: ^0.32.11
         version: 0.32.11


### PR DESCRIPTION
## Summary

- re-export Submission and SubmissionResult from stable Zod, Valibot, and Yup entrypoints
- add type tests that verify every adapter exposes the canonical DOM types
- add matching Vitest type-test coverage for Yup

Related to https://github.com/edmundhung/conform/issues/1143#issuecomment-5199036973

## Testing

- TypeScript type tests for Zod v3 and v4
- TypeScript type tests for Valibot
- Vitest typecheck project for Yup
- isolated pnpm consumer declaration emit with TypeScript 7.0.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

- Re-exports portable `Submission` and `SubmissionResult` types from the Valibot, Yup, and Zod entrypoints.
- Adds type tests for Valibot, Yup, and Zod v3/v4 against `@conform-to/dom`.
- Adds Yup Vitest configuration and test dependencies.
- Adds changesets for the affected adapters.

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->