### PR TITLE
docs(examples): align Radix and Headless UI readmes

### DIFF
--- a/docs/integration/ui-libraries.md
+++ b/docs/integration/ui-libraries.md
@@ -85,9 +85,9 @@ If the same field metadata is repeatedly mapped to your custom component props, 
 
 We've prepared examples for integrating with popular UI libraries:
 
+- [Base UI](../../examples/base-ui/), or via [shadcn/ui](../../examples/shadcn-base-ui/)
+- [Radix UI](../../examples/radix-ui/), or via [shadcn/ui](../../examples/shadcn-ui/)
 - [React Aria Components](../../examples/react-aria/)
-- [Shadcn UI](../../examples/shadcn-ui/)
-- [Radix UI](../../examples/radix-ui/)
 - [Chakra UI](../../examples/chakra-ui/)
 - [Headless UI](../../examples/headless-ui/)
 - [Material UI](../../examples/material-ui/)

--- a/docs/ja/integration/ui-libraries.md
+++ b/docs/ja/integration/ui-libraries.md
@@ -85,9 +85,9 @@ function MyInput({ name, defaultValue }) {
 
 一般的なUIライブラリと統合する際の例をいくつか紹介します。
 
+- [Base UI](../../examples/base-ui/)、または [shadcn/ui](../../examples/shadcn-base-ui/) 経由
+- [Radix UI](../../examples/radix-ui/)、または [shadcn/ui](../../examples/shadcn-ui/) 経由
 - [React Aria Components](../../examples/react-aria/)
-- [Shadcn UI](../../examples/shadcn-ui/)
-- [Radix UI](../../examples/radix-ui/)
 - [Chakra UI](../../examples/chakra-ui/)
 - [Headless UI](../../examples/headless-ui/)
 - [Material UI](../../examples/material-ui/)

--- a/examples/headless-ui/README.md
+++ b/examples/headless-ui/README.md
@@ -1,186 +1,37 @@
 # Headless UI Example
 
-> This guide focuses on behavior specific to Headless UI. See [Integrating with UI Libraries](../../docs/integration/ui-libraries.md) for the general concept and the [`useControl`](../../docs/api/react/future/useControl.md) API.
+[Headless UI](https://headlessui.com/) provides accessible, unstyled React components designed to integrate with Tailwind CSS.
 
-[Headless UI](https://headlessui.com/) provides completely unstyled, accessible UI components designed to integrate with Tailwind CSS.
+This Vite React project demonstrates how to use Headless UI 2.2 components with Conform and Zod 4 validation through `@conform-to/zod/v4/future`. It covers native-style fields alongside Checkbox, Combobox, Listbox, RadioGroup, and Switch.
 
-This example demonstrates how to integrate Conform with Headless UI 2.2 using custom metadata. It covers Field, Fieldset, Legend, Label, Description, Input, Textarea, Select, Checkbox, Listbox, Combobox, Switch, and RadioGroup.
+## Integration
 
-## Use a Single Named Control
+Headless UI's Input, Textarea, and Select receive Conform's field props directly because their native controls own the submitted values. Compound components use [`useControl`](../../docs/api/react/future/useControl.md) with a hidden native input, checkbox, or multiple select.
 
-In this example, Listbox, Combobox, Switch, RadioGroup, and Checkbox render a hidden base control registered with `useControl`:
+The adapters translate Headless UI's scalar, checked, and array value shapes and leave the visible components unnamed so each field produces one canonical set of `FormData` entries. They also preserve initial and updated defaults, restore visible state on reset, and forward blur and invalid-submission focus to the interactive component.
 
-```tsx
-const control = useControl({
-  defaultValue,
-  onFocus() {
-    buttonRef.current?.focus();
-  },
-});
+[`configureForms`](../../docs/api/react/future/configureForms.md#integrating-with-ui-libraries) exposes the native and compound-component mappings as typed field props. See [Integrating with UI Libraries](../../docs/integration/ui-libraries.md) for the general pattern.
 
-return (
-  <Listbox
-    value={control.options ?? []}
-    onChange={(value) => control.change(value)}
-    multiple
-  >
-    <select
-      ref={control.register}
-      name={name}
-      defaultValue={defaultValue}
-      hidden
-      multiple
-    >
-      {options.map((option) => (
-        <option key={option.value} value={option.value} />
-      ))}
-    </select>
-    <ListboxButton ref={buttonRef}>{/* ... */}</ListboxButton>
-  </Listbox>
-);
-```
+| Pattern | Components | Form integration |
+| --- | --- | --- |
+| Native form control | Input, Textarea, Select | The interactive element owns the name and serialization |
+| Unnamed compound control | Checkbox, Combobox, Listbox, RadioGroup, Switch | The Headless UI component handles interaction and focus |
+| `useControl` with a registered input | Checkbox, Combobox, RadioGroup, Switch | A hidden input or checkbox owns the scalar or boolean value |
+| Array registered control | Listbox | A hidden multiple select serializes repeated values |
 
-The Headless UI component remains unnamed, so the base control is the only named control for the field.
+Conform remains the source of validation and form state, while Headless UI supplies accessible interaction and field composition. The application keeps its native `<form {...form.props}>`.
 
-## Handle Headless UI Value Shapes
+## Project Structure
 
-Listbox supports multiple values, so it reads `control.options` and registers a multiple select. Rendering an option for every possible value preserves multiple default values, reset behavior, and repeated `FormData` entries.
-
-Combobox uses `control.value` for the submitted value. Its local `query` state only filters the displayed options and is cleared when the popup closes:
-
-```tsx
-<Combobox
-  value={control.value || null}
-  onChange={(value: string | null) => control.change(value ?? '')}
-  onClose={() => setQuery('')}
->
-  {/* ... */}
-</Combobox>
-```
-
-Switch and Checkbox map their boolean state to `control.checked`. RadioGroup and Combobox pass their string values directly to `control.change()`.
-
-## Forward Focus to the Interactive Element
-
-When Conform focuses a registered control after an invalid submission, each component forwards focus to the corresponding Headless UI element:
-
-| Component | Focus target |
-| --- | --- |
-| Listbox | `ListboxButton` |
-| Combobox | `ComboboxInput` |
-| Switch | `Switch` |
-| Checkbox | `Checkbox` |
-| RadioGroup | Checked radio or first radio |
-
-RadioGroup's root is not the element users focus, so `onFocus` locates a radio instead:
-
-```tsx
-const control = useControl({
-  defaultValue,
-  onFocus() {
-    const item =
-      groupRef.current?.querySelector<HTMLElement>('[data-checked]') ??
-      groupRef.current?.querySelector<HTMLElement>('[role="radio"]');
-
-    item?.focus();
-  },
-});
-```
-
-## Match Headless UI Interaction Boundaries
-
-Blur events bubble through Listbox and RadioGroup when focus moves between their internal elements. Notify Conform only when focus leaves the whole component:
-
-```tsx
-<RadioGroup
-  onBlur={(event) => {
-    if (!event.currentTarget.contains(event.relatedTarget)) {
-      control.blur();
-    }
-  }}
->
-  {/* ... */}
-</RadioGroup>
-```
-
-Combobox forwards blur from its input, while Switch and Checkbox can forward their blur events directly.
-
-## Apply ARIA Attributes to the Accessible Control
-
-The hidden native control owns the field name and value. Validation attributes belong on the Headless UI element exposed to assistive technology:
-
-| Component | ARIA attribute target |
-| --- | --- |
-| Listbox | `ListboxButton` |
-| Combobox | `ComboboxInput` |
-| Switch | `Switch` |
-| Checkbox | `Checkbox` |
-| RadioGroup | `RadioGroup` root |
-
-`Field`, `Label`, and `Description` associate labels and errors with Listbox, Combobox, Switch, and Checkbox. RadioGroup manages its own label and description context, so this example labels its root explicitly and associates its external error through `aria-errormessage`:
-
-```tsx
-<ExampleRadioGroup
-  aria-label="Color (RadioGroup)"
-  aria-invalid={fields.color.ariaInvalid}
-  aria-errormessage={fields.color.ariaDescribedBy}
-/>
-
-<p id={fields.color.errorId}>{fields.color.errors}</p>
-```
-
-## Custom Metadata
-
-The Headless UI components can receive field metadata explicitly:
-
-```tsx
-<ExampleListBox
-  options={options}
-  id={fields.owner.id}
-  name={fields.owner.name}
-  defaultValue={fields.owner.defaultOptions}
-  aria-invalid={fields.owner.ariaInvalid}
-  aria-describedby={fields.owner.ariaDescribedBy}
-/>
-```
-
-To avoid repeating that mapping at every call site, [`forms.ts`](./src/forms.ts) uses [`configureForms`](../../docs/api/react/future/configureForms.md#integrating-with-ui-libraries) to provide typed props for every form control:
-
-```tsx
-import { configureForms } from '@conform-to/react/future';
-
-const forms = configureForms({
-  extendFieldMetadata(metadata) {
-    return {
-      get listBoxProps() {
-        return {
-          id: metadata.id,
-          name: metadata.name,
-          defaultValue: metadata.defaultOptions,
-          'aria-invalid': metadata.ariaInvalid,
-          'aria-describedby': metadata.ariaDescribedBy,
-        } satisfies Partial<React.ComponentProps<typeof ExampleListBox>>;
-      },
-      // ... other component props
-    };
-  },
-});
-
-export const useForm = forms.useForm;
-```
-
-The main application can then spread those props with full type safety. Its nearby comments preserve the explicit mapping shown above:
-
-```tsx
-<ExampleListBox options={options} {...fields.owner.listBoxProps} />
-```
-
-See [`components.tsx`](./src/components.tsx) for the Headless UI components and [`forms.ts`](./src/forms.ts) for all metadata mappings.
+- [`App.tsx`](./src/App.tsx) contains the form and keeps useful explicit Conform prop mappings in nearby comments.
+- [`components.tsx`](./src/components.tsx) contains the Headless UI component adapters.
+- [`forms.ts`](./src/forms.ts) uses [`configureForms`](../../docs/api/react/future/configureForms.md#integrating-with-ui-libraries) to expose the mappings as typed field props.
+- [`tests/index.test.ts`](./tests/index.test.ts) verifies validation, focus delegation, selection, repeated values, submission, updated defaults, and reset behavior.
 
 ## Demo
 
 <!-- sandbox src="/examples/headless-ui" -->
 
-Try it out on [Stackblitz](https://stackblitz.com/github/edmundhung/conform/tree/main/examples/headless-ui).
+Try it out on [StackBlitz](https://stackblitz.com/github/edmundhung/conform/tree/main/examples/headless-ui).
 
 <!-- /sandbox -->

--- a/examples/radix-ui/README.md
+++ b/examples/radix-ui/README.md
@@ -1,222 +1,36 @@
 # Radix UI Example
 
-> This guide focuses on behavior specific to Radix UI. See [Integrating with UI Libraries](../../docs/integration/ui-libraries.md) for the general concept and the [`useControl`](../../docs/api/react/future/useControl.md) API.
+[Radix UI](https://www.radix-ui.com/) provides accessible, unstyled React primitives for building application and design-system interfaces.
 
-[Radix UI](https://www.radix-ui.com/) is a headless UI library, offering flexible, unstyled primitives for creating customizable and accessible components, allowing developers to manage the visual layer independently.
+This Vite React project demonstrates how to use Radix UI 1.6 components with Conform and Zod 4 validation through `@conform-to/zod/v4/future`. It covers Checkbox, RadioGroup, Select, Slider, Switch, and ToggleGroup through the `radix-ui` package.
 
-This example demonstrates how to integrate Conform with Radix UI 1.6 using custom metadata. It covers Checkbox, RadioGroup, Select, Slider, Switch, and ToggleGroup through the `radix-ui` package.
+## Integration
 
-## Use a Single Named Control
+The Radix components in this example use [`useControl`](../../docs/api/react/future/useControl.md) with a hidden native input. The native input owns the field name and submitted value, while the visible Radix primitive handles interaction.
 
-Several Radix primitives support form submission through an internal input when they receive a `name`. This example instead renders a hidden native input registered with `useControl` and leaves the Radix primitive unnamed:
+The adapters leave Radix's internal inputs unnamed to avoid duplicate `FormData` entries. They translate checked, scalar, and array value shapes, preserve initial and updated defaults, restore visible state on reset, and forward blur and invalid-submission focus to the interactive component.
 
-```tsx
-const control = useControl({
-  defaultValue,
-  onFocus() {
-    selectRef.current?.focus();
-  },
-});
+[`configureForms`](../../docs/api/react/future/configureForms.md#integrating-with-ui-libraries) exposes these mappings as typed field props so the form can spread them onto each adapter. See [Integrating with UI Libraries](../../docs/integration/ui-libraries.md) for the general pattern.
 
-return (
-  <>
-    <input ref={control.register} name={name} hidden />
-    <RadixSelect.Root
-      value={control.value ?? ''}
-      onValueChange={(value) => control.change(value)}
-    >
-      <RadixSelect.Trigger ref={selectRef}>{/* ... */}</RadixSelect.Trigger>
-    </RadixSelect.Root>
-  </>
-);
-```
+| Pattern | Components | Form integration |
+| --- | --- | --- |
+| Unnamed compound control | Checkbox, RadioGroup, Select, Slider, Switch, ToggleGroup | The Radix UI primitive handles interaction and focus |
+| `useControl` with a registered input | RadioGroup, Select, Slider, ToggleGroup | A hidden input owns the scalar value |
+| Checkbox registered control | Checkbox, Switch | A hidden checkbox owns the boolean value |
 
-The registered input is the only named control for the field. This avoids duplicate form values and provides the same integration model for primitives such as ToggleGroup that do not expose equivalent form props.
+Conform remains the source of validation and form state, while Radix UI supplies accessible interaction primitives. The application keeps its native `<form {...form.props}>`.
 
-## Handle Radix Value Shapes
+## Project Structure
 
-Most Radix values can be passed directly to `control.change()`. Three primitives need additional consideration in this example.
-
-Radix Checkbox can report `indeterminate` in addition to a boolean. The field in this example has a boolean schema, so it normalizes `indeterminate` to `false`:
-
-```tsx
-<RadixCheckbox.Root
-  checked={control.checked}
-  onCheckedChange={(checked) =>
-    control.change(checked === 'indeterminate' ? false : checked)
-  }
-/>
-```
-
-This is an application choice, not a requirement of the Radix integration. If `indeterminate` is meaningful to the form, it can instead be stored as a distinct string in a hidden native input.
-
-Radix Slider always reports an array because it can support multiple thumbs. This example has one thumb, so it stores the first number as a string:
-
-```tsx
-<RadixSlider.Root
-  value={[control.value ? parseFloat(control.value) : 0]}
-  onValueChange={(value) => control.change(value[0].toString())}
-/>
-```
-
-A single-value ToggleGroup reports an empty string when its active item is deselected. This example passes that value directly to `control.change()`.
-
-## Forward Focus to the Interactive Element
-
-When Conform focuses the hidden native input after an invalid submission, each adapter forwards focus to the corresponding Radix element:
-
-| Primitive | Focus target |
-| --- | --- |
-| Checkbox | `Checkbox.Root` |
-| Switch | `Switch.Root` |
-| Select | `Select.Trigger` |
-| Slider | `Slider.Thumb` |
-| RadioGroup | Checked item or first radio |
-| ToggleGroup | Active item or first button |
-
-RadioGroup and ToggleGroup roots are not the items users focus, so their adapters locate an item instead:
-
-```tsx
-const control = useControl({
-  defaultValue,
-  onFocus() {
-    const item =
-      radioGroupRef.current?.querySelector<HTMLElement>(
-        '[data-state="checked"]',
-      ) ??
-      radioGroupRef.current?.querySelector<HTMLElement>('[role="radio"]');
-
-    item?.focus();
-  },
-});
-```
-
-ToggleGroup uses the same pattern with its active `data-state="on"` item.
-
-## Match Radix Interaction Boundaries
-
-Blur events bubble through RadioGroup and ToggleGroup when focus moves between their items. Notify Conform only when focus leaves the whole group:
-
-```tsx
-<RadixRadioGroup.Root
-  onBlur={(event) => {
-    // Ignore blur events when focus moves between items in the group.
-    if (!event.currentTarget.contains(event.relatedTarget)) {
-      control.blur();
-    }
-  }}
-/>
-```
-
-Select manages focus across portalled content. This example treats closing the popup as the end of the field interaction:
-
-```tsx
-<RadixSelect.Root
-  onOpenChange={(open) => {
-    if (!open) {
-      control.blur();
-    }
-  }}
-/>
-```
-
-Checkbox, Slider, and Switch can forward their blur events directly.
-
-## Apply ARIA Attributes to the Accessible Control
-
-The hidden native input owns the field name and value. The `aria-invalid`, `aria-describedby`, and `aria-labelledby` attributes belong on the Radix element exposed to assistive technology as the control:
-
-| Primitive | ARIA attribute target |
-| --- | --- |
-| Checkbox | `Checkbox.Root` |
-| Switch | `Switch.Root` |
-| Select | `Select.Trigger` |
-| Slider | `Slider.Thumb` |
-| RadioGroup | `RadioGroup.Root` |
-| ToggleGroup | `ToggleGroup.Root` |
-
-Checkbox, Switch, and Select use the Radix element's ID for their label association:
-
-```tsx
-<RadixSelect.Trigger
-  id={id}
-  aria-invalid={ariaInvalid}
-  aria-describedby={ariaDescribedBy}
-/>
-
-<label htmlFor={id}>Country</label>
-```
-
-RadioGroup, ToggleGroup, and Slider use `aria-labelledby`:
-
-```tsx
-<span id={`${field.id}-label`}>Car type</span>
-
-<ExampleRadioGroup
-  aria-labelledby={`${field.id}-label`}
-  aria-invalid={field.ariaInvalid}
-  aria-describedby={field.ariaDescribedBy}
-/>
-```
-
-The `aria-describedby` value references the error element through Conform's error ID:
-
-```tsx
-<span id={field.errorId}>{field.errors}</span>
-```
-
-## Custom Metadata
-
-The adapters can receive field metadata explicitly:
-
-```tsx
-<ExampleSelect
-  items={countries}
-  id={fields.userCountry.id}
-  name={fields.userCountry.name}
-  defaultValue={fields.userCountry.defaultValue}
-  aria-invalid={fields.userCountry.ariaInvalid}
-  aria-describedby={fields.userCountry.ariaDescribedBy}
-/>
-```
-
-To avoid repeating that mapping at every call site, [`forms.ts`](./src/forms.ts) uses [`configureForms`](../../docs/api/react/future/configureForms.md#integrating-with-ui-libraries) to provide typed props for each adapter:
-
-```tsx
-import { configureForms } from '@conform-to/react/future';
-
-const result = configureForms({
-  extendFieldMetadata(metadata) {
-    return {
-      get selectProps() {
-        return {
-          id: metadata.id,
-          name: metadata.name,
-          defaultValue: metadata.defaultValue,
-          'aria-invalid': metadata.ariaInvalid,
-          'aria-describedby': metadata.ariaDescribedBy,
-        } satisfies Partial<React.ComponentProps<typeof ExampleSelect>>;
-      },
-      // ... other component props
-    };
-  },
-});
-
-export const useForm = result.useForm;
-```
-
-The main application can then spread those props with full type safety. Its nearby comments preserve the explicit mapping shown above:
-
-```tsx
-<ExampleSelect {...fields.userCountry.selectProps} />
-```
-
-See [`form.tsx`](./src/form.tsx) for the complete adapters and [`forms.ts`](./src/forms.ts) for all metadata mappings.
+- [`App.tsx`](./src/App.tsx) contains the form and keeps useful explicit Conform prop mappings in nearby comments.
+- [`form.tsx`](./src/form.tsx) contains the Radix UI component adapters.
+- [`forms.ts`](./src/forms.ts) uses [`configureForms`](../../docs/api/react/future/configureForms.md#integrating-with-ui-libraries) to expose the mappings as typed field props.
+- [`tests/index.test.ts`](./tests/index.test.ts) verifies validation focus and blur, submission, updated defaults, reset behavior, and modal interaction.
 
 ## Demo
 
 <!-- sandbox src="/examples/radix-ui" -->
 
-Try it out on [Stackblitz](https://stackblitz.com/github/edmundhung/conform/tree/main/examples/radix-ui).
+Try it out on [StackBlitz](https://stackblitz.com/github/edmundhung/conform/tree/main/examples/radix-ui).
 
 <!-- /sandbox -->


### PR DESCRIPTION
## Summary
- reshape the Radix UI and Headless UI READMEs around the concise structure used by newer UI-library examples
- retain the library-specific integration patterns, project layout, and demo links
- group the Base UI and Radix UI examples with their corresponding shadcn/ui variants in the English and Japanese integration indexes

## Verification
- git diff --check
- staged-file formatting via the pre-commit hook

Documentation-only change; browser tests were not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Generated Summary</summary>

- Simplified the Radix UI and Headless UI READMEs while preserving integration patterns, project structure, tests, and demo links.
- Updated English and Japanese indexes to group Base UI and Radix UI with their shadcn/ui variants.
- Verified formatting with `git diff --check` and the pre-commit hook.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->