### PR TITLE
feat(examples): add Base UI integration

### DIFF
--- a/examples/base-ui/.gitignore
+++ b/examples/base-ui/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/examples/base-ui/.oxlintrc.json
+++ b/examples/base-ui/.oxlintrc.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "./node_modules/oxlint/configuration_schema.json",
+	"plugins": ["react", "typescript", "oxc"],
+	"rules": {
+		"react/rules-of-hooks": "error",
+		"react/only-export-components": ["warn", { "allowConstantExport": true }]
+	}
+}

--- a/examples/base-ui/README.md
+++ b/examples/base-ui/README.md
@@ -6,9 +6,9 @@ This Vite React project demonstrates how to use `@base-ui/react` directly with C
 
 ## Integration
 
-Base UI Input and the native textarea rendered by Field.Control receive Conform's `name`, `defaultValue`, and validation attributes directly. Compound controls use [`useControl`](../../docs/api/react/future/useControl.md) with a [`BaseControl`](../../docs/api/react/future/BaseControl.md). The base control is the single named form control, while the Base UI primitive handles interaction.
+Base UI Input and the native textarea rendered by Field.Control receive Conform's `name` and `defaultValue` directly. Base UI's Field generates and associates the control, label, description, and error IDs, and propagates the invalid state to its controls. Compound controls use [`useControl`](../../docs/api/react/future/useControl.md) with a [`BaseControl`](../../docs/api/react/future/BaseControl.md). The base control is the single named form control, while the Base UI primitive handles interaction.
 
-The adapters leave Base UI's internal inputs unnamed to avoid duplicate `FormData` entries. They translate boolean, array, and numeric values, forward value changes to the base control, move focus to the interactive element after invalid submission, and report blur only when focus leaves a compound control. `Field.Error` uses Base UI's external-validation mode so its context associates Conform's error with every nested control. Because `useControl` follows Conform's current default, reset restores updated defaults without remounting the components.
+The adapters leave Base UI's internal inputs unnamed to avoid duplicate `FormData` entries. They translate boolean, array, and numeric values, forward value changes to the base control, move focus to the interactive element after invalid submission, and report blur only when focus leaves a compound control. `Field.Error` uses Base UI's external-validation mode so its context associates Conform's error with every nested control, while `Field.Item` associates each checkbox and radio with its own label. Because `useControl` follows Conform's current default, reset restores updated defaults without remounting the components.
 
 | Pattern | Components | Form integration |
 | --- | --- | --- |

--- a/examples/base-ui/README.md
+++ b/examples/base-ui/README.md
@@ -1,95 +1,35 @@
 # Base UI Example
 
