### PR TITLE
feat(conform-react): add FormBoundary

### DIFF
--- a/.changeset/tidy-forms-cross-roots.md
+++ b/.changeset/tidy-forms-cross-roots.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/react': minor
+---
+
+Add a `FormBoundary` component to the future React export. It delegates input and blur events so form-associated controls rendered outside the form element can participate in validation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,7 @@
     - [configureForms](./api/react/future/configureForms.md)
     - [isDirty](./api/react/future/isDirty.md)
     - [BaseControl](./api/react/future/BaseControl.md)
+    - [FormBoundary](./api/react/future/FormBoundary.md)
     - [FormProvider](./api/react/future/FormProvider.md)
     - [PreserveBoundary](./api/react/future/PreserveBoundary.md)
     - [memoize](./api/react/future/memoize.md)

--- a/docs/api/react/future/FormBoundary.md
+++ b/docs/api/react/future/FormBoundary.md
@@ -1,0 +1,43 @@
+# FormBoundary
+
+> The `FormBoundary` component is part of Conform's future export. These APIs are experimental and may change in minor versions. [Learn more](https://github.com/edmundhung/conform/discussions/954)
+
+A React component that delegates input and blur events. This lets controls associated through the `form` attribute participate in validation even when they are rendered outside the `<form>` element.
+
+```tsx
+import { FormBoundary, useForm } from '@conform-to/react/future';
+
+export default function Example() {
+  return (
+    <FormBoundary>
+      <Form />
+    </FormBoundary>
+  );
+}
+
+function Form() {
+  const { form, fields } = useForm({
+    id: 'example',
+    shouldValidate: 'onBlur',
+  });
+
+  return (
+    <>
+      <form {...form.props}>
+        <button>Submit</button>
+      </form>
+      <input
+        form={form.id}
+        name={fields.title.name}
+        defaultValue={fields.title.defaultValue}
+      />
+    </>
+  );
+}
+```
+
+## Props
+
+### `children`
+
+The forms and form-associated controls within the boundary.

--- a/packages/conform-react/future/boundary.ts
+++ b/packages/conform-react/future/boundary.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'react';
+
+export type FormBoundaryListener = {
+	handleInput: (event: React.FormEvent) => void;
+	handleBlur: (event: React.FocusEvent) => void;
+};
+
+export type FormBoundaryContextValue = {
+	register: (listener: FormBoundaryListener) => () => void;
+};
+
+export const FormBoundaryContext =
+	createContext<FormBoundaryContextValue | null>(null);

--- a/packages/conform-react/future/forms.tsx
+++ b/packages/conform-react/future/forms.tsx
@@ -5,13 +5,20 @@ import {
 	defaultSerialize,
 	FormValue,
 } from '@conform-to/dom/future';
-import { useContext, useMemo, useId, useState, createContext } from 'react';
+import {
+	useContext,
+	useMemo,
+	useId,
+	useState,
+	createContext,
+	useRef,
+} from 'react';
 import {
 	focusFirstInvalidField,
 	createIntentDispatcher,
 	getFormElement,
 } from './dom';
