### PR TITLE
fix(conform-dom): preserve focus during intent submission

### DIFF
--- a/.changeset/calm-dialogs-focus.md
+++ b/.changeset/calm-dialogs-focus.md
@@ -1,0 +1,5 @@
+---
+'@conform-to/dom': patch
+---
+
+Fix focus management when validating a form inside a modal.

--- a/examples/radix-ui/src/main.tsx
+++ b/examples/radix-ui/src/main.tsx
@@ -2,9 +2,10 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
+import { TestModal } from './test-modal.tsx';
 
 createRoot(document.getElementById('root')!).render(
 	<StrictMode>
-		<App />
+		{window.location.pathname === '/modal' ? <TestModal /> : <App />}
 	</StrictMode>,
 );

--- a/examples/radix-ui/src/test-modal.tsx
+++ b/examples/radix-ui/src/test-modal.tsx
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import { coerceFormValue } from '@conform-to/zod/v4/future';
+import { Dialog as RadixDialog } from 'radix-ui';
+import { useForm } from './forms';
+
+const schema = coerceFormValue(
+	z.object({
+		firstName: z.string().min(1),
+		lastName: z.string().min(1),
+	}),
+);
+
+export function TestModal() {
+	const { form, fields } = useForm(schema, {});
+
+	return (
+		<RadixDialog.Root defaultOpen>
+			<RadixDialog.Content aria-describedby={undefined}>
+				<RadixDialog.Title>Modal form</RadixDialog.Title>
+				<form {...form.props}>
+					<label htmlFor={fields.firstName.id}>First name</label>
+					<input id={fields.firstName.id} name={fields.firstName.name} />
+					<label htmlFor={fields.lastName.id}>Last name</label>
+					<input id={fields.lastName.id} name={fields.lastName.name} />
+				</form>
+			</RadixDialog.Content>
+		</RadixDialog.Root>
+	);
+}

--- a/examples/radix-ui/tests/index.test.ts
+++ b/examples/radix-ui/tests/index.test.ts
@@ -209,4 +209,18 @@ test.describe('radix-ui', () => {
 			await expect.poll(form.formData).toEqual(Array.from(defaults));
 		});
 	});
+
+	test('should preserve focus during blur validation in a modal', async ({
+		page,
+	}) => {
+		await page.goto('/modal');
+
+		const firstName = page.getByLabel('First name');
+		const lastName = page.getByLabel('Last name');
+
+		await firstName.click();
+		await lastName.click();
+
+		await expect(lastName).toBeFocused();
+	});
 });

