### PR TITLE
ci: replace Corepack with pnpm setup

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,17 +12,11 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Setup pnpm
+      - name: Setup pnpm and Node
         uses: pnpm/setup@v2
         with:
-          install: false
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm i
+          runtime: node@22
+          cache: true
       - name: Build packages
         run: pnpm build
       - name: Publish to pkg.pr.new

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Enable Corepack
-        run: |
-          npm i -g corepack@latest
-          corepack enable
+      - name: Setup pnpm
+        uses: pnpm/setup@v2
+        with:
+          install: false
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Enable Corepack
-        run: |
-          npm i -g corepack@latest
-          corepack enable
+      - name: Setup pnpm
+        uses: pnpm/setup@v2
+        with:
+          install: false
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,18 +15,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Setup pnpm
+      - name: Setup pnpm and Node
         uses: pnpm/setup@v2
         with:
-          install: false
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
-      - name: Install dependencies
-        run: pnpm i
+          runtime: node@24
       - name: Build packages
         run: pnpm build
       - name: Create Release Pull Request or Publish to npm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,17 +35,11 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Setup pnpm
+      - name: Setup pnpm and Node
         uses: pnpm/setup@v2
         with:
-          install: false
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm i
+          runtime: node@${{ matrix.node }}
+          cache: true
       - name: Build packages
         run: pnpm build
       - name: Install Playwright Browsers
@@ -65,17 +59,11 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Setup pnpm
+      - name: Setup pnpm and Node
         uses: pnpm/setup@v2
         with:
-          install: false
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm i
+          runtime: node@22
+          cache: true
       - name: Build packages
         run: pnpm build
       - name: Install Playwright Browsers
@@ -101,17 +89,11 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Setup pnpm
+      - name: Setup pnpm and Node
         uses: pnpm/setup@v2
         with:
-          install: false
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm i
+          runtime: node@${{ matrix.node }}
+          cache: true
       - name: Build packages
         run: pnpm build
       - name: Install Playwright Browsers
@@ -124,17 +106,11 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Setup pnpm
+      - name: Setup pnpm and Node
         uses: pnpm/setup@v2
         with:
-          install: false
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm i
+          runtime: node@22
+          cache: true
       - name: Build packages
         run: pnpm build
       - name: Run Typecheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,10 +35,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Enable Corepack
-        run: |
-          npm i -g corepack@latest --force
-          corepack enable
+      - name: Setup pnpm
+        uses: pnpm/setup@v2
+        with:
+          install: false
       - name: Setup node
         uses: actions/setup-node@v4
         with:
@@ -65,10 +65,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Enable Corepack
-        run: |
-          npm i -g corepack@latest
-          corepack enable
+      - name: Setup pnpm
+        uses: pnpm/setup@v2
+        with:
+          install: false
       - name: Setup node
         uses: actions/setup-node@v4
         with:
@@ -101,10 +101,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Enable Corepack
-        run: |
-          npm i -g corepack@latest
-          corepack enable
+      - name: Setup pnpm
+        uses: pnpm/setup@v2
+        with:
+          install: false
       - name: Setup node
         uses: actions/setup-node@v4
         with:
@@ -124,10 +124,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Enable Corepack
-        run: |
-          npm i -g corepack@latest
-          corepack enable
+      - name: Setup pnpm
+        uses: pnpm/setup@v2
+        with:
+          install: false
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,17 +33,11 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Setup pnpm
+      - name: Setup pnpm and Node
         uses: pnpm/setup@v2
         with:
-          install: false
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm i
+          runtime: node@22
+          cache: true
       - name: Build packages
         run: pnpm build
       - name: Install pre-release
@@ -69,17 +63,11 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Setup pnpm
+      - name: Setup pnpm and Node
         uses: pnpm/setup@v2
         with:
-          install: false
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm i
+          runtime: node@22
+          cache: true
       - name: Build packages
         if: inputs.preview == ''
         run: pnpm build

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,10 +33,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Enable Corepack
-        run: |
-          npm i -g corepack@latest --force
-          corepack enable
+      - name: Setup pnpm
+        uses: pnpm/setup@v2
+        with:
+          install: false
       - name: Setup node
         uses: actions/setup-node@v4
         with:
@@ -69,10 +69,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Enable Corepack
-        run: |
-          npm i -g corepack@latest --force
-          corepack enable
+      - name: Setup pnpm
+        uses: pnpm/setup@v2
+        with:
+          install: false
       - name: Setup node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

- replace Corepack and actions/setup-node with pnpm/setup@v2 for pnpm-based jobs
- let the action read the pnpm version from package.json
- let pnpm/setup provision the requested Node runtime and install dependencies
- enable pnpm store caching for non-release jobs
- keep release installs uncached while retaining npm OIDC publishing

## Validation

- checked workflow formatting with oxfmt
- parsed the changed workflow YAML files
- ran git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

Updated CI workflows to use `pnpm/setup@v2` for pnpm and Node provisioning. The workflows retain pnpm caching, registry settings, and explicit installation steps where required.

Validation included workflow formatting, YAML parsing, and `git diff --check`.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->