-import { useLatest, useConform } from './hooks';
+import { useLatest, useConform, useSafeLayoutEffect } from './hooks';
 import { StandardSchemaV1 } from './standard-schema';
 import {
 	isTouched,
@@ -51,6 +58,52 @@ import {
 	parseIntent,
 	resolveIntent,
 } from './intent';
+import {
+	FormBoundaryContext,
+	type FormBoundaryContextValue,
+	type FormBoundaryListener,
+} from './boundary';
+
+/**
+ * Delegates input and blur events from associated forms and controls rendered
+ * within the boundary.
+ */
+export function FormBoundary(props: {
+	children: React.ReactNode;
+}): React.ReactElement {
+	const listenersRef = useRef(new Set<FormBoundaryListener>());
+	const context = useMemo<FormBoundaryContextValue>(
+		() => ({
+			register(listener) {
+				const listeners = listenersRef.current;
+
+				listeners.add(listener);
+				return () => listeners.delete(listener);
+			},
+		}),
+		[],
+	);
+
+	return (
+		<FormBoundaryContext.Provider value={context}>
+			<div
+				style={{ display: 'contents' }}
+				onInput={(event) => {
+					for (const listener of Array.from(listenersRef.current)) {
+						listener.handleInput(event);
+					}
+				}}
+				onBlur={(event) => {
+					for (const listener of Array.from(listenersRef.current)) {
+						listener.handleBlur(event);
+					}
+				}}
+			>
+				{props.children}
+			</div>
+		</FormBoundaryContext.Provider>
+	);
+}
 
 export function configureForms<
 	BaseErrorShape = any,
@@ -371,6 +424,7 @@ export function configureForms<
 		const constraint =
 			options.constraint ??
 			(schema ? globalConfig.getConstraints?.(schema) : undefined);
+		const boundary = useContext(FormBoundaryContext);
 		const optionsRef = useLatest(options);
 		const serialize = useMemo(
 			() => resolveSerialize(options.serialize, globalSerialize),
@@ -490,6 +544,7 @@ export function configureForms<
 		>(
 			() => ({
 				formId,
+				eventDelegated: boundary !== null,
 				intentName: globalConfig.intentName,
 				state,
 				serialize,
@@ -572,7 +627,24 @@ export function configureForms<
 					}
 				},
 			}),
-			[formId, state, serialize, constraint, handleSubmit, intent, optionsRef],
+			[
+				formId,
+				boundary,
+				state,
+				serialize,
+				constraint,
+				handleSubmit,
+				intent,
+				optionsRef,
+			],
+		);
+		useSafeLayoutEffect(
+			() =>
+				boundary?.register({
+					handleInput: context.handleInput,
+					handleBlur: context.handleBlur,
+				}),
+			[boundary, context],
 		);
 		const form = useMemo(
 			() =>

--- a/packages/conform-react/future/index.ts
+++ b/packages/conform-react/future/index.ts
@@ -37,6 +37,7 @@ export type {
 } from './types';
 export {
 	configureForms,
+	FormBoundary,
 	FormProvider,
 	useForm,
 	useFormMetadata,

--- a/packages/conform-react/future/state.ts
+++ b/packages/conform-react/future/state.ts
@@ -818,8 +818,12 @@ export function getFormMetadata<
 		props: {
 			id: context.formId,
 			onSubmit: context.handleSubmit,
-			onInput: context.handleInput,
-			onBlur: context.handleBlur,
+			...(context.eventDelegated
+				? {}
+				: {
+						onInput: context.handleInput,
+						onBlur: context.handleBlur,
+					}),
 			noValidate: true,
 		},
 		context,

--- a/packages/conform-react/future/types.ts
+++ b/packages/conform-react/future/types.ts
@@ -608,6 +608,8 @@ export interface FormContext<
 > {
 	/** The form's unique identifier */
 	formId: string;
+	/** Whether input and blur events are delegated to a FormBoundary. */
+	eventDelegated?: boolean;
 	/** The name of the submit button field that indicates the submission intent. */
 	intentName: string;
 	/** Internal form state with validation results and field data */
@@ -1058,8 +1060,8 @@ export type FormMetadata<
 		props: Readonly<{
 			id: string;
 			onSubmit: React.FormEventHandler<HTMLFormElement>;
-			onBlur: React.FocusEventHandler<HTMLFormElement>;
-			onInput: React.FormEventHandler<HTMLFormElement>;
+			onBlur?: React.FocusEventHandler<HTMLFormElement> | undefined;
+			onInput?: React.FormEventHandler<HTMLFormElement> | undefined;
 			noValidate: boolean;
 		}>;
 		/** The current state of the form */

--- a/packages/conform-react/tests/FormBoundary.browser.test.tsx
+++ b/packages/conform-react/tests/FormBoundary.browser.test.tsx
@@ -1,0 +1,63 @@
+/// <reference types="@vitest/browser/matchers" />
+import { expect, test } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-react';
+import { useState } from 'react';
+import { FormBoundary, useForm } from '../future';
+
+function TestForm() {
+	const [blurred, setBlurred] = useState(false);
+	const { form, fields } = useForm<{ title: string }, string[]>({
+		id: 'example',
+		defaultValue: { title: 'Initial title' },
+		shouldValidate: 'onInput',
+		onBlur() {
+			setBlurred(true);
+		},
+		onValidate({ payload, error }) {
+			if (!payload.title) {
+				error.fieldErrors.title = ['Title is required'];
+			}
+
+			return error;
+		},
+	});
+
+	return (
+		<>
+			<form {...form.props} />
+			<label>
+				Title
+				<input
+					form={form.id}
+					name={fields.title.name}
+					defaultValue={fields.title.defaultValue}
+					aria-describedby={fields.title.ariaDescribedBy}
+				/>
+			</label>
+			<div id={fields.title.errorId}>
+				{fields.title.errors?.join(', ') ?? 'n/a'}
+			</div>
+			<output aria-label="Blur status">
+				{blurred ? 'blurred' : 'pending'}
+			</output>
+		</>
+	);
+}
+
+test('delegates events from controls outside the form element', async () => {
+	const screen = render(
+		<FormBoundary>
+			<TestForm />
+		</FormBoundary>,
+	);
+	const title = screen.getByLabelText('Title');
+
+	await userEvent.clear(title);
+	await expect.element(title).toHaveAccessibleDescription('Title is required');
+
+	await userEvent.click(document.body);
+	await expect
+		.element(screen.getByLabelText('Blur status'))
+		.toHaveTextContent('blurred');
+});

--- a/packages/conform-react/tests/state.test.ts
+++ b/packages/conform-react/tests/state.test.ts
@@ -38,6 +38,7 @@ function createContext(
 ): FormContext<any> {
 	return {
 		formId: 'test-id',
+		eventDelegated: false,
 		intentName: DEFAULT_INTENT_NAME,
 		serialize: defaultSerialize,
 		constraint: null,
@@ -1746,7 +1747,17 @@ test('getFormMetadata', () => {
 	// Test props
 	expect(metadata.props.id).toBe('test-id');
 	expect(metadata.props.onSubmit).toBe(context.handleSubmit);
+	expect(metadata.props.onInput).toBe(context.handleInput);
+	expect(metadata.props.onBlur).toBe(context.handleBlur);
 	expect(metadata.props.noValidate).toBe(true);
+
+	const delegatedMetadata = getFormMetadata({
+		...context,
+		eventDelegated: true,
+	});
+
+	expect(delegatedMetadata.props.onInput).toBeUndefined();
+	expect(delegatedMetadata.props.onBlur).toBeUndefined();
 
 	// Test methods exist
 	expect(typeof metadata.getField).toBe('function');


### PR DESCRIPTION
## Summary
- add a future `FormBoundary` component for delegated input and blur handling
- let form-associated controls outside the form element participate in validation
- omit duplicate form-level input and blur handlers while a boundary is active
- keep form lookup and DOM-root behavior outside the boundary contract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

Adds the experimental `FormBoundary` API. It delegates input and blur events for form-associated controls rendered outside the form, while preventing duplicate form-level handlers. Documentation, exports, tests, and a changeset are included.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->