-> This guide focuses on behavior specific to Base UI. See [Integrating with UI Libraries](../../docs/integration/ui-libraries.md) for the general concept and the [`useControl`](../../docs/api/react/future/useControl.md) API.
+[Base UI](https://base-ui.com/) provides unstyled, accessible React primitives.
 
-[Base UI](https://base-ui.com/) provides unstyled, accessible React primitives. This example integrates Conform directly with `@base-ui/react`. Unlike `examples/shadcn-base-ui`, it does not use shadcn/ui components, generated registries, or copied shadcn code.
+This Vite React project demonstrates how to use `@base-ui/react` directly with Conform and Zod 4 validation. Unlike `examples/shadcn-base-ui`, it does not use shadcn/ui components, generated registries, or copied shadcn component code.
 
-The example keeps a native `<form {...form.props}>` and uses Conform as the only source of validation and form state. It covers Input, textarea, Checkbox, CheckboxGroup, RadioGroup, Select, Combobox, NumberField, Slider, and Switch.
+## Integration
 
-## Choose the Native Form Control
+Base UI Input and the native textarea rendered by Field.Control receive Conform's `name`, `defaultValue`, and validation attributes directly. Compound controls use [`useControl`](../../docs/api/react/future/useControl.md) with a [`BaseControl`](../../docs/api/react/future/BaseControl.md). The base control is the single named form control, while the Base UI primitive handles interaction.
 
-Use the control Base UI already renders when it has the required name, default, focus, reset, and `FormData` behavior. Add `useControl` only when the primitive's live value must be synchronized with Conform.
+The adapters leave Base UI's internal inputs unnamed to avoid duplicate `FormData` entries. They translate boolean, array, and numeric values, forward value changes to the base control, move focus to the interactive element after invalid submission, and report blur only when focus leaves a compound control. Because `useControl` follows Conform's current default, reset restores updated defaults without remounting the components.
 
-| Pattern | Components | Conform integration |
+| Pattern | Components | Form integration |
 | --- | --- | --- |
-| Native form integration | Input, textarea | Receive `name` and `defaultValue` directly |
-| Hidden-input integration | Checkbox, CheckboxGroup, RadioGroup, Select, Combobox, NumberField, Switch | Base UI owns the named input and serialization |
-| Requires `useControl` | Slider | Registers Base UI's range input and synchronizes its controlled numeric value |
-| Requires `BaseControl` | None | No field in this example has a structured value that needs an additional base control |
+| Native form control | Input, textarea | The interactive element owns the name and serialization |
+| Base UI internal input | Checkbox, CheckboxGroup, RadioGroup, Select, Combobox, NumberField, Slider, Switch | Unnamed; used only for interaction and accessible focus |
+| `useControl` with `BaseControl` | All compound controls above | A hidden input or checkbox owns scalar and boolean values |
+| Array `BaseControl` | CheckboxGroup | A hidden multiple select serializes repeated values |
 
-CheckboxGroup is an array field, but it is not a structured multi-field value: each checked Base UI input contributes the same name to `FormData`. Adding a `BaseControl` would duplicate that native behavior.
+Conform remains the only source of validation and form state. Base UI supplies field structure and accessible interaction, and the application keeps its native `<form {...form.props}>`. See [Integrating with UI Libraries](../../docs/integration/ui-libraries.md) for the general pattern.
 
-## Preserve Base UI's Hidden Inputs
+## Project Structure
 
-Base UI composites accept native form props on their root. For example, Select receives Conform's name and initial value directly:
-
-```tsx
-<Select.Root name={name} defaultValue={defaultValue} inputRef={inputRef}>
-  <Select.Trigger aria-invalid={invalid || undefined}>
-    {/* ... */}
-  </Select.Trigger>
-</Select.Root>
-```
-
-The Base UI hidden input remains the single named control. Validation attributes belong on the visible trigger, input, group, or thumb exposed to assistive technology.
-
-## Synchronize Only the Controlled Slider
-
-Slider is controlled to demonstrate `useControl` without adding a duplicate hidden input. Its existing range input is registered as the base control:
-
-```tsx
-const control = useControl({ defaultValue });
-
-<Slider.Root
-  name={name}
-  value={Number(control.value)}
-  onValueChange={(value) => control.change(String(value))}
->
-  <Slider.Thumb
-    inputRef={control.register}
-    onBlur={() => control.blur()}
-  />
-</Slider.Root>;
-```
-
-This keeps the same input responsible for browser serialization, Conform focus, blur validation, and reset behavior.
-
-## Match Focus, Blur, and Reset Boundaries
-
-For composites whose visible element and hidden input are separate, blur from the visible control is forwarded to the named input so Conform's `shouldValidate: "onBlur"` receives the correct field name. Base UI continues to own the value.
-
-The field collection is keyed by the current URL defaults and remounted after a reset. This restores the visual state of Base UI's uncontrolled composites for both a Conform reset intent and `HTMLFormElement.reset()`. After a successful submission, the submitted `FormData` becomes the URL and the next reset baseline.
-
-## Custom Metadata
-
-[`src/forms.ts`](./src/forms.ts) uses [`configureForms`](../../docs/api/react/future/configureForms.md#integrating-with-ui-libraries) to provide typed props for each component:
-
-```tsx
-const forms = configureForms({
-  extendFieldMetadata(metadata) {
-    return {
-      get selectProps() {
-        return {
-          id: metadata.id,
-          name: metadata.name,
-          defaultValue: metadata.defaultValue,
-          invalid: !metadata.valid,
-          errors: metadata.errors,
-        } satisfies Partial<React.ComponentProps<typeof SelectField>>;
-      },
-    };
-  },
-});
-```
-
-The application spreads those props with full type safety. Nearby `Equivalent to:` comments preserve the explicit metadata mapping for readers.
-
-Compared with the Radix and Headless UI examples, Base UI's own form-compatible inputs remain canonical instead of being replaced. Compared with the shadcn/Base UI example, these adapters compose Base UI primitives directly and contain no generated component layer.
+- [`App.tsx`](./src/App.tsx) contains the form, schema, URL-backed defaults, and explicit Conform prop mappings.
+- [`components.tsx`](./src/components.tsx) contains the Base UI field components and compound-control adapters.
+- [`forms.ts`](./src/forms.ts) uses [`configureForms`](../../docs/api/react/future/configureForms.md#integrating-with-ui-libraries) to expose those mappings as typed field props.
+- [`tests/index.test.ts`](./tests/index.test.ts) verifies validation, submission, focus, updated defaults, and reset behavior.
 
 ## Demo
 
 <!-- sandbox src="/examples/base-ui" -->
 
-Try it on [StackBlitz](https://stackblitz.com/github/edmundhung/conform/tree/main/examples/base-ui).
+Try it out on [StackBlitz](https://stackblitz.com/github/edmundhung/conform/tree/main/examples/base-ui).
 
 <!-- /sandbox -->

--- a/examples/base-ui/README.md
+++ b/examples/base-ui/README.md
@@ -8,7 +8,7 @@ This Vite React project demonstrates how to use `@base-ui/react` directly with C
 
 Base UI Input and the native textarea rendered by Field.Control receive Conform's `name`, `defaultValue`, and validation attributes directly. Compound controls use [`useControl`](../../docs/api/react/future/useControl.md) with a [`BaseControl`](../../docs/api/react/future/BaseControl.md). The base control is the single named form control, while the Base UI primitive handles interaction.
 
-The adapters leave Base UI's internal inputs unnamed to avoid duplicate `FormData` entries. They translate boolean, array, and numeric values, forward value changes to the base control, move focus to the interactive element after invalid submission, and report blur only when focus leaves a compound control. Because `useControl` follows Conform's current default, reset restores updated defaults without remounting the components.
+The adapters leave Base UI's internal inputs unnamed to avoid duplicate `FormData` entries. They translate boolean, array, and numeric values, forward value changes to the base control, move focus to the interactive element after invalid submission, and report blur only when focus leaves a compound control. `Field.Error` uses Base UI's external-validation mode so its context associates Conform's error with every nested control. Because `useControl` follows Conform's current default, reset restores updated defaults without remounting the components.
 
 | Pattern | Components | Form integration |
 | --- | --- | --- |
@@ -22,7 +22,7 @@ Conform remains the only source of validation and form state. Base UI supplies f
 ## Project Structure
 
 - [`App.tsx`](./src/App.tsx) contains the form, schema, URL-backed defaults, and explicit Conform prop mappings.
-- [`components.tsx`](./src/components.tsx) contains the Base UI field components and compound-control adapters.
+- [`components.tsx`](./src/components.tsx) contains only the compound-control adapters; field composition stays in `App.tsx`.
 - [`forms.ts`](./src/forms.ts) uses [`configureForms`](../../docs/api/react/future/configureForms.md#integrating-with-ui-libraries) to expose those mappings as typed field props.
 - [`tests/index.test.ts`](./tests/index.test.ts) verifies validation, submission, focus, updated defaults, and reset behavior.
 

--- a/examples/base-ui/README.md
+++ b/examples/base-ui/README.md
@@ -2,7 +2,7 @@
 
 > This guide focuses on behavior specific to Base UI. See [Integrating with UI Libraries](../../docs/integration/ui-libraries.md) for the general concept and the [`useControl`](../../docs/api/react/future/useControl.md) API.
 
-[Base UI](https://base-ui.com/) provides unstyled, accessible React primitives. This example integrates Conform directly with `@base-ui/react`. Unlike [`examples/shadcn-base-ui`](../shadcn-base-ui), it does not use shadcn/ui components, generated registries, or copied shadcn code.
+[Base UI](https://base-ui.com/) provides unstyled, accessible React primitives. This example integrates Conform directly with `@base-ui/react`. Unlike `examples/shadcn-base-ui`, it does not use shadcn/ui components, generated registries, or copied shadcn code.
 
 The example keeps a native `<form {...form.props}>` and uses Conform as the only source of validation and form state. It covers Input, textarea, Checkbox, CheckboxGroup, RadioGroup, Select, Combobox, NumberField, Slider, and Switch.
 

--- a/examples/base-ui/README.md
+++ b/examples/base-ui/README.md
@@ -1,0 +1,95 @@
+# Base UI Example
+
+> This guide focuses on behavior specific to Base UI. See [Integrating with UI Libraries](../../docs/integration/ui-libraries.md) for the general concept and the [`useControl`](../../docs/api/react/future/useControl.md) API.
+
+[Base UI](https://base-ui.com/) provides unstyled, accessible React primitives. This example integrates Conform directly with `@base-ui/react`. Unlike [`examples/shadcn-base-ui`](../shadcn-base-ui), it does not use shadcn/ui components, generated registries, or copied shadcn code.
+
+The example keeps a native `<form {...form.props}>` and uses Conform as the only source of validation and form state. It covers Input, textarea, Checkbox, CheckboxGroup, RadioGroup, Select, Combobox, NumberField, Slider, and Switch.
+
+## Choose the Native Form Control
+
+Use the control Base UI already renders when it has the required name, default, focus, reset, and `FormData` behavior. Add `useControl` only when the primitive's live value must be synchronized with Conform.
+
+| Pattern | Components | Conform integration |
+| --- | --- | --- |
+| Native form integration | Input, textarea | Receive `name` and `defaultValue` directly |
+| Hidden-input integration | Checkbox, CheckboxGroup, RadioGroup, Select, Combobox, NumberField, Switch | Base UI owns the named input and serialization |
+| Requires `useControl` | Slider | Registers Base UI's range input and synchronizes its controlled numeric value |
+| Requires `BaseControl` | None | No field in this example has a structured value that needs an additional base control |
+
+CheckboxGroup is an array field, but it is not a structured multi-field value: each checked Base UI input contributes the same name to `FormData`. Adding a `BaseControl` would duplicate that native behavior.
+
+## Preserve Base UI's Hidden Inputs
+
+Base UI composites accept native form props on their root. For example, Select receives Conform's name and initial value directly:
+
+```tsx
+<Select.Root name={name} defaultValue={defaultValue} inputRef={inputRef}>
+  <Select.Trigger aria-invalid={invalid || undefined}>
+    {/* ... */}
+  </Select.Trigger>
+</Select.Root>
+```
+
+The Base UI hidden input remains the single named control. Validation attributes belong on the visible trigger, input, group, or thumb exposed to assistive technology.
+
+## Synchronize Only the Controlled Slider
+
+Slider is controlled to demonstrate `useControl` without adding a duplicate hidden input. Its existing range input is registered as the base control:
+
+```tsx
+const control = useControl({ defaultValue });
+
+<Slider.Root
+  name={name}
+  value={Number(control.value)}
+  onValueChange={(value) => control.change(String(value))}
+>
+  <Slider.Thumb
+    inputRef={control.register}
+    onBlur={() => control.blur()}
+  />
+</Slider.Root>;
+```
+
+This keeps the same input responsible for browser serialization, Conform focus, blur validation, and reset behavior.
+
+## Match Focus, Blur, and Reset Boundaries
+
+For composites whose visible element and hidden input are separate, blur from the visible control is forwarded to the named input so Conform's `shouldValidate: "onBlur"` receives the correct field name. Base UI continues to own the value.
+
+The field collection is keyed by the current URL defaults and remounted after a reset. This restores the visual state of Base UI's uncontrolled composites for both a Conform reset intent and `HTMLFormElement.reset()`. After a successful submission, the submitted `FormData` becomes the URL and the next reset baseline.
+
+## Custom Metadata
+
+[`src/forms.ts`](./src/forms.ts) uses [`configureForms`](../../docs/api/react/future/configureForms.md#integrating-with-ui-libraries) to provide typed props for each component:
+
+```tsx
+const forms = configureForms({
+  extendFieldMetadata(metadata) {
+    return {
+      get selectProps() {
+        return {
+          id: metadata.id,
+          name: metadata.name,
+          defaultValue: metadata.defaultValue,
+          invalid: !metadata.valid,
+          errors: metadata.errors,
+        } satisfies Partial<React.ComponentProps<typeof SelectField>>;
+      },
+    };
+  },
+});
+```
+
+The application spreads those props with full type safety. Nearby `Equivalent to:` comments preserve the explicit metadata mapping for readers.
+
+Compared with the Radix and Headless UI examples, Base UI's own form-compatible inputs remain canonical instead of being replaced. Compared with the shadcn/Base UI example, these adapters compose Base UI primitives directly and contain no generated component layer.
+
+## Demo
+
+<!-- sandbox src="/examples/base-ui" -->
+
+Try it on [StackBlitz](https://stackblitz.com/github/edmundhung/conform/tree/main/examples/base-ui).
+
+<!-- /sandbox -->

--- a/examples/base-ui/index.html
+++ b/examples/base-ui/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta name="description" content="Conform with Base UI primitives" />
+		<title>Base UI Example</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/src/main.tsx"></script>
+	</body>
+</html>

--- a/examples/base-ui/package.json
+++ b/examples/base-ui/package.json
@@ -1,0 +1,40 @@
+{
+	"name": "base-ui-example",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module",
+	"scripts": {
+		"dev": "vite",
+		"build": "tsc -b && vite build",
+		"typecheck": "tsc -b",
+		"test": "playwright test",
+		"lint": "oxlint",
+		"preview": "vite preview"
+	},
+	"dependencies": {
+		"@base-ui/react": "^1.7.0",
+		"@conform-to/react": "^1.21.0",
+		"@conform-to/zod": "^1.21.0",
+		"react": "^19.2.7",
+		"react-dom": "^19.2.7",
+		"zod": "^4.4.3"
+	},
+	"dependenciesMeta": {
+		"@conform-to/react": {
+			"injected": true
+		},
+		"@conform-to/zod": {
+			"injected": true
+		}
+	},
+	"devDependencies": {
+		"@playwright/test": "^1.49.1",
+		"@types/node": "^24.13.3",
+		"@types/react": "^19.2.17",
+		"@types/react-dom": "^19.2.3",
+		"@vitejs/plugin-react": "^6.0.3",
+		"oxlint": "^1.74.0",
+		"typescript": "~6.0.2",
+		"vite": "^8.1.5"
+	}
+}

--- a/examples/base-ui/playwright.config.ts
+++ b/examples/base-ui/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+	testDir: 'tests',
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: process.env.CI ? 'github' : undefined,
+	use: {
+		trace: 'on-first-retry',
+		timezoneId: 'UTC',
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: devices['Desktop Chrome'],
+		},
+		{
+			name: 'firefox',
+			use: devices['Desktop Firefox'],
+		},
+		{
+			name: 'webkit',
+			use: devices['Desktop Safari'],
+		},
+	],
+	webServer: {
+		command: 'pnpm run build && pnpm run preview --port 4177',
+		port: 4177,
+		reuseExistingServer: !process.env.CI,
+	},
+});

--- a/examples/base-ui/src/App.tsx
+++ b/examples/base-ui/src/App.tsx
@@ -1,17 +1,19 @@
+import { Checkbox } from '@base-ui/react/checkbox';
+import { Field } from '@base-ui/react/field';
+import { Input } from '@base-ui/react/input';
+import { Radio } from '@base-ui/react/radio';
 import { coerceFormValue } from '@conform-to/zod/v4/future';
 import { useState } from 'react';
 import { z } from 'zod';
 import {
-	CheckboxField,
-	CheckboxGroupField,
-	ComboboxField,
+	CheckboxControl,
+	CheckboxGroupControl,
+	ComboboxControl,
 	NumberFieldControl,
-	RadioGroupField,
-	SelectField,
-	SliderField,
-	SwitchField,
-	TextareaField,
-	TextInputField,
+	RadioGroupControl,
+	SelectControl,
+	SliderControl,
+	SwitchControl,
 } from './components';
 import { useForm } from './forms';
 
@@ -110,6 +112,7 @@ export default function App() {
 			setSubmittedValue(value);
 		},
 	});
+
 	return (
 		<main>
 			<form
@@ -127,141 +130,354 @@ export default function App() {
 				</header>
 
 				<div className="field-list">
-					<TextInputField
-						label="Full name"
-						description="A native Base UI Input."
-						{...fields.fullName.textInputProps}
-						// Equivalent to:
-						// id={fields.fullName.id}
-						// name={fields.fullName.name}
-						// defaultValue={fields.fullName.defaultValue}
-						// aria-describedby={`${fields.fullName.id}-description ${fields.fullName.ariaDescribedBy ?? ''}`.trim()}
-						// invalid={!fields.fullName.valid}
-						// errors={fields.fullName.errors}
-					/>
+					<Field.Root className="field" invalid={!fields.fullName.valid}>
+						<Field.Label id={`${fields.fullName.id}-label`} className="label">
+							Full name
+						</Field.Label>
+						<Input
+							className="text-control"
+							{...fields.fullName.inputProps}
+							// Equivalent to:
+							// id={fields.fullName.id}
+							// name={fields.fullName.name}
+							// defaultValue={fields.fullName.defaultValue}
+							// aria-labelledby={`${fields.fullName.id}-label`}
+							// aria-describedby={`${fields.fullName.id}-description ${fields.fullName.ariaDescribedBy ?? ''}`.trim()}
+							// aria-invalid={fields.fullName.ariaInvalid}
+						/>
+						<Field.Description
+							id={`${fields.fullName.id}-description`}
+							className="description"
+						>
+							A native Base UI Input.
+						</Field.Description>
+						<Field.Error
+							id={fields.fullName.errorId}
+							className="error"
+							match
+							role={fields.fullName.errors?.length ? 'alert' : undefined}
+						>
+							{fields.fullName.errors?.join(', ')}
+						</Field.Error>
+					</Field.Root>
 
-					<TextareaField
-						label="Bio"
-						description="Field.Control renders a native textarea."
-						{...fields.bio.textareaProps}
-						// Equivalent to:
-						// id={fields.bio.id}
-						// name={fields.bio.name}
-						// defaultValue={fields.bio.defaultValue}
-						// aria-describedby={`${fields.bio.id}-description ${fields.bio.ariaDescribedBy ?? ''}`.trim()}
-						// invalid={!fields.bio.valid}
-						// errors={fields.bio.errors}
-					/>
+					<Field.Root className="field" invalid={!fields.bio.valid}>
+						<Field.Label id={`${fields.bio.id}-label`} className="label">
+							Bio
+						</Field.Label>
+						<Field.Control
+							render={<textarea rows={4} />}
+							className="text-control"
+							{...fields.bio.textareaProps}
+							// Equivalent to:
+							// id={fields.bio.id}
+							// name={fields.bio.name}
+							// defaultValue={fields.bio.defaultValue}
+							// aria-labelledby={`${fields.bio.id}-label`}
+							// aria-describedby={`${fields.bio.id}-description ${fields.bio.ariaDescribedBy ?? ''}`.trim()}
+							// aria-invalid={fields.bio.ariaInvalid}
+						/>
+						<Field.Description
+							id={`${fields.bio.id}-description`}
+							className="description"
+						>
+							Field.Control renders a native textarea.
+						</Field.Description>
+						<Field.Error
+							id={fields.bio.errorId}
+							className="error"
+							match
+							role={fields.bio.errors?.length ? 'alert' : undefined}
+						>
+							{fields.bio.errors?.join(', ')}
+						</Field.Error>
+					</Field.Root>
 
-					<CheckboxField
-						label="Accept terms"
-						description="The visible checkbox is synchronized with a BaseControl."
-						{...fields.acceptTerms.checkboxProps}
-						// Equivalent to:
-						// id={fields.acceptTerms.id}
-						// name={fields.acceptTerms.name}
-						// defaultChecked={fields.acceptTerms.defaultChecked}
-						// aria-describedby={`${fields.acceptTerms.id}-description ${fields.acceptTerms.ariaDescribedBy ?? ''}`.trim()}
-						// invalid={!fields.acceptTerms.valid}
-						// errors={fields.acceptTerms.errors}
-					/>
+					<Field.Root className="field" invalid={!fields.acceptTerms.valid}>
+						<Field.Label
+							id={`${fields.acceptTerms.id}-label`}
+							className="choice-label"
+						>
+							<CheckboxControl
+								{...fields.acceptTerms.checkboxProps}
+								// Equivalent to:
+								// id={fields.acceptTerms.id}
+								// name={fields.acceptTerms.name}
+								// defaultChecked={fields.acceptTerms.defaultChecked}
+								// aria-labelledby={`${fields.acceptTerms.id}-label`}
+								// aria-describedby={`${fields.acceptTerms.id}-description ${fields.acceptTerms.ariaDescribedBy ?? ''}`.trim()}
+								// invalid={!fields.acceptTerms.valid}
+							/>
+							Accept terms
+						</Field.Label>
+						<Field.Description
+							id={`${fields.acceptTerms.id}-description`}
+							className="description"
+						>
+							The visible checkbox is synchronized with a BaseControl.
+						</Field.Description>
+						<Field.Error
+							id={fields.acceptTerms.errorId}
+							className="error"
+							match
+							role={fields.acceptTerms.errors?.length ? 'alert' : undefined}
+						>
+							{fields.acceptTerms.errors?.join(', ')}
+						</Field.Error>
+					</Field.Root>
 
-					<CheckboxGroupField
-						label="Interests"
-						description="A multiple BaseControl serializes the selected values."
-						items={interestOptions}
-						{...fields.interests.checkboxGroupProps}
-						// Equivalent to:
-						// id={fields.interests.id}
-						// name={fields.interests.name}
-						// defaultValue={fields.interests.defaultOptions}
-						// aria-describedby={`${fields.interests.id}-description ${fields.interests.ariaDescribedBy ?? ''}`.trim()}
-						// invalid={!fields.interests.valid}
-						// errors={fields.interests.errors}
-					/>
+					<Field.Root className="field" invalid={!fields.interests.valid}>
+						<Field.Label id={`${fields.interests.id}-label`} className="label">
+							Interests
+						</Field.Label>
+						<CheckboxGroupControl
+							{...fields.interests.checkboxGroupProps}
+							// Equivalent to:
+							// id={fields.interests.id}
+							// name={fields.interests.name}
+							// defaultValue={fields.interests.defaultOptions}
+							// aria-labelledby={`${fields.interests.id}-label`}
+							// aria-describedby={`${fields.interests.id}-description ${fields.interests.ariaDescribedBy ?? ''}`.trim()}
+							// invalid={!fields.interests.valid}
+						>
+							{interestOptions.map((item) => (
+								<label className="choice-label" key={item.value}>
+									<Checkbox.Root
+										className="checkbox"
+										value={item.value}
+										aria-labelledby={`${fields.interests.id}-${item.value}-label`}
+									>
+										<Checkbox.Indicator className="checkbox-indicator">
+											✓
+										</Checkbox.Indicator>
+									</Checkbox.Root>
+									<span id={`${fields.interests.id}-${item.value}-label`}>
+										{item.label}
+									</span>
+								</label>
+							))}
+						</CheckboxGroupControl>
+						<Field.Description
+							id={`${fields.interests.id}-description`}
+							className="description"
+						>
+							A multiple BaseControl serializes the selected values.
+						</Field.Description>
+						<Field.Error
+							id={fields.interests.errorId}
+							className="error"
+							match
+							role={fields.interests.errors?.length ? 'alert' : undefined}
+						>
+							{fields.interests.errors?.join(', ')}
+						</Field.Error>
+					</Field.Root>
 
-					<RadioGroupField
-						label="Plan"
-						description="The BaseControl serializes one scalar value."
-						items={planOptions}
-						{...fields.plan.radioGroupProps}
-						// Equivalent to:
-						// id={fields.plan.id}
-						// name={fields.plan.name}
-						// defaultValue={fields.plan.defaultValue}
-						// aria-describedby={`${fields.plan.id}-description ${fields.plan.ariaDescribedBy ?? ''}`.trim()}
-						// invalid={!fields.plan.valid}
-						// errors={fields.plan.errors}
-					/>
+					<Field.Root className="field" invalid={!fields.plan.valid}>
+						<Field.Label id={`${fields.plan.id}-label`} className="label">
+							Plan
+						</Field.Label>
+						<RadioGroupControl
+							{...fields.plan.radioGroupProps}
+							// Equivalent to:
+							// id={fields.plan.id}
+							// name={fields.plan.name}
+							// defaultValue={fields.plan.defaultValue}
+							// aria-labelledby={`${fields.plan.id}-label`}
+							// aria-describedby={`${fields.plan.id}-description ${fields.plan.ariaDescribedBy ?? ''}`.trim()}
+							// invalid={!fields.plan.valid}
+						>
+							{planOptions.map((item) => (
+								<label className="choice-label" key={item.value}>
+									<Radio.Root
+										className="radio"
+										value={item.value}
+										aria-labelledby={`${fields.plan.id}-${item.value}-label`}
+									>
+										<Radio.Indicator className="radio-indicator" />
+									</Radio.Root>
+									<span id={`${fields.plan.id}-${item.value}-label`}>
+										{item.label}
+									</span>
+								</label>
+							))}
+						</RadioGroupControl>
+						<Field.Description
+							id={`${fields.plan.id}-description`}
+							className="description"
+						>
+							The BaseControl serializes one scalar value.
+						</Field.Description>
+						<Field.Error
+							id={fields.plan.errorId}
+							className="error"
+							match
+							role={fields.plan.errors?.length ? 'alert' : undefined}
+						>
+							{fields.plan.errors?.join(', ')}
+						</Field.Error>
+					</Field.Root>
 
-					<SelectField
-						label="Country"
-						description="Select is synchronized with a scalar BaseControl."
-						placeholder="Choose a country"
-						items={countryOptions}
-						{...fields.country.selectProps}
-						// Equivalent to:
-						// id={fields.country.id}
-						// name={fields.country.name}
-						// defaultValue={fields.country.defaultValue}
-						// aria-describedby={`${fields.country.id}-description ${fields.country.ariaDescribedBy ?? ''}`.trim()}
-						// invalid={!fields.country.valid}
-						// errors={fields.country.errors}
-					/>
+					<Field.Root className="field" invalid={!fields.country.valid}>
+						<Field.Label id={`${fields.country.id}-label`} className="label">
+							Country
+						</Field.Label>
+						<SelectControl
+							placeholder="Choose a country"
+							items={countryOptions}
+							{...fields.country.selectProps}
+							// Equivalent to:
+							// id={fields.country.id}
+							// name={fields.country.name}
+							// defaultValue={fields.country.defaultValue}
+							// aria-labelledby={`${fields.country.id}-label`}
+							// aria-describedby={`${fields.country.id}-description ${fields.country.ariaDescribedBy ?? ''}`.trim()}
+							// invalid={!fields.country.valid}
+						/>
+						<Field.Description
+							id={`${fields.country.id}-description`}
+							className="description"
+						>
+							Select is synchronized with a scalar BaseControl.
+						</Field.Description>
+						<Field.Error
+							id={fields.country.errorId}
+							className="error"
+							match
+							role={fields.country.errors?.length ? 'alert' : undefined}
+						>
+							{fields.country.errors?.join(', ')}
+						</Field.Error>
+					</Field.Root>
 
-					<ComboboxField
-						label="Framework"
-						description="Filtering is transient; BaseControl stores the selection."
-						placeholder="Search frameworks"
-						items={frameworkOptions}
-						{...fields.framework.comboboxProps}
-						// Equivalent to:
-						// id={fields.framework.id}
-						// name={fields.framework.name}
-						// defaultValue={fields.framework.defaultValue}
-						// aria-describedby={`${fields.framework.id}-description ${fields.framework.ariaDescribedBy ?? ''}`.trim()}
-						// invalid={!fields.framework.valid}
-						// errors={fields.framework.errors}
-					/>
+					<Field.Root className="field" invalid={!fields.framework.valid}>
+						<Field.Label id={`${fields.framework.id}-label`} className="label">
+							Framework
+						</Field.Label>
+						<ComboboxControl
+							placeholder="Search frameworks"
+							triggerLabel="Open Framework"
+							items={frameworkOptions}
+							{...fields.framework.comboboxProps}
+							// Equivalent to:
+							// id={fields.framework.id}
+							// name={fields.framework.name}
+							// defaultValue={fields.framework.defaultValue}
+							// aria-labelledby={`${fields.framework.id}-label`}
+							// aria-describedby={`${fields.framework.id}-description ${fields.framework.ariaDescribedBy ?? ''}`.trim()}
+							// invalid={!fields.framework.valid}
+						/>
+						<Field.Description
+							id={`${fields.framework.id}-description`}
+							className="description"
+						>
+							Filtering is transient; BaseControl stores the selection.
+						</Field.Description>
+						<Field.Error
+							id={fields.framework.errorId}
+							className="error"
+							match
+							role={fields.framework.errors?.length ? 'alert' : undefined}
+						>
+							{fields.framework.errors?.join(', ')}
+						</Field.Error>
+					</Field.Root>
 
-					<NumberFieldControl
-						label="Quantity"
-						description="BaseControl stores the raw value before Zod coercion."
-						{...fields.quantity.numberFieldProps}
-						// Equivalent to:
-						// id={fields.quantity.id}
-						// name={fields.quantity.name}
-						// defaultValue={fields.quantity.defaultValue}
-						// aria-describedby={`${fields.quantity.id}-description ${fields.quantity.ariaDescribedBy ?? ''}`.trim()}
-						// invalid={!fields.quantity.valid}
-						// errors={fields.quantity.errors}
-					/>
+					<Field.Root className="field" invalid={!fields.quantity.valid}>
+						<Field.Label id={`${fields.quantity.id}-label`} className="label">
+							Quantity
+						</Field.Label>
+						<NumberFieldControl
+							label="Quantity"
+							{...fields.quantity.numberFieldProps}
+							// Equivalent to:
+							// id={fields.quantity.id}
+							// name={fields.quantity.name}
+							// defaultValue={fields.quantity.defaultValue}
+							// aria-labelledby={`${fields.quantity.id}-label`}
+							// aria-describedby={`${fields.quantity.id}-description ${fields.quantity.ariaDescribedBy ?? ''}`.trim()}
+							// invalid={!fields.quantity.valid}
+						/>
+						<Field.Description
+							id={`${fields.quantity.id}-description`}
+							className="description"
+						>
+							BaseControl stores the raw value before Zod coercion.
+						</Field.Description>
+						<Field.Error
+							id={fields.quantity.errorId}
+							className="error"
+							match
+							role={fields.quantity.errors?.length ? 'alert' : undefined}
+						>
+							{fields.quantity.errors?.join(', ')}
+						</Field.Error>
+					</Field.Root>
 
-					<SliderField
-						label="Budget"
-						description="The range input is controlled through useControl."
-						{...fields.budget.sliderProps}
-						// Equivalent to:
-						// id={fields.budget.id}
-						// name={fields.budget.name}
-						// defaultValue={fields.budget.defaultValue}
-						// aria-describedby={`${fields.budget.id}-description ${fields.budget.ariaDescribedBy ?? ''}`.trim()}
-						// invalid={!fields.budget.valid}
-						// errors={fields.budget.errors}
-					/>
+					<Field.Root className="field" invalid={!fields.budget.valid}>
+						<Field.Label id={`${fields.budget.id}-label`} className="label">
+							Budget
+						</Field.Label>
+						<SliderControl
+							{...fields.budget.sliderProps}
+							// Equivalent to:
+							// id={fields.budget.id}
+							// name={fields.budget.name}
+							// defaultValue={fields.budget.defaultValue}
+							// aria-labelledby={`${fields.budget.id}-label`}
+							// aria-describedby={`${fields.budget.id}-description ${fields.budget.ariaDescribedBy ?? ''}`.trim()}
+							// invalid={!fields.budget.valid}
+						/>
+						<Field.Description
+							id={`${fields.budget.id}-description`}
+							className="description"
+						>
+							The range input is controlled through useControl.
+						</Field.Description>
+						<Field.Error
+							id={fields.budget.errorId}
+							className="error"
+							match
+							role={fields.budget.errors?.length ? 'alert' : undefined}
+						>
+							{fields.budget.errors?.join(', ')}
+						</Field.Error>
+					</Field.Root>
 
-					<SwitchField
-						label="Product notifications"
-						description="A checkbox BaseControl submits “on” while enabled."
-						{...fields.notifications.switchProps}
-						// Equivalent to:
-						// id={fields.notifications.id}
-						// name={fields.notifications.name}
-						// defaultChecked={fields.notifications.defaultChecked}
-						// aria-describedby={`${fields.notifications.id}-description ${fields.notifications.ariaDescribedBy ?? ''}`.trim()}
-						// invalid={!fields.notifications.valid}
-						// errors={fields.notifications.errors}
-					/>
+					<Field.Root className="field" invalid={!fields.notifications.valid}>
+						<div className="switch-row">
+							<Field.Label
+								id={`${fields.notifications.id}-label`}
+								className="label"
+							>
+								Product notifications
+							</Field.Label>
+							<SwitchControl
+								{...fields.notifications.switchProps}
+								// Equivalent to:
+								// id={fields.notifications.id}
+								// name={fields.notifications.name}
+								// defaultChecked={fields.notifications.defaultChecked}
+								// aria-labelledby={`${fields.notifications.id}-label`}
+								// aria-describedby={`${fields.notifications.id}-description ${fields.notifications.ariaDescribedBy ?? ''}`.trim()}
+								// invalid={!fields.notifications.valid}
+							/>
+						</div>
+						<Field.Description
+							id={`${fields.notifications.id}-description`}
+							className="description"
+						>
+							A checkbox BaseControl submits “on” while enabled.
+						</Field.Description>
+						<Field.Error
+							id={fields.notifications.errorId}
+							className="error"
+							match
+							role={fields.notifications.errors?.length ? 'alert' : undefined}
+						>
+							{fields.notifications.errors?.join(', ')}
+						</Field.Error>
+					</Field.Root>
 				</div>
 
 				{submittedValue ? (

--- a/examples/base-ui/src/App.tsx
+++ b/examples/base-ui/src/App.tsx
@@ -53,30 +53,6 @@ const schema = coerceFormValue(
 	}),
 );
 
-const interestOptions = [
-	{ value: 'design', label: 'Design' },
-	{ value: 'engineering', label: 'Engineering' },
-	{ value: 'research', label: 'Research' },
-];
-
-const planOptions = [
-	{ value: 'starter', label: 'Starter' },
-	{ value: 'professional', label: 'Professional' },
-	{ value: 'enterprise', label: 'Enterprise' },
-];
-
-const countryOptions = [
-	{ value: 'gb', label: 'United Kingdom' },
-	{ value: 'ca', label: 'Canada' },
-	{ value: 'jp', label: 'Japan' },
-];
-
-const frameworkOptions = [
-	{ value: 'react', label: 'React' },
-	{ value: 'vue', label: 'Vue' },
-	{ value: 'svelte', label: 'Svelte' },
-];
-
 export default function App() {
 	const [submittedValue, setSubmittedValue] = useState<z.output<
 		typeof schema
@@ -142,11 +118,7 @@ export default function App() {
 						<Field.Description className="description">
 							A native Base UI Input.
 						</Field.Description>
-						<Field.Error
-							className="error"
-							match
-							role={fields.fullName.errors?.length ? 'alert' : undefined}
-						>
+						<Field.Error className="error" match>
 							{fields.fullName.errors?.join(', ')}
 						</Field.Error>
 					</Field.Root>
@@ -164,11 +136,7 @@ export default function App() {
 						<Field.Description className="description">
 							Field.Control renders a native textarea.
 						</Field.Description>
-						<Field.Error
-							className="error"
-							match
-							role={fields.bio.errors?.length ? 'alert' : undefined}
-						>
+						<Field.Error className="error" match>
 							{fields.bio.errors?.join(', ')}
 						</Field.Error>
 					</Field.Root>
@@ -186,11 +154,7 @@ export default function App() {
 						<Field.Description className="description">
 							The visible checkbox is synchronized with a BaseControl.
 						</Field.Description>
-						<Field.Error
-							className="error"
-							match
-							role={fields.acceptTerms.errors?.length ? 'alert' : undefined}
-						>
+						<Field.Error className="error" match>
 							{fields.acceptTerms.errors?.join(', ')}
 						</Field.Error>
 					</Field.Root>
@@ -209,7 +173,11 @@ export default function App() {
 							// name={fields.interests.name}
 							// defaultValue={fields.interests.defaultOptions}
 						>
-							{interestOptions.map((item) => (
+							{[
+								{ value: 'design', label: 'Design' },
+								{ value: 'engineering', label: 'Engineering' },
+								{ value: 'research', label: 'Research' },
+							].map((item) => (
 								<Field.Item className="choice-label" key={item.value}>
 									<Checkbox.Root className="checkbox" value={item.value}>
 										<Checkbox.Indicator className="checkbox-indicator">
@@ -223,11 +191,7 @@ export default function App() {
 						<Field.Description className="description">
 							A multiple BaseControl serializes the selected values.
 						</Field.Description>
-						<Field.Error
-							className="error"
-							match
-							role={fields.interests.errors?.length ? 'alert' : undefined}
-						>
+						<Field.Error className="error" match>
 							{fields.interests.errors?.join(', ')}
 						</Field.Error>
 					</Field.Root>
@@ -246,7 +210,11 @@ export default function App() {
 							// name={fields.plan.name}
 							// defaultValue={fields.plan.defaultValue}
 						>
-							{planOptions.map((item) => (
+							{[
+								{ value: 'starter', label: 'Starter' },
+								{ value: 'professional', label: 'Professional' },
+								{ value: 'enterprise', label: 'Enterprise' },
+							].map((item) => (
 								<Field.Item className="choice-label" key={item.value}>
 									<Radio.Root className="radio" value={item.value}>
 										<Radio.Indicator className="radio-indicator" />
@@ -258,11 +226,7 @@ export default function App() {
 						<Field.Description className="description">
 							The BaseControl serializes one scalar value.
 						</Field.Description>
-						<Field.Error
-							className="error"
-							match
-							role={fields.plan.errors?.length ? 'alert' : undefined}
-						>
+						<Field.Error className="error" match>
 							{fields.plan.errors?.join(', ')}
 						</Field.Error>
 					</Field.Root>
@@ -271,7 +235,11 @@ export default function App() {
 						<Field.Label className="label">Country</Field.Label>
 						<SelectControl
 							placeholder="Choose a country"
-							items={countryOptions}
+							items={[
+								{ value: 'gb', label: 'United Kingdom' },
+								{ value: 'ca', label: 'Canada' },
+								{ value: 'jp', label: 'Japan' },
+							]}
 							{...fields.country.selectProps}
 							// Equivalent to:
 							// name={fields.country.name}
@@ -280,11 +248,7 @@ export default function App() {
 						<Field.Description className="description">
 							Select is synchronized with a scalar BaseControl.
 						</Field.Description>
-						<Field.Error
-							className="error"
-							match
-							role={fields.country.errors?.length ? 'alert' : undefined}
-						>
+						<Field.Error className="error" match>
 							{fields.country.errors?.join(', ')}
 						</Field.Error>
 					</Field.Root>
@@ -294,7 +258,11 @@ export default function App() {
 						<ComboboxControl
 							placeholder="Search frameworks"
 							triggerLabel="Open Framework"
-							items={frameworkOptions}
+							items={[
+								{ value: 'react', label: 'React' },
+								{ value: 'vue', label: 'Vue' },
+								{ value: 'svelte', label: 'Svelte' },
+							]}
 							{...fields.framework.comboboxProps}
 							// Equivalent to:
 							// name={fields.framework.name}
@@ -303,11 +271,7 @@ export default function App() {
 						<Field.Description className="description">
 							Filtering is transient; BaseControl stores the selection.
 						</Field.Description>
-						<Field.Error
-							className="error"
-							match
-							role={fields.framework.errors?.length ? 'alert' : undefined}
-						>
+						<Field.Error className="error" match>
 							{fields.framework.errors?.join(', ')}
 						</Field.Error>
 					</Field.Root>
@@ -324,11 +288,7 @@ export default function App() {
 						<Field.Description className="description">
 							BaseControl stores the raw value before Zod coercion.
 						</Field.Description>
-						<Field.Error
-							className="error"
-							match
-							role={fields.quantity.errors?.length ? 'alert' : undefined}
-						>
+						<Field.Error className="error" match>
 							{fields.quantity.errors?.join(', ')}
 						</Field.Error>
 					</Field.Root>
@@ -344,11 +304,7 @@ export default function App() {
 						<Field.Description className="description">
 							The range input is controlled through useControl.
 						</Field.Description>
-						<Field.Error
-							className="error"
-							match
-							role={fields.budget.errors?.length ? 'alert' : undefined}
-						>
+						<Field.Error className="error" match>
 							{fields.budget.errors?.join(', ')}
 						</Field.Error>
 					</Field.Root>
@@ -366,11 +322,7 @@ export default function App() {
 						<Field.Description className="description">
 							A checkbox BaseControl submits “on” while enabled.
 						</Field.Description>
-						<Field.Error
-							className="error"
-							match
-							role={fields.notifications.errors?.length ? 'alert' : undefined}
-						>
+						<Field.Error className="error" match>
 							{fields.notifications.errors?.join(', ')}
 						</Field.Error>
 					</Field.Root>

--- a/examples/base-ui/src/App.tsx
+++ b/examples/base-ui/src/App.tsx
@@ -131,7 +131,7 @@ export default function App() {
 
 				<div className="field-list">
 					<Field.Root className="field" invalid={!fields.fullName.valid}>
-						<Field.Label id={`${fields.fullName.id}-label`} className="label">
+						<Field.Label id={fields.fullName.labelId} className="label">
 							Full name
 						</Field.Label>
 						<Input
@@ -141,12 +141,12 @@ export default function App() {
 							// id={fields.fullName.id}
 							// name={fields.fullName.name}
 							// defaultValue={fields.fullName.defaultValue}
-							// aria-labelledby={`${fields.fullName.id}-label`}
-							// aria-describedby={`${fields.fullName.id}-description ${fields.fullName.ariaDescribedBy ?? ''}`.trim()}
+							// aria-labelledby={fields.fullName.labelId}
+							// aria-describedby={`${fields.fullName.descriptionId} ${fields.fullName.ariaDescribedBy ?? ''}`.trim()}
 							// aria-invalid={fields.fullName.ariaInvalid}
 						/>
 						<Field.Description
-							id={`${fields.fullName.id}-description`}
+							id={fields.fullName.descriptionId}
 							className="description"
 						>
 							A native Base UI Input.
@@ -162,7 +162,7 @@ export default function App() {
 					</Field.Root>
 
 					<Field.Root className="field" invalid={!fields.bio.valid}>
-						<Field.Label id={`${fields.bio.id}-label`} className="label">
+						<Field.Label id={fields.bio.labelId} className="label">
 							Bio
 						</Field.Label>
 						<Field.Control
@@ -173,12 +173,12 @@ export default function App() {
 							// id={fields.bio.id}
 							// name={fields.bio.name}
 							// defaultValue={fields.bio.defaultValue}
-							// aria-labelledby={`${fields.bio.id}-label`}
-							// aria-describedby={`${fields.bio.id}-description ${fields.bio.ariaDescribedBy ?? ''}`.trim()}
+							// aria-labelledby={fields.bio.labelId}
+							// aria-describedby={`${fields.bio.descriptionId} ${fields.bio.ariaDescribedBy ?? ''}`.trim()}
 							// aria-invalid={fields.bio.ariaInvalid}
 						/>
 						<Field.Description
-							id={`${fields.bio.id}-description`}
+							id={fields.bio.descriptionId}
 							className="description"
 						>
 							Field.Control renders a native textarea.
@@ -195,7 +195,7 @@ export default function App() {
 
 					<Field.Root className="field" invalid={!fields.acceptTerms.valid}>
 						<Field.Label
-							id={`${fields.acceptTerms.id}-label`}
+							id={fields.acceptTerms.labelId}
 							className="choice-label"
 						>
 							<CheckboxControl
@@ -204,14 +204,14 @@ export default function App() {
 								// id={fields.acceptTerms.id}
 								// name={fields.acceptTerms.name}
 								// defaultChecked={fields.acceptTerms.defaultChecked}
-								// aria-labelledby={`${fields.acceptTerms.id}-label`}
-								// aria-describedby={`${fields.acceptTerms.id}-description ${fields.acceptTerms.ariaDescribedBy ?? ''}`.trim()}
+								// aria-labelledby={fields.acceptTerms.labelId}
+								// aria-describedby={`${fields.acceptTerms.descriptionId} ${fields.acceptTerms.ariaDescribedBy ?? ''}`.trim()}
 								// invalid={!fields.acceptTerms.valid}
 							/>
 							Accept terms
 						</Field.Label>
 						<Field.Description
-							id={`${fields.acceptTerms.id}-description`}
+							id={fields.acceptTerms.descriptionId}
 							className="description"
 						>
 							The visible checkbox is synchronized with a BaseControl.
@@ -227,7 +227,7 @@ export default function App() {
 					</Field.Root>
 
 					<Field.Root className="field" invalid={!fields.interests.valid}>
-						<Field.Label id={`${fields.interests.id}-label`} className="label">
+						<Field.Label id={fields.interests.labelId} className="label">
 							Interests
 						</Field.Label>
 						<CheckboxGroupControl
@@ -236,8 +236,8 @@ export default function App() {
 							// id={fields.interests.id}
 							// name={fields.interests.name}
 							// defaultValue={fields.interests.defaultOptions}
-							// aria-labelledby={`${fields.interests.id}-label`}
-							// aria-describedby={`${fields.interests.id}-description ${fields.interests.ariaDescribedBy ?? ''}`.trim()}
+							// aria-labelledby={fields.interests.labelId}
+							// aria-describedby={`${fields.interests.descriptionId} ${fields.interests.ariaDescribedBy ?? ''}`.trim()}
 							// invalid={!fields.interests.valid}
 						>
 							{interestOptions.map((item) => (
@@ -258,7 +258,7 @@ export default function App() {
 							))}
 						</CheckboxGroupControl>
 						<Field.Description
-							id={`${fields.interests.id}-description`}
+							id={fields.interests.descriptionId}
 							className="description"
 						>
 							A multiple BaseControl serializes the selected values.
@@ -274,7 +274,7 @@ export default function App() {
 					</Field.Root>
 
 					<Field.Root className="field" invalid={!fields.plan.valid}>
-						<Field.Label id={`${fields.plan.id}-label`} className="label">
+						<Field.Label id={fields.plan.labelId} className="label">
 							Plan
 						</Field.Label>
 						<RadioGroupControl
@@ -283,8 +283,8 @@ export default function App() {
 							// id={fields.plan.id}
 							// name={fields.plan.name}
 							// defaultValue={fields.plan.defaultValue}
-							// aria-labelledby={`${fields.plan.id}-label`}
-							// aria-describedby={`${fields.plan.id}-description ${fields.plan.ariaDescribedBy ?? ''}`.trim()}
+							// aria-labelledby={fields.plan.labelId}
+							// aria-describedby={`${fields.plan.descriptionId} ${fields.plan.ariaDescribedBy ?? ''}`.trim()}
 							// invalid={!fields.plan.valid}
 						>
 							{planOptions.map((item) => (
@@ -303,7 +303,7 @@ export default function App() {
 							))}
 						</RadioGroupControl>
 						<Field.Description
-							id={`${fields.plan.id}-description`}
+							id={fields.plan.descriptionId}
 							className="description"
 						>
 							The BaseControl serializes one scalar value.
@@ -319,7 +319,7 @@ export default function App() {
 					</Field.Root>
 
 					<Field.Root className="field" invalid={!fields.country.valid}>
-						<Field.Label id={`${fields.country.id}-label`} className="label">
+						<Field.Label id={fields.country.labelId} className="label">
 							Country
 						</Field.Label>
 						<SelectControl
@@ -330,12 +330,12 @@ export default function App() {
 							// id={fields.country.id}
 							// name={fields.country.name}
 							// defaultValue={fields.country.defaultValue}
-							// aria-labelledby={`${fields.country.id}-label`}
-							// aria-describedby={`${fields.country.id}-description ${fields.country.ariaDescribedBy ?? ''}`.trim()}
+							// aria-labelledby={fields.country.labelId}
+							// aria-describedby={`${fields.country.descriptionId} ${fields.country.ariaDescribedBy ?? ''}`.trim()}
 							// invalid={!fields.country.valid}
 						/>
 						<Field.Description
-							id={`${fields.country.id}-description`}
+							id={fields.country.descriptionId}
 							className="description"
 						>
 							Select is synchronized with a scalar BaseControl.
@@ -351,7 +351,7 @@ export default function App() {
 					</Field.Root>
 
 					<Field.Root className="field" invalid={!fields.framework.valid}>
-						<Field.Label id={`${fields.framework.id}-label`} className="label">
+						<Field.Label id={fields.framework.labelId} className="label">
 							Framework
 						</Field.Label>
 						<ComboboxControl
@@ -363,12 +363,12 @@ export default function App() {
 							// id={fields.framework.id}
 							// name={fields.framework.name}
 							// defaultValue={fields.framework.defaultValue}
-							// aria-labelledby={`${fields.framework.id}-label`}
-							// aria-describedby={`${fields.framework.id}-description ${fields.framework.ariaDescribedBy ?? ''}`.trim()}
+							// aria-labelledby={fields.framework.labelId}
+							// aria-describedby={`${fields.framework.descriptionId} ${fields.framework.ariaDescribedBy ?? ''}`.trim()}
 							// invalid={!fields.framework.valid}
 						/>
 						<Field.Description
-							id={`${fields.framework.id}-description`}
+							id={fields.framework.descriptionId}
 							className="description"
 						>
 							Filtering is transient; BaseControl stores the selection.
@@ -384,7 +384,7 @@ export default function App() {
 					</Field.Root>
 
 					<Field.Root className="field" invalid={!fields.quantity.valid}>
-						<Field.Label id={`${fields.quantity.id}-label`} className="label">
+						<Field.Label id={fields.quantity.labelId} className="label">
 							Quantity
 						</Field.Label>
 						<NumberFieldControl
@@ -394,12 +394,12 @@ export default function App() {
 							// id={fields.quantity.id}
 							// name={fields.quantity.name}
 							// defaultValue={fields.quantity.defaultValue}
-							// aria-labelledby={`${fields.quantity.id}-label`}
-							// aria-describedby={`${fields.quantity.id}-description ${fields.quantity.ariaDescribedBy ?? ''}`.trim()}
+							// aria-labelledby={fields.quantity.labelId}
+							// aria-describedby={`${fields.quantity.descriptionId} ${fields.quantity.ariaDescribedBy ?? ''}`.trim()}
 							// invalid={!fields.quantity.valid}
 						/>
 						<Field.Description
-							id={`${fields.quantity.id}-description`}
+							id={fields.quantity.descriptionId}
 							className="description"
 						>
 							BaseControl stores the raw value before Zod coercion.
@@ -415,7 +415,7 @@ export default function App() {
 					</Field.Root>
 
 					<Field.Root className="field" invalid={!fields.budget.valid}>
-						<Field.Label id={`${fields.budget.id}-label`} className="label">
+						<Field.Label id={fields.budget.labelId} className="label">
 							Budget
 						</Field.Label>
 						<SliderControl
@@ -424,12 +424,12 @@ export default function App() {
 							// id={fields.budget.id}
 							// name={fields.budget.name}
 							// defaultValue={fields.budget.defaultValue}
-							// aria-labelledby={`${fields.budget.id}-label`}
-							// aria-describedby={`${fields.budget.id}-description ${fields.budget.ariaDescribedBy ?? ''}`.trim()}
+							// aria-labelledby={fields.budget.labelId}
+							// aria-describedby={`${fields.budget.descriptionId} ${fields.budget.ariaDescribedBy ?? ''}`.trim()}
 							// invalid={!fields.budget.valid}
 						/>
 						<Field.Description
-							id={`${fields.budget.id}-description`}
+							id={fields.budget.descriptionId}
 							className="description"
 						>
 							The range input is controlled through useControl.
@@ -446,10 +446,7 @@ export default function App() {
 
 					<Field.Root className="field" invalid={!fields.notifications.valid}>
 						<div className="switch-row">
-							<Field.Label
-								id={`${fields.notifications.id}-label`}
-								className="label"
-							>
+							<Field.Label id={fields.notifications.labelId} className="label">
 								Product notifications
 							</Field.Label>
 							<SwitchControl
@@ -458,13 +455,13 @@ export default function App() {
 								// id={fields.notifications.id}
 								// name={fields.notifications.name}
 								// defaultChecked={fields.notifications.defaultChecked}
-								// aria-labelledby={`${fields.notifications.id}-label`}
-								// aria-describedby={`${fields.notifications.id}-description ${fields.notifications.ariaDescribedBy ?? ''}`.trim()}
+								// aria-labelledby={fields.notifications.labelId}
+								// aria-describedby={`${fields.notifications.descriptionId} ${fields.notifications.ariaDescribedBy ?? ''}`.trim()}
 								// invalid={!fields.notifications.valid}
 							/>
 						</div>
 						<Field.Description
-							id={`${fields.notifications.id}-description`}
+							id={fields.notifications.descriptionId}
 							className="description"
 						>
 							A checkbox BaseControl submits “on” while enabled.

--- a/examples/base-ui/src/App.tsx
+++ b/examples/base-ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { coerceFormValue } from '@conform-to/zod/v4/future';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { z } from 'zod';
 import {
 	CheckboxField,
@@ -23,9 +23,9 @@ const schema = coerceFormValue(
 		bio: z
 			.string({ error: 'Enter at least 10 characters' })
 			.min(10, 'Enter at least 10 characters'),
-		acceptTerms: z
-			.boolean()
-			.refine((value) => value, 'Accept the terms to continue'),
+		acceptTerms: z.literal(true, {
+			error: 'Accept the terms to continue',
+		}),
 		interests: z
 			.enum(['design', 'engineering', 'research'])
 			.array()
@@ -39,13 +39,15 @@ const schema = coerceFormValue(
 		}),
 		quantity: z
 			.number()
-			.min(1, 'Use at least 1')
+			.min(2, 'Use at least 2')
 			.max(10, 'Use no more than 10'),
 		budget: z
 			.number()
-			.min(0, 'Budget cannot be negative')
+			.min(10, 'Use a budget of at least 10')
 			.max(100, 'Budget cannot exceed 100'),
-		notifications: z.boolean(),
+		notifications: z.literal(true, {
+			error: 'Enable product notifications',
+		}),
 	}),
 );
 
@@ -74,8 +76,6 @@ const frameworkOptions = [
 ];
 
 export default function App() {
-	const formRef = useRef<HTMLFormElement>(null);
-	const [resetKey, setResetKey] = useState(0);
 	const [submittedValue, setSubmittedValue] = useState<z.output<
 		typeof schema
 	> | null>(null);
@@ -110,25 +110,10 @@ export default function App() {
 			setSubmittedValue(value);
 		},
 	});
-	const remountFields = useCallback(() => {
-		setResetKey((key) => key + 1);
-	}, []);
-
-	useEffect(() => {
-		const formElement = formRef.current;
-		if (!formElement) {
-			return;
-		}
-
-		formElement.addEventListener('reset', remountFields);
-		return () => formElement.removeEventListener('reset', remountFields);
-	}, [remountFields]);
-
 	return (
 		<main>
 			<form
 				{...form.props}
-				ref={formRef}
 				className="form-card"
 				onChange={() => setSubmittedValue(null)}
 			>
@@ -141,7 +126,7 @@ export default function App() {
 					</p>
 				</header>
 
-				<div className="field-list" key={`${searchParams}:${resetKey}`}>
+				<div className="field-list">
 					<TextInputField
 						label="Full name"
 						description="A native Base UI Input."
@@ -168,7 +153,7 @@ export default function App() {
 
 					<CheckboxField
 						label="Accept terms"
-						description="The Base UI checkbox owns a hidden native checkbox."
+						description="The visible checkbox is synchronized with a BaseControl."
 						{...fields.acceptTerms.checkboxProps}
 						// Equivalent to:
 						// id={fields.acceptTerms.id}
@@ -180,7 +165,7 @@ export default function App() {
 
 					<CheckboxGroupField
 						label="Interests"
-						description="Each checked item contributes the same name to FormData."
+						description="A multiple BaseControl serializes the selected values."
 						items={interestOptions}
 						{...fields.interests.checkboxGroupProps}
 						// Equivalent to:
@@ -193,7 +178,7 @@ export default function App() {
 
 					<RadioGroupField
 						label="Plan"
-						description="The group serializes one scalar value."
+						description="The BaseControl serializes one scalar value."
 						items={planOptions}
 						{...fields.plan.radioGroupProps}
 						// Equivalent to:
@@ -206,7 +191,7 @@ export default function App() {
 
 					<SelectField
 						label="Country"
-						description="Select maintains a form-compatible hidden input."
+						description="Select is synchronized with a scalar BaseControl."
 						placeholder="Choose a country"
 						items={countryOptions}
 						{...fields.country.selectProps}
@@ -220,7 +205,7 @@ export default function App() {
 
 					<ComboboxField
 						label="Framework"
-						description="Filtering is transient; the selected value is submitted."
+						description="Filtering is transient; BaseControl stores the selection."
 						placeholder="Search frameworks"
 						items={frameworkOptions}
 						{...fields.framework.comboboxProps}
@@ -234,7 +219,7 @@ export default function App() {
 
 					<NumberFieldControl
 						label="Quantity"
-						description="Use the buttons or arrow keys; Zod receives a coerced number."
+						description="BaseControl stores the raw value before Zod coercion."
 						{...fields.quantity.numberFieldProps}
 						// Equivalent to:
 						// id={fields.quantity.id}
@@ -246,7 +231,7 @@ export default function App() {
 
 					<SliderField
 						label="Budget"
-						description="A controlled Base UI slider synchronized through useControl."
+						description="The range input is controlled through useControl."
 						{...fields.budget.sliderProps}
 						// Equivalent to:
 						// id={fields.budget.id}
@@ -258,7 +243,7 @@ export default function App() {
 
 					<SwitchField
 						label="Product notifications"
-						description="The hidden checkbox submits “on” only while enabled."
+						description="A checkbox BaseControl submits “on” while enabled."
 						{...fields.notifications.switchProps}
 						// Equivalent to:
 						// id={fields.notifications.id}

--- a/examples/base-ui/src/App.tsx
+++ b/examples/base-ui/src/App.tsx
@@ -1,0 +1,294 @@
+import { coerceFormValue } from '@conform-to/zod/v4/future';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { z } from 'zod';
+import {
+	CheckboxField,
+	CheckboxGroupField,
+	ComboboxField,
+	NumberFieldControl,
+	RadioGroupField,
+	SelectField,
+	SliderField,
+	SwitchField,
+	TextareaField,
+	TextInputField,
+} from './components';
+import { useForm } from './forms';
+
+const schema = coerceFormValue(
+	z.object({
+		fullName: z
+			.string({ error: 'Enter at least 2 characters' })
+			.min(2, 'Enter at least 2 characters'),
+		bio: z
+			.string({ error: 'Enter at least 10 characters' })
+			.min(10, 'Enter at least 10 characters'),
+		acceptTerms: z
+			.boolean()
+			.refine((value) => value, 'Accept the terms to continue'),
+		interests: z
+			.enum(['design', 'engineering', 'research'])
+			.array()
+			.min(1, 'Choose at least one interest'),
+		plan: z.enum(['starter', 'professional', 'enterprise'], {
+			error: 'Choose a plan',
+		}),
+		country: z.enum(['gb', 'ca', 'jp'], { error: 'Choose a country' }),
+		framework: z.enum(['react', 'vue', 'svelte'], {
+			error: 'Choose a framework',
+		}),
+		quantity: z
+			.number()
+			.min(1, 'Use at least 1')
+			.max(10, 'Use no more than 10'),
+		budget: z
+			.number()
+			.min(0, 'Budget cannot be negative')
+			.max(100, 'Budget cannot exceed 100'),
+		notifications: z.boolean(),
+	}),
+);
+
+const interestOptions = [
+	{ value: 'design', label: 'Design' },
+	{ value: 'engineering', label: 'Engineering' },
+	{ value: 'research', label: 'Research' },
+];
+
+const planOptions = [
+	{ value: 'starter', label: 'Starter' },
+	{ value: 'professional', label: 'Professional' },
+	{ value: 'enterprise', label: 'Enterprise' },
+];
+
+const countryOptions = [
+	{ value: 'gb', label: 'United Kingdom' },
+	{ value: 'ca', label: 'Canada' },
+	{ value: 'jp', label: 'Japan' },
+];
+
+const frameworkOptions = [
+	{ value: 'react', label: 'React' },
+	{ value: 'vue', label: 'Vue' },
+	{ value: 'svelte', label: 'Svelte' },
+];
+
+export default function App() {
+	const formRef = useRef<HTMLFormElement>(null);
+	const [resetKey, setResetKey] = useState(0);
+	const [submittedValue, setSubmittedValue] = useState<z.output<
+		typeof schema
+	> | null>(null);
+	const [searchParams, setSearchParams] = useState(() => {
+		const searchParams = new URLSearchParams(window.location.search);
+
+		if (!searchParams.has('quantity')) {
+			searchParams.set('quantity', '1');
+		}
+
+		if (!searchParams.has('budget')) {
+			searchParams.set('budget', '50');
+		}
+
+		return searchParams;
+	});
+	const { form, fields, intent } = useForm(schema, {
+		defaultValue: searchParams,
+		onSubmit(event, { formData, value }) {
+			event.preventDefault();
+
+			const url = new URL(document.URL);
+			const searchParams = new URLSearchParams();
+			formData.forEach((entry, name) => {
+				if (typeof entry === 'string') {
+					searchParams.append(name, entry);
+				}
+			});
+			url.search = searchParams.toString();
+			window.history.pushState(null, '', url);
+			setSearchParams(searchParams);
+			setSubmittedValue(value);
+		},
+	});
+	const remountFields = useCallback(() => {
+		setResetKey((key) => key + 1);
+	}, []);
+
+	useEffect(() => {
+		const formElement = formRef.current;
+		if (!formElement) {
+			return;
+		}
+
+		formElement.addEventListener('reset', remountFields);
+		return () => formElement.removeEventListener('reset', remountFields);
+	}, [remountFields]);
+
+	return (
+		<main>
+			<form
+				{...form.props}
+				ref={formRef}
+				className="form-card"
+				onChange={() => setSubmittedValue(null)}
+			>
+				<header>
+					<p className="eyebrow">Conform × Base UI</p>
+					<h1>Base UI Example</h1>
+					<p className="intro">
+						Direct Base UI primitives with Conform owning validation and form
+						state.
+					</p>
+				</header>
+
+				<div className="field-list" key={`${searchParams}:${resetKey}`}>
+					<TextInputField
+						label="Full name"
+						description="A native Base UI Input."
+						{...fields.fullName.textInputProps}
+						// Equivalent to:
+						// id={fields.fullName.id}
+						// name={fields.fullName.name}
+						// defaultValue={fields.fullName.defaultValue}
+						// invalid={!fields.fullName.valid}
+						// errors={fields.fullName.errors}
+					/>
+
+					<TextareaField
+						label="Bio"
+						description="Field.Control renders a native textarea."
+						{...fields.bio.textareaProps}
+						// Equivalent to:
+						// id={fields.bio.id}
+						// name={fields.bio.name}
+						// defaultValue={fields.bio.defaultValue}
+						// invalid={!fields.bio.valid}
+						// errors={fields.bio.errors}
+					/>
+
+					<CheckboxField
+						label="Accept terms"
+						description="The Base UI checkbox owns a hidden native checkbox."
+						{...fields.acceptTerms.checkboxProps}
+						// Equivalent to:
+						// id={fields.acceptTerms.id}
+						// name={fields.acceptTerms.name}
+						// defaultChecked={fields.acceptTerms.defaultChecked}
+						// invalid={!fields.acceptTerms.valid}
+						// errors={fields.acceptTerms.errors}
+					/>
+
+					<CheckboxGroupField
+						label="Interests"
+						description="Each checked item contributes the same name to FormData."
+						items={interestOptions}
+						{...fields.interests.checkboxGroupProps}
+						// Equivalent to:
+						// id={fields.interests.id}
+						// name={fields.interests.name}
+						// defaultValue={fields.interests.defaultOptions}
+						// invalid={!fields.interests.valid}
+						// errors={fields.interests.errors}
+					/>
+
+					<RadioGroupField
+						label="Plan"
+						description="The group serializes one scalar value."
+						items={planOptions}
+						{...fields.plan.radioGroupProps}
+						// Equivalent to:
+						// id={fields.plan.id}
+						// name={fields.plan.name}
+						// defaultValue={fields.plan.defaultValue}
+						// invalid={!fields.plan.valid}
+						// errors={fields.plan.errors}
+					/>
+
+					<SelectField
+						label="Country"
+						description="Select maintains a form-compatible hidden input."
+						placeholder="Choose a country"
+						items={countryOptions}
+						{...fields.country.selectProps}
+						// Equivalent to:
+						// id={fields.country.id}
+						// name={fields.country.name}
+						// defaultValue={fields.country.defaultValue}
+						// invalid={!fields.country.valid}
+						// errors={fields.country.errors}
+					/>
+
+					<ComboboxField
+						label="Framework"
+						description="Filtering is transient; the selected value is submitted."
+						placeholder="Search frameworks"
+						items={frameworkOptions}
+						{...fields.framework.comboboxProps}
+						// Equivalent to:
+						// id={fields.framework.id}
+						// name={fields.framework.name}
+						// defaultValue={fields.framework.defaultValue}
+						// invalid={!fields.framework.valid}
+						// errors={fields.framework.errors}
+					/>
+
+					<NumberFieldControl
+						label="Quantity"
+						description="Use the buttons or arrow keys; Zod receives a coerced number."
+						{...fields.quantity.numberFieldProps}
+						// Equivalent to:
+						// id={fields.quantity.id}
+						// name={fields.quantity.name}
+						// defaultValue={fields.quantity.defaultValue}
+						// invalid={!fields.quantity.valid}
+						// errors={fields.quantity.errors}
+					/>
+
+					<SliderField
+						label="Budget"
+						description="A controlled Base UI slider synchronized through useControl."
+						{...fields.budget.sliderProps}
+						// Equivalent to:
+						// id={fields.budget.id}
+						// name={fields.budget.name}
+						// defaultValue={fields.budget.defaultValue}
+						// invalid={!fields.budget.valid}
+						// errors={fields.budget.errors}
+					/>
+
+					<SwitchField
+						label="Product notifications"
+						description="The hidden checkbox submits “on” only while enabled."
+						{...fields.notifications.switchProps}
+						// Equivalent to:
+						// id={fields.notifications.id}
+						// name={fields.notifications.name}
+						// defaultChecked={fields.notifications.defaultChecked}
+						// invalid={!fields.notifications.valid}
+						// errors={fields.notifications.errors}
+					/>
+				</div>
+
+				{submittedValue ? (
+					<section className="submitted" aria-live="polite">
+						<h2>Parsed submission</h2>
+						<pre>{JSON.stringify(submittedValue, null, 2)}</pre>
+					</section>
+				) : null}
+
+				<footer>
+					<button
+						className="button secondary"
+						type="button"
+						onClick={() => intent.reset()}
+					>
+						Reset
+					</button>
+					<button className="button primary" type="submit">
+						Submit
+					</button>
+				</footer>
+			</form>
+		</main>
+	);
+}

--- a/examples/base-ui/src/App.tsx
+++ b/examples/base-ui/src/App.tsx
@@ -135,6 +135,7 @@ export default function App() {
 						// id={fields.fullName.id}
 						// name={fields.fullName.name}
 						// defaultValue={fields.fullName.defaultValue}
+						// aria-describedby={`${fields.fullName.id}-description ${fields.fullName.ariaDescribedBy ?? ''}`.trim()}
 						// invalid={!fields.fullName.valid}
 						// errors={fields.fullName.errors}
 					/>
@@ -147,6 +148,7 @@ export default function App() {
 						// id={fields.bio.id}
 						// name={fields.bio.name}
 						// defaultValue={fields.bio.defaultValue}
+						// aria-describedby={`${fields.bio.id}-description ${fields.bio.ariaDescribedBy ?? ''}`.trim()}
 						// invalid={!fields.bio.valid}
 						// errors={fields.bio.errors}
 					/>
@@ -159,6 +161,7 @@ export default function App() {
 						// id={fields.acceptTerms.id}
 						// name={fields.acceptTerms.name}
 						// defaultChecked={fields.acceptTerms.defaultChecked}
+						// aria-describedby={`${fields.acceptTerms.id}-description ${fields.acceptTerms.ariaDescribedBy ?? ''}`.trim()}
 						// invalid={!fields.acceptTerms.valid}
 						// errors={fields.acceptTerms.errors}
 					/>
@@ -172,6 +175,7 @@ export default function App() {
 						// id={fields.interests.id}
 						// name={fields.interests.name}
 						// defaultValue={fields.interests.defaultOptions}
+						// aria-describedby={`${fields.interests.id}-description ${fields.interests.ariaDescribedBy ?? ''}`.trim()}
 						// invalid={!fields.interests.valid}
 						// errors={fields.interests.errors}
 					/>
@@ -185,6 +189,7 @@ export default function App() {
 						// id={fields.plan.id}
 						// name={fields.plan.name}
 						// defaultValue={fields.plan.defaultValue}
+						// aria-describedby={`${fields.plan.id}-description ${fields.plan.ariaDescribedBy ?? ''}`.trim()}
 						// invalid={!fields.plan.valid}
 						// errors={fields.plan.errors}
 					/>
@@ -199,6 +204,7 @@ export default function App() {
 						// id={fields.country.id}
 						// name={fields.country.name}
 						// defaultValue={fields.country.defaultValue}
+						// aria-describedby={`${fields.country.id}-description ${fields.country.ariaDescribedBy ?? ''}`.trim()}
 						// invalid={!fields.country.valid}
 						// errors={fields.country.errors}
 					/>
@@ -213,6 +219,7 @@ export default function App() {
 						// id={fields.framework.id}
 						// name={fields.framework.name}
 						// defaultValue={fields.framework.defaultValue}
+						// aria-describedby={`${fields.framework.id}-description ${fields.framework.ariaDescribedBy ?? ''}`.trim()}
 						// invalid={!fields.framework.valid}
 						// errors={fields.framework.errors}
 					/>
@@ -225,6 +232,7 @@ export default function App() {
 						// id={fields.quantity.id}
 						// name={fields.quantity.name}
 						// defaultValue={fields.quantity.defaultValue}
+						// aria-describedby={`${fields.quantity.id}-description ${fields.quantity.ariaDescribedBy ?? ''}`.trim()}
 						// invalid={!fields.quantity.valid}
 						// errors={fields.quantity.errors}
 					/>
@@ -237,6 +245,7 @@ export default function App() {
 						// id={fields.budget.id}
 						// name={fields.budget.name}
 						// defaultValue={fields.budget.defaultValue}
+						// aria-describedby={`${fields.budget.id}-description ${fields.budget.ariaDescribedBy ?? ''}`.trim()}
 						// invalid={!fields.budget.valid}
 						// errors={fields.budget.errors}
 					/>
@@ -249,6 +258,7 @@ export default function App() {
 						// id={fields.notifications.id}
 						// name={fields.notifications.name}
 						// defaultChecked={fields.notifications.defaultChecked}
+						// aria-describedby={`${fields.notifications.id}-description ${fields.notifications.ariaDescribedBy ?? ''}`.trim()}
 						// invalid={!fields.notifications.valid}
 						// errors={fields.notifications.errors}
 					/>

--- a/examples/base-ui/src/App.tsx
+++ b/examples/base-ui/src/App.tsx
@@ -131,28 +131,18 @@ export default function App() {
 
 				<div className="field-list">
 					<Field.Root className="field" invalid={!fields.fullName.valid}>
-						<Field.Label id={fields.fullName.labelId} className="label">
-							Full name
-						</Field.Label>
+						<Field.Label className="label">Full name</Field.Label>
 						<Input
 							className="text-control"
 							{...fields.fullName.inputProps}
 							// Equivalent to:
-							// id={fields.fullName.id}
 							// name={fields.fullName.name}
 							// defaultValue={fields.fullName.defaultValue}
-							// aria-labelledby={fields.fullName.labelId}
-							// aria-describedby={`${fields.fullName.descriptionId} ${fields.fullName.ariaDescribedBy ?? ''}`.trim()}
-							// aria-invalid={fields.fullName.ariaInvalid}
 						/>
-						<Field.Description
-							id={fields.fullName.descriptionId}
-							className="description"
-						>
+						<Field.Description className="description">
 							A native Base UI Input.
 						</Field.Description>
 						<Field.Error
-							id={fields.fullName.errorId}
 							className="error"
 							match
 							role={fields.fullName.errors?.length ? 'alert' : undefined}
@@ -162,29 +152,19 @@ export default function App() {
 					</Field.Root>
 
 					<Field.Root className="field" invalid={!fields.bio.valid}>
-						<Field.Label id={fields.bio.labelId} className="label">
-							Bio
-						</Field.Label>
+						<Field.Label className="label">Bio</Field.Label>
 						<Field.Control
 							render={<textarea rows={4} />}
 							className="text-control"
 							{...fields.bio.textareaProps}
 							// Equivalent to:
-							// id={fields.bio.id}
 							// name={fields.bio.name}
 							// defaultValue={fields.bio.defaultValue}
-							// aria-labelledby={fields.bio.labelId}
-							// aria-describedby={`${fields.bio.descriptionId} ${fields.bio.ariaDescribedBy ?? ''}`.trim()}
-							// aria-invalid={fields.bio.ariaInvalid}
 						/>
-						<Field.Description
-							id={fields.bio.descriptionId}
-							className="description"
-						>
+						<Field.Description className="description">
 							Field.Control renders a native textarea.
 						</Field.Description>
 						<Field.Error
-							id={fields.bio.errorId}
 							className="error"
 							match
 							role={fields.bio.errors?.length ? 'alert' : undefined}
@@ -194,30 +174,19 @@ export default function App() {
 					</Field.Root>
 
 					<Field.Root className="field" invalid={!fields.acceptTerms.valid}>
-						<Field.Label
-							id={fields.acceptTerms.labelId}
-							className="choice-label"
-						>
+						<Field.Label className="choice-label">
 							<CheckboxControl
 								{...fields.acceptTerms.checkboxProps}
 								// Equivalent to:
-								// id={fields.acceptTerms.id}
 								// name={fields.acceptTerms.name}
 								// defaultChecked={fields.acceptTerms.defaultChecked}
-								// aria-labelledby={fields.acceptTerms.labelId}
-								// aria-describedby={`${fields.acceptTerms.descriptionId} ${fields.acceptTerms.ariaDescribedBy ?? ''}`.trim()}
-								// invalid={!fields.acceptTerms.valid}
 							/>
 							Accept terms
 						</Field.Label>
-						<Field.Description
-							id={fields.acceptTerms.descriptionId}
-							className="description"
-						>
+						<Field.Description className="description">
 							The visible checkbox is synchronized with a BaseControl.
 						</Field.Description>
 						<Field.Error
-							id={fields.acceptTerms.errorId}
 							className="error"
 							match
 							role={fields.acceptTerms.errors?.length ? 'alert' : undefined}
@@ -227,44 +196,34 @@ export default function App() {
 					</Field.Root>
 
 					<Field.Root className="field" invalid={!fields.interests.valid}>
-						<Field.Label id={fields.interests.labelId} className="label">
+						<Field.Label
+							className="label"
+							nativeLabel={false}
+							render={<span />}
+						>
 							Interests
 						</Field.Label>
 						<CheckboxGroupControl
 							{...fields.interests.checkboxGroupProps}
 							// Equivalent to:
-							// id={fields.interests.id}
 							// name={fields.interests.name}
 							// defaultValue={fields.interests.defaultOptions}
-							// aria-labelledby={fields.interests.labelId}
-							// aria-describedby={`${fields.interests.descriptionId} ${fields.interests.ariaDescribedBy ?? ''}`.trim()}
-							// invalid={!fields.interests.valid}
 						>
 							{interestOptions.map((item) => (
-								<label className="choice-label" key={item.value}>
-									<Checkbox.Root
-										className="checkbox"
-										value={item.value}
-										aria-labelledby={`${fields.interests.id}-${item.value}-label`}
-									>
+								<Field.Item className="choice-label" key={item.value}>
+									<Checkbox.Root className="checkbox" value={item.value}>
 										<Checkbox.Indicator className="checkbox-indicator">
 											✓
 										</Checkbox.Indicator>
 									</Checkbox.Root>
-									<span id={`${fields.interests.id}-${item.value}-label`}>
-										{item.label}
-									</span>
-								</label>
+									<Field.Label>{item.label}</Field.Label>
+								</Field.Item>
 							))}
 						</CheckboxGroupControl>
-						<Field.Description
-							id={fields.interests.descriptionId}
-							className="description"
-						>
+						<Field.Description className="description">
 							A multiple BaseControl serializes the selected values.
 						</Field.Description>
 						<Field.Error
-							id={fields.interests.errorId}
 							className="error"
 							match
 							role={fields.interests.errors?.length ? 'alert' : undefined}
@@ -274,42 +233,32 @@ export default function App() {
 					</Field.Root>
 
 					<Field.Root className="field" invalid={!fields.plan.valid}>
-						<Field.Label id={fields.plan.labelId} className="label">
+						<Field.Label
+							className="label"
+							nativeLabel={false}
+							render={<span />}
+						>
 							Plan
 						</Field.Label>
 						<RadioGroupControl
 							{...fields.plan.radioGroupProps}
 							// Equivalent to:
-							// id={fields.plan.id}
 							// name={fields.plan.name}
 							// defaultValue={fields.plan.defaultValue}
-							// aria-labelledby={fields.plan.labelId}
-							// aria-describedby={`${fields.plan.descriptionId} ${fields.plan.ariaDescribedBy ?? ''}`.trim()}
-							// invalid={!fields.plan.valid}
 						>
 							{planOptions.map((item) => (
-								<label className="choice-label" key={item.value}>
-									<Radio.Root
-										className="radio"
-										value={item.value}
-										aria-labelledby={`${fields.plan.id}-${item.value}-label`}
-									>
+								<Field.Item className="choice-label" key={item.value}>
+									<Radio.Root className="radio" value={item.value}>
 										<Radio.Indicator className="radio-indicator" />
 									</Radio.Root>
-									<span id={`${fields.plan.id}-${item.value}-label`}>
-										{item.label}
-									</span>
-								</label>
+									<Field.Label>{item.label}</Field.Label>
+								</Field.Item>
 							))}
 						</RadioGroupControl>
-						<Field.Description
-							id={fields.plan.descriptionId}
-							className="description"
-						>
+						<Field.Description className="description">
 							The BaseControl serializes one scalar value.
 						</Field.Description>
 						<Field.Error
-							id={fields.plan.errorId}
 							className="error"
 							match
 							role={fields.plan.errors?.length ? 'alert' : undefined}
@@ -319,29 +268,19 @@ export default function App() {
 					</Field.Root>
 
 					<Field.Root className="field" invalid={!fields.country.valid}>
-						<Field.Label id={fields.country.labelId} className="label">
-							Country
-						</Field.Label>
+						<Field.Label className="label">Country</Field.Label>
 						<SelectControl
 							placeholder="Choose a country"
 							items={countryOptions}
 							{...fields.country.selectProps}
 							// Equivalent to:
-							// id={fields.country.id}
 							// name={fields.country.name}
 							// defaultValue={fields.country.defaultValue}
-							// aria-labelledby={fields.country.labelId}
-							// aria-describedby={`${fields.country.descriptionId} ${fields.country.ariaDescribedBy ?? ''}`.trim()}
-							// invalid={!fields.country.valid}
 						/>
-						<Field.Description
-							id={fields.country.descriptionId}
-							className="description"
-						>
+						<Field.Description className="description">
 							Select is synchronized with a scalar BaseControl.
 						</Field.Description>
 						<Field.Error
-							id={fields.country.errorId}
 							className="error"
 							match
 							role={fields.country.errors?.length ? 'alert' : undefined}
@@ -351,30 +290,20 @@ export default function App() {
 					</Field.Root>
 
 					<Field.Root className="field" invalid={!fields.framework.valid}>
-						<Field.Label id={fields.framework.labelId} className="label">
-							Framework
-						</Field.Label>
+						<Field.Label className="label">Framework</Field.Label>
 						<ComboboxControl
 							placeholder="Search frameworks"
 							triggerLabel="Open Framework"
 							items={frameworkOptions}
 							{...fields.framework.comboboxProps}
 							// Equivalent to:
-							// id={fields.framework.id}
 							// name={fields.framework.name}
 							// defaultValue={fields.framework.defaultValue}
-							// aria-labelledby={fields.framework.labelId}
-							// aria-describedby={`${fields.framework.descriptionId} ${fields.framework.ariaDescribedBy ?? ''}`.trim()}
-							// invalid={!fields.framework.valid}
 						/>
-						<Field.Description
-							id={fields.framework.descriptionId}
-							className="description"
-						>
+						<Field.Description className="description">
 							Filtering is transient; BaseControl stores the selection.
 						</Field.Description>
 						<Field.Error
-							id={fields.framework.errorId}
 							className="error"
 							match
 							role={fields.framework.errors?.length ? 'alert' : undefined}
@@ -384,28 +313,18 @@ export default function App() {
 					</Field.Root>
 
 					<Field.Root className="field" invalid={!fields.quantity.valid}>
-						<Field.Label id={fields.quantity.labelId} className="label">
-							Quantity
-						</Field.Label>
+						<Field.Label className="label">Quantity</Field.Label>
 						<NumberFieldControl
 							label="Quantity"
 							{...fields.quantity.numberFieldProps}
 							// Equivalent to:
-							// id={fields.quantity.id}
 							// name={fields.quantity.name}
 							// defaultValue={fields.quantity.defaultValue}
-							// aria-labelledby={fields.quantity.labelId}
-							// aria-describedby={`${fields.quantity.descriptionId} ${fields.quantity.ariaDescribedBy ?? ''}`.trim()}
-							// invalid={!fields.quantity.valid}
 						/>
-						<Field.Description
-							id={fields.quantity.descriptionId}
-							className="description"
-						>
+						<Field.Description className="description">
 							BaseControl stores the raw value before Zod coercion.
 						</Field.Description>
 						<Field.Error
-							id={fields.quantity.errorId}
 							className="error"
 							match
 							role={fields.quantity.errors?.length ? 'alert' : undefined}
@@ -415,27 +334,17 @@ export default function App() {
 					</Field.Root>
 
 					<Field.Root className="field" invalid={!fields.budget.valid}>
-						<Field.Label id={fields.budget.labelId} className="label">
-							Budget
-						</Field.Label>
+						<Field.Label className="label">Budget</Field.Label>
 						<SliderControl
 							{...fields.budget.sliderProps}
 							// Equivalent to:
-							// id={fields.budget.id}
 							// name={fields.budget.name}
 							// defaultValue={fields.budget.defaultValue}
-							// aria-labelledby={fields.budget.labelId}
-							// aria-describedby={`${fields.budget.descriptionId} ${fields.budget.ariaDescribedBy ?? ''}`.trim()}
-							// invalid={!fields.budget.valid}
 						/>
-						<Field.Description
-							id={fields.budget.descriptionId}
-							className="description"
-						>
+						<Field.Description className="description">
 							The range input is controlled through useControl.
 						</Field.Description>
 						<Field.Error
-							id={fields.budget.errorId}
 							className="error"
 							match
 							role={fields.budget.errors?.length ? 'alert' : undefined}
@@ -446,28 +355,18 @@ export default function App() {
 
 					<Field.Root className="field" invalid={!fields.notifications.valid}>
 						<div className="switch-row">
-							<Field.Label id={fields.notifications.labelId} className="label">
-								Product notifications
-							</Field.Label>
+							<Field.Label className="label">Product notifications</Field.Label>
 							<SwitchControl
 								{...fields.notifications.switchProps}
 								// Equivalent to:
-								// id={fields.notifications.id}
 								// name={fields.notifications.name}
 								// defaultChecked={fields.notifications.defaultChecked}
-								// aria-labelledby={fields.notifications.labelId}
-								// aria-describedby={`${fields.notifications.descriptionId} ${fields.notifications.ariaDescribedBy ?? ''}`.trim()}
-								// invalid={!fields.notifications.valid}
 							/>
 						</div>
-						<Field.Description
-							id={fields.notifications.descriptionId}
-							className="description"
-						>
+						<Field.Description className="description">
 							A checkbox BaseControl submits “on” while enabled.
 						</Field.Description>
 						<Field.Error
-							id={fields.notifications.errorId}
 							className="error"
 							match
 							role={fields.notifications.errors?.length ? 'alert' : undefined}

--- a/examples/base-ui/src/components.tsx
+++ b/examples/base-ui/src/components.tsx
@@ -9,7 +9,7 @@ import { RadioGroup } from '@base-ui/react/radio-group';
 import { Select } from '@base-ui/react/select';
 import { Slider } from '@base-ui/react/slider';
 import { Switch } from '@base-ui/react/switch';
-import { useControl } from '@conform-to/react/future';
+import { BaseControl, useControl } from '@conform-to/react/future';
 import { useRef, type FocusEvent } from 'react';
 
 type FieldStatusProps = {
@@ -39,15 +39,6 @@ function getDescriptionIds(id: string, invalid: boolean): string | undefined {
 	return invalid ? `${id}-description ${id}-error` : `${id}-description`;
 }
 
-function notifyConformBlur(input: HTMLInputElement | null) {
-	if (!input) {
-		return;
-	}
-
-	input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
-	input.dispatchEvent(new FocusEvent('blur'));
-}
-
 function isFocusLeaving(event: FocusEvent<HTMLElement>) {
 	return !event.currentTarget.contains(event.relatedTarget);
 }
@@ -73,7 +64,7 @@ export function TextInputField(props: StringFieldProps) {
 	const { id, label, invalid, name, defaultValue } = props;
 
 	return (
-		<Field.Root className="field" name={name} invalid={invalid}>
+		<Field.Root className="field" invalid={invalid}>
 			<Field.Label id={`${id}-label`} className="label">
 				{label}
 			</Field.Label>
@@ -95,7 +86,7 @@ export function TextareaField(props: StringFieldProps) {
 	const { id, label, invalid, name, defaultValue } = props;
 
 	return (
-		<Field.Root className="field" name={name} invalid={invalid}>
+		<Field.Root className="field" invalid={invalid}>
 			<Field.Label id={`${id}-label`} className="label">
 				{label}
 			</Field.Label>
@@ -116,19 +107,32 @@ export function TextareaField(props: StringFieldProps) {
 
 export function CheckboxField(props: BooleanFieldProps) {
 	const { id, label, invalid, name, defaultChecked } = props;
-	const inputRef = useRef<HTMLInputElement>(null);
+	const checkboxRef = useRef<HTMLElement>(null);
+	const control = useControl({
+		defaultChecked,
+		value: 'on',
+		onFocus() {
+			checkboxRef.current?.focus();
+		},
+	});
 
 	return (
-		<Field.Root className="field" name={name} invalid={invalid}>
+		<Field.Root className="field" invalid={invalid}>
+			<BaseControl
+				type="checkbox"
+				name={name}
+				value="on"
+				defaultChecked={defaultChecked ?? false}
+				ref={control.register}
+			/>
 			<Field.Label id={`${id}-label`} className="choice-label">
 				<Checkbox.Root
 					id={id}
 					className="checkbox"
-					name={name}
-					value="on"
-					defaultChecked={defaultChecked}
-					inputRef={inputRef}
-					onBlur={() => notifyConformBlur(inputRef.current)}
+					ref={checkboxRef}
+					checked={control.checked ?? false}
+					onCheckedChange={(checked) => control.change(checked)}
+					onBlur={() => control.blur()}
 					aria-labelledby={`${id}-label`}
 					aria-describedby={getDescriptionIds(id, invalid)}
 					aria-invalid={invalid || undefined}
@@ -152,19 +156,32 @@ export type CheckboxGroupFieldProps = FieldStatusProps & {
 
 export function CheckboxGroupField(props: CheckboxGroupFieldProps) {
 	const { id, label, invalid, name, defaultValue, items } = props;
-	const inputRef = useRef<HTMLInputElement>(null);
+	const firstCheckboxRef = useRef<HTMLElement>(null);
+	const control = useControl({
+		defaultValue,
+		onFocus() {
+			firstCheckboxRef.current?.focus();
+		},
+	});
 
 	return (
-		<Field.Root className="field" name={name} invalid={invalid}>
+		<Field.Root className="field" invalid={invalid}>
+			<BaseControl
+				type="select"
+				name={name}
+				defaultValue={control.defaultValue ?? []}
+				ref={control.register}
+			/>
 			<Field.Label id={`${id}-label`} className="label">
 				{label}
 			</Field.Label>
 			<CheckboxGroup
 				className="choice-group"
-				defaultValue={defaultValue}
+				value={control.options ?? []}
+				onValueChange={(value) => control.change(value)}
 				onBlur={(event) => {
-					if (event.target !== inputRef.current && isFocusLeaving(event)) {
-						notifyConformBlur(inputRef.current);
+					if (isFocusLeaving(event)) {
+						control.blur();
 					}
 				}}
 				aria-labelledby={`${id}-label`}
@@ -175,10 +192,11 @@ export function CheckboxGroupField(props: CheckboxGroupFieldProps) {
 					<label className="choice-label" key={item.value}>
 						<Checkbox.Root
 							className="checkbox"
-							name={name}
 							value={item.value}
-							inputRef={index === 0 ? inputRef : undefined}
+							ref={index === 0 ? firstCheckboxRef : undefined}
 							aria-labelledby={`${id}-${item.value}-label`}
+							aria-describedby={getDescriptionIds(id, invalid)}
+							aria-invalid={invalid || undefined}
 						>
 							<Checkbox.Indicator className="checkbox-indicator">
 								✓
@@ -199,33 +217,46 @@ export type RadioGroupFieldProps = StringFieldProps & {
 
 export function RadioGroupField(props: RadioGroupFieldProps) {
 	const { id, label, invalid, name, defaultValue, items } = props;
-	const inputRef = useRef<HTMLInputElement>(null);
+	const firstRadioRef = useRef<HTMLElement>(null);
+	const control = useControl({
+		defaultValue,
+		onFocus() {
+			firstRadioRef.current?.focus();
+		},
+	});
 
 	return (
-		<Field.Root className="field" name={name} invalid={invalid}>
+		<Field.Root className="field" invalid={invalid}>
+			<BaseControl
+				name={name}
+				defaultValue={control.defaultValue ?? ''}
+				ref={control.register}
+			/>
 			<Field.Label id={`${id}-label`} className="label">
 				{label}
 			</Field.Label>
 			<RadioGroup
 				className="choice-group"
-				name={name}
-				defaultValue={defaultValue}
-				inputRef={inputRef}
+				value={control.value ?? ''}
+				onValueChange={(value) => control.change(value)}
 				onBlur={(event) => {
-					if (event.target !== inputRef.current && isFocusLeaving(event)) {
-						notifyConformBlur(inputRef.current);
+					if (isFocusLeaving(event)) {
+						control.blur();
 					}
 				}}
 				aria-labelledby={`${id}-label`}
 				aria-describedby={getDescriptionIds(id, invalid)}
 				aria-invalid={invalid || undefined}
 			>
-				{items.map((item) => (
+				{items.map((item, index) => (
 					<label className="choice-label" key={item.value}>
 						<Radio.Root
 							className="radio"
+							ref={index === 0 ? firstRadioRef : undefined}
 							value={item.value}
 							aria-labelledby={`${id}-${item.value}-label`}
+							aria-describedby={getDescriptionIds(id, invalid)}
+							aria-invalid={invalid || undefined}
 						>
 							<Radio.Indicator className="radio-indicator" />
 						</Radio.Root>
@@ -248,21 +279,36 @@ export function SelectField(props: SelectFieldProps) {
 	const labels = Object.fromEntries(
 		items.map((item) => [item.value, item.label]),
 	);
-	const inputRef = useRef<HTMLInputElement>(null);
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const control = useControl({
+		defaultValue,
+		onFocus() {
+			triggerRef.current?.focus();
+		},
+	});
 
 	return (
-		<Field.Root className="field" name={name} invalid={invalid}>
+		<Field.Root className="field" invalid={invalid}>
+			<BaseControl
+				name={name}
+				defaultValue={control.defaultValue ?? ''}
+				ref={control.register}
+			/>
 			<Field.Label id={`${id}-label`} className="label">
 				{label}
 			</Field.Label>
-			<Select.Root name={name} defaultValue={defaultValue} inputRef={inputRef}>
+			<Select.Root
+				value={control.value || null}
+				onValueChange={(value) => control.change(value ?? '')}
+			>
 				<Select.Trigger
 					id={id}
 					className="select-trigger"
+					ref={triggerRef}
 					aria-labelledby={`${id}-label`}
 					aria-describedby={getDescriptionIds(id, invalid)}
 					aria-invalid={invalid || undefined}
-					onBlur={() => notifyConformBlur(inputRef.current)}
+					onBlur={() => control.blur()}
 				>
 					<Select.Value placeholder={placeholder}>
 						{(value: string | null) =>
@@ -306,28 +352,39 @@ export function ComboboxField(props: ComboboxFieldProps) {
 	);
 	const values = items.map((item) => item.value);
 	const inputRef = useRef<HTMLInputElement>(null);
+	const control = useControl({
+		defaultValue,
+		onFocus() {
+			inputRef.current?.focus();
+		},
+	});
 
 	return (
-		<Field.Root className="field" name={name} invalid={invalid}>
+		<Field.Root className="field" invalid={invalid}>
+			<BaseControl
+				name={name}
+				defaultValue={control.defaultValue ?? ''}
+				ref={control.register}
+			/>
 			<Field.Label id={`${id}-label`} className="label">
 				{label}
 			</Field.Label>
 			<Combobox.Root
-				name={name}
 				items={values}
-				defaultValue={defaultValue}
+				value={control.value || null}
+				onValueChange={(value) => control.change(value ?? '')}
 				itemToStringLabel={(value) => labels[value] ?? value}
-				inputRef={inputRef}
 			>
 				<Combobox.InputGroup className="combobox-group">
 					<Combobox.Input
 						id={id}
 						className="combobox-input"
+						ref={inputRef}
 						placeholder={placeholder}
 						aria-labelledby={`${id}-label`}
 						aria-describedby={getDescriptionIds(id, invalid)}
 						aria-invalid={invalid || undefined}
-						onBlur={() => notifyConformBlur(inputRef.current)}
+						onBlur={() => control.blur()}
 					/>
 					<Combobox.Trigger
 						className="combobox-trigger"
@@ -363,19 +420,36 @@ export function ComboboxField(props: ComboboxFieldProps) {
 
 export function NumberFieldControl(props: StringFieldProps) {
 	const { id, label, invalid, name, defaultValue } = props;
-	const numericDefault = defaultValue ? Number(defaultValue) : undefined;
 	const inputRef = useRef<HTMLInputElement>(null);
+	const control = useControl({
+		defaultValue,
+		onFocus() {
+			inputRef.current?.focus();
+		},
+	});
+	const value = control.value ? Number(control.value) : null;
 
 	return (
-		<Field.Root className="field" name={name} invalid={invalid}>
+		<Field.Root className="field" invalid={invalid}>
+			<BaseControl
+				name={name}
+				defaultValue={control.defaultValue ?? ''}
+				ref={control.register}
+			/>
 			<Field.Label id={`${id}-label`} className="label">
 				{label}
 			</Field.Label>
 			<NumberField.Root
 				id={id}
-				name={name}
-				defaultValue={numericDefault}
-				inputRef={inputRef}
+				value={value}
+				onValueChange={(nextValue) =>
+					control.change(nextValue == null ? '' : String(nextValue))
+				}
+				onBlur={(event) => {
+					if (isFocusLeaving(event)) {
+						control.blur();
+					}
+				}}
 				min={1}
 				max={10}
 			>
@@ -388,10 +462,10 @@ export function NumberFieldControl(props: StringFieldProps) {
 					</NumberField.Decrement>
 					<NumberField.Input
 						className="number-input"
+						ref={inputRef}
 						aria-labelledby={`${id}-label`}
 						aria-describedby={getDescriptionIds(id, invalid)}
 						aria-invalid={invalid || undefined}
-						onBlur={() => notifyConformBlur(inputRef.current)}
 					/>
 					<NumberField.Increment
 						className="stepper"
@@ -418,13 +492,17 @@ export function SliderField(props: StringFieldProps) {
 	const value = Number(control.value || 50);
 
 	return (
-		<Field.Root className="field" name={name} invalid={invalid}>
+		<Field.Root className="field" invalid={invalid}>
+			<BaseControl
+				name={name}
+				defaultValue={control.defaultValue ?? '50'}
+				ref={control.register}
+			/>
 			<Field.Label id={`${id}-label`} className="label">
 				{label}
 			</Field.Label>
 			<Slider.Root
 				className="slider-root"
-				name={name}
 				value={value}
 				min={0}
 				max={100}
@@ -437,10 +515,7 @@ export function SliderField(props: StringFieldProps) {
 						<Slider.Indicator className="slider-indicator" />
 						<Slider.Thumb
 							className="slider-thumb"
-							inputRef={(element) => {
-								thumbInputRef.current = element;
-								control.register(element);
-							}}
+							inputRef={thumbInputRef}
 							onBlur={() => control.blur()}
 							aria-labelledby={`${id}-label`}
 							aria-describedby={getDescriptionIds(id, invalid)}
@@ -456,10 +531,24 @@ export function SliderField(props: StringFieldProps) {
 
 export function SwitchField(props: BooleanFieldProps) {
 	const { id, label, invalid, name, defaultChecked } = props;
-	const inputRef = useRef<HTMLInputElement>(null);
+	const switchRef = useRef<HTMLElement>(null);
+	const control = useControl({
+		defaultChecked,
+		value: 'on',
+		onFocus() {
+			switchRef.current?.focus();
+		},
+	});
 
 	return (
-		<Field.Root className="field" name={name} invalid={invalid}>
+		<Field.Root className="field" invalid={invalid}>
+			<BaseControl
+				type="checkbox"
+				name={name}
+				value="on"
+				defaultChecked={defaultChecked ?? false}
+				ref={control.register}
+			/>
 			<div className="switch-row">
 				<Field.Label id={`${id}-label`} className="label">
 					{label}
@@ -467,11 +556,10 @@ export function SwitchField(props: BooleanFieldProps) {
 				<Switch.Root
 					id={id}
 					className="switch"
-					name={name}
-					value="on"
-					defaultChecked={defaultChecked}
-					inputRef={inputRef}
-					onBlur={() => notifyConformBlur(inputRef.current)}
+					ref={switchRef}
+					checked={control.checked ?? false}
+					onCheckedChange={(checked) => control.change(checked)}
+					onBlur={() => control.blur()}
 					aria-labelledby={`${id}-label`}
 					aria-describedby={getDescriptionIds(id, invalid)}
 					aria-invalid={invalid || undefined}

--- a/examples/base-ui/src/components.tsx
+++ b/examples/base-ui/src/components.tsx
@@ -488,7 +488,8 @@ export function SliderField(props: StringFieldProps) {
 			thumbInputRef.current?.focus();
 		},
 	});
-	const value = Number(control.value || 50);
+	const numericValue = Number(control.value || 50);
+	const value = Number.isFinite(numericValue) ? numericValue : 50;
 
 	return (
 		<Field.Root className="field" invalid={invalid}>

--- a/examples/base-ui/src/components.tsx
+++ b/examples/base-ui/src/components.tsx
@@ -9,28 +9,17 @@ import { Switch } from '@base-ui/react/switch';
 import { BaseControl, useControl } from '@conform-to/react/future';
 import { useRef, type FocusEvent, type ReactNode } from 'react';
 
-type ControlProps = {
-	name: string;
-	defaultValue?: string;
-};
-
-type CheckedControlProps = Omit<ControlProps, 'defaultValue'> & {
-	defaultChecked?: boolean;
-};
-
-type Option = {
-	label: string;
-	value: string;
-};
-
 function isFocusLeaving(event: FocusEvent<HTMLElement>) {
 	return !event.currentTarget.contains(event.relatedTarget);
 }
 
-export type CheckboxControlProps = CheckedControlProps;
-
-export function CheckboxControl(props: CheckboxControlProps) {
-	const { name, defaultChecked } = props;
+export function CheckboxControl({
+	name,
+	defaultChecked,
+}: {
+	name: string;
+	defaultChecked?: boolean;
+}) {
 	const checkboxRef = useRef<HTMLElement>(null);
 	const control = useControl({
 		defaultChecked,
@@ -64,13 +53,15 @@ export function CheckboxControl(props: CheckboxControlProps) {
 	);
 }
 
-export type CheckboxGroupControlProps = Omit<ControlProps, 'defaultValue'> & {
+export function CheckboxGroupControl({
+	name,
+	defaultValue,
+	children,
+}: {
+	name: string;
 	defaultValue?: string[];
 	children: ReactNode;
-};
-
-export function CheckboxGroupControl(props: CheckboxGroupControlProps) {
-	const { name, defaultValue, children } = props;
+}) {
 	const groupRef = useRef<HTMLDivElement>(null);
 	const control = useControl({
 		defaultValue,
@@ -106,12 +97,15 @@ export function CheckboxGroupControl(props: CheckboxGroupControlProps) {
 	);
 }
 
-export type RadioGroupControlProps = ControlProps & {
+export function RadioGroupControl({
+	name,
+	defaultValue,
+	children,
+}: {
+	name: string;
+	defaultValue?: string;
 	children: ReactNode;
-};
-
-export function RadioGroupControl(props: RadioGroupControlProps) {
-	const { name, defaultValue, children } = props;
+}) {
 	const groupRef = useRef<HTMLDivElement>(null);
 	const control = useControl({
 		defaultValue,
@@ -144,13 +138,17 @@ export function RadioGroupControl(props: RadioGroupControlProps) {
 	);
 }
 
-export type SelectControlProps = ControlProps & {
-	items: Option[];
+export function SelectControl({
+	name,
+	defaultValue,
+	items,
+	placeholder,
+}: {
+	name: string;
+	defaultValue?: string;
+	items: Array<{ label: string; value: string }>;
 	placeholder?: string;
-};
-
-export function SelectControl(props: SelectControlProps) {
-	const { name, defaultValue, items, placeholder } = props;
+}) {
 	const labels = Object.fromEntries(
 		items.map((item) => [item.value, item.label]),
 	);
@@ -210,14 +208,19 @@ export function SelectControl(props: SelectControlProps) {
 	);
 }
 
-export type ComboboxControlProps = ControlProps & {
-	items: Option[];
+export function ComboboxControl({
+	name,
+	defaultValue,
+	items,
+	placeholder,
+	triggerLabel,
+}: {
+	name: string;
+	defaultValue?: string;
+	items: Array<{ label: string; value: string }>;
 	placeholder?: string;
 	triggerLabel: string;
-};
-
-export function ComboboxControl(props: ComboboxControlProps) {
-	const { name, defaultValue, items, placeholder, triggerLabel } = props;
+}) {
 	const labels = Object.fromEntries(
 		items.map((item) => [item.value, item.label]),
 	);
@@ -281,12 +284,15 @@ export function ComboboxControl(props: ComboboxControlProps) {
 	);
 }
 
-export type NumberFieldControlProps = ControlProps & {
+export function NumberFieldControl({
+	name,
+	defaultValue,
+	label,
+}: {
+	name: string;
+	defaultValue?: string;
 	label: string;
-};
-
-export function NumberFieldControl(props: NumberFieldControlProps) {
-	const { label, name, defaultValue } = props;
+}) {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const control = useControl({
 		defaultValue,
@@ -338,10 +344,13 @@ export function NumberFieldControl(props: NumberFieldControlProps) {
 	);
 }
 
-export type SliderControlProps = ControlProps;
-
-export function SliderControl(props: SliderControlProps) {
-	const { name, defaultValue } = props;
+export function SliderControl({
+	name,
+	defaultValue,
+}: {
+	name: string;
+	defaultValue?: string;
+}) {
 	const thumbInputRef = useRef<HTMLInputElement>(null);
 	const control = useControl({
 		defaultValue: defaultValue || '50',
@@ -383,10 +392,13 @@ export function SliderControl(props: SliderControlProps) {
 	);
 }
 
-export type SwitchControlProps = CheckedControlProps;
-
-export function SwitchControl(props: SwitchControlProps) {
-	const { name, defaultChecked } = props;
+export function SwitchControl({
+	name,
+	defaultChecked,
+}: {
+	name: string;
+	defaultChecked?: boolean;
+}) {
 	const switchRef = useRef<HTMLElement>(null);
 	const control = useControl({
 		defaultChecked,

--- a/examples/base-ui/src/components.tsx
+++ b/examples/base-ui/src/components.tsx
@@ -1,0 +1,485 @@
+import { Checkbox } from '@base-ui/react/checkbox';
+import { CheckboxGroup } from '@base-ui/react/checkbox-group';
+import { Combobox } from '@base-ui/react/combobox';
+import { Field } from '@base-ui/react/field';
+import { Input } from '@base-ui/react/input';
+import { NumberField } from '@base-ui/react/number-field';
+import { Radio } from '@base-ui/react/radio';
+import { RadioGroup } from '@base-ui/react/radio-group';
+import { Select } from '@base-ui/react/select';
+import { Slider } from '@base-ui/react/slider';
+import { Switch } from '@base-ui/react/switch';
+import { useControl } from '@conform-to/react/future';
+import { useRef, type FocusEvent } from 'react';
+
+type FieldStatusProps = {
+	id: string;
+	label: string;
+	description: string;
+	errors?: string[];
+	invalid: boolean;
+};
+
+type StringFieldProps = FieldStatusProps & {
+	name: string;
+	defaultValue?: string;
+};
+
+type BooleanFieldProps = FieldStatusProps & {
+	name: string;
+	defaultChecked?: boolean;
+};
+
+type Option = {
+	label: string;
+	value: string;
+};
+
+function getDescriptionIds(id: string, invalid: boolean): string | undefined {
+	return invalid ? `${id}-description ${id}-error` : `${id}-description`;
+}
+
+function notifyConformBlur(input: HTMLInputElement | null) {
+	if (!input) {
+		return;
+	}
+
+	input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+	input.dispatchEvent(new FocusEvent('blur'));
+}
+
+function isFocusLeaving(event: FocusEvent<HTMLElement>) {
+	return !event.currentTarget.contains(event.relatedTarget);
+}
+
+function FieldMessages({ id, description, errors }: FieldStatusProps) {
+	return (
+		<>
+			<Field.Description id={`${id}-description`} className="description">
+				{description}
+			</Field.Description>
+			<div
+				id={`${id}-error`}
+				className="error"
+				role={errors?.length ? 'alert' : undefined}
+			>
+				{errors?.join(', ')}
+			</div>
+		</>
+	);
+}
+
+export function TextInputField(props: StringFieldProps) {
+	const { id, label, invalid, name, defaultValue } = props;
+
+	return (
+		<Field.Root className="field" name={name} invalid={invalid}>
+			<Field.Label id={`${id}-label`} className="label">
+				{label}
+			</Field.Label>
+			<Input
+				id={id}
+				className="text-control"
+				name={name}
+				defaultValue={defaultValue}
+				aria-labelledby={`${id}-label`}
+				aria-describedby={getDescriptionIds(id, invalid)}
+				aria-invalid={invalid || undefined}
+			/>
+			<FieldMessages {...props} />
+		</Field.Root>
+	);
+}
+
+export function TextareaField(props: StringFieldProps) {
+	const { id, label, invalid, name, defaultValue } = props;
+
+	return (
+		<Field.Root className="field" name={name} invalid={invalid}>
+			<Field.Label id={`${id}-label`} className="label">
+				{label}
+			</Field.Label>
+			<Field.Control
+				render={<textarea rows={4} />}
+				id={id}
+				className="text-control"
+				name={name}
+				defaultValue={defaultValue}
+				aria-labelledby={`${id}-label`}
+				aria-describedby={getDescriptionIds(id, invalid)}
+				aria-invalid={invalid || undefined}
+			/>
+			<FieldMessages {...props} />
+		</Field.Root>
+	);
+}
+
+export function CheckboxField(props: BooleanFieldProps) {
+	const { id, label, invalid, name, defaultChecked } = props;
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	return (
+		<Field.Root className="field" name={name} invalid={invalid}>
+			<Field.Label id={`${id}-label`} className="choice-label">
+				<Checkbox.Root
+					id={id}
+					className="checkbox"
+					name={name}
+					value="on"
+					defaultChecked={defaultChecked}
+					inputRef={inputRef}
+					onBlur={() => notifyConformBlur(inputRef.current)}
+					aria-labelledby={`${id}-label`}
+					aria-describedby={getDescriptionIds(id, invalid)}
+					aria-invalid={invalid || undefined}
+				>
+					<Checkbox.Indicator className="checkbox-indicator">
+						✓
+					</Checkbox.Indicator>
+				</Checkbox.Root>
+				{label}
+			</Field.Label>
+			<FieldMessages {...props} />
+		</Field.Root>
+	);
+}
+
+export type CheckboxGroupFieldProps = FieldStatusProps & {
+	name: string;
+	defaultValue?: string[];
+	items: Option[];
+};
+
+export function CheckboxGroupField(props: CheckboxGroupFieldProps) {
+	const { id, label, invalid, name, defaultValue, items } = props;
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	return (
+		<Field.Root className="field" name={name} invalid={invalid}>
+			<Field.Label id={`${id}-label`} className="label">
+				{label}
+			</Field.Label>
+			<CheckboxGroup
+				className="choice-group"
+				defaultValue={defaultValue}
+				onBlur={(event) => {
+					if (event.target !== inputRef.current && isFocusLeaving(event)) {
+						notifyConformBlur(inputRef.current);
+					}
+				}}
+				aria-labelledby={`${id}-label`}
+				aria-describedby={getDescriptionIds(id, invalid)}
+				aria-invalid={invalid || undefined}
+			>
+				{items.map((item, index) => (
+					<label className="choice-label" key={item.value}>
+						<Checkbox.Root
+							className="checkbox"
+							name={name}
+							value={item.value}
+							inputRef={index === 0 ? inputRef : undefined}
+							aria-labelledby={`${id}-${item.value}-label`}
+						>
+							<Checkbox.Indicator className="checkbox-indicator">
+								✓
+							</Checkbox.Indicator>
+						</Checkbox.Root>
+						<span id={`${id}-${item.value}-label`}>{item.label}</span>
+					</label>
+				))}
+			</CheckboxGroup>
+			<FieldMessages {...props} />
+		</Field.Root>
+	);
+}
+
+export type RadioGroupFieldProps = StringFieldProps & {
+	items: Option[];
+};
+
+export function RadioGroupField(props: RadioGroupFieldProps) {
+	const { id, label, invalid, name, defaultValue, items } = props;
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	return (
+		<Field.Root className="field" name={name} invalid={invalid}>
+			<Field.Label id={`${id}-label`} className="label">
+				{label}
+			</Field.Label>
+			<RadioGroup
+				className="choice-group"
+				name={name}
+				defaultValue={defaultValue}
+				inputRef={inputRef}
+				onBlur={(event) => {
+					if (event.target !== inputRef.current && isFocusLeaving(event)) {
+						notifyConformBlur(inputRef.current);
+					}
+				}}
+				aria-labelledby={`${id}-label`}
+				aria-describedby={getDescriptionIds(id, invalid)}
+				aria-invalid={invalid || undefined}
+			>
+				{items.map((item) => (
+					<label className="choice-label" key={item.value}>
+						<Radio.Root
+							className="radio"
+							value={item.value}
+							aria-labelledby={`${id}-${item.value}-label`}
+						>
+							<Radio.Indicator className="radio-indicator" />
+						</Radio.Root>
+						<span id={`${id}-${item.value}-label`}>{item.label}</span>
+					</label>
+				))}
+			</RadioGroup>
+			<FieldMessages {...props} />
+		</Field.Root>
+	);
+}
+
+export type SelectFieldProps = StringFieldProps & {
+	items: Option[];
+	placeholder?: string;
+};
+
+export function SelectField(props: SelectFieldProps) {
+	const { id, label, invalid, name, defaultValue, items, placeholder } = props;
+	const labels = Object.fromEntries(
+		items.map((item) => [item.value, item.label]),
+	);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	return (
+		<Field.Root className="field" name={name} invalid={invalid}>
+			<Field.Label id={`${id}-label`} className="label">
+				{label}
+			</Field.Label>
+			<Select.Root name={name} defaultValue={defaultValue} inputRef={inputRef}>
+				<Select.Trigger
+					id={id}
+					className="select-trigger"
+					aria-labelledby={`${id}-label`}
+					aria-describedby={getDescriptionIds(id, invalid)}
+					aria-invalid={invalid || undefined}
+					onBlur={() => notifyConformBlur(inputRef.current)}
+				>
+					<Select.Value placeholder={placeholder}>
+						{(value: string | null) =>
+							value ? labels[value] : (placeholder ?? 'Choose an option')
+						}
+					</Select.Value>
+					<Select.Icon aria-hidden>⌄</Select.Icon>
+				</Select.Trigger>
+				<Select.Portal>
+					<Select.Positioner className="popup-positioner" sideOffset={6}>
+						<Select.Popup className="popup">
+							<Select.List>
+								{items.map((item) => (
+									<Select.Item
+										className="popup-item"
+										key={item.value}
+										value={item.value}
+									>
+										<Select.ItemIndicator className="item-indicator">
+											✓
+										</Select.ItemIndicator>
+										<Select.ItemText>{item.label}</Select.ItemText>
+									</Select.Item>
+								))}
+							</Select.List>
+						</Select.Popup>
+					</Select.Positioner>
+				</Select.Portal>
+			</Select.Root>
+			<FieldMessages {...props} />
+		</Field.Root>
+	);
+}
+
+export type ComboboxFieldProps = SelectFieldProps;
+
+export function ComboboxField(props: ComboboxFieldProps) {
+	const { id, label, invalid, name, defaultValue, items, placeholder } = props;
+	const labels = Object.fromEntries(
+		items.map((item) => [item.value, item.label]),
+	);
+	const values = items.map((item) => item.value);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	return (
+		<Field.Root className="field" name={name} invalid={invalid}>
+			<Field.Label id={`${id}-label`} className="label">
+				{label}
+			</Field.Label>
+			<Combobox.Root
+				name={name}
+				items={values}
+				defaultValue={defaultValue}
+				itemToStringLabel={(value) => labels[value] ?? value}
+				inputRef={inputRef}
+			>
+				<Combobox.InputGroup className="combobox-group">
+					<Combobox.Input
+						id={id}
+						className="combobox-input"
+						placeholder={placeholder}
+						aria-labelledby={`${id}-label`}
+						aria-describedby={getDescriptionIds(id, invalid)}
+						aria-invalid={invalid || undefined}
+						onBlur={() => notifyConformBlur(inputRef.current)}
+					/>
+					<Combobox.Trigger
+						className="combobox-trigger"
+						aria-label={`Open ${label}`}
+					>
+						⌄
+					</Combobox.Trigger>
+				</Combobox.InputGroup>
+				<Combobox.Portal>
+					<Combobox.Positioner className="popup-positioner" sideOffset={6}>
+						<Combobox.Popup className="popup">
+							<Combobox.Empty className="popup-empty">
+								No matches
+							</Combobox.Empty>
+							<Combobox.List>
+								{(value: string) => (
+									<Combobox.Item className="popup-item" value={value}>
+										<Combobox.ItemIndicator className="item-indicator">
+											✓
+										</Combobox.ItemIndicator>
+										{labels[value]}
+									</Combobox.Item>
+								)}
+							</Combobox.List>
+						</Combobox.Popup>
+					</Combobox.Positioner>
+				</Combobox.Portal>
+			</Combobox.Root>
+			<FieldMessages {...props} />
+		</Field.Root>
+	);
+}
+
+export function NumberFieldControl(props: StringFieldProps) {
+	const { id, label, invalid, name, defaultValue } = props;
+	const numericDefault = defaultValue ? Number(defaultValue) : undefined;
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	return (
+		<Field.Root className="field" name={name} invalid={invalid}>
+			<Field.Label id={`${id}-label`} className="label">
+				{label}
+			</Field.Label>
+			<NumberField.Root
+				id={id}
+				name={name}
+				defaultValue={numericDefault}
+				inputRef={inputRef}
+				min={1}
+				max={10}
+			>
+				<NumberField.Group className="number-group">
+					<NumberField.Decrement
+						className="stepper"
+						aria-label={`Decrease ${label}`}
+					>
+						−
+					</NumberField.Decrement>
+					<NumberField.Input
+						className="number-input"
+						aria-labelledby={`${id}-label`}
+						aria-describedby={getDescriptionIds(id, invalid)}
+						aria-invalid={invalid || undefined}
+						onBlur={() => notifyConformBlur(inputRef.current)}
+					/>
+					<NumberField.Increment
+						className="stepper"
+						aria-label={`Increase ${label}`}
+					>
+						+
+					</NumberField.Increment>
+				</NumberField.Group>
+			</NumberField.Root>
+			<FieldMessages {...props} />
+		</Field.Root>
+	);
+}
+
+export function SliderField(props: StringFieldProps) {
+	const { id, label, invalid, name, defaultValue } = props;
+	const thumbInputRef = useRef<HTMLInputElement>(null);
+	const control = useControl({
+		defaultValue: defaultValue ?? '50',
+		onFocus() {
+			thumbInputRef.current?.focus();
+		},
+	});
+	const value = Number(control.value ?? 50);
+
+	return (
+		<Field.Root className="field" name={name} invalid={invalid}>
+			<Field.Label id={`${id}-label`} className="label">
+				{label}
+			</Field.Label>
+			<Slider.Root
+				className="slider-root"
+				name={name}
+				value={value}
+				min={0}
+				max={100}
+				step={5}
+				onValueChange={(nextValue) => control.change(String(nextValue))}
+			>
+				<Slider.Value className="slider-value" />
+				<Slider.Control className="slider-control">
+					<Slider.Track className="slider-track">
+						<Slider.Indicator className="slider-indicator" />
+						<Slider.Thumb
+							className="slider-thumb"
+							inputRef={(element) => {
+								thumbInputRef.current = element;
+								control.register(element);
+							}}
+							onBlur={() => control.blur()}
+							aria-labelledby={`${id}-label`}
+							aria-describedby={getDescriptionIds(id, invalid)}
+							aria-invalid={invalid || undefined}
+						/>
+					</Slider.Track>
+				</Slider.Control>
+			</Slider.Root>
+			<FieldMessages {...props} />
+		</Field.Root>
+	);
+}
+
+export function SwitchField(props: BooleanFieldProps) {
+	const { id, label, invalid, name, defaultChecked } = props;
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	return (
+		<Field.Root className="field" name={name} invalid={invalid}>
+			<div className="switch-row">
+				<Field.Label id={`${id}-label`} className="label">
+					{label}
+				</Field.Label>
+				<Switch.Root
+					id={id}
+					className="switch"
+					name={name}
+					value="on"
+					defaultChecked={defaultChecked}
+					inputRef={inputRef}
+					onBlur={() => notifyConformBlur(inputRef.current)}
+					aria-labelledby={`${id}-label`}
+					aria-describedby={getDescriptionIds(id, invalid)}
+					aria-invalid={invalid || undefined}
+				>
+					<Switch.Thumb className="switch-thumb" />
+				</Switch.Root>
+			</div>
+			<FieldMessages {...props} />
+		</Field.Root>
+	);
+}

--- a/examples/base-ui/src/components.tsx
+++ b/examples/base-ui/src/components.tsx
@@ -18,6 +18,7 @@ type FieldStatusProps = {
 	description: string;
 	errors?: string[];
 	invalid: boolean;
+	'aria-describedby'?: string;
 };
 
 type StringFieldProps = FieldStatusProps & {
@@ -34,10 +35,6 @@ type Option = {
 	label: string;
 	value: string;
 };
-
-function getDescriptionIds(id: string, invalid: boolean): string | undefined {
-	return invalid ? `${id}-description ${id}-error` : `${id}-description`;
-}
 
 function isFocusLeaving(event: FocusEvent<HTMLElement>) {
 	return !event.currentTarget.contains(event.relatedTarget);
@@ -74,7 +71,7 @@ export function TextInputField(props: StringFieldProps) {
 				name={name}
 				defaultValue={defaultValue}
 				aria-labelledby={`${id}-label`}
-				aria-describedby={getDescriptionIds(id, invalid)}
+				aria-describedby={props['aria-describedby']}
 				aria-invalid={invalid || undefined}
 			/>
 			<FieldMessages {...props} />
@@ -97,7 +94,7 @@ export function TextareaField(props: StringFieldProps) {
 				name={name}
 				defaultValue={defaultValue}
 				aria-labelledby={`${id}-label`}
-				aria-describedby={getDescriptionIds(id, invalid)}
+				aria-describedby={props['aria-describedby']}
 				aria-invalid={invalid || undefined}
 			/>
 			<FieldMessages {...props} />
@@ -134,7 +131,7 @@ export function CheckboxField(props: BooleanFieldProps) {
 					onCheckedChange={(checked) => control.change(checked)}
 					onBlur={() => control.blur()}
 					aria-labelledby={`${id}-label`}
-					aria-describedby={getDescriptionIds(id, invalid)}
+					aria-describedby={props['aria-describedby']}
 					aria-invalid={invalid || undefined}
 				>
 					<Checkbox.Indicator className="checkbox-indicator">
@@ -185,7 +182,7 @@ export function CheckboxGroupField(props: CheckboxGroupFieldProps) {
 					}
 				}}
 				aria-labelledby={`${id}-label`}
-				aria-describedby={getDescriptionIds(id, invalid)}
+				aria-describedby={props['aria-describedby']}
 				aria-invalid={invalid || undefined}
 			>
 				{items.map((item, index) => (
@@ -195,7 +192,7 @@ export function CheckboxGroupField(props: CheckboxGroupFieldProps) {
 							value={item.value}
 							ref={index === 0 ? firstCheckboxRef : undefined}
 							aria-labelledby={`${id}-${item.value}-label`}
-							aria-describedby={getDescriptionIds(id, invalid)}
+							aria-describedby={props['aria-describedby']}
 							aria-invalid={invalid || undefined}
 						>
 							<Checkbox.Indicator className="checkbox-indicator">
@@ -245,7 +242,7 @@ export function RadioGroupField(props: RadioGroupFieldProps) {
 					}
 				}}
 				aria-labelledby={`${id}-label`}
-				aria-describedby={getDescriptionIds(id, invalid)}
+				aria-describedby={props['aria-describedby']}
 				aria-invalid={invalid || undefined}
 			>
 				{items.map((item, index) => (
@@ -255,7 +252,7 @@ export function RadioGroupField(props: RadioGroupFieldProps) {
 							ref={index === 0 ? firstRadioRef : undefined}
 							value={item.value}
 							aria-labelledby={`${id}-${item.value}-label`}
-							aria-describedby={getDescriptionIds(id, invalid)}
+							aria-describedby={props['aria-describedby']}
 							aria-invalid={invalid || undefined}
 						>
 							<Radio.Indicator className="radio-indicator" />
@@ -306,7 +303,7 @@ export function SelectField(props: SelectFieldProps) {
 					className="select-trigger"
 					ref={triggerRef}
 					aria-labelledby={`${id}-label`}
-					aria-describedby={getDescriptionIds(id, invalid)}
+					aria-describedby={props['aria-describedby']}
 					aria-invalid={invalid || undefined}
 					onBlur={() => control.blur()}
 				>
@@ -382,7 +379,7 @@ export function ComboboxField(props: ComboboxFieldProps) {
 						ref={inputRef}
 						placeholder={placeholder}
 						aria-labelledby={`${id}-label`}
-						aria-describedby={getDescriptionIds(id, invalid)}
+						aria-describedby={props['aria-describedby']}
 						aria-invalid={invalid || undefined}
 						onBlur={() => control.blur()}
 					/>
@@ -427,7 +424,9 @@ export function NumberFieldControl(props: StringFieldProps) {
 			inputRef.current?.focus();
 		},
 	});
-	const value = control.value ? Number(control.value) : null;
+	const numericValue = Number(control.value);
+	const value =
+		control.value === '' || Number.isNaN(numericValue) ? null : numericValue;
 
 	return (
 		<Field.Root className="field" invalid={invalid}>
@@ -464,7 +463,7 @@ export function NumberFieldControl(props: StringFieldProps) {
 						className="number-input"
 						ref={inputRef}
 						aria-labelledby={`${id}-label`}
-						aria-describedby={getDescriptionIds(id, invalid)}
+						aria-describedby={props['aria-describedby']}
 						aria-invalid={invalid || undefined}
 					/>
 					<NumberField.Increment
@@ -518,7 +517,7 @@ export function SliderField(props: StringFieldProps) {
 							inputRef={thumbInputRef}
 							onBlur={() => control.blur()}
 							aria-labelledby={`${id}-label`}
-							aria-describedby={getDescriptionIds(id, invalid)}
+							aria-describedby={props['aria-describedby']}
 							aria-invalid={invalid || undefined}
 						/>
 					</Slider.Track>
@@ -561,7 +560,7 @@ export function SwitchField(props: BooleanFieldProps) {
 					onCheckedChange={(checked) => control.change(checked)}
 					onBlur={() => control.blur()}
 					aria-labelledby={`${id}-label`}
-					aria-describedby={getDescriptionIds(id, invalid)}
+					aria-describedby={props['aria-describedby']}
 					aria-invalid={invalid || undefined}
 				>
 					<Switch.Thumb className="switch-thumb" />

--- a/examples/base-ui/src/components.tsx
+++ b/examples/base-ui/src/components.tsx
@@ -10,12 +10,8 @@ import { BaseControl, useControl } from '@conform-to/react/future';
 import { useRef, type FocusEvent, type ReactNode } from 'react';
 
 type ControlProps = {
-	id: string;
 	name: string;
 	defaultValue?: string;
-	invalid: boolean;
-	'aria-describedby'?: string;
-	'aria-labelledby'?: string;
 };
 
 type CheckedControlProps = Omit<ControlProps, 'defaultValue'> & {
@@ -34,7 +30,7 @@ function isFocusLeaving(event: FocusEvent<HTMLElement>) {
 export type CheckboxControlProps = CheckedControlProps;
 
 export function CheckboxControl(props: CheckboxControlProps) {
-	const { id, invalid, name, defaultChecked } = props;
+	const { name, defaultChecked } = props;
 	const checkboxRef = useRef<HTMLElement>(null);
 	const control = useControl({
 		defaultChecked,
@@ -54,15 +50,11 @@ export function CheckboxControl(props: CheckboxControlProps) {
 				ref={control.register}
 			/>
 			<Checkbox.Root
-				id={id}
 				className="checkbox"
 				ref={checkboxRef}
 				checked={control.checked ?? false}
 				onCheckedChange={(checked) => control.change(checked)}
 				onBlur={() => control.blur()}
-				aria-labelledby={props['aria-labelledby']}
-				aria-describedby={props['aria-describedby']}
-				aria-invalid={invalid || undefined}
 			>
 				<Checkbox.Indicator className="checkbox-indicator">
 					✓
@@ -78,7 +70,7 @@ export type CheckboxGroupControlProps = Omit<ControlProps, 'defaultValue'> & {
 };
 
 export function CheckboxGroupControl(props: CheckboxGroupControlProps) {
-	const { invalid, name, defaultValue, children } = props;
+	const { name, defaultValue, children } = props;
 	const groupRef = useRef<HTMLDivElement>(null);
 	const control = useControl({
 		defaultValue,
@@ -107,9 +99,6 @@ export function CheckboxGroupControl(props: CheckboxGroupControlProps) {
 						control.blur();
 					}
 				}}
-				aria-labelledby={props['aria-labelledby']}
-				aria-describedby={props['aria-describedby']}
-				aria-invalid={invalid || undefined}
 			>
 				{children}
 			</CheckboxGroup>
@@ -122,7 +111,7 @@ export type RadioGroupControlProps = ControlProps & {
 };
 
 export function RadioGroupControl(props: RadioGroupControlProps) {
-	const { invalid, name, defaultValue, children } = props;
+	const { name, defaultValue, children } = props;
 	const groupRef = useRef<HTMLDivElement>(null);
 	const control = useControl({
 		defaultValue,
@@ -148,9 +137,6 @@ export function RadioGroupControl(props: RadioGroupControlProps) {
 						control.blur();
 					}
 				}}
-				aria-labelledby={props['aria-labelledby']}
-				aria-describedby={props['aria-describedby']}
-				aria-invalid={invalid || undefined}
 			>
 				{children}
 			</RadioGroup>
@@ -164,7 +150,7 @@ export type SelectControlProps = ControlProps & {
 };
 
 export function SelectControl(props: SelectControlProps) {
-	const { id, invalid, name, defaultValue, items, placeholder } = props;
+	const { name, defaultValue, items, placeholder } = props;
 	const labels = Object.fromEntries(
 		items.map((item) => [item.value, item.label]),
 	);
@@ -188,12 +174,8 @@ export function SelectControl(props: SelectControlProps) {
 				onValueChange={(value) => control.change(value ?? '')}
 			>
 				<Select.Trigger
-					id={id}
 					className="select-trigger"
 					ref={triggerRef}
-					aria-labelledby={props['aria-labelledby']}
-					aria-describedby={props['aria-describedby']}
-					aria-invalid={invalid || undefined}
 					onBlur={() => control.blur()}
 				>
 					<Select.Value placeholder={placeholder}>
@@ -235,8 +217,7 @@ export type ComboboxControlProps = ControlProps & {
 };
 
 export function ComboboxControl(props: ComboboxControlProps) {
-	const { id, invalid, name, defaultValue, items, placeholder, triggerLabel } =
-		props;
+	const { name, defaultValue, items, placeholder, triggerLabel } = props;
 	const labels = Object.fromEntries(
 		items.map((item) => [item.value, item.label]),
 	);
@@ -264,13 +245,9 @@ export function ComboboxControl(props: ComboboxControlProps) {
 			>
 				<Combobox.InputGroup className="combobox-group">
 					<Combobox.Input
-						id={id}
 						className="combobox-input"
 						ref={inputRef}
 						placeholder={placeholder}
-						aria-labelledby={props['aria-labelledby']}
-						aria-describedby={props['aria-describedby']}
-						aria-invalid={invalid || undefined}
 						onBlur={() => control.blur()}
 					/>
 					<Combobox.Trigger
@@ -309,7 +286,7 @@ export type NumberFieldControlProps = ControlProps & {
 };
 
 export function NumberFieldControl(props: NumberFieldControlProps) {
-	const { id, invalid, label, name, defaultValue } = props;
+	const { label, name, defaultValue } = props;
 	const inputRef = useRef<HTMLInputElement>(null);
 	const control = useControl({
 		defaultValue,
@@ -329,7 +306,6 @@ export function NumberFieldControl(props: NumberFieldControlProps) {
 				ref={control.register}
 			/>
 			<NumberField.Root
-				id={id}
 				value={value}
 				onValueChange={(nextValue) =>
 					control.change(nextValue == null ? '' : String(nextValue))
@@ -349,13 +325,7 @@ export function NumberFieldControl(props: NumberFieldControlProps) {
 					>
 						−
 					</NumberField.Decrement>
-					<NumberField.Input
-						className="number-input"
-						ref={inputRef}
-						aria-labelledby={props['aria-labelledby']}
-						aria-describedby={props['aria-describedby']}
-						aria-invalid={invalid || undefined}
-					/>
+					<NumberField.Input className="number-input" ref={inputRef} />
 					<NumberField.Increment
 						className="stepper"
 						aria-label={`Increase ${label}`}
@@ -371,7 +341,7 @@ export function NumberFieldControl(props: NumberFieldControlProps) {
 export type SliderControlProps = ControlProps;
 
 export function SliderControl(props: SliderControlProps) {
-	const { invalid, name, defaultValue } = props;
+	const { name, defaultValue } = props;
 	const thumbInputRef = useRef<HTMLInputElement>(null);
 	const control = useControl({
 		defaultValue: defaultValue || '50',
@@ -405,9 +375,6 @@ export function SliderControl(props: SliderControlProps) {
 							className="slider-thumb"
 							inputRef={thumbInputRef}
 							onBlur={() => control.blur()}
-							aria-labelledby={props['aria-labelledby']}
-							aria-describedby={props['aria-describedby']}
-							aria-invalid={invalid || undefined}
 						/>
 					</Slider.Track>
 				</Slider.Control>
@@ -419,7 +386,7 @@ export function SliderControl(props: SliderControlProps) {
 export type SwitchControlProps = CheckedControlProps;
 
 export function SwitchControl(props: SwitchControlProps) {
-	const { id, invalid, name, defaultChecked } = props;
+	const { name, defaultChecked } = props;
 	const switchRef = useRef<HTMLElement>(null);
 	const control = useControl({
 		defaultChecked,
@@ -439,15 +406,11 @@ export function SwitchControl(props: SwitchControlProps) {
 				ref={control.register}
 			/>
 			<Switch.Root
-				id={id}
 				className="switch"
 				ref={switchRef}
 				checked={control.checked ?? false}
 				onCheckedChange={(checked) => control.change(checked)}
 				onBlur={() => control.blur()}
-				aria-labelledby={props['aria-labelledby']}
-				aria-describedby={props['aria-describedby']}
-				aria-invalid={invalid || undefined}
 			>
 				<Switch.Thumb className="switch-thumb" />
 			</Switch.Root>

--- a/examples/base-ui/src/components.tsx
+++ b/examples/base-ui/src/components.tsx
@@ -488,7 +488,7 @@ export function SliderField(props: StringFieldProps) {
 			thumbInputRef.current?.focus();
 		},
 	});
-	const numericValue = Number(control.value || 50);
+	const numericValue = Number(control.value);
 	const value = Number.isFinite(numericValue) ? numericValue : 50;
 
 	return (

--- a/examples/base-ui/src/components.tsx
+++ b/examples/base-ui/src/components.tsx
@@ -1,33 +1,24 @@
 import { Checkbox } from '@base-ui/react/checkbox';
 import { CheckboxGroup } from '@base-ui/react/checkbox-group';
 import { Combobox } from '@base-ui/react/combobox';
-import { Field } from '@base-ui/react/field';
-import { Input } from '@base-ui/react/input';
 import { NumberField } from '@base-ui/react/number-field';
-import { Radio } from '@base-ui/react/radio';
 import { RadioGroup } from '@base-ui/react/radio-group';
 import { Select } from '@base-ui/react/select';
 import { Slider } from '@base-ui/react/slider';
 import { Switch } from '@base-ui/react/switch';
 import { BaseControl, useControl } from '@conform-to/react/future';
-import { useRef, type FocusEvent } from 'react';
+import { useRef, type FocusEvent, type ReactNode } from 'react';
 
-type FieldStatusProps = {
+type ControlProps = {
 	id: string;
-	label: string;
-	description: string;
-	errors?: string[];
-	invalid: boolean;
-	'aria-describedby'?: string;
-};
-
-type StringFieldProps = FieldStatusProps & {
 	name: string;
 	defaultValue?: string;
+	invalid: boolean;
+	'aria-describedby'?: string;
+	'aria-labelledby'?: string;
 };
 
-type BooleanFieldProps = FieldStatusProps & {
-	name: string;
+type CheckedControlProps = Omit<ControlProps, 'defaultValue'> & {
 	defaultChecked?: boolean;
 };
 
@@ -40,70 +31,10 @@ function isFocusLeaving(event: FocusEvent<HTMLElement>) {
 	return !event.currentTarget.contains(event.relatedTarget);
 }
 
-function FieldMessages({ id, description, errors }: FieldStatusProps) {
-	return (
-		<>
-			<Field.Description id={`${id}-description`} className="description">
-				{description}
-			</Field.Description>
-			<div
-				id={`${id}-error`}
-				className="error"
-				role={errors?.length ? 'alert' : undefined}
-			>
-				{errors?.join(', ')}
-			</div>
-		</>
-	);
-}
+export type CheckboxControlProps = CheckedControlProps;
 
-export function TextInputField(props: StringFieldProps) {
-	const { id, label, invalid, name, defaultValue } = props;
-
-	return (
-		<Field.Root className="field" invalid={invalid}>
-			<Field.Label id={`${id}-label`} className="label">
-				{label}
-			</Field.Label>
-			<Input
-				id={id}
-				className="text-control"
-				name={name}
-				defaultValue={defaultValue}
-				aria-labelledby={`${id}-label`}
-				aria-describedby={props['aria-describedby']}
-				aria-invalid={invalid || undefined}
-			/>
-			<FieldMessages {...props} />
-		</Field.Root>
-	);
-}
-
-export function TextareaField(props: StringFieldProps) {
-	const { id, label, invalid, name, defaultValue } = props;
-
-	return (
-		<Field.Root className="field" invalid={invalid}>
-			<Field.Label id={`${id}-label`} className="label">
-				{label}
-			</Field.Label>
-			<Field.Control
-				render={<textarea rows={4} />}
-				id={id}
-				className="text-control"
-				name={name}
-				defaultValue={defaultValue}
-				aria-labelledby={`${id}-label`}
-				aria-describedby={props['aria-describedby']}
-				aria-invalid={invalid || undefined}
-			/>
-			<FieldMessages {...props} />
-		</Field.Root>
-	);
-}
-
-export function CheckboxField(props: BooleanFieldProps) {
-	const { id, label, invalid, name, defaultChecked } = props;
+export function CheckboxControl(props: CheckboxControlProps) {
+	const { id, invalid, name, defaultChecked } = props;
 	const checkboxRef = useRef<HTMLElement>(null);
 	const control = useControl({
 		defaultChecked,
@@ -114,7 +45,7 @@ export function CheckboxField(props: BooleanFieldProps) {
 	});
 
 	return (
-		<Field.Root className="field" invalid={invalid}>
+		<>
 			<BaseControl
 				type="checkbox"
 				name={name}
@@ -122,58 +53,53 @@ export function CheckboxField(props: BooleanFieldProps) {
 				defaultChecked={defaultChecked ?? false}
 				ref={control.register}
 			/>
-			<Field.Label id={`${id}-label`} className="choice-label">
-				<Checkbox.Root
-					id={id}
-					className="checkbox"
-					ref={checkboxRef}
-					checked={control.checked ?? false}
-					onCheckedChange={(checked) => control.change(checked)}
-					onBlur={() => control.blur()}
-					aria-labelledby={`${id}-label`}
-					aria-describedby={props['aria-describedby']}
-					aria-invalid={invalid || undefined}
-				>
-					<Checkbox.Indicator className="checkbox-indicator">
-						✓
-					</Checkbox.Indicator>
-				</Checkbox.Root>
-				{label}
-			</Field.Label>
-			<FieldMessages {...props} />
-		</Field.Root>
+			<Checkbox.Root
+				id={id}
+				className="checkbox"
+				ref={checkboxRef}
+				checked={control.checked ?? false}
+				onCheckedChange={(checked) => control.change(checked)}
+				onBlur={() => control.blur()}
+				aria-labelledby={props['aria-labelledby']}
+				aria-describedby={props['aria-describedby']}
+				aria-invalid={invalid || undefined}
+			>
+				<Checkbox.Indicator className="checkbox-indicator">
+					✓
+				</Checkbox.Indicator>
+			</Checkbox.Root>
+		</>
 	);
 }
 
-export type CheckboxGroupFieldProps = FieldStatusProps & {
-	name: string;
+export type CheckboxGroupControlProps = Omit<ControlProps, 'defaultValue'> & {
 	defaultValue?: string[];
-	items: Option[];
+	children: ReactNode;
 };
 
-export function CheckboxGroupField(props: CheckboxGroupFieldProps) {
-	const { id, label, invalid, name, defaultValue, items } = props;
-	const firstCheckboxRef = useRef<HTMLElement>(null);
+export function CheckboxGroupControl(props: CheckboxGroupControlProps) {
+	const { invalid, name, defaultValue, children } = props;
+	const groupRef = useRef<HTMLDivElement>(null);
 	const control = useControl({
 		defaultValue,
 		onFocus() {
-			firstCheckboxRef.current?.focus();
+			groupRef.current
+				?.querySelector<HTMLElement>('[role="checkbox"]')
+				?.focus();
 		},
 	});
 
 	return (
-		<Field.Root className="field" invalid={invalid}>
+		<>
 			<BaseControl
 				type="select"
 				name={name}
 				defaultValue={control.defaultValue ?? []}
 				ref={control.register}
 			/>
-			<Field.Label id={`${id}-label`} className="label">
-				{label}
-			</Field.Label>
 			<CheckboxGroup
 				className="choice-group"
+				ref={groupRef}
 				value={control.options ?? []}
 				onValueChange={(value) => control.change(value)}
 				onBlur={(event) => {
@@ -181,59 +107,40 @@ export function CheckboxGroupField(props: CheckboxGroupFieldProps) {
 						control.blur();
 					}
 				}}
-				aria-labelledby={`${id}-label`}
+				aria-labelledby={props['aria-labelledby']}
 				aria-describedby={props['aria-describedby']}
 				aria-invalid={invalid || undefined}
 			>
-				{items.map((item, index) => (
-					<label className="choice-label" key={item.value}>
-						<Checkbox.Root
-							className="checkbox"
-							value={item.value}
-							ref={index === 0 ? firstCheckboxRef : undefined}
-							aria-labelledby={`${id}-${item.value}-label`}
-							aria-describedby={props['aria-describedby']}
-							aria-invalid={invalid || undefined}
-						>
-							<Checkbox.Indicator className="checkbox-indicator">
-								✓
-							</Checkbox.Indicator>
-						</Checkbox.Root>
-						<span id={`${id}-${item.value}-label`}>{item.label}</span>
-					</label>
-				))}
+				{children}
 			</CheckboxGroup>
-			<FieldMessages {...props} />
-		</Field.Root>
+		</>
 	);
 }
 
-export type RadioGroupFieldProps = StringFieldProps & {
-	items: Option[];
+export type RadioGroupControlProps = ControlProps & {
+	children: ReactNode;
 };
 
-export function RadioGroupField(props: RadioGroupFieldProps) {
-	const { id, label, invalid, name, defaultValue, items } = props;
-	const firstRadioRef = useRef<HTMLElement>(null);
+export function RadioGroupControl(props: RadioGroupControlProps) {
+	const { invalid, name, defaultValue, children } = props;
+	const groupRef = useRef<HTMLDivElement>(null);
 	const control = useControl({
 		defaultValue,
 		onFocus() {
-			firstRadioRef.current?.focus();
+			groupRef.current?.querySelector<HTMLElement>('[role="radio"]')?.focus();
 		},
 	});
 
 	return (
-		<Field.Root className="field" invalid={invalid}>
+		<>
 			<BaseControl
 				name={name}
 				defaultValue={control.defaultValue ?? ''}
 				ref={control.register}
 			/>
-			<Field.Label id={`${id}-label`} className="label">
-				{label}
-			</Field.Label>
 			<RadioGroup
 				className="choice-group"
+				ref={groupRef}
 				value={control.value ?? ''}
 				onValueChange={(value) => control.change(value)}
 				onBlur={(event) => {
@@ -241,38 +148,23 @@ export function RadioGroupField(props: RadioGroupFieldProps) {
 						control.blur();
 					}
 				}}
-				aria-labelledby={`${id}-label`}
+				aria-labelledby={props['aria-labelledby']}
 				aria-describedby={props['aria-describedby']}
 				aria-invalid={invalid || undefined}
 			>
-				{items.map((item, index) => (
-					<label className="choice-label" key={item.value}>
-						<Radio.Root
-							className="radio"
-							ref={index === 0 ? firstRadioRef : undefined}
-							value={item.value}
-							aria-labelledby={`${id}-${item.value}-label`}
-							aria-describedby={props['aria-describedby']}
-							aria-invalid={invalid || undefined}
-						>
-							<Radio.Indicator className="radio-indicator" />
-						</Radio.Root>
-						<span id={`${id}-${item.value}-label`}>{item.label}</span>
-					</label>
-				))}
+				{children}
 			</RadioGroup>
-			<FieldMessages {...props} />
-		</Field.Root>
+		</>
 	);
 }
 
-export type SelectFieldProps = StringFieldProps & {
+export type SelectControlProps = ControlProps & {
 	items: Option[];
 	placeholder?: string;
 };
 
-export function SelectField(props: SelectFieldProps) {
-	const { id, label, invalid, name, defaultValue, items, placeholder } = props;
+export function SelectControl(props: SelectControlProps) {
+	const { id, invalid, name, defaultValue, items, placeholder } = props;
 	const labels = Object.fromEntries(
 		items.map((item) => [item.value, item.label]),
 	);
@@ -285,15 +177,12 @@ export function SelectField(props: SelectFieldProps) {
 	});
 
 	return (
-		<Field.Root className="field" invalid={invalid}>
+		<>
 			<BaseControl
 				name={name}
 				defaultValue={control.defaultValue ?? ''}
 				ref={control.register}
 			/>
-			<Field.Label id={`${id}-label`} className="label">
-				{label}
-			</Field.Label>
 			<Select.Root
 				value={control.value || null}
 				onValueChange={(value) => control.change(value ?? '')}
@@ -302,7 +191,7 @@ export function SelectField(props: SelectFieldProps) {
 					id={id}
 					className="select-trigger"
 					ref={triggerRef}
-					aria-labelledby={`${id}-label`}
+					aria-labelledby={props['aria-labelledby']}
 					aria-describedby={props['aria-describedby']}
 					aria-invalid={invalid || undefined}
 					onBlur={() => control.blur()}
@@ -335,15 +224,19 @@ export function SelectField(props: SelectFieldProps) {
 					</Select.Positioner>
 				</Select.Portal>
 			</Select.Root>
-			<FieldMessages {...props} />
-		</Field.Root>
+		</>
 	);
 }
 
-export type ComboboxFieldProps = SelectFieldProps;
+export type ComboboxControlProps = ControlProps & {
+	items: Option[];
+	placeholder?: string;
+	triggerLabel: string;
+};
 
-export function ComboboxField(props: ComboboxFieldProps) {
-	const { id, label, invalid, name, defaultValue, items, placeholder } = props;
+export function ComboboxControl(props: ComboboxControlProps) {
+	const { id, invalid, name, defaultValue, items, placeholder, triggerLabel } =
+		props;
 	const labels = Object.fromEntries(
 		items.map((item) => [item.value, item.label]),
 	);
@@ -357,15 +250,12 @@ export function ComboboxField(props: ComboboxFieldProps) {
 	});
 
 	return (
-		<Field.Root className="field" invalid={invalid}>
+		<>
 			<BaseControl
 				name={name}
 				defaultValue={control.defaultValue ?? ''}
 				ref={control.register}
 			/>
-			<Field.Label id={`${id}-label`} className="label">
-				{label}
-			</Field.Label>
 			<Combobox.Root
 				items={values}
 				value={control.value || null}
@@ -378,14 +268,14 @@ export function ComboboxField(props: ComboboxFieldProps) {
 						className="combobox-input"
 						ref={inputRef}
 						placeholder={placeholder}
-						aria-labelledby={`${id}-label`}
+						aria-labelledby={props['aria-labelledby']}
 						aria-describedby={props['aria-describedby']}
 						aria-invalid={invalid || undefined}
 						onBlur={() => control.blur()}
 					/>
 					<Combobox.Trigger
 						className="combobox-trigger"
-						aria-label={`Open ${label}`}
+						aria-label={triggerLabel}
 					>
 						⌄
 					</Combobox.Trigger>
@@ -410,13 +300,16 @@ export function ComboboxField(props: ComboboxFieldProps) {
 					</Combobox.Positioner>
 				</Combobox.Portal>
 			</Combobox.Root>
-			<FieldMessages {...props} />
-		</Field.Root>
+		</>
 	);
 }
 
-export function NumberFieldControl(props: StringFieldProps) {
-	const { id, label, invalid, name, defaultValue } = props;
+export type NumberFieldControlProps = ControlProps & {
+	label: string;
+};
+
+export function NumberFieldControl(props: NumberFieldControlProps) {
+	const { id, invalid, label, name, defaultValue } = props;
 	const inputRef = useRef<HTMLInputElement>(null);
 	const control = useControl({
 		defaultValue,
@@ -429,15 +322,12 @@ export function NumberFieldControl(props: StringFieldProps) {
 		control.value === '' || Number.isNaN(numericValue) ? null : numericValue;
 
 	return (
-		<Field.Root className="field" invalid={invalid}>
+		<>
 			<BaseControl
 				name={name}
 				defaultValue={control.defaultValue ?? ''}
 				ref={control.register}
 			/>
-			<Field.Label id={`${id}-label`} className="label">
-				{label}
-			</Field.Label>
 			<NumberField.Root
 				id={id}
 				value={value}
@@ -462,7 +352,7 @@ export function NumberFieldControl(props: StringFieldProps) {
 					<NumberField.Input
 						className="number-input"
 						ref={inputRef}
-						aria-labelledby={`${id}-label`}
+						aria-labelledby={props['aria-labelledby']}
 						aria-describedby={props['aria-describedby']}
 						aria-invalid={invalid || undefined}
 					/>
@@ -474,13 +364,14 @@ export function NumberFieldControl(props: StringFieldProps) {
 					</NumberField.Increment>
 				</NumberField.Group>
 			</NumberField.Root>
-			<FieldMessages {...props} />
-		</Field.Root>
+		</>
 	);
 }
 
-export function SliderField(props: StringFieldProps) {
-	const { id, label, invalid, name, defaultValue } = props;
+export type SliderControlProps = ControlProps;
+
+export function SliderControl(props: SliderControlProps) {
+	const { invalid, name, defaultValue } = props;
 	const thumbInputRef = useRef<HTMLInputElement>(null);
 	const control = useControl({
 		defaultValue: defaultValue || '50',
@@ -492,15 +383,12 @@ export function SliderField(props: StringFieldProps) {
 	const value = Number.isFinite(numericValue) ? numericValue : 50;
 
 	return (
-		<Field.Root className="field" invalid={invalid}>
+		<>
 			<BaseControl
 				name={name}
 				defaultValue={control.defaultValue ?? '50'}
 				ref={control.register}
 			/>
-			<Field.Label id={`${id}-label`} className="label">
-				{label}
-			</Field.Label>
 			<Slider.Root
 				className="slider-root"
 				value={value}
@@ -517,20 +405,21 @@ export function SliderField(props: StringFieldProps) {
 							className="slider-thumb"
 							inputRef={thumbInputRef}
 							onBlur={() => control.blur()}
-							aria-labelledby={`${id}-label`}
+							aria-labelledby={props['aria-labelledby']}
 							aria-describedby={props['aria-describedby']}
 							aria-invalid={invalid || undefined}
 						/>
 					</Slider.Track>
 				</Slider.Control>
 			</Slider.Root>
-			<FieldMessages {...props} />
-		</Field.Root>
+		</>
 	);
 }
 
-export function SwitchField(props: BooleanFieldProps) {
-	const { id, label, invalid, name, defaultChecked } = props;
+export type SwitchControlProps = CheckedControlProps;
+
+export function SwitchControl(props: SwitchControlProps) {
+	const { id, invalid, name, defaultChecked } = props;
 	const switchRef = useRef<HTMLElement>(null);
 	const control = useControl({
 		defaultChecked,
@@ -541,7 +430,7 @@ export function SwitchField(props: BooleanFieldProps) {
 	});
 
 	return (
-		<Field.Root className="field" invalid={invalid}>
+		<>
 			<BaseControl
 				type="checkbox"
 				name={name}
@@ -549,25 +438,19 @@ export function SwitchField(props: BooleanFieldProps) {
 				defaultChecked={defaultChecked ?? false}
 				ref={control.register}
 			/>
-			<div className="switch-row">
-				<Field.Label id={`${id}-label`} className="label">
-					{label}
-				</Field.Label>
-				<Switch.Root
-					id={id}
-					className="switch"
-					ref={switchRef}
-					checked={control.checked ?? false}
-					onCheckedChange={(checked) => control.change(checked)}
-					onBlur={() => control.blur()}
-					aria-labelledby={`${id}-label`}
-					aria-describedby={props['aria-describedby']}
-					aria-invalid={invalid || undefined}
-				>
-					<Switch.Thumb className="switch-thumb" />
-				</Switch.Root>
-			</div>
-			<FieldMessages {...props} />
-		</Field.Root>
+			<Switch.Root
+				id={id}
+				className="switch"
+				ref={switchRef}
+				checked={control.checked ?? false}
+				onCheckedChange={(checked) => control.change(checked)}
+				onBlur={() => control.blur()}
+				aria-labelledby={props['aria-labelledby']}
+				aria-describedby={props['aria-describedby']}
+				aria-invalid={invalid || undefined}
+			>
+				<Switch.Thumb className="switch-thumb" />
+			</Switch.Root>
+		</>
 	);
 }

--- a/examples/base-ui/src/components.tsx
+++ b/examples/base-ui/src/components.tsx
@@ -410,12 +410,12 @@ export function SliderField(props: StringFieldProps) {
 	const { id, label, invalid, name, defaultValue } = props;
 	const thumbInputRef = useRef<HTMLInputElement>(null);
 	const control = useControl({
-		defaultValue: defaultValue ?? '50',
+		defaultValue: defaultValue || '50',
 		onFocus() {
 			thumbInputRef.current?.focus();
 		},
 	});
-	const value = Number(control.value ?? 50);
+	const value = Number(control.value || 50);
 
 	return (
 		<Field.Root className="field" name={name} invalid={invalid}>

--- a/examples/base-ui/src/forms.ts
+++ b/examples/base-ui/src/forms.ts
@@ -27,71 +27,115 @@ const forms = configureForms({
 	shouldValidate: 'onBlur',
 	shouldRevalidate: 'onInput',
 	extendFieldMetadata(metadata) {
-		const status = {
-			id: metadata.id,
-			name: metadata.name,
-			invalid: !metadata.valid,
-			errors: metadata.errors,
-		};
 		return {
 			get textInputProps() {
 				return {
-					...status,
+					id: metadata.id,
+					name: metadata.name,
 					defaultValue: metadata.defaultValue,
+					'aria-describedby':
+						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
+					invalid: !metadata.valid,
+					errors: metadata.errors,
 				} satisfies Partial<ComponentProps<typeof TextInputField>>;
 			},
 			get textareaProps() {
 				return {
-					...status,
+					id: metadata.id,
+					name: metadata.name,
 					defaultValue: metadata.defaultValue,
+					'aria-describedby':
+						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
+					invalid: !metadata.valid,
+					errors: metadata.errors,
 				} satisfies Partial<ComponentProps<typeof TextareaField>>;
 			},
 			get checkboxProps() {
 				return {
-					...status,
+					id: metadata.id,
+					name: metadata.name,
 					defaultChecked: metadata.defaultChecked,
+					'aria-describedby':
+						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
+					invalid: !metadata.valid,
+					errors: metadata.errors,
 				} satisfies Partial<ComponentProps<typeof CheckboxField>>;
 			},
 			get checkboxGroupProps() {
 				return {
-					...status,
+					id: metadata.id,
+					name: metadata.name,
 					defaultValue: metadata.defaultOptions,
+					'aria-describedby':
+						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
+					invalid: !metadata.valid,
+					errors: metadata.errors,
 				} satisfies Partial<ComponentProps<typeof CheckboxGroupField>>;
 			},
 			get radioGroupProps() {
 				return {
-					...status,
+					id: metadata.id,
+					name: metadata.name,
 					defaultValue: metadata.defaultValue,
+					'aria-describedby':
+						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
+					invalid: !metadata.valid,
+					errors: metadata.errors,
 				} satisfies Partial<ComponentProps<typeof RadioGroupField>>;
 			},
 			get selectProps() {
 				return {
-					...status,
+					id: metadata.id,
+					name: metadata.name,
 					defaultValue: metadata.defaultValue,
+					'aria-describedby':
+						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
+					invalid: !metadata.valid,
+					errors: metadata.errors,
 				} satisfies Partial<ComponentProps<typeof SelectField>>;
 			},
 			get comboboxProps() {
 				return {
-					...status,
+					id: metadata.id,
+					name: metadata.name,
 					defaultValue: metadata.defaultValue,
+					'aria-describedby':
+						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
+					invalid: !metadata.valid,
+					errors: metadata.errors,
 				} satisfies Partial<ComponentProps<typeof ComboboxField>>;
 			},
 			get numberFieldProps() {
 				return {
-					...status,
+					id: metadata.id,
+					name: metadata.name,
 					defaultValue: metadata.defaultValue,
+					'aria-describedby':
+						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
+					invalid: !metadata.valid,
+					errors: metadata.errors,
 				} satisfies Partial<ComponentProps<typeof NumberFieldControl>>;
 			},
 			get sliderProps() {
 				return {
-					...status,
+					id: metadata.id,
+					name: metadata.name,
 					defaultValue: metadata.defaultValue,
+					'aria-describedby':
+						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
+					invalid: !metadata.valid,
+					errors: metadata.errors,
 				} satisfies Partial<ComponentProps<typeof SliderField>>;
 			},
 			get switchProps() {
 				return {
-					...status,
+					id: metadata.id,
+					name: metadata.name,
 					defaultChecked: metadata.defaultChecked,
+					'aria-describedby':
+						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
+					invalid: !metadata.valid,
+					errors: metadata.errors,
 				} satisfies Partial<ComponentProps<typeof SwitchField>>;
 			},
 		};

--- a/examples/base-ui/src/forms.ts
+++ b/examples/base-ui/src/forms.ts
@@ -1,12 +1,4 @@
-import {
-	configureForms,
-	type FieldMetadata as BaseFieldMetadata,
-	type Fieldset as BaseFieldset,
-	type FormMetadata as BaseFormMetadata,
-	type InferBaseErrorShape,
-	type InferCustomFieldMetadata,
-	type InferCustomFormMetadata,
-} from '@conform-to/react/future';
+import { configureForms } from '@conform-to/react/future';
 import { getConstraints } from '@conform-to/zod/v4/future';
 import type { Input } from '@base-ui/react/input';
 import type { ComponentProps } from 'react';
@@ -90,22 +82,5 @@ const forms = configureForms({
 		};
 	},
 });
-
-type BaseErrorShape = InferBaseErrorShape<typeof forms.config>;
-type CustomFormMetadata = InferCustomFormMetadata<typeof forms.config>;
-type CustomFieldMetadata = InferCustomFieldMetadata<typeof forms.config>;
-
-export type FormMetadata<ErrorShape extends BaseErrorShape = BaseErrorShape> =
-	BaseFormMetadata<ErrorShape, CustomFormMetadata, CustomFieldMetadata>;
-
-export type FieldMetadata<
-	FieldShape,
-	ErrorShape extends BaseErrorShape = BaseErrorShape,
-> = BaseFieldMetadata<FieldShape, ErrorShape, CustomFieldMetadata>;
-
-export type Fieldset<
-	FieldShape,
-	ErrorShape extends BaseErrorShape = BaseErrorShape,
-> = BaseFieldset<FieldShape, ErrorShape, CustomFieldMetadata>;
 
 export const useForm = forms.useForm;

--- a/examples/base-ui/src/forms.ts
+++ b/examples/base-ui/src/forms.ts
@@ -27,120 +27,64 @@ const forms = configureForms({
 	shouldRevalidate: 'onInput',
 	extendFieldMetadata(metadata) {
 		return {
-			get labelId() {
-				return `${metadata.id}-label`;
-			},
-			get descriptionId() {
-				return `${metadata.id}-description`;
-			},
 			get inputProps() {
 				return {
-					id: metadata.id,
 					name: metadata.name,
 					defaultValue: metadata.defaultValue,
-					'aria-labelledby': `${metadata.id}-label`,
-					'aria-describedby':
-						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
-					'aria-invalid': metadata.ariaInvalid,
 				} satisfies Partial<ComponentProps<typeof Input>>;
 			},
 			get textareaProps() {
 				return {
-					id: metadata.id,
 					name: metadata.name,
 					defaultValue: metadata.defaultValue,
-					'aria-labelledby': `${metadata.id}-label`,
-					'aria-describedby':
-						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
-					'aria-invalid': metadata.ariaInvalid,
 				} satisfies Partial<ComponentProps<'textarea'>>;
 			},
 			get checkboxProps() {
 				return {
-					id: metadata.id,
 					name: metadata.name,
 					defaultChecked: metadata.defaultChecked,
-					'aria-labelledby': `${metadata.id}-label`,
-					'aria-describedby':
-						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
-					invalid: !metadata.valid,
 				} satisfies Partial<ComponentProps<typeof CheckboxControl>>;
 			},
 			get checkboxGroupProps() {
 				return {
-					id: metadata.id,
 					name: metadata.name,
 					defaultValue: metadata.defaultOptions,
-					'aria-labelledby': `${metadata.id}-label`,
-					'aria-describedby':
-						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
-					invalid: !metadata.valid,
 				} satisfies Partial<ComponentProps<typeof CheckboxGroupControl>>;
 			},
 			get radioGroupProps() {
 				return {
-					id: metadata.id,
 					name: metadata.name,
 					defaultValue: metadata.defaultValue,
-					'aria-labelledby': `${metadata.id}-label`,
-					'aria-describedby':
-						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
-					invalid: !metadata.valid,
 				} satisfies Partial<ComponentProps<typeof RadioGroupControl>>;
 			},
 			get selectProps() {
 				return {
-					id: metadata.id,
 					name: metadata.name,
 					defaultValue: metadata.defaultValue,
-					'aria-labelledby': `${metadata.id}-label`,
-					'aria-describedby':
-						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
-					invalid: !metadata.valid,
 				} satisfies Partial<ComponentProps<typeof SelectControl>>;
 			},
 			get comboboxProps() {
 				return {
-					id: metadata.id,
 					name: metadata.name,
 					defaultValue: metadata.defaultValue,
-					'aria-labelledby': `${metadata.id}-label`,
-					'aria-describedby':
-						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
-					invalid: !metadata.valid,
 				} satisfies Partial<ComponentProps<typeof ComboboxControl>>;
 			},
 			get numberFieldProps() {
 				return {
-					id: metadata.id,
 					name: metadata.name,
 					defaultValue: metadata.defaultValue,
-					'aria-labelledby': `${metadata.id}-label`,
-					'aria-describedby':
-						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
-					invalid: !metadata.valid,
 				} satisfies Partial<ComponentProps<typeof NumberFieldControl>>;
 			},
 			get sliderProps() {
 				return {
-					id: metadata.id,
 					name: metadata.name,
 					defaultValue: metadata.defaultValue,
-					'aria-labelledby': `${metadata.id}-label`,
-					'aria-describedby':
-						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
-					invalid: !metadata.valid,
 				} satisfies Partial<ComponentProps<typeof SliderControl>>;
 			},
 			get switchProps() {
 				return {
-					id: metadata.id,
 					name: metadata.name,
 					defaultChecked: metadata.defaultChecked,
-					'aria-labelledby': `${metadata.id}-label`,
-					'aria-describedby':
-						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
-					invalid: !metadata.valid,
 				} satisfies Partial<ComponentProps<typeof SwitchControl>>;
 			},
 		};

--- a/examples/base-ui/src/forms.ts
+++ b/examples/base-ui/src/forms.ts
@@ -27,6 +27,12 @@ const forms = configureForms({
 	shouldRevalidate: 'onInput',
 	extendFieldMetadata(metadata) {
 		return {
+			get labelId() {
+				return `${metadata.id}-label`;
+			},
+			get descriptionId() {
+				return `${metadata.id}-description`;
+			},
 			get inputProps() {
 				return {
 					id: metadata.id,

--- a/examples/base-ui/src/forms.ts
+++ b/examples/base-ui/src/forms.ts
@@ -1,0 +1,118 @@
+import {
+	configureForms,
+	type FieldMetadata as BaseFieldMetadata,
+	type Fieldset as BaseFieldset,
+	type FormMetadata as BaseFormMetadata,
+	type InferBaseErrorShape,
+	type InferCustomFieldMetadata,
+	type InferCustomFormMetadata,
+} from '@conform-to/react/future';
+import { getConstraints } from '@conform-to/zod/v4/future';
+import type { ComponentProps } from 'react';
+import type {
+	CheckboxField,
+	CheckboxGroupField,
+	ComboboxField,
+	NumberFieldControl,
+	RadioGroupField,
+	SelectField,
+	SliderField,
+	SwitchField,
+	TextareaField,
+	TextInputField,
+} from './components';
+
+const forms = configureForms({
+	getConstraints,
+	shouldValidate: 'onBlur',
+	shouldRevalidate: 'onInput',
+	extendFieldMetadata(metadata) {
+		const status = {
+			id: metadata.id,
+			name: metadata.name,
+			invalid: !metadata.valid,
+			errors: metadata.errors,
+		};
+		return {
+			get textInputProps() {
+				return {
+					...status,
+					defaultValue: metadata.defaultValue,
+				} satisfies Partial<ComponentProps<typeof TextInputField>>;
+			},
+			get textareaProps() {
+				return {
+					...status,
+					defaultValue: metadata.defaultValue,
+				} satisfies Partial<ComponentProps<typeof TextareaField>>;
+			},
+			get checkboxProps() {
+				return {
+					...status,
+					defaultChecked: metadata.defaultChecked,
+				} satisfies Partial<ComponentProps<typeof CheckboxField>>;
+			},
+			get checkboxGroupProps() {
+				return {
+					...status,
+					defaultValue: metadata.defaultOptions,
+				} satisfies Partial<ComponentProps<typeof CheckboxGroupField>>;
+			},
+			get radioGroupProps() {
+				return {
+					...status,
+					defaultValue: metadata.defaultValue,
+				} satisfies Partial<ComponentProps<typeof RadioGroupField>>;
+			},
+			get selectProps() {
+				return {
+					...status,
+					defaultValue: metadata.defaultValue,
+				} satisfies Partial<ComponentProps<typeof SelectField>>;
+			},
+			get comboboxProps() {
+				return {
+					...status,
+					defaultValue: metadata.defaultValue,
+				} satisfies Partial<ComponentProps<typeof ComboboxField>>;
+			},
+			get numberFieldProps() {
+				return {
+					...status,
+					defaultValue: metadata.defaultValue,
+				} satisfies Partial<ComponentProps<typeof NumberFieldControl>>;
+			},
+			get sliderProps() {
+				return {
+					...status,
+					defaultValue: metadata.defaultValue,
+				} satisfies Partial<ComponentProps<typeof SliderField>>;
+			},
+			get switchProps() {
+				return {
+					...status,
+					defaultChecked: metadata.defaultChecked,
+				} satisfies Partial<ComponentProps<typeof SwitchField>>;
+			},
+		};
+	},
+});
+
+type BaseErrorShape = InferBaseErrorShape<typeof forms.config>;
+type CustomFormMetadata = InferCustomFormMetadata<typeof forms.config>;
+type CustomFieldMetadata = InferCustomFieldMetadata<typeof forms.config>;
+
+export type FormMetadata<ErrorShape extends BaseErrorShape = BaseErrorShape> =
+	BaseFormMetadata<ErrorShape, CustomFormMetadata, CustomFieldMetadata>;
+
+export type FieldMetadata<
+	FieldShape,
+	ErrorShape extends BaseErrorShape = BaseErrorShape,
+> = BaseFieldMetadata<FieldShape, ErrorShape, CustomFieldMetadata>;
+
+export type Fieldset<
+	FieldShape,
+	ErrorShape extends BaseErrorShape = BaseErrorShape,
+> = BaseFieldset<FieldShape, ErrorShape, CustomFieldMetadata>;
+
+export const useForm = forms.useForm;

--- a/examples/base-ui/src/forms.ts
+++ b/examples/base-ui/src/forms.ts
@@ -8,18 +8,17 @@ import {
 	type InferCustomFormMetadata,
 } from '@conform-to/react/future';
 import { getConstraints } from '@conform-to/zod/v4/future';
+import type { Input } from '@base-ui/react/input';
 import type { ComponentProps } from 'react';
 import type {
-	CheckboxField,
-	CheckboxGroupField,
-	ComboboxField,
+	CheckboxControl,
+	CheckboxGroupControl,
+	ComboboxControl,
 	NumberFieldControl,
-	RadioGroupField,
-	SelectField,
-	SliderField,
-	SwitchField,
-	TextareaField,
-	TextInputField,
+	RadioGroupControl,
+	SelectControl,
+	SliderControl,
+	SwitchControl,
 } from './components';
 
 const forms = configureForms({
@@ -28,92 +27,92 @@ const forms = configureForms({
 	shouldRevalidate: 'onInput',
 	extendFieldMetadata(metadata) {
 		return {
-			get textInputProps() {
+			get inputProps() {
 				return {
 					id: metadata.id,
 					name: metadata.name,
 					defaultValue: metadata.defaultValue,
+					'aria-labelledby': `${metadata.id}-label`,
 					'aria-describedby':
 						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
-					invalid: !metadata.valid,
-					errors: metadata.errors,
-				} satisfies Partial<ComponentProps<typeof TextInputField>>;
+					'aria-invalid': metadata.ariaInvalid,
+				} satisfies Partial<ComponentProps<typeof Input>>;
 			},
 			get textareaProps() {
 				return {
 					id: metadata.id,
 					name: metadata.name,
 					defaultValue: metadata.defaultValue,
+					'aria-labelledby': `${metadata.id}-label`,
 					'aria-describedby':
 						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
-					invalid: !metadata.valid,
-					errors: metadata.errors,
-				} satisfies Partial<ComponentProps<typeof TextareaField>>;
+					'aria-invalid': metadata.ariaInvalid,
+				} satisfies Partial<ComponentProps<'textarea'>>;
 			},
 			get checkboxProps() {
 				return {
 					id: metadata.id,
 					name: metadata.name,
 					defaultChecked: metadata.defaultChecked,
+					'aria-labelledby': `${metadata.id}-label`,
 					'aria-describedby':
 						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
 					invalid: !metadata.valid,
-					errors: metadata.errors,
-				} satisfies Partial<ComponentProps<typeof CheckboxField>>;
+				} satisfies Partial<ComponentProps<typeof CheckboxControl>>;
 			},
 			get checkboxGroupProps() {
 				return {
 					id: metadata.id,
 					name: metadata.name,
 					defaultValue: metadata.defaultOptions,
+					'aria-labelledby': `${metadata.id}-label`,
 					'aria-describedby':
 						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
 					invalid: !metadata.valid,
-					errors: metadata.errors,
-				} satisfies Partial<ComponentProps<typeof CheckboxGroupField>>;
+				} satisfies Partial<ComponentProps<typeof CheckboxGroupControl>>;
 			},
 			get radioGroupProps() {
 				return {
 					id: metadata.id,
 					name: metadata.name,
 					defaultValue: metadata.defaultValue,
+					'aria-labelledby': `${metadata.id}-label`,
 					'aria-describedby':
 						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
 					invalid: !metadata.valid,
-					errors: metadata.errors,
-				} satisfies Partial<ComponentProps<typeof RadioGroupField>>;
+				} satisfies Partial<ComponentProps<typeof RadioGroupControl>>;
 			},
 			get selectProps() {
 				return {
 					id: metadata.id,
 					name: metadata.name,
 					defaultValue: metadata.defaultValue,
+					'aria-labelledby': `${metadata.id}-label`,
 					'aria-describedby':
 						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
 					invalid: !metadata.valid,
-					errors: metadata.errors,
-				} satisfies Partial<ComponentProps<typeof SelectField>>;
+				} satisfies Partial<ComponentProps<typeof SelectControl>>;
 			},
 			get comboboxProps() {
 				return {
 					id: metadata.id,
 					name: metadata.name,
 					defaultValue: metadata.defaultValue,
+					'aria-labelledby': `${metadata.id}-label`,
 					'aria-describedby':
 						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
 					invalid: !metadata.valid,
-					errors: metadata.errors,
-				} satisfies Partial<ComponentProps<typeof ComboboxField>>;
+				} satisfies Partial<ComponentProps<typeof ComboboxControl>>;
 			},
 			get numberFieldProps() {
 				return {
 					id: metadata.id,
 					name: metadata.name,
 					defaultValue: metadata.defaultValue,
+					'aria-labelledby': `${metadata.id}-label`,
 					'aria-describedby':
 						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
 					invalid: !metadata.valid,
-					errors: metadata.errors,
 				} satisfies Partial<ComponentProps<typeof NumberFieldControl>>;
 			},
 			get sliderProps() {
@@ -121,22 +120,22 @@ const forms = configureForms({
 					id: metadata.id,
 					name: metadata.name,
 					defaultValue: metadata.defaultValue,
+					'aria-labelledby': `${metadata.id}-label`,
 					'aria-describedby':
 						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
 					invalid: !metadata.valid,
-					errors: metadata.errors,
-				} satisfies Partial<ComponentProps<typeof SliderField>>;
+				} satisfies Partial<ComponentProps<typeof SliderControl>>;
 			},
 			get switchProps() {
 				return {
 					id: metadata.id,
 					name: metadata.name,
 					defaultChecked: metadata.defaultChecked,
+					'aria-labelledby': `${metadata.id}-label`,
 					'aria-describedby':
 						`${metadata.id}-description ${metadata.ariaDescribedBy ?? ''}`.trim(),
 					invalid: !metadata.valid,
-					errors: metadata.errors,
-				} satisfies Partial<ComponentProps<typeof SwitchField>>;
+				} satisfies Partial<ComponentProps<typeof SwitchControl>>;
 			},
 		};
 	},

--- a/examples/base-ui/src/index.css
+++ b/examples/base-ui/src/index.css
@@ -1,0 +1,404 @@
+:root {
+	font-family:
+		Inter,
+		ui-sans-serif,
+		system-ui,
+		-apple-system,
+		BlinkMacSystemFont,
+		'Segoe UI',
+		sans-serif;
+	color: #17221b;
+	background: #eef2ed;
+	font-synthesis: none;
+}
+
+* {
+	box-sizing: border-box;
+}
+
+body {
+	margin: 0;
+}
+
+button,
+input,
+textarea {
+	font: inherit;
+}
+
+main {
+	min-height: 100vh;
+	padding: 3rem 1rem;
+}
+
+.form-card {
+	display: grid;
+	gap: 1.75rem;
+	width: min(100%, 44rem);
+	margin: 0 auto;
+	padding: clamp(1.5rem, 5vw, 3rem);
+	border: 1px solid #d5ddd6;
+	border-radius: 1.25rem;
+	background: #fff;
+	box-shadow: 0 1.25rem 4rem rgb(29 49 36 / 10%);
+}
+
+header {
+	display: grid;
+	gap: 0.5rem;
+}
+
+h1,
+h2,
+p {
+	margin: 0;
+}
+
+h1 {
+	font-size: clamp(2rem, 7vw, 3.5rem);
+	letter-spacing: -0.04em;
+}
+
+.eyebrow {
+	color: #1e6f4a;
+	font-size: 0.78rem;
+	font-weight: 750;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+}
+
+.intro,
+.description {
+	color: #657069;
+}
+
+.field {
+	display: grid;
+	gap: 0.55rem;
+}
+
+.field-list {
+	display: grid;
+	gap: 1.75rem;
+}
+
+.label {
+	font-weight: 700;
+}
+
+.description,
+.error {
+	font-size: 0.875rem;
+}
+
+.error {
+	color: #b42318;
+	font-weight: 650;
+	min-height: 1.2em;
+}
+
+.text-control,
+.select-trigger,
+.combobox-group,
+.number-group {
+	width: 100%;
+	min-height: 2.75rem;
+	border: 1px solid #aeb9b1;
+	border-radius: 0.65rem;
+	background: #fff;
+	color: inherit;
+}
+
+.text-control {
+	padding: 0.72rem 0.85rem;
+	resize: vertical;
+}
+
+.select-trigger {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0.7rem 0.85rem;
+	cursor: pointer;
+}
+
+.combobox-group,
+.number-group {
+	display: flex;
+	overflow: hidden;
+}
+
+.combobox-input,
+.number-input {
+	min-width: 0;
+	flex: 1;
+	border: 0;
+	outline: 0;
+	background: transparent;
+}
+
+.combobox-input {
+	padding: 0.7rem 0.85rem;
+}
+
+.combobox-trigger,
+.stepper {
+	display: grid;
+	width: 2.75rem;
+	place-items: center;
+	border: 0;
+	background: #eef2ed;
+	cursor: pointer;
+}
+
+.number-input {
+	padding: 0.7rem;
+	text-align: center;
+}
+
+.choice-group {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.8rem 1.25rem;
+}
+
+.choice-label,
+.switch-row {
+	display: flex;
+	align-items: center;
+	gap: 0.55rem;
+	cursor: pointer;
+}
+
+.switch-row {
+	justify-content: space-between;
+}
+
+.checkbox,
+.radio {
+	display: grid;
+	width: 1.3rem;
+	height: 1.3rem;
+	flex: none;
+	place-items: center;
+	border: 1px solid #849188;
+	background: #fff;
+	cursor: pointer;
+}
+
+.checkbox {
+	border-radius: 0.3rem;
+}
+
+.radio {
+	border-radius: 50%;
+}
+
+.checkbox[data-checked],
+.radio[data-checked] {
+	border-color: #216e4c;
+	background: #216e4c;
+}
+
+.checkbox-indicator {
+	color: #fff;
+	font-size: 0.85rem;
+	font-weight: 800;
+}
+
+.radio-indicator {
+	width: 0.45rem;
+	height: 0.45rem;
+	border-radius: 50%;
+	background: #fff;
+}
+
+.popup-positioner {
+	z-index: 10;
+}
+
+.popup {
+	min-width: var(--anchor-width);
+	padding: 0.35rem;
+	border: 1px solid #c8d0ca;
+	border-radius: 0.65rem;
+	background: #fff;
+	box-shadow: 0 0.8rem 2rem rgb(29 49 36 / 18%);
+}
+
+.popup-item {
+	position: relative;
+	display: flex;
+	min-height: 2.35rem;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.45rem 0.65rem 0.45rem 1.75rem;
+	border-radius: 0.45rem;
+	cursor: pointer;
+	outline: 0;
+}
+
+.popup-item[data-highlighted] {
+	background: #e4efe8;
+}
+
+.item-indicator {
+	position: absolute;
+	left: 0.55rem;
+	color: #216e4c;
+}
+
+.popup-empty {
+	padding: 0.7rem;
+	color: #657069;
+}
+
+.slider-root {
+	display: grid;
+	grid-template-columns: 1fr auto;
+	gap: 0.65rem;
+	align-items: center;
+}
+
+.slider-control {
+	display: flex;
+	min-height: 2rem;
+	align-items: center;
+	grid-column: 1;
+	grid-row: 1;
+	touch-action: none;
+	user-select: none;
+}
+
+.slider-track {
+	position: relative;
+	width: 100%;
+	height: 0.45rem;
+	border-radius: 999px;
+	background: #dbe2dc;
+}
+
+.slider-indicator {
+	position: absolute;
+	height: 100%;
+	border-radius: inherit;
+	background: #216e4c;
+}
+
+.slider-thumb {
+	width: 1.25rem;
+	height: 1.25rem;
+	border: 3px solid #216e4c;
+	border-radius: 50%;
+	background: #fff;
+	box-shadow: 0 2px 5px rgb(29 49 36 / 20%);
+}
+
+.slider-value {
+	grid-column: 2;
+	grid-row: 1;
+	font-variant-numeric: tabular-nums;
+}
+
+.switch {
+	position: relative;
+	display: flex;
+	width: 2.8rem;
+	height: 1.55rem;
+	align-items: center;
+	padding: 0.15rem;
+	border: 0;
+	border-radius: 999px;
+	background: #aeb9b1;
+	cursor: pointer;
+}
+
+.switch[data-checked] {
+	background: #216e4c;
+}
+
+.switch-thumb {
+	width: 1.25rem;
+	height: 1.25rem;
+	border-radius: 50%;
+	background: #fff;
+	transition: transform 120ms ease;
+}
+
+.switch[data-checked] .switch-thumb {
+	transform: translateX(1.25rem);
+}
+
+[aria-invalid='true'] {
+	border-color: #d92d20;
+}
+
+:where(
+	input,
+	textarea,
+	button,
+	[role='checkbox'],
+	[role='radio'],
+	[role='switch']
+):focus-visible,
+.slider-thumb:has(input:focus-visible) {
+	outline: 3px solid rgb(33 110 76 / 28%);
+	outline-offset: 2px;
+}
+
+.submitted {
+	display: grid;
+	gap: 0.75rem;
+	padding: 1rem;
+	border-radius: 0.75rem;
+	background: #f2f6f3;
+}
+
+.submitted h2 {
+	font-size: 1rem;
+}
+
+.submitted pre {
+	overflow: auto;
+	margin: 0;
+	font-size: 0.82rem;
+}
+
+footer {
+	display: flex;
+	gap: 0.75rem;
+}
+
+.button {
+	min-height: 2.75rem;
+	flex: 1;
+	border: 1px solid #216e4c;
+	border-radius: 0.65rem;
+	font-weight: 750;
+	cursor: pointer;
+}
+
+.primary {
+	background: #216e4c;
+	color: #fff;
+}
+
+.secondary {
+	background: #fff;
+	color: #216e4c;
+}
+
+@media (max-width: 32rem) {
+	main {
+		padding: 0;
+	}
+
+	.form-card {
+		border: 0;
+		border-radius: 0;
+	}
+
+	.choice-group {
+		flex-direction: column;
+	}
+}

--- a/examples/base-ui/src/main.tsx
+++ b/examples/base-ui/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+createRoot(document.getElementById('root')!).render(
+	<StrictMode>
+		<App />
+	</StrictMode>,
+);

--- a/examples/base-ui/tests/index.test.ts
+++ b/examples/base-ui/tests/index.test.ts
@@ -203,7 +203,9 @@ test.describe('base-ui', () => {
 		});
 
 		test('coerces NumberField and controls Slider values', async ({ page }) => {
-			const form = await getForm(page);
+			const form = await getForm(page, new URLSearchParams({ budget: '' }));
+
+			await expect(form.budget).toHaveValue('50');
 
 			await form.quantity.fill('');
 			await form.quantity.fill('3');

--- a/examples/base-ui/tests/index.test.ts
+++ b/examples/base-ui/tests/index.test.ts
@@ -1,375 +1,244 @@
 import { expect, test, type Page } from '@playwright/test';
 
 test.describe('base-ui', () => {
-	test.describe('form', () => {
-		async function getForm(page: Page, searchParams?: URLSearchParams) {
-			await page.goto(`/?${searchParams?.toString() ?? ''}`);
+	async function getForm(page: Page, searchParams?: URLSearchParams) {
+		await page.goto(searchParams ? `/?${searchParams}` : '/');
 
-			const form = page.locator('form');
-			return {
-				container: form,
-				heading: page.getByRole('heading', { name: 'Base UI Example' }),
-				fullName: page.getByLabel('Full name'),
-				bio: page.getByLabel('Bio'),
-				acceptTerms: page.getByRole('checkbox', { name: 'Accept terms' }),
-				interestsGroup: page.getByRole('group', { name: 'Interests' }),
-				design: page.getByRole('checkbox', { name: 'Design' }),
-				engineering: page.getByRole('checkbox', { name: 'Engineering' }),
-				research: page.getByRole('checkbox', { name: 'Research' }),
-				starter: page.getByRole('radio', { name: 'Starter' }),
-				professional: page.getByRole('radio', { name: 'Professional' }),
-				planGroup: page.getByRole('radiogroup', { name: 'Plan' }),
-				country: page.getByRole('combobox', { name: 'Country' }),
-				framework: page.getByRole('combobox', { name: 'Framework' }),
-				quantity: page.getByLabel('Quantity', { exact: true }),
-				budget: page.getByRole('slider', { name: 'Budget' }),
-				notifications: page.getByRole('switch', {
-					name: 'Product notifications',
-				}),
-				resetButton: page.getByRole('button', { name: 'Reset' }),
-				submitButton: page.getByRole('button', { name: 'Submit' }),
-				formData: () =>
-					form.evaluate((element) =>
-						Array.from(new FormData(element as HTMLFormElement)).map(
-							([name, value]) => [name, String(value)] as const,
-						),
-					),
-				submittedValue: async () =>
-					JSON.parse(
-						await page.locator('.submitted pre').innerText(),
-					) as unknown,
-			};
-		}
+		const form = page.locator('form');
+		const country = form.getByRole('combobox', { name: 'Country' });
+		const framework = form.getByRole('combobox', { name: 'Framework' });
+		const quantity = form.getByLabel('Quantity', { exact: true });
+		const budget = form.getByRole('slider', { name: 'Budget' });
 
-		async function chooseCountry(page: Page, name: string) {
-			await page.getByRole('combobox', { name: 'Country' }).click();
-			await page.getByRole('option', { name }).click();
-		}
-
-		async function chooseFramework(page: Page, name: string) {
-			const input = page.getByRole('combobox', { name: 'Framework' });
-			await input.fill(name.slice(0, 2));
-			await page.getByRole('option', { name }).click();
-		}
-
-		async function setBudget(page: Page, value: number) {
-			const slider = page.getByRole('slider', { name: 'Budget' });
-			await slider.press('Home');
-			for (let current = 0; current < value; current += 5) {
-				await slider.press('ArrowRight');
-			}
-		}
-
-		async function completeRequiredFields(page: Page) {
-			const form = await getForm(page);
-			await form.fullName.fill('Ada Lovelace');
-			await form.bio.fill('Writes thoughtful programs.');
-			await form.acceptTerms.click();
-			await form.design.click();
-			await form.professional.click();
-			await chooseCountry(page, 'United Kingdom');
-			await chooseFramework(page, 'React');
-			await form.quantity.fill('');
-			await form.quantity.fill('3');
-			return form;
-		}
-
-		test('validates on submit and focuses each invalid control', async ({
-			page,
-		}) => {
-			const form = await getForm(page);
-
-			await form.submitButton.click();
-			await expect(form.fullName).toBeFocused();
-			await expect(form.fullName).toHaveAttribute('aria-invalid', 'true');
-			await expect(form.fullName).toHaveAccessibleDescription(
-				'A native Base UI Input. Enter at least 2 characters',
-			);
-			await form.fullName.fill('Ada Lovelace');
-
-			await form.submitButton.click();
-			await expect(form.bio).toBeFocused();
-			await form.bio.fill('Writes thoughtful programs.');
-
-			await form.submitButton.click();
-			await expect(form.acceptTerms).toBeFocused();
-			await form.acceptTerms.click();
-
-			await form.submitButton.click();
-			await expect(form.design).toBeFocused();
-			await form.design.click();
-
-			await form.submitButton.click();
-			await expect(form.starter).toBeFocused();
-			await form.starter.click();
-
-			await form.submitButton.click();
-			await expect(form.country).toBeFocused();
-			await chooseCountry(page, 'Canada');
-
-			await form.submitButton.click();
-			await expect(form.framework).toBeFocused();
-			await chooseFramework(page, 'React');
-		});
-
-		test('validates native controls on blur', async ({ page }) => {
-			const form = await getForm(page);
-
-			await form.fullName.fill('A');
-			await form.heading.click();
-
-			await expect(form.fullName).toHaveAttribute('aria-invalid', 'true');
-			await expect(page.getByText('Enter at least 2 characters')).toBeVisible();
-
-			await form.acceptTerms.click();
-			await form.acceptTerms.click();
-			await form.acceptTerms.focus();
-			await form.heading.click();
-			await expect(form.acceptTerms).toHaveAttribute('aria-invalid', 'true');
-
-			await form.design.focus();
-			await form.heading.click();
-			await expect(form.interestsGroup).toHaveAttribute('aria-invalid', 'true');
-			await expect(form.interestsGroup).toHaveAccessibleDescription(
-				'Each checked item contributes the same name to FormData. Choose at least one interest',
-			);
-
-			await form.starter.focus();
-			await form.heading.click();
-			await expect(form.planGroup).toHaveAttribute('aria-invalid', 'true');
-			await expect(form.planGroup).toHaveAccessibleDescription(
-				'The group serializes one scalar value. Choose a plan',
-			);
-
-			await form.country.click();
-			await form.country.press('Escape');
-			await form.country.press('Tab');
-			await expect(form.country).toHaveAttribute('aria-invalid', 'true');
-			await expect(form.country).toHaveAccessibleDescription(
-				'Select maintains a form-compatible hidden input. Choose a country',
-			);
-		});
-
-		test('serializes boolean and array checkboxes through Base UI hidden inputs', async ({
-			page,
-		}) => {
-			const form = await getForm(page);
-
-			await form.acceptTerms.click();
-			await form.design.click();
-			await form.research.click();
-
-			await expect
-				.poll(() =>
-					form.container.evaluate((element) => {
-						const data = new FormData(element as HTMLFormElement);
-						return {
-							acceptTerms: data.get('acceptTerms'),
-							interests: data.getAll('interests'),
-						};
-					}),
-				)
-				.toEqual({
-					acceptTerms: 'on',
-					interests: ['design', 'research'],
-				});
-
-			await form.acceptTerms.click();
-			await expect
-				.poll(() =>
-					form.container.evaluate((element) =>
-						new FormData(element as HTMLFormElement).has('acceptTerms'),
-					),
-				)
-				.toBe(false);
-		});
-
-		test('selects values with Select and Combobox', async ({ page }) => {
-			const form = await getForm(page);
-
-			await chooseCountry(page, 'Canada');
-			await chooseFramework(page, 'Svelte');
-
-			await expect(form.country).toContainText('Canada');
-			await expect(form.framework).toHaveValue('Svelte');
-			await expect
-				.poll(() =>
-					form.container.evaluate((element) => {
-						const data = new FormData(element as HTMLFormElement);
-						return [data.get('country'), data.get('framework')];
-					}),
-				)
-				.toEqual(['ca', 'svelte']);
-		});
-
-		test('coerces NumberField and controls Slider values', async ({ page }) => {
-			const form = await getForm(page, new URLSearchParams({ budget: '' }));
-
-			await expect(form.budget).toHaveValue('50');
-
-			await form.quantity.fill('');
-			await form.quantity.fill('3');
-			await page.getByRole('button', { name: 'Increase Quantity' }).click();
-			await setBudget(page, 75);
-
-			await expect(form.quantity).toHaveValue('4');
-			await expect(form.budget).toHaveValue('75');
-			await expect
-				.poll(() =>
-					form.container.evaluate((element) => {
-						const data = new FormData(element as HTMLFormElement);
-						return [data.get('quantity'), data.get('budget')];
-					}),
-				)
-				.toEqual(['4', '75']);
-		});
-
-		test('resets native, hidden-input, and useControl-backed components', async ({
-			page,
-		}) => {
-			const defaults = new URLSearchParams([
-				['fullName', 'Grace Hopper'],
-				['bio', 'Pioneered practical compiler technology.'],
-				['acceptTerms', 'on'],
-				['interests', 'engineering'],
-				['interests', 'research'],
-				['plan', 'enterprise'],
-				['country', 'jp'],
-				['framework', 'svelte'],
-				['quantity', '6'],
-				['budget', '70'],
-				['notifications', 'on'],
-			]);
-
-			for (const reset of ['conform', 'browser']) {
-				const form = await getForm(page, defaults);
-
-				await form.fullName.fill('Changed name');
-				await form.bio.fill('Changed biography text.');
-				await form.acceptTerms.click();
-				await form.engineering.click();
-				await form.design.click();
-				await form.starter.click();
-				await chooseCountry(page, 'Canada');
-				await chooseFramework(page, 'React');
-				await form.quantity.fill('2');
-				await setBudget(page, 80);
-				await form.notifications.click();
-
-				if (reset === 'conform') {
-					await form.resetButton.click();
-				} else {
-					await form.container.evaluate((element) =>
-						(element as HTMLFormElement).reset(),
-					);
+		return {
+			form,
+			heading: page.getByRole('heading', { name: 'Base UI Example' }),
+			fullName: form.getByLabel('Full name'),
+			bio: form.getByLabel('Bio'),
+			acceptTerms: form.getByRole('checkbox', { name: 'Accept terms' }),
+			interestsGroup: form.getByRole('group', { name: 'Interests' }),
+			design: form.getByRole('checkbox', { name: 'Design' }),
+			engineering: form.getByRole('checkbox', { name: 'Engineering' }),
+			research: form.getByRole('checkbox', { name: 'Research' }),
+			planGroup: form.getByRole('radiogroup', { name: 'Plan' }),
+			starter: form.getByRole('radio', { name: 'Starter' }),
+			professional: form.getByRole('radio', { name: 'Professional' }),
+			enterprise: form.getByRole('radio', { name: 'Enterprise' }),
+			country,
+			async chooseCountry(name: string) {
+				await country.click();
+				await page.getByRole('option', { name }).click();
+			},
+			framework,
+			async chooseFramework(name: string) {
+				await framework.fill(name.slice(0, 2));
+				await page.getByRole('option', { name }).click();
+			},
+			quantity,
+			async setQuantity(value: string) {
+				await quantity.fill('');
+				await quantity.fill(value);
+			},
+			increaseQuantity: form.getByRole('button', {
+				name: 'Increase Quantity',
+			}),
+			budget,
+			async setBudget(value: number) {
+				await budget.press('Home');
+				for (let current = 0; current < value; current += 5) {
+					await budget.press('ArrowRight');
 				}
+			},
+			notifications: form.getByRole('switch', {
+				name: 'Product notifications',
+			}),
+			resetButton: form.getByRole('button', { name: 'Reset' }),
+			submitButton: form.getByRole('button', { name: 'Submit' }),
+			submittedValue: () =>
+				form
+					.locator('.submitted pre')
+					.innerText()
+					.then((value) => JSON.parse(value)),
+		};
+	}
 
-				await expect(form.fullName).toHaveValue('Grace Hopper');
-				await expect(form.acceptTerms).toBeChecked();
-				await expect(form.engineering).toBeChecked();
-				await expect(form.research).toBeChecked();
-				await expect(form.design).not.toBeChecked();
-				await expect(
-					page.getByRole('radio', { name: 'Enterprise' }),
-				).toBeChecked();
-				await expect(form.country).toContainText('Japan');
-				await expect(form.framework).toHaveValue('Svelte');
-				await expect(form.quantity).toHaveValue('6');
-				await expect(form.budget).toHaveValue('70');
-				await expect(form.notifications).toBeChecked();
-				await expect.poll(form.formData).toEqual(Array.from(defaults));
-			}
+	test('validation and submission', async ({ page }) => {
+		const controls = await getForm(page, new URLSearchParams({ budget: '' }));
+
+		// An empty URL default falls back to the slider's presentation default.
+		await expect(controls.budget).toHaveValue('50');
+
+		await controls.fullName.fill('A');
+		await controls.heading.click();
+		await expect(controls.fullName).toHaveAccessibleDescription(
+			'A native Base UI Input. Enter at least 2 characters',
+		);
+
+		await controls.design.focus();
+		await controls.heading.click();
+		await expect(controls.interestsGroup).toHaveAccessibleDescription(
+			'A multiple BaseControl serializes the selected values. Choose at least one interest',
+		);
+
+		await controls.fullName.fill('Ada Lovelace');
+		await controls.bio.fill('Writes thoughtful programs.');
+		await controls.setBudget(0);
+
+		await controls.submitButton.click();
+		await expect(controls.acceptTerms).toBeFocused();
+		await expect(controls.acceptTerms).toHaveAccessibleDescription(
+			'The visible checkbox is synchronized with a BaseControl. Accept the terms to continue',
+		);
+		await controls.acceptTerms.click();
+
+		await controls.submitButton.click();
+		await expect(controls.design).toBeFocused();
+		await expect(controls.design).toHaveAccessibleDescription(
+			'A multiple BaseControl serializes the selected values. Choose at least one interest',
+		);
+		await controls.design.click();
+		await controls.engineering.click();
+
+		await controls.submitButton.click();
+		await expect(controls.starter).toBeFocused();
+		await expect(controls.planGroup).toHaveAccessibleDescription(
+			'The BaseControl serializes one scalar value. Choose a plan',
+		);
+		await expect(controls.starter).toHaveAccessibleDescription(
+			'The BaseControl serializes one scalar value. Choose a plan',
+		);
+		await controls.professional.click();
+
+		await controls.submitButton.click();
+		await expect(controls.country).toBeFocused();
+		await expect(controls.country).toHaveAccessibleDescription(
+			'Select is synchronized with a scalar BaseControl. Choose a country',
+		);
+		await controls.chooseCountry('Canada');
+
+		await controls.submitButton.click();
+		await expect(controls.framework).toBeFocused();
+		await expect(controls.framework).toHaveAccessibleDescription(
+			'Filtering is transient; BaseControl stores the selection. Choose a framework',
+		);
+		await controls.chooseFramework('Svelte');
+
+		await controls.submitButton.click();
+		await expect(controls.quantity).toBeFocused();
+		await expect(controls.quantity).toHaveAccessibleDescription(
+			'BaseControl stores the raw value before Zod coercion. Use at least 2',
+		);
+		await controls.setQuantity('3');
+		await controls.increaseQuantity.click();
+
+		await controls.submitButton.click();
+		await expect(controls.budget).toBeFocused();
+		await expect(controls.budget).toHaveAccessibleDescription(
+			'The range input is controlled through useControl. Use a budget of at least 10',
+		);
+		await controls.setBudget(65);
+
+		await controls.submitButton.click();
+		await expect(controls.notifications).toBeFocused();
+		await expect(controls.notifications).toHaveAccessibleDescription(
+			'A checkbox BaseControl submits “on” while enabled. Enable product notifications',
+		);
+		await controls.notifications.click();
+
+		await controls.submitButton.click();
+
+		await expect.poll(controls.submittedValue).toEqual({
+			fullName: 'Ada Lovelace',
+			bio: 'Writes thoughtful programs.',
+			acceptTerms: true,
+			interests: ['design', 'engineering'],
+			plan: 'professional',
+			country: 'ca',
+			framework: 'svelte',
+			quantity: 4,
+			budget: 65,
+			notifications: true,
 		});
+		await expect
+			.poll(() => new URL(page.url()).searchParams.getAll('interests'))
+			.toEqual(['design', 'engineering']);
+	});
 
-		test('resets to the last successful submission', async ({ page }) => {
-			const form = await completeRequiredFields(page);
-			await form.engineering.click();
-			await setBudget(page, 65);
-			await form.notifications.click();
-			await form.submitButton.click();
-			await expect.poll(form.submittedValue).toMatchObject({ budget: 65 });
+	test('updated defaults and reset', async ({ page }) => {
+		const defaults = new URLSearchParams([
+			['fullName', 'Grace Hopper'],
+			['bio', 'Pioneered practical compiler technology.'],
+			['interests', 'research'],
+			['plan', 'enterprise'],
+			['country', 'jp'],
+			['framework', 'svelte'],
+			['quantity', '6'],
+			['budget', '70'],
+		]);
+		const controls = await getForm(page, defaults);
 
-			await form.fullName.fill('Changed name');
-			await form.design.click();
-			await chooseCountry(page, 'Japan');
-			await chooseFramework(page, 'Vue');
-			await form.quantity.fill('8');
-			await setBudget(page, 80);
-			await form.notifications.click();
-			await form.resetButton.click();
+		await expect(controls.fullName).toHaveValue('Grace Hopper');
+		await expect(controls.research).toBeChecked();
+		await expect(controls.enterprise).toBeChecked();
+		await expect(controls.country).toContainText('Japan');
+		await expect(controls.framework).toHaveValue('Svelte');
 
-			await expect(form.fullName).toHaveValue('Ada Lovelace');
-			await expect(form.design).toBeChecked();
-			await expect(form.engineering).toBeChecked();
-			await expect(form.country).toContainText('United Kingdom');
-			await expect(form.framework).toHaveValue('React');
-			await expect(form.quantity).toHaveValue('3');
-			await expect(form.budget).toHaveValue('65');
-			await expect(form.notifications).toBeChecked();
-		});
+		await controls.fullName.fill('Ada Lovelace');
+		await controls.bio.fill('Writes thoughtful programs.');
+		await controls.acceptTerms.click();
+		await controls.research.click();
+		await controls.design.click();
+		await controls.engineering.click();
+		await controls.professional.click();
+		await controls.chooseCountry('United Kingdom');
+		await controls.chooseFramework('React');
+		await controls.setQuantity('4');
+		await controls.setBudget(65);
+		await controls.notifications.click();
+		await controls.submitButton.click();
 
-		test('restores every default from URL search parameters', async ({
-			page,
-		}) => {
-			const searchParams = new URLSearchParams([
-				['fullName', 'Grace Hopper'],
-				['bio', 'Pioneered practical compiler technology.'],
-				['acceptTerms', 'on'],
-				['interests', 'engineering'],
-				['interests', 'research'],
-				['plan', 'enterprise'],
-				['country', 'jp'],
-				['framework', 'svelte'],
-				['quantity', '6'],
-				['budget', '70'],
-				['notifications', 'on'],
-			]);
-			const form = await getForm(page, searchParams);
+		const submittedValue = {
+			fullName: 'Ada Lovelace',
+			bio: 'Writes thoughtful programs.',
+			acceptTerms: true,
+			interests: ['design', 'engineering'],
+			plan: 'professional',
+			country: 'gb',
+			framework: 'react',
+			quantity: 4,
+			budget: 65,
+			notifications: true,
+		};
+		await expect.poll(controls.submittedValue).toEqual(submittedValue);
 
-			await expect(form.fullName).toHaveValue('Grace Hopper');
-			await expect(form.engineering).toBeChecked();
-			await expect(form.research).toBeChecked();
-			await expect(
-				page.getByRole('radio', { name: 'Enterprise' }),
-			).toBeChecked();
-			await expect(form.country).toContainText('Japan');
-			await expect(form.framework).toHaveValue('Svelte');
-			await expect(form.quantity).toHaveValue('6');
-			await expect(form.budget).toHaveValue('70');
-			await expect(form.notifications).toBeChecked();
-		});
+		await controls.fullName.fill('Changed name');
+		await controls.bio.fill('Changed biography text.');
+		await controls.acceptTerms.click();
+		await controls.design.click();
+		await controls.research.click();
+		await controls.starter.click();
+		await controls.chooseCountry('Canada');
+		await controls.chooseFramework('Vue');
+		await controls.setQuantity('9');
+		await controls.setBudget(80);
+		await controls.notifications.click();
 
-		test('submits parsed data and updates the URL', async ({ page }) => {
-			const form = await completeRequiredFields(page);
-			await form.engineering.click();
-			await setBudget(page, 65);
-			await form.notifications.click();
-			await form.submitButton.click();
+		await controls.resetButton.click();
 
-			expect(
-				(await page.locator('.error').allTextContents()).filter((error) =>
-					error.trim(),
-				),
-			).toEqual([]);
-			await expect.poll(form.submittedValue).toEqual({
-				fullName: 'Ada Lovelace',
-				bio: 'Writes thoughtful programs.',
-				acceptTerms: true,
-				interests: ['design', 'engineering'],
-				plan: 'professional',
-				country: 'gb',
-				framework: 'react',
-				quantity: 3,
-				budget: 65,
-				notifications: true,
-			});
+		await expect(controls.fullName).toHaveValue('Ada Lovelace');
+		await expect(controls.bio).toHaveValue('Writes thoughtful programs.');
+		await expect(controls.acceptTerms).toBeChecked();
+		await expect(controls.design).toBeChecked();
+		await expect(controls.engineering).toBeChecked();
+		await expect(controls.research).not.toBeChecked();
+		await expect(controls.professional).toBeChecked();
+		await expect(controls.country).toContainText('United Kingdom');
+		await expect(controls.framework).toHaveValue('React');
+		await expect(controls.quantity).toHaveValue('4');
+		await expect(controls.budget).toHaveValue('65');
+		await expect(controls.notifications).toBeChecked();
 
-			await expect
-				.poll(() => new URL(page.url()).searchParams.get('budget'))
-				.toBe('65');
-			await expect
-				.poll(() => new URL(page.url()).searchParams.getAll('interests'))
-				.toEqual(['design', 'engineering']);
-		});
+		await controls.submitButton.click();
+		await expect.poll(controls.submittedValue).toEqual(submittedValue);
 	});
 });

--- a/examples/base-ui/tests/index.test.ts
+++ b/examples/base-ui/tests/index.test.ts
@@ -63,12 +63,6 @@ test.describe('base-ui', () => {
 	}
 
 	test('validation and submission', async ({ page }) => {
-		const malformedDefaults = await getForm(
-			page,
-			new URLSearchParams({ budget: 'abc' }),
-		);
-		await expect(malformedDefaults.budget).toHaveValue('50');
-
 		const controls = await getForm(page, new URLSearchParams({ budget: '' }));
 
 		// An empty URL default falls back to the slider's presentation default.

--- a/examples/base-ui/tests/index.test.ts
+++ b/examples/base-ui/tests/index.test.ts
@@ -63,6 +63,12 @@ test.describe('base-ui', () => {
 	}
 
 	test('validation and submission', async ({ page }) => {
+		const malformedDefaults = await getForm(
+			page,
+			new URLSearchParams({ budget: 'abc' }),
+		);
+		await expect(malformedDefaults.budget).toHaveValue('50');
+
 		const controls = await getForm(page, new URLSearchParams({ budget: '' }));
 
 		// An empty URL default falls back to the slider's presentation default.

--- a/examples/base-ui/tests/index.test.ts
+++ b/examples/base-ui/tests/index.test.ts
@@ -73,6 +73,7 @@ test.describe('base-ui', () => {
 		await expect(controls.fullName).toHaveAccessibleDescription(
 			'A native Base UI Input. Enter at least 2 characters',
 		);
+		await expect(controls.fullName).toHaveAttribute('aria-invalid', 'true');
 
 		await controls.design.focus();
 		await controls.heading.click();
@@ -89,6 +90,7 @@ test.describe('base-ui', () => {
 		await expect(controls.acceptTerms).toHaveAccessibleDescription(
 			'The visible checkbox is synchronized with a BaseControl. Accept the terms to continue',
 		);
+		await expect(controls.acceptTerms).toHaveAttribute('aria-invalid', 'true');
 		await controls.acceptTerms.click();
 
 		await controls.submitButton.click();

--- a/examples/base-ui/tests/index.test.ts
+++ b/examples/base-ui/tests/index.test.ts
@@ -1,0 +1,373 @@
+import { expect, test, type Page } from '@playwright/test';
+
+test.describe('base-ui', () => {
+	test.describe('form', () => {
+		async function getForm(page: Page, searchParams?: URLSearchParams) {
+			await page.goto(`/?${searchParams?.toString() ?? ''}`);
+
+			const form = page.locator('form');
+			return {
+				container: form,
+				heading: page.getByRole('heading', { name: 'Base UI Example' }),
+				fullName: page.getByLabel('Full name'),
+				bio: page.getByLabel('Bio'),
+				acceptTerms: page.getByRole('checkbox', { name: 'Accept terms' }),
+				interestsGroup: page.getByRole('group', { name: 'Interests' }),
+				design: page.getByRole('checkbox', { name: 'Design' }),
+				engineering: page.getByRole('checkbox', { name: 'Engineering' }),
+				research: page.getByRole('checkbox', { name: 'Research' }),
+				starter: page.getByRole('radio', { name: 'Starter' }),
+				professional: page.getByRole('radio', { name: 'Professional' }),
+				planGroup: page.getByRole('radiogroup', { name: 'Plan' }),
+				country: page.getByRole('combobox', { name: 'Country' }),
+				framework: page.getByRole('combobox', { name: 'Framework' }),
+				quantity: page.getByLabel('Quantity', { exact: true }),
+				budget: page.getByRole('slider', { name: 'Budget' }),
+				notifications: page.getByRole('switch', {
+					name: 'Product notifications',
+				}),
+				resetButton: page.getByRole('button', { name: 'Reset' }),
+				submitButton: page.getByRole('button', { name: 'Submit' }),
+				formData: () =>
+					form.evaluate((element) =>
+						Array.from(new FormData(element as HTMLFormElement)).map(
+							([name, value]) => [name, String(value)] as const,
+						),
+					),
+				submittedValue: async () =>
+					JSON.parse(
+						await page.locator('.submitted pre').innerText(),
+					) as unknown,
+			};
+		}
+
+		async function chooseCountry(page: Page, name: string) {
+			await page.getByRole('combobox', { name: 'Country' }).click();
+			await page.getByRole('option', { name }).click();
+		}
+
+		async function chooseFramework(page: Page, name: string) {
+			const input = page.getByRole('combobox', { name: 'Framework' });
+			await input.fill(name.slice(0, 2));
+			await page.getByRole('option', { name }).click();
+		}
+
+		async function setBudget(page: Page, value: number) {
+			const slider = page.getByRole('slider', { name: 'Budget' });
+			await slider.press('Home');
+			for (let current = 0; current < value; current += 5) {
+				await slider.press('ArrowRight');
+			}
+		}
+
+		async function completeRequiredFields(page: Page) {
+			const form = await getForm(page);
+			await form.fullName.fill('Ada Lovelace');
+			await form.bio.fill('Writes thoughtful programs.');
+			await form.acceptTerms.click();
+			await form.design.click();
+			await form.professional.click();
+			await chooseCountry(page, 'United Kingdom');
+			await chooseFramework(page, 'React');
+			await form.quantity.fill('');
+			await form.quantity.fill('3');
+			return form;
+		}
+
+		test('validates on submit and focuses each invalid control', async ({
+			page,
+		}) => {
+			const form = await getForm(page);
+
+			await form.submitButton.click();
+			await expect(form.fullName).toBeFocused();
+			await expect(form.fullName).toHaveAttribute('aria-invalid', 'true');
+			await expect(form.fullName).toHaveAccessibleDescription(
+				'A native Base UI Input. Enter at least 2 characters',
+			);
+			await form.fullName.fill('Ada Lovelace');
+
+			await form.submitButton.click();
+			await expect(form.bio).toBeFocused();
+			await form.bio.fill('Writes thoughtful programs.');
+
+			await form.submitButton.click();
+			await expect(form.acceptTerms).toBeFocused();
+			await form.acceptTerms.click();
+
+			await form.submitButton.click();
+			await expect(form.design).toBeFocused();
+			await form.design.click();
+
+			await form.submitButton.click();
+			await expect(form.starter).toBeFocused();
+			await form.starter.click();
+
+			await form.submitButton.click();
+			await expect(form.country).toBeFocused();
+			await chooseCountry(page, 'Canada');
+
+			await form.submitButton.click();
+			await expect(form.framework).toBeFocused();
+			await chooseFramework(page, 'React');
+		});
+
+		test('validates native controls on blur', async ({ page }) => {
+			const form = await getForm(page);
+
+			await form.fullName.fill('A');
+			await form.heading.click();
+
+			await expect(form.fullName).toHaveAttribute('aria-invalid', 'true');
+			await expect(page.getByText('Enter at least 2 characters')).toBeVisible();
+
+			await form.acceptTerms.click();
+			await form.acceptTerms.click();
+			await form.acceptTerms.focus();
+			await form.heading.click();
+			await expect(form.acceptTerms).toHaveAttribute('aria-invalid', 'true');
+
+			await form.design.focus();
+			await form.heading.click();
+			await expect(form.interestsGroup).toHaveAttribute('aria-invalid', 'true');
+			await expect(form.interestsGroup).toHaveAccessibleDescription(
+				'Each checked item contributes the same name to FormData. Choose at least one interest',
+			);
+
+			await form.starter.focus();
+			await form.heading.click();
+			await expect(form.planGroup).toHaveAttribute('aria-invalid', 'true');
+			await expect(form.planGroup).toHaveAccessibleDescription(
+				'The group serializes one scalar value. Choose a plan',
+			);
+
+			await form.country.click();
+			await form.country.press('Escape');
+			await form.country.press('Tab');
+			await expect(form.country).toHaveAttribute('aria-invalid', 'true');
+			await expect(form.country).toHaveAccessibleDescription(
+				'Select maintains a form-compatible hidden input. Choose a country',
+			);
+		});
+
+		test('serializes boolean and array checkboxes through Base UI hidden inputs', async ({
+			page,
+		}) => {
+			const form = await getForm(page);
+
+			await form.acceptTerms.click();
+			await form.design.click();
+			await form.research.click();
+
+			await expect
+				.poll(() =>
+					form.container.evaluate((element) => {
+						const data = new FormData(element as HTMLFormElement);
+						return {
+							acceptTerms: data.get('acceptTerms'),
+							interests: data.getAll('interests'),
+						};
+					}),
+				)
+				.toEqual({
+					acceptTerms: 'on',
+					interests: ['design', 'research'],
+				});
+
+			await form.acceptTerms.click();
+			await expect
+				.poll(() =>
+					form.container.evaluate((element) =>
+						new FormData(element as HTMLFormElement).has('acceptTerms'),
+					),
+				)
+				.toBe(false);
+		});
+
+		test('selects values with Select and Combobox', async ({ page }) => {
+			const form = await getForm(page);
+
+			await chooseCountry(page, 'Canada');
+			await chooseFramework(page, 'Svelte');
+
+			await expect(form.country).toContainText('Canada');
+			await expect(form.framework).toHaveValue('Svelte');
+			await expect
+				.poll(() =>
+					form.container.evaluate((element) => {
+						const data = new FormData(element as HTMLFormElement);
+						return [data.get('country'), data.get('framework')];
+					}),
+				)
+				.toEqual(['ca', 'svelte']);
+		});
+
+		test('coerces NumberField and controls Slider values', async ({ page }) => {
+			const form = await getForm(page);
+
+			await form.quantity.fill('');
+			await form.quantity.fill('3');
+			await page.getByRole('button', { name: 'Increase Quantity' }).click();
+			await setBudget(page, 75);
+
+			await expect(form.quantity).toHaveValue('4');
+			await expect(form.budget).toHaveValue('75');
+			await expect
+				.poll(() =>
+					form.container.evaluate((element) => {
+						const data = new FormData(element as HTMLFormElement);
+						return [data.get('quantity'), data.get('budget')];
+					}),
+				)
+				.toEqual(['4', '75']);
+		});
+
+		test('resets native, hidden-input, and useControl-backed components', async ({
+			page,
+		}) => {
+			const defaults = new URLSearchParams([
+				['fullName', 'Grace Hopper'],
+				['bio', 'Pioneered practical compiler technology.'],
+				['acceptTerms', 'on'],
+				['interests', 'engineering'],
+				['interests', 'research'],
+				['plan', 'enterprise'],
+				['country', 'jp'],
+				['framework', 'svelte'],
+				['quantity', '6'],
+				['budget', '70'],
+				['notifications', 'on'],
+			]);
+
+			for (const reset of ['conform', 'browser']) {
+				const form = await getForm(page, defaults);
+
+				await form.fullName.fill('Changed name');
+				await form.bio.fill('Changed biography text.');
+				await form.acceptTerms.click();
+				await form.engineering.click();
+				await form.design.click();
+				await form.starter.click();
+				await chooseCountry(page, 'Canada');
+				await chooseFramework(page, 'React');
+				await form.quantity.fill('2');
+				await setBudget(page, 80);
+				await form.notifications.click();
+
+				if (reset === 'conform') {
+					await form.resetButton.click();
+				} else {
+					await form.container.evaluate((element) =>
+						(element as HTMLFormElement).reset(),
+					);
+				}
+
+				await expect(form.fullName).toHaveValue('Grace Hopper');
+				await expect(form.acceptTerms).toBeChecked();
+				await expect(form.engineering).toBeChecked();
+				await expect(form.research).toBeChecked();
+				await expect(form.design).not.toBeChecked();
+				await expect(
+					page.getByRole('radio', { name: 'Enterprise' }),
+				).toBeChecked();
+				await expect(form.country).toContainText('Japan');
+				await expect(form.framework).toHaveValue('Svelte');
+				await expect(form.quantity).toHaveValue('6');
+				await expect(form.budget).toHaveValue('70');
+				await expect(form.notifications).toBeChecked();
+				await expect.poll(form.formData).toEqual(Array.from(defaults));
+			}
+		});
+
+		test('resets to the last successful submission', async ({ page }) => {
+			const form = await completeRequiredFields(page);
+			await form.engineering.click();
+			await setBudget(page, 65);
+			await form.notifications.click();
+			await form.submitButton.click();
+			await expect.poll(form.submittedValue).toMatchObject({ budget: 65 });
+
+			await form.fullName.fill('Changed name');
+			await form.design.click();
+			await chooseCountry(page, 'Japan');
+			await chooseFramework(page, 'Vue');
+			await form.quantity.fill('8');
+			await setBudget(page, 80);
+			await form.notifications.click();
+			await form.resetButton.click();
+
+			await expect(form.fullName).toHaveValue('Ada Lovelace');
+			await expect(form.design).toBeChecked();
+			await expect(form.engineering).toBeChecked();
+			await expect(form.country).toContainText('United Kingdom');
+			await expect(form.framework).toHaveValue('React');
+			await expect(form.quantity).toHaveValue('3');
+			await expect(form.budget).toHaveValue('65');
+			await expect(form.notifications).toBeChecked();
+		});
+
+		test('restores every default from URL search parameters', async ({
+			page,
+		}) => {
+			const searchParams = new URLSearchParams([
+				['fullName', 'Grace Hopper'],
+				['bio', 'Pioneered practical compiler technology.'],
+				['acceptTerms', 'on'],
+				['interests', 'engineering'],
+				['interests', 'research'],
+				['plan', 'enterprise'],
+				['country', 'jp'],
+				['framework', 'svelte'],
+				['quantity', '6'],
+				['budget', '70'],
+				['notifications', 'on'],
+			]);
+			const form = await getForm(page, searchParams);
+
+			await expect(form.fullName).toHaveValue('Grace Hopper');
+			await expect(form.engineering).toBeChecked();
+			await expect(form.research).toBeChecked();
+			await expect(
+				page.getByRole('radio', { name: 'Enterprise' }),
+			).toBeChecked();
+			await expect(form.country).toContainText('Japan');
+			await expect(form.framework).toHaveValue('Svelte');
+			await expect(form.quantity).toHaveValue('6');
+			await expect(form.budget).toHaveValue('70');
+			await expect(form.notifications).toBeChecked();
+		});
+
+		test('submits parsed data and updates the URL', async ({ page }) => {
+			const form = await completeRequiredFields(page);
+			await form.engineering.click();
+			await setBudget(page, 65);
+			await form.notifications.click();
+			await form.submitButton.click();
+
+			expect(
+				(await page.locator('.error').allTextContents()).filter((error) =>
+					error.trim(),
+				),
+			).toEqual([]);
+			await expect.poll(form.submittedValue).toEqual({
+				fullName: 'Ada Lovelace',
+				bio: 'Writes thoughtful programs.',
+				acceptTerms: true,
+				interests: ['design', 'engineering'],
+				plan: 'professional',
+				country: 'gb',
+				framework: 'react',
+				quantity: 3,
+				budget: 65,
+				notifications: true,
+			});
+
+			await expect
+				.poll(() => new URL(page.url()).searchParams.get('budget'))
+				.toBe('65');
+			await expect
+				.poll(() => new URL(page.url()).searchParams.getAll('interests'))
+				.toEqual(['design', 'engineering']);
+		});
+	});
+});

--- a/examples/base-ui/tsconfig.app.json
+++ b/examples/base-ui/tsconfig.app.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+		"target": "es2023",
+		"lib": ["ES2023", "DOM"],
+		"module": "esnext",
+		"types": ["vite/client"],
+		"allowArbitraryExtensions": true,
+		"skipLibCheck": true,
+
+		/* Bundler mode */
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"moduleDetection": "force",
+		"noEmit": true,
+		"jsx": "react-jsx",
+
+		/* Linting */
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"erasableSyntaxOnly": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"include": ["src"]
+}

--- a/examples/base-ui/tsconfig.json
+++ b/examples/base-ui/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"files": [],
+	"references": [
+		{ "path": "./tsconfig.app.json" },
+		{ "path": "./tsconfig.node.json" }
+	]
+}

--- a/examples/base-ui/tsconfig.node.json
+++ b/examples/base-ui/tsconfig.node.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+		"target": "es2023",
+		"lib": ["ES2023"],
+		"types": ["node"],
+		"skipLibCheck": true,
+
+		/* Bundler mode */
+		"module": "nodenext",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"moduleDetection": "force",
+		"noEmit": true,
+
+		/* Linting */
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"erasableSyntaxOnly": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"include": ["vite.config.ts"]
+}

--- a/examples/base-ui/vite.config.ts
+++ b/examples/base-ui/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+	plugins: [react()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,57 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
 
+  examples/base-ui:
+    dependencies:
+      '@base-ui/react':
+        specifier: ^1.7.0
+        version: 1.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@conform-to/react':
+        specifier: ^1.21.0
+        version: file:packages/conform-react(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@conform-to/zod':
+        specifier: ^1.21.0
+        version: file:packages/conform-zod(zod@4.4.3)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    dependenciesMeta:
+      '@conform-to/react':
+        injected: true
+      '@conform-to/zod':
+        injected: true
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.49.1
+        version: 1.49.1
+      '@types/node':
+        specifier: ^24.13.3
+        version: 24.13.3
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.3
+        version: 6.0.3(vite@8.1.5(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+      oxlint:
+        specifier: ^1.74.0
+        version: 1.74.0
+      typescript:
+        specifier: ~6.0.2
+        version: 6.0.3
+      vite:
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@24.13.3)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
+
   examples/chakra-ui:
     dependencies:
       '@chakra-ui/react':
@@ -2107,8 +2158,35 @@ packages:
       date-fns:
         optional: true
 
+  '@base-ui/react@1.7.0':
+    resolution: {integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
   '@base-ui/utils@0.3.1':
     resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@base-ui/utils@0.3.2':
+    resolution: {integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -14310,7 +14388,30 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@base-ui/react@1.7.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@base-ui/utils@0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@base-ui/utils@0.3.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@floating-ui/utils': 0.2.12


### PR DESCRIPTION
## Summary

- add a pure @base-ui/react example using typed configureForms metadata
- keep Base UI native and hidden inputs canonical, with useControl only for the controlled Slider
- cover validation focus and blur, FormData serialization, URL defaults, Conform and browser resets, and reset-to-submitted values
- align the Vite, TypeScript, Oxlint, README, Playwright, and pnpm injection setup with the recently modernized examples

## Verification

- pnpm --filter base-ui-example run build
- pnpm --filter base-ui-example run lint
- pnpm --filter base-ui-example run typecheck
- pnpm --filter base-ui-example run test (27 passed across Chromium, Firefox, and WebKit)
- pnpm exec oxfmt --check examples/base-ui
- frozen lockfile install and git diff checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

- Added a standalone `@base-ui/react` example with typed `configureForms` metadata.
- Demonstrated native and hidden inputs, controlled Slider integration, validation, focus and blur handling, URL defaults, form resets, and reset-to-submitted values.
- Added reusable accessible field components, styling, documentation, and 27 Playwright tests across Chromium, Firefox, and WebKit.
- Added Vite, TypeScript, Oxlint, Playwright, and pnpm dependency configuration for the example.

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->