### PR TITLE
feat(conform-react): support cross-root form refs

### DIFF
--- a/.changeset/quiet-forms-cross-roots.md
+++ b/.changeset/quiet-forms-cross-roots.md
@@ -1,0 +1,6 @@
+---
+'@conform-to/dom': patch
+'@conform-to/react': minor
+---
+
+Allow `useForm()` to receive a user-owned `formRef` for forms rendered in an iframe or shadow root, and make DOM operations use the form element's owning document.

--- a/docs/api/react/future/useForm.md
+++ b/docs/api/react/future/useForm.md
@@ -34,6 +34,19 @@ A configuration object with the following properties:
 
 Optional form identifier. If not provided, a unique ID is automatically generated with [useId()](https://react.dev/reference/react/useId).
 
+### `formRef?: RefObject<HTMLFormElement | null>`
+
+Optional user-owned reference to the form element. Pass the same ref to the `<form>` when it is rendered outside the global document, such as in an iframe or shadow root.
+
+```tsx
+const formRef = useRef<HTMLFormElement>(null);
+const { form } = useForm({ formRef });
+
+return <form ref={formRef} {...form.props} />;
+```
+
+When omitted, Conform resolves the form through its ID in the global document.
+
 ### `key?: string`
 
 Optional key for form state reset. When the key changes, the form resets to its initial state.

--- a/packages/conform-dom/dom.ts
+++ b/packages/conform-dom/dom.ts
@@ -18,6 +18,8 @@ export type Submitter = HTMLInputElement | HTMLButtonElement;
 const CONFORM_INTERNAL_EVENT = 'conform:internal';
 
 export function dispatchInternalUpdateEvent(form: HTMLFormElement): void {
+	const Event = form.ownerDocument.defaultView?.Event ?? globalThis.Event;
+
 	form.dispatchEvent(new Event(CONFORM_INTERNAL_EVENT));
 }
 
@@ -52,7 +54,7 @@ export function isSubmitter(
  * is a form control excluding submit, button and reset type.
  */
 export function isFieldElement(element: unknown): element is FieldElement {
-	if (element instanceof Element) {
+	if (isGlobalInstance(element, 'Element')) {
 		if (isInputElement(element)) {
 			return (
 				element.type !== 'submit' &&
@@ -81,7 +83,12 @@ export function isGlobalInstance<
 	obj: unknown,
 	className: ClassName,
 ): obj is InstanceType<(typeof globalThis)[ClassName]> {
-	const Ctor = globalThis[className];
+	const ownerDocument =
+		typeof obj === 'object' && obj !== null && 'ownerDocument' in obj
+			? (obj.ownerDocument as Document | null)
+			: null;
+	const scope = ownerDocument?.defaultView ?? globalThis;
+	const Ctor = scope[className] ?? globalThis[className];
 	return typeof Ctor === 'function' && obj instanceof Ctor;
 }
 
@@ -165,7 +172,7 @@ export function requestSubmit(
 	} else if (submitter) {
 		submitter.click();
 	} else {
-		const submitButton = document.createElement('button');
+		const submitButton = form.ownerDocument.createElement('button');
 
 		submitButton.hidden = true;
 
@@ -184,7 +191,7 @@ export function requestIntent(
 	intentName: string,
 	intentValue: string,
 ): void {
-	const submitter = document.createElement('button');
+	const submitter = formElement.ownerDocument.createElement('button');
 
 	submitter.name = intentName;
 	submitter.value = intentValue;
@@ -459,7 +466,7 @@ export function isCheckboxGroup(
 	if (element.type === 'checkbox') {
 		for (const input of element.form?.elements ?? []) {
 			if (
-				input instanceof HTMLInputElement &&
+				isGlobalInstance(input, 'HTMLInputElement') &&
 				input !== element &&
 				input.type === 'checkbox' &&
 				input.name === element.name
@@ -491,7 +498,10 @@ export function change(
 ): boolean {
 	let isChanged = false;
 
-	if (element instanceof HTMLFieldSetElement || Array.isArray(element)) {
+	if (
+		isGlobalInstance(element, 'HTMLFieldSetElement') ||
+		Array.isArray(element)
+	) {
 		let baseName: string;
 		let inputs: Element[];
 		let preventDefault: boolean;
@@ -535,7 +545,13 @@ export function change(
 		});
 	}
 
-	if (element instanceof Element && (isChanged || options?.forceDispatch)) {
+	if (
+		isGlobalInstance(element, 'Element') &&
+		(isChanged || options?.forceDispatch)
+	) {
+		const view = element.ownerDocument.defaultView;
+		const InputEvent = view?.InputEvent ?? globalThis.InputEvent;
+		const Event = view?.Event ?? globalThis.Event;
 		const inputEvent = new InputEvent('input', {
 			bubbles: true,
 			cancelable: true,
@@ -563,6 +579,9 @@ export function change(
  * Dispatches focus and focusin events on the given element.
  */
 export function focus(element: Element): void {
+	const FocusEvent =
+		element.ownerDocument.defaultView?.FocusEvent ?? globalThis.FocusEvent;
+
 	// Only focusin event will be bubbled
 	element.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
 	element.dispatchEvent(new FocusEvent('focus'));
@@ -572,6 +591,9 @@ export function focus(element: Element): void {
  * Dispatches blur and focusout events on the given element.
  */
 export function blur(element: Element): void {
+	const FocusEvent =
+		element.ownerDocument.defaultView?.FocusEvent ?? globalThis.FocusEvent;
+
 	// Only focusout event will be bubbled
 	element.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
 	element.dispatchEvent(new FocusEvent('blur'));

--- a/packages/conform-dom/formdata.ts
+++ b/packages/conform-dom/formdata.ts
@@ -74,6 +74,8 @@ export function getFormData(
 	form: HTMLFormElement,
 	submitter?: HTMLElement | null,
 ): FormData {
+	const FormData =
+		form.ownerDocument.defaultView?.FormData ?? globalThis.FormData;
 	const payload = new FormData(form, submitter);
 
 	if (submitter) {

--- a/packages/conform-react/future/dom.ts
+++ b/packages/conform-react/future/dom.ts
@@ -116,7 +116,7 @@ export function resolveControlPayload(
 		return options;
 	}
 
-	if (input instanceof HTMLInputElement) {
+	if (isGlobalInstance(input, 'HTMLInputElement')) {
 		switch (input.type) {
 			case 'file': {
 				return input.files ? Array.from(input.files) : [];
@@ -125,9 +125,9 @@ export function resolveControlPayload(
 			case 'checkbox':
 				return input.checked ? input.value : null;
 		}
-	} else if (input instanceof HTMLSelectElement && input.multiple) {
+	} else if (isGlobalInstance(input, 'HTMLSelectElement') && input.multiple) {
 		return Array.from(input.selectedOptions).map((option) => option.value);
-	} else if (input instanceof HTMLFieldSetElement) {
+	} else if (isGlobalInstance(input, 'HTMLFieldSetElement')) {
 		if (input.elements.length === 0) {
 			return null;
 		}
@@ -204,7 +204,10 @@ export function focusFirstInvalidField<ErrorShape>(
 
 	for (const element of ctx.formElement.elements) {
 		if (
-			!(isFieldElement(element) || element instanceof HTMLFieldSetElement) ||
+			!(
+				isFieldElement(element) ||
+				isGlobalInstance(element, 'HTMLFieldSetElement')
+			) ||
 			element.name === '' ||
 			!hasFieldError(ctx.error, element.name)
 		) {

--- a/packages/conform-react/future/forms.tsx
+++ b/packages/conform-react/future/forms.tsx
@@ -1,4 +1,4 @@
-import { isFieldElement, FieldName } from '@conform-to/dom';
+import { isFieldElement, isGlobalInstance, FieldName } from '@conform-to/dom';
 import {
 	type Submission,
 	DEFAULT_INTENT_NAME,
@@ -381,6 +381,7 @@ export function configureForms<
 		);
 		const fallbackId = useId();
 		const formId = options.id ?? `form-${fallbackId}`;
+		const formRef = options.formRef ?? formId;
 		const [state, handleSubmit] = useConform<
 			FormShape,
 			ErrorShape,
@@ -388,7 +389,7 @@ export function configureForms<
 			any,
 			SchemaErrorShape,
 			GlobalCustomStateHandlers
-		>(formId, {
+		>(formRef, {
 			...options,
 			intentHandlers: mergeIntentHandlers(
 				globalIntentHandlers,
@@ -484,7 +485,7 @@ export function configureForms<
 				);
 			},
 		});
-		const intent = useIntent<FormShape, GlobalIntentHandlers>(formId);
+		const intent = useIntent<FormShape, GlobalIntentHandlers>(formRef);
 		const context = useMemo<
 			FormContext<ErrorShape, FormCustomState<GlobalCustomStateHandlers>>
 		>(
@@ -499,11 +500,11 @@ export function configureForms<
 					if (
 						!(
 							isFieldElement(event.target) ||
-							event.target instanceof HTMLFieldSetElement
+							isGlobalInstance(event.target, 'HTMLFieldSetElement')
 						) ||
 						event.target.name === '' ||
 						event.target.form === null ||
-						event.target.form !== getFormElement(formId)
+						event.target.form !== getFormElement(formRef)
 					) {
 						return;
 					}
@@ -537,11 +538,11 @@ export function configureForms<
 					if (
 						!(
 							isFieldElement(event.target) ||
-							event.target instanceof HTMLFieldSetElement
+							isGlobalInstance(event.target, 'HTMLFieldSetElement')
 						) ||
 						event.target.name === '' ||
 						event.target.form === null ||
-						event.target.form !== getFormElement(formId)
+						event.target.form !== getFormElement(formRef)
 					) {
 						return;
 					}
@@ -572,7 +573,16 @@ export function configureForms<
 					}
 				},
 			}),
-			[formId, state, serialize, constraint, handleSubmit, intent, optionsRef],
+			[
+				formId,
+				formRef,
+				state,
+				serialize,
+				constraint,
+				handleSubmit,
+				intent,
+				optionsRef,
+			],
 		);
 		const form = useMemo(
 			() =>

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -503,6 +503,11 @@ export type FormOptions<
 > = {
 	/** Optional form identifier. If not provided, a unique ID is automatically generated. */
 	id?: string | undefined;
+	/**
+	 * Optional reference to the form element. Use this when the form is rendered
+	 * outside the global document, such as in an iframe or shadow root.
+	 */
+	formRef?: React.RefObject<HTMLFormElement | null> | undefined;
 	/** Optional key for form state reset. When the key changes, the form resets to its initial state. */
 	key?: string | undefined;
 	/** Server-side submission result for form state synchronization. */

--- a/packages/conform-react/tests/useFormRef.browser.test.tsx
+++ b/packages/conform-react/tests/useFormRef.browser.test.tsx
@@ -1,0 +1,139 @@
+/// <reference types="@vitest/browser/matchers" />
+import { expect, test } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { useCallback, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useForm } from '../future';
+
+function TestForm(props: { label: string }) {
+	const formRef = useRef<HTMLFormElement>(null);
+	const [submitted, setSubmitted] = useState(false);
+	const { form, fields, intent } = useForm<
+		{ title: string },
+		string[],
+		{ title: string }
+	>({
+		id: 'example',
+		formRef,
+		defaultValue: { title: 'Initial title' },
+		onValidate({ payload }) {
+			return {
+				error: null,
+				value: { title: String(payload.title ?? '') },
+			};
+		},
+		onSubmit(event) {
+			event.preventDefault();
+			setSubmitted(formRef.current === event.currentTarget);
+		},
+	});
+
+	return (
+		<form ref={formRef} {...form.props}>
+			<label>
+				{props.label}
+				<input
+					name={fields.title.name}
+					defaultValue={fields.title.defaultValue}
+				/>
+			</label>
+			<button
+				type="button"
+				onClick={() =>
+					intent.update({ name: fields.title.name, value: 'Updated' })
+				}
+			>
+				Update {props.label}
+			</button>
+			<button>Submit {props.label}</button>
+			<output aria-label={`${props.label} result`}>
+				{submitted ? 'submitted' : 'pending'}
+			</output>
+		</form>
+	);
+}
+
+test('uses a user-owned form ref inside a shadow root', async () => {
+	const host = document.createElement('div');
+	const shadowRoot = host.attachShadow({ mode: 'open' });
+	const decoy = document.createElement('form');
+
+	decoy.id = 'example';
+	document.body.append(decoy, host);
+
+	function ShadowPortal() {
+		return createPortal(<TestForm label="Shadow title" />, shadowRoot);
+	}
+
+	const screen = render(<ShadowPortal />);
+	const title = screen.getByLabelText('Shadow title', { exact: true });
+
+	await userEvent.click(
+		screen.getByRole('button', { name: 'Update Shadow title' }),
+	);
+	await expect.element(title).toHaveValue('Updated');
+
+	await userEvent.click(
+		screen.getByRole('button', { name: 'Submit Shadow title' }),
+	);
+	await expect
+		.element(screen.getByLabelText('Shadow title result'))
+		.toHaveTextContent('submitted');
+
+	decoy.remove();
+	host.remove();
+});
+
+test('uses a user-owned form ref inside an iframe document', async () => {
+	const decoy = document.createElement('form');
+
+	decoy.id = 'example';
+	document.body.append(decoy);
+
+	function IframePortal() {
+		const [iframeDocument, setIframeDocument] = useState<Document | null>(null);
+		const iframeRef = useCallback((iframe: HTMLIFrameElement | null) => {
+			setIframeDocument(iframe?.contentDocument ?? null);
+		}, []);
+
+		return (
+			<>
+				<iframe ref={iframeRef} title="Form frame" />
+				{iframeDocument
+					? createPortal(<TestForm label="Iframe title" />, iframeDocument.body)
+					: null}
+			</>
+		);
+	}
+
+	const screen = render(<IframePortal />);
+	const iframe = screen.container.querySelector('iframe')!;
+
+	await expect
+		.poll(() => iframe.contentDocument?.querySelector('input'))
+		.toBeTruthy();
+
+	const iframeDocument = iframe.contentDocument!;
+	const title = iframeDocument.querySelector('input')!;
+	const update = Array.from(iframeDocument.querySelectorAll('button')).find(
+		(button) => button.textContent === 'Update Iframe title',
+	)!;
+	const submit = Array.from(iframeDocument.querySelectorAll('button')).find(
+		(button) => button.textContent === 'Submit Iframe title',
+	)!;
+
+	update.click();
+	await expect.poll(() => title.value).toBe('Updated');
+
+	submit.click();
+	await expect
+		.poll(
+			() =>
+				iframeDocument.querySelector('output[aria-label="Iframe title result"]')
+					?.textContent,
+		)
+		.toBe('submitted');
+
+	decoy.remove();
+});


### PR DESCRIPTION
## Summary
- add an optional user-owned `formRef` to the future `useForm()` API
- keep ID-based form lookup unchanged when no ref is supplied
- use owning-document constructors for cross-realm form operations
- cover Shadow DOM and iframe portals across Chromium, Firefox, and WebKit

Fixes #920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

- Added optional `formRef` support to `useForm`.
- Preserved ID-based lookup when `formRef` is absent.
- Resolved DOM constructors and events from the form’s owning document.
- Added Shadow DOM and iframe portal coverage across Chromium, Firefox, and WebKit.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->