### PR TITLE
fix(conform-react): reset structural controls with forms

### DIFF
--- a/.changeset/reset-structural-controls.md
+++ b/.changeset/reset-structural-controls.md
@@ -1,0 +1,6 @@
+---
+'@conform-to/dom': patch
+'@conform-to/react': patch
+---
+
+Keep structural controls synchronized with their default payload during native form resets, and ignore canceled reset events.

--- a/docs/api/react/future/useControl.md
+++ b/docs/api/react/future/useControl.md
@@ -303,7 +303,7 @@ function DateRangeField(props: { name: string }) {
 }
 ```
 
-The fieldset descendants follow `control.defaultValue`. Both Conform resets and native `form.reset()` calls restore the original structured value automatically.
+The fieldset descendants follow `control.defaultValue`. Both Conform resets and native `form.reset()` calls restore the current structured default automatically.
 
 ## Tips
 

--- a/docs/api/react/future/useControl.md
+++ b/docs/api/react/future/useControl.md
@@ -303,6 +303,8 @@ function DateRangeField(props: { name: string }) {
 }
 ```
 
+The fieldset descendants follow `control.defaultValue`. Both Conform resets and native `form.reset()` calls restore the original structured value automatically.
+
 ## Tips
 
 ### Progressive enhancement

--- a/packages/conform-dom/dom.ts
+++ b/packages/conform-dom/dom.ts
@@ -298,6 +298,10 @@ export function createGlobalFormsObserver() {
 		if (form instanceof HTMLFormElement) {
 			// Reset event is fired before the form is reset, so we need to wait for the next tick
 			setTimeout(() => {
+				if (event.defaultPrevented) {
+					return;
+				}
+
 				formListeners.forEach((callback) => {
 					callback({ type: 'reset', target: form });
 				});

--- a/packages/conform-dom/tests/dom.browser.test.ts
+++ b/packages/conform-dom/tests/dom.browser.test.ts
@@ -358,6 +358,35 @@ describe('createGlobalFormsObserver', () => {
 		});
 	});
 
+	it('ignores canceled reset events', async (ctx) => {
+		const observer = createGlobalFormsObserver();
+		const form = document.createElement('form');
+		const input = document.createElement('input');
+		const resetButton = document.createElement('button');
+		resetButton.type = 'reset';
+		form.append(input, resetButton);
+		document.body.append(form);
+
+		const formListener = vi.fn();
+		const fieldListener = vi.fn();
+		const resetHandler = (event: Event) => event.preventDefault();
+		form.addEventListener('reset', resetHandler);
+		ctx.onTestFinished(observer.onFormUpdate(formListener));
+		ctx.onTestFinished(observer.onFieldUpdate(fieldListener));
+		ctx.onTestFinished(() => form.removeEventListener('reset', resetHandler));
+		ctx.onTestFinished(() => {
+			observer.dispose();
+			form.remove();
+		});
+
+		await userEvent.click(resetButton);
+		// Let the observer's next-tick reset callback run before checking that it
+		// returned early for the canceled event.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(formListener).not.toBeCalled();
+		expect(fieldListener).not.toBeCalled();
+	});
+
 	it('listens to submit event', async (ctx) => {
 		const observer = createGlobalFormsObserver();
 		const form = document.createElement('form');

--- a/packages/conform-react/future/hooks.tsx
+++ b/packages/conform-react/future/hooks.tsx
@@ -691,6 +691,24 @@ export function useControl(options: ControlOptions = {}): Control<any> {
 		[observer],
 	);
 
+	useEffect(
+		() =>
+			observer.onFormUpdate((event) => {
+				const input = inputRef.current;
+
+				if (
+					event.type === 'reset' &&
+					input instanceof HTMLFieldSetElement &&
+					event.target === input.form
+				) {
+					flushSync(() => {
+						setStructuralOverride(null);
+					});
+				}
+			}),
+		[observer],
+	);
+
 	const payloadSnapshot = useSyncExternalStore(
 		useCallback(
 			(callback) =>

--- a/packages/conform-react/tests/useControl.browser.test.tsx
+++ b/packages/conform-react/tests/useControl.browser.test.tsx
@@ -1025,6 +1025,7 @@ describe('future export: useControl', () => {
 		const listValue = screen.getByLabelText('List value');
 		const changeButton = screen.getByText('Change');
 		const clearButton = screen.getByText('Clear');
+		const resetButton = screen.getByText('Reset');
 
 		await expect
 			.element(listValue)
@@ -1048,9 +1049,67 @@ describe('future export: useControl', () => {
 			'nested.list[1].value': 'banana',
 		});
 
+		await userEvent.click(resetButton);
+		await expect
+			.element(listValue)
+			.toHaveTextContent(JSON.stringify([{ key: '', value: '' }]));
+		await expect.element(formElement).toHaveFormValues({
+			'nested.list[0].key': '',
+			'nested.list[0].value': '',
+		});
+
+		await userEvent.click(changeButton);
+
 		await userEvent.click(clearButton);
 		await expect.element(listValue).toHaveTextContent('null');
 		await expect.element(formElement).toHaveFormValues({});
+	});
+
+	it('resets a fieldset to its latest default value', async () => {
+		function TestForm(props: { defaultValue: { name: string } }) {
+			const control = useControl({
+				defaultValue: props.defaultValue,
+				parse(payload) {
+					return payload;
+				},
+			});
+
+			return (
+				<Form>
+					<BaseControl
+						type="fieldset"
+						name="profile"
+						ref={control.register}
+						defaultValue={control.defaultValue}
+					/>
+					<button
+						type="button"
+						onClick={() => control.change({ name: 'Draft' })}
+					>
+						Change profile
+					</button>
+					<output aria-label="Profile state">
+						{JSON.stringify(control.payload)}
+					</output>
+				</Form>
+			);
+		}
+
+		const screen = render(<TestForm defaultValue={{ name: 'Initial' }} />);
+		const formElement = screen.container.querySelector('form');
+		const state = screen.getByLabelText('Profile state');
+
+		await userEvent.click(screen.getByText('Change profile'));
+		await expect.element(state).toHaveTextContent('{"name":"Draft"}');
+
+		screen.rerender(<TestForm defaultValue={{ name: 'Updated' }} />);
+		await expect.element(state).toHaveTextContent('{"name":"Draft"}');
+
+		await userEvent.click(screen.getByText('Reset'));
+		await expect.element(state).toHaveTextContent('{"name":"Updated"}');
+		await expect.element(formElement).toHaveFormValues({
+			'profile.name': 'Updated',
+		});
 	});
 
 	it('updates fieldset value on form update and reset', async () => {


### PR DESCRIPTION
## Summary

- restore fieldset-backed controls to their current default payload after a successful native form reset
- ignore canceled reset events in the global form observer
- document native reset behavior for structural controls

## Why

Native reset support has been part of `useControl` since its introduction, but fieldset-backed controls added later could keep their changed structural override because a fieldset has no native value/default pair. Clearing that override makes the control fall back to the latest option-derived default, matching the other `BaseControl` modes.

## Verification

- `pnpm --dir packages/conform-react run typecheck`
- `pnpm --dir packages/conform-dom run typecheck`
- `pnpm run lint`
- Conform DOM browser suite: 105 passed across Chromium, Firefox, and WebKit
- `useControl` browser suite: 72 passed across Chromium, Firefox, and WebKit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<details>
<summary>Generated Summary</summary>

- `useControl` restores the latest `control.defaultValue` after native resets on fieldset-backed controls.
- Canceled reset events do not trigger Conform reset callbacks or field updates.
- Added documentation and browser tests for reset behavior.

</details>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->