### PR TITLE
ci: enable release git tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,6 @@ jobs:
           pr-title: 'release: bump packages version'
           commit-message: 'release: bump packages version'
           version-script: pnpm run version
-          publish-script: pnpm publish -r
+          publish-script: pnpm exec changeset publish
           create-github-releases: false
-          push-git-tags: false
+          push-git-tags: true


### PR DESCRIPTION
Enable Changesets v2 to push package git tags while keeping GitHub releases disabled.

The publish command now runs `changeset publish` instead of plain `pnpm publish -r`. Changesets CLI v3 delegates publishing to pnpm and emits the `CHANGESETS_OUTPUT` metadata that changesets/action requires to identify and push the generated tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

The release workflow now uses `changeset publish` to publish packages and generate package Git tags. GitHub release creation remains disabled.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->