--- a/packages/conform-dom/dom.ts
+++ b/packages/conform-dom/dom.ts
@@ -176,24 +176,40 @@ export function requestSubmit(
 }
 
 /**
- * Triggers form submission with an intent value. This is achieved by
- * creating a hidden button element with the intent value and then submitting it with the form.
+ * Triggers form submission with an intent value using a temporary submitter.
  */
 export function requestIntent(
 	formElement: HTMLFormElement,
 	intentName: string,
 	intentValue: string,
 ): void {
+	const document = formElement.ownerDocument;
 	const submitter = document.createElement('button');
+	const formId = formElement.getAttribute('id');
+	let container: Node = formElement;
 
 	submitter.name = intentName;
 	submitter.value = intentValue;
 	submitter.hidden = true;
 	submitter.formNoValidate = true;
 
-	formElement.appendChild(submitter);
-	requestSubmit(formElement, submitter);
-	formElement.removeChild(submitter);
+	if (formId) {
+		const root = formElement.getRootNode();
+
+		// Keep the temporary submitter outside forms with an ID so its removal does
+		// not disrupt focus management in modal dialogs during blur validation.
+		// See https://github.com/edmundhung/conform/issues/783
+		container = root === document ? document.body : root;
+		submitter.setAttribute('form', formId);
+	}
+
+	container.appendChild(submitter);
+
+	try {
+		requestSubmit(formElement, submitter);
+	} finally {
+		submitter.remove();
+	}
 }
 
 export function createFileList(value: File | File[]): FileList {

--- a/packages/conform-dom/form.ts
+++ b/packages/conform-dom/form.ts
@@ -14,7 +14,7 @@ import {
 	getFormAction,
 	getFormEncType,
 	getFormMethod,
-	requestSubmit,
+	requestIntent,
 	updateField,
 	isDirtyInput,
 } from './dom';
@@ -1027,17 +1027,10 @@ export function createFormContext<
 
 	function dispatch(intent: Intent): void {
 		const form = getFormElement();
-		const submitter = document.createElement('button');
 		const buttonProps = getControlButtonProps(intent);
 
-		submitter.name = buttonProps.name;
-		submitter.value = buttonProps.value;
-		submitter.hidden = true;
-		submitter.formNoValidate = true;
-
-		form?.appendChild(submitter);
-		requestSubmit(form, submitter);
-		form?.removeChild(submitter);
+		invariant(form !== null, 'Form element is required to trigger submission.');
+		requestIntent(form, buttonProps.name, buttonProps.value);
 	}
 
 	function getControlButtonProps(intent: Intent): ControlButtonProps {

--- a/packages/conform-dom/tests/dom.browser.test.ts
+++ b/packages/conform-dom/tests/dom.browser.test.ts
@@ -8,6 +8,7 @@ import {
 	focus,
 	blur,
 	requestSubmit,
+	requestIntent,
 	createFileList,
 	isFieldElement,
 	isGlobalInstance,
@@ -1044,6 +1045,57 @@ describe('requestSubmit', () => {
 		expect(() => requestSubmit(form, submitter)).toThrow(
 			'Submitter must be a button or input element or null.',
 		);
+	});
+});
+
+describe('requestIntent', () => {
+	it('supports a form containing a field named id', (ctx) => {
+		const form = document.createElement('form');
+		const input = document.createElement('input');
+		const handleSubmit = vi.fn();
+		const submitEventListener = (event: SubmitEvent) => {
+			event.preventDefault();
+			const submitter = event.submitter as HTMLButtonElement;
+
+			handleSubmit(submitter.parentElement, submitter.form);
+		};
+
+		form.id = 'test-form';
+		input.name = 'id';
+		form.appendChild(input);
+		form.addEventListener('submit', submitEventListener);
+		document.body.appendChild(form);
+		ctx.onTestFinished(() => {
+			form.removeEventListener('submit', submitEventListener);
+			form.remove();
+		});
+
+		requestIntent(form, 'intent', 'clobbered');
+
+		expect(handleSubmit).toHaveBeenCalledWith(document.body, form);
+	});
+
+	it('mounts the submitter inside a form without an ID', (ctx) => {
+		const form = document.createElement('form');
+		const handleSubmit = vi.fn();
+		const submitEventListener = (event: SubmitEvent) => {
+			event.preventDefault();
+			const submitter = event.submitter as HTMLButtonElement;
+
+			handleSubmit(submitter.parentElement, submitter.form);
+		};
+
+		form.addEventListener('submit', submitEventListener);
+		document.body.appendChild(form);
+		ctx.onTestFinished(() => {
+			form.removeEventListener('submit', submitEventListener);
+			form.remove();
+		});
+
+		requestIntent(form, 'intent', 'fallback');
+
+		expect(handleSubmit).toHaveBeenCalledWith(form, form);
+		expect(form.elements).toHaveLength(0);
 	});
 });
 


### PR DESCRIPTION
## Summary

- mount temporary intent submitters outside Conform-managed forms that already have an ID
- preserve the original in-form behavior for forms without an ID
- avoid form named-property clobbering when reading the form ID
- remove the submitter synchronously without mutating the modal or managed form subtree
- route stable v1 and future intent submission through the shared implementation
- add a dedicated minimal two-input form inside a Radix modal
- add focused browser regressions without changing the existing example form or its tests

## Testing

- conform-dom: build and typecheck passed; 278 tests passed across Chromium, Firefox, and WebKit
- Astro todo scenario: 3 tests passed across Chromium, Firefox, and WebKit
- Radix UI example: 18 tests passed across Chromium, Firefox, and WebKit
- Headless UI example: 23 tests passed across Chromium, Firefox, and WebKit; 1 existing WebKit skip

Fixes #783

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

- Preserve focus during intent submission in modal forms.
- Mount temporary submitters outside forms with IDs to avoid named-property clobbering.
- Keep submitters inside forms without IDs.
- Centralize intent submission and guarantee synchronous cleanup.
- Add DOM and Radix modal regression tests.
- Add a patch changeset for `@conform-to/dom`.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->