### PR TITLE
fix(conform-react): ignore portal form submissions

### DIFF
--- a/.changeset/tidy-portals-submit.md
+++ b/.changeset/tidy-portals-submit.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/react': patch
+---
+
+Ignore submit events dispatched by a different form through a React portal in the future APIs.

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -411,6 +411,12 @@ export function useConform<
 
 	const handleSubmit = useCallback(
 		(event: React.FormEvent<HTMLFormElement>) => {
+			// Submit events from a form rendered in a portal bubble through the
+			// React tree. Ignore them unless they originated from this form.
+			if (event.target !== event.currentTarget) {
+				return;
+			}
+
 			const abortController = new AbortController();
 
 			// Keep track of the abort controller so we can cancel the previous request if a new one is made

--- a/packages/conform-react/tests/useForm.browser.test.tsx
+++ b/packages/conform-react/tests/useForm.browser.test.tsx
@@ -2,6 +2,7 @@
 import { describe, test, expect, vi, beforeAll, afterAll } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { Locator, userEvent, server } from 'vitest/browser';
+import { createPortal } from 'react-dom';
 import {
 	type FormValue,
 	type FormError,
@@ -490,6 +491,46 @@ describe.each(testCases)('future export: $name', ({ useForm }) => {
 			await expect.element(title).toHaveValue('Updated title');
 		},
 	);
+
+	test('ignores submit events dispatched by a form rendered in a portal', async (ctx) => {
+		const portalRoot = document.createElement('div');
+		const handleValidate = vi.fn(() => ({ error: null }));
+		const handleSubmit = vi.fn((event: React.FormEvent<HTMLFormElement>) => {
+			event.preventDefault();
+		});
+
+		document.body.appendChild(portalRoot);
+		ctx.onTestFinished(() => portalRoot.remove());
+
+		function FormWithPortal() {
+			const { form } = useForm({
+				onValidate: handleValidate,
+				onSubmit: handleSubmit,
+			});
+
+			return (
+				<form {...form.props}>
+					<input name="outer" defaultValue="outer value" />
+					{createPortal(
+						<form onSubmit={(event) => event.preventDefault()}>
+							<input name="inner" defaultValue="inner value" />
+							<button type="submit">Submit inner form</button>
+						</form>,
+						portalRoot,
+					)}
+				</form>
+			);
+		}
+
+		const screen = render(<FormWithPortal />);
+
+		await userEvent.click(
+			screen.getByRole('button', { name: 'Submit inner form' }),
+		);
+
+		expect(handleValidate).not.toHaveBeenCalled();
+		expect(handleSubmit).not.toHaveBeenCalled();
+	});
 
 	test('shouldValidate: onSubmit (default)', async () => {
 		const screen = render(<Form />);


### PR DESCRIPTION
## Summary

- ignore submit events that originated from a different form and bubbled through the React tree
- add a regression test using a real React portal for both future `useForm` implementations
- add a patch changeset for `@conform-to/react`

Related to #991

## Testing

- `./node_modules/.bin/oxlint packages/conform-react/future/hooks.tsx packages/conform-react/tests/useForm.browser.test.tsx`
- `./node_modules/.bin/tsc --project packages/conform-react/tsconfig.json --noEmit`
- `git diff --check`

The focused Vitest browser runner was attempted locally but hung before test collection in the desktop environment; CI will execute the added browser regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

- Ignore submit events from forms other than the active Conform form.
- Add portal coverage for `useForm` to prevent incorrect validation and submission callbacks.
- Add a patch changeset for `@conform-to/react`